### PR TITLE
persist names of bound variables for pretty printing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,13 +21,13 @@ library:
     - aeson
     - bound
     - bytestring
+    - comonad
     - conduit
     - containers
     - deriving-compat
     - directory
     - exceptions
     - filepath
-    - monad-supply
     - network-uri
     - optparse-applicative
     - parsec
@@ -75,5 +75,4 @@ tests:
     - QuickCheck
     - pretty
     - network-uri
-    - monad-supply
     - text

--- a/src/Eucalypt/Core/EvalByName.hs
+++ b/src/Eucalypt/Core/EvalByName.hs
@@ -8,7 +8,7 @@ Stability   : experimental
 -}
 module Eucalypt.Core.EvalByName where
 
-import Bound
+import Bound.Name (instantiate1Name, instantiateName)
 import Eucalypt.Core.Builtin
 import Eucalypt.Core.Error
 import Eucalypt.Core.Interpreter
@@ -34,7 +34,7 @@ instantiateLet :: CoreExpr -> CoreExpr
 instantiateLet (CoreLet bs b) = inst b
   where
     es = map inst bs
-    inst = instantiate (es !!)
+    inst = instantiateName (es !!)
 instantiateLet _ = undefined
 
 -- | Monadic WHNF to support abort and runtime error.
@@ -43,7 +43,7 @@ whnfM :: CoreExpr -> Interpreter CoreExpr
 whnfM e@(CoreApp f x) = do
   f' <- whnfM f
   case f' of
-    CoreLam body -> whnfM $ instantiate1 x body
+    CoreLam body -> whnfM $ instantiate1Name x body
     CorePAp arity expr args ->
       let args' = (args ++ [x])
        in if length args' < arity

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,8 +39,7 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-  - monad-supply-0.7
+extra-deps: []
   
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Eucalypt/Core/PrettySpec.hs
+++ b/test/Eucalypt/Core/PrettySpec.hs
@@ -11,8 +11,18 @@ main = hspec spec
 spec :: Spec
 spec =
 
-  describe "PPrint" $
+  describe "PPrint" $ do
 
     it "prints applications" $
-      pprint expr  `shouldBe` "(($+ 2) 5)"
-        where expr = CoreApp (CoreApp (CoreVar  "+") (CorePrim (CoreInt 2))) (CorePrim (CoreInt 5))
+      pprint (appexp (var "+") [int 2, int 5]) `shouldBe` "(($+ 2) 5)"
+
+    it "reconstructs bound names in lambdas" $
+      pprint (lamexp "foo" (var "foo")) `shouldBe` "(\\ foo. $foo)"
+
+    it "reconstructs bound names in lets" $
+      pprint (letexp [("foo", int 2), ("bar", int 3)] (appexp (var "+") [var "foo", var "bar"]))
+      `shouldBe` "let foo = 2\n    bar = 3\n    in (($+ $foo) $bar)"
+
+    it "uses placeholders for unused bindings in lets" $
+      pprint (letexp [("foo", int 2), ("bar", int 3)] (var "foo"))
+      `shouldBe` "let foo = 2\n    _? = 3\n    in $foo"


### PR DESCRIPTION
Unused variables names are lost as they're stored on the binding
but we can live with that.