### PR TITLE
string interpolation - cut 1...

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -30,7 +30,6 @@ io: {
 }
 
 
-
 TODO(x): ""
 
 ##
@@ -618,3 +617,65 @@ match-select-values(re, b): b select-items(by-key-match(re)) map(value)
 
 ` "`select-values(p?, b)` - return items from block `b` where values match predicate `p?`"
 select-values(p?, b): b map(value) filter(p?)
+
+` :suppress
+_block: {
+  ` { doc: "If `k` satisfies `k?` then `v!` else `v`" export: :suppress }
+  alter?(k?, v!, k, v): [k, if(k k?, v!, v)]
+
+  ` { doc: "If `k` satisfies `k?` then `v!` else `v`" export: :suppress }
+  update?(k?, f, k, v): [k, if(k k?, v f, v)]
+}
+
+# By property alteration of blocks
+
+` { doc: "Alter block `b` so any value with key `k` has value `v``"
+    export: :suppress }
+alter-value(k, v, b): b map-kv(_block.alter?(= k, v))
+
+` { doc: "Alter block `b` so any value with key `k` has value `f(v)`
+where v is the existing value"
+    export: :suppress }
+update-value(k, f, b): b map-kv(_block.update?(= k, f))
+
+` { doc: "Alter block `b` by setting to value `v` at path-of-keys `ks`"
+    export: :suppress }
+alter(ks, v, b): b foldr(update-value, const(v), ks)
+
+` { doc: "Alter block `b` by applying `f` to value at path-of-keys `ks`"
+    export: :suppress}
+update(ks, f, b): b foldr(update-value, f, ks)
+
+` { doc: "update-value-or(k, f, d, b) - Set `k` in block `b` to `f(v)` where
+v is existing value, otherwise add with default value `d`."
+    export: :suppress }
+update-value-or(k, f, d, b): {
+  acc(st, el): if(k = (el key),
+                  [cons([k, f(el value)], st first), []],
+		  [cons(el, st first), st second])
+  final-state: foldl(acc,
+                     [[], [[k, d]]],
+		     b elements)
+  final-block: final-state (append flip uncurry) reverse block
+}.final-block
+
+` { doc: "set(k, v, b) - Set `k` in block `b` to `v`, adding if absent."
+    export: :suppress}
+set-value(k, v): update-value-or(k, const(v), v)
+
+
+` { doc: "tongue(ks, v) - Create a block with a single nested
+path-of-keys `ks` down to value `v`"
+    export: :suppress}
+tongue(ks, v): {
+  t(k, e): [[k, e]] block
+  ret: foldr(t, v, ks) 
+}.ret
+
+` { doc: "merge-at(ks, v, b) - merge block `v` into value at path-of-keys `ks`"
+    export: :suppress }
+merge-at(ks, v, b): if(ks nil?,
+                       b v,
+		       b update-value-or(ks head,
+		                         merge-at(ks tail, v),
+					 tongue(ks tail, v)))

--- a/src/Eucalypt/Core/Anaphora.hs
+++ b/src/Eucalypt/Core/Anaphora.hs
@@ -1,0 +1,33 @@
+{-|
+Module      : Eucalypt.Core.Syn
+Description : Facilities for handling anaphoric params in Eucalypt syntax
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+
+module Eucalypt.Core.Anaphora where
+
+-- | Various types of anaphoric references appear in the Eucalypt
+-- syntax, notably expression anaphora ('_', '_0', '_1'), and string
+-- anaphora ({}, {0}, {1}).
+--
+-- This typeclass allows us to treat them similarly
+class (Eq a, Show a) => Anaphora a where
+
+  -- | The unnumberedAnaphor for this type (e.g. '_') where the index
+  -- is implicitly inferred from sequenc
+  unnumberedAnaphor :: a
+
+  -- | Is a an anaphor (numbered or not)
+  isAnaphor :: a -> Bool
+
+  -- | Read the index from an anaphor if it is numbered
+  toNumber :: a -> Maybe Int
+
+  -- | Create an anaphor for the specified number
+  fromNumber :: Int -> a
+
+  -- | A name for rendering
+  toName :: a -> String

--- a/src/Eucalypt/Core/Cook.hs
+++ b/src/Eucalypt/Core/Cook.hs
@@ -17,6 +17,7 @@ import Control.Monad.State.Lazy
 import Data.Bifunctor
 import Data.List (foldl')
 import Data.Monoid
+import Eucalypt.Core.Anaphora
 import Eucalypt.Core.Error
 import Eucalypt.Core.Interpreter
 import Eucalypt.Core.Syn
@@ -79,7 +80,7 @@ cookSoup parentAnaphoric es = do
     inAnaphoricLambda = parentAnaphoric || imAnaphoric
 
 cookScope ::
-     (Anaphora a, Show b)
+     (Anaphora a, Eq b, Show b)
   => Bool
   -> Scope (Name String b) CoreExp a
   -> Interpreter (Scope (Name String b) CoreExp a)
@@ -331,7 +332,7 @@ validExprSeq l r = filler ((snd . bindSides) l) ((fst . bindSides) r)
 -- op or an anaphoric parameter
 filler :: Anaphora a => BindSide -> BindSide -> Maybe (CoreExp a)
 filler ValueLike ValueLike = Just catOp
-filler OpLike OpLike = Just expressionAnaphorus
+filler OpLike OpLike = Just $ return unnumberedAnaphor
 filler _ _ = Nothing
 
 -- | Make a given expression valid by inserting catenation and

--- a/src/Eucalypt/Core/Desugar.hs
+++ b/src/Eucalypt/Core/Desugar.hs
@@ -15,15 +15,17 @@ import Control.Monad.State.Strict
 import Data.Char (isUpper)
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe, mapMaybe)
+import Eucalypt.Core.Anaphora ()
 import Eucalypt.Core.Syn as Syn
 import Eucalypt.Core.Target
 import Eucalypt.Core.Unit
 import Eucalypt.Reporting.Location
 import Eucalypt.Syntax.Ast as Ast
 
+
 -- | Transform a literal into its value
-desugarLiteral :: PrimitiveLiteral -> Primitive
-desugarLiteral lit =
+desugarLiteral :: PrimitiveLiteral -> CoreExpr
+desugarLiteral lit = CorePrim $
   case lit of
     VInt i -> CoreInt i
     VFloat f -> CoreFloat f
@@ -257,6 +259,18 @@ translateBlock blk = do
         Just (tgt, doc) -> recordTarget tgt doc
         Nothing -> return ()
 
+-- | Translates a string literal pattern expression into core
+-- representation - currently a concatenation of vars and literals,
+-- possibly as a lambda.
+translateStringPattern :: [StringChunk] -> CoreExpr
+translateStringPattern cs =
+  let exprs = map sub cs
+      conc = Syn.app (Syn.bif "JOIN") [Syn.str "", CoreList exprs]
+  in bindAnaphora $ numberAnaphora conc >>= \(Reference v) -> Syn.var v
+  where
+    sub :: StringChunk -> CoreExp Target
+    sub (Interpolation InterpolationRequest{refTarget=t}) = Syn.var t
+    sub (LiteralContent s) = Syn.str s
 
 
 -- | Descend through the AST, translating to CoreExpr and recording
@@ -264,12 +278,13 @@ translateBlock blk = do
 translate :: Expression -> Translate CoreExpr
 translate Located {locatee = expr} =
   case expr of
-    ELiteral lit -> return $ CorePrim $ desugarLiteral lit
+    ELiteral lit -> return $ desugarLiteral lit
     EBlock blk -> translateBlock blk
     EList components -> CoreList <$> traverse varifyTranslate components
     EName n -> return $ CoreName $ atomicName n
     EOpSoup _ es -> translateSoup es
     EApplyTuple as -> CoreArgTuple <$> traverse varifyTranslate as
+    EStringPattern chunks -> return $ translateStringPattern chunks
   where
     varifyTranslate = translate >=> return . varify
 

--- a/src/Eucalypt/Core/Desugar.hs
+++ b/src/Eucalypt/Core/Desugar.hs
@@ -265,11 +265,12 @@ translateBlock blk = do
 translateStringPattern :: [StringChunk] -> CoreExpr
 translateStringPattern cs =
   let exprs = map sub cs
-      conc = Syn.app (Syn.bif "JOIN") [Syn.str "", CoreList exprs]
-  in bindAnaphora $ numberAnaphora conc >>= \(Reference v) -> Syn.var v
+      conc = Syn.app (Syn.bif "JOIN") [CoreList exprs, Syn.str ""]
+   in bindAnaphora (numberAnaphora conc) >>= \(Reference v) -> Syn.var v
   where
     sub :: StringChunk -> CoreExp Target
-    sub (Interpolation InterpolationRequest{refTarget=t}) = Syn.var t
+    sub (Interpolation InterpolationRequest {refTarget = t}) =
+      Syn.app (Syn.bif "STR") [Syn.var t]
     sub (LiteralContent s) = Syn.str s
 
 

--- a/src/Eucalypt/Driver/Input.hs
+++ b/src/Eucalypt/Driver/Input.hs
@@ -4,7 +4,7 @@ module Eucalypt.Driver.Input
 import Control.Applicative ((<|>))
 import Data.Maybe (fromMaybe)
 import Data.Void
-import Eucalypt.Syntax.ParseExpr (normalIdentifier)
+import Eucalypt.Syntax.ParseCommon (normalIdentifier)
 import Network.URI
 import System.FilePath
 import Text.Megaparsec

--- a/src/Eucalypt/Syntax/ParseCommon.hs
+++ b/src/Eucalypt/Syntax/ParseCommon.hs
@@ -6,7 +6,7 @@ License     :
 Maintainer  : greg@curvelogic.co.uk
 Stability   : experimental
 -}
-module Eucalypt.Syntax.ParseExpr where
+module Eucalypt.Syntax.ParseCommon where
 
 import Data.Void (Void)
 import Text.Megaparsec
@@ -39,6 +39,15 @@ symbol = L.symbol sc
 colon :: Parser String
 colon = symbol ":"
 
+comma :: Parser String
+comma = symbol ","
+
+parens :: Parser a -> Parser a
+parens = between (symbol "(") (char ')')
+
+braces :: Parser a -> Parser a
+braces = between (symbol "{") (char '}')
+
 -- | A normal (non-operator) identifier, n.b. leading digits are legal
 -- in Eucalypt: @5v@ is an identifier.
 normalIdentifier :: Parser String
@@ -46,5 +55,5 @@ normalIdentifier =
   ((:) <$> normalIdentStartChar <*> many normalIdentContinuationChar) <?>
   "normal identifier"
   where
-    normalIdentStartChar = alphaNumChar <|> oneOf "$?_"
+    normalIdentStartChar = letterChar <|> oneOf "$?_"
     normalIdentContinuationChar = alphaNumChar <|> oneOf "$?!_-*"

--- a/src/Eucalypt/Syntax/ParseCommon.hs
+++ b/src/Eucalypt/Syntax/ParseCommon.hs
@@ -1,0 +1,50 @@
+{-|
+Module      : Eucalypt.Syntax.ParseCommon
+Description : Basic parsers for syntax elements of Eucalypt
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+module Eucalypt.Syntax.ParseExpr where
+
+import Data.Void (Void)
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+type Parser = Parsec Void String
+
+
+-- | Whitespace parser also discards line comments for now
+sc :: Parser ()
+sc = L.space space1 lineComment empty
+  where
+    lineComment = L.skipLineComment "#"
+
+
+-- | In some areas, we don't consume whitespace
+nosc :: Parser ()
+nosc = L.space empty empty empty
+
+
+-- | A lexeme parser cannot be interpreted as a function to be applied
+-- and so consumes trailing whitespace
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+symbol :: String -> Parser String
+symbol = L.symbol sc
+
+colon :: Parser String
+colon = symbol ":"
+
+-- | A normal (non-operator) identifier, n.b. leading digits are legal
+-- in Eucalypt: @5v@ is an identifier.
+normalIdentifier :: Parser String
+normalIdentifier =
+  ((:) <$> normalIdentStartChar <*> many normalIdentContinuationChar) <?>
+  "normal identifier"
+  where
+    normalIdentStartChar = alphaNumChar <|> oneOf "$?_"
+    normalIdentContinuationChar = alphaNumChar <|> oneOf "$?!_-*"

--- a/src/Eucalypt/Syntax/ParseExpr.hs
+++ b/src/Eucalypt/Syntax/ParseExpr.hs
@@ -10,7 +10,6 @@ module Eucalypt.Syntax.ParseExpr where
 
 import Data.Bifunctor (first)
 import Data.Char (isAscii, isSymbol)
-import Data.Void (Void)
 import Eucalypt.Reporting.Location
 import Eucalypt.Syntax.Ast
 import Eucalypt.Syntax.Error
@@ -144,12 +143,6 @@ atom = try primitive <|> name
 -- ? calls
 -- 
 
-comma :: Parser String
-comma = symbol ","
-         
-parens :: Parser a -> Parser a         
-parens = between (symbol "(") (char ')')
-
 tuple :: Parser [Expression]
 tuple = parens $ expression `sepBy1` comma
 
@@ -270,9 +263,6 @@ anyDeclaration = label "declaration" $ lexeme $ located $ do
 
 blockContent :: Parser Block
 blockContent = sc >> located (Block <$> many anyDeclaration)
-
-braces :: Parser a -> Parser a         
-braces = between (symbol "{") (char '}')
 
 blockLiteral :: Parser Expression
 blockLiteral = located $ EBlock <$> braces blockContent

--- a/src/Eucalypt/Syntax/ParseExpr.hs
+++ b/src/Eucalypt/Syntax/ParseExpr.hs
@@ -128,6 +128,7 @@ stringLiteral :: Parser Expression
 stringLiteral = located $ do
   chunks <- char '"' *> quotedStringContent <* char '"'
   return $ case chunks of
+    [] -> ELiteral $ VStr ""
     [LiteralContent s] -> ELiteral $ VStr s
     xs -> EStringPattern xs
 

--- a/src/Eucalypt/Syntax/ParseString.hs
+++ b/src/Eucalypt/Syntax/ParseString.hs
@@ -10,33 +10,12 @@ module Eucalypt.Syntax.ParseString where
 
 import Data.Bifunctor (first)
 import Data.Char (digitToInt)
+import Eucalypt.Syntax.Ast
 import Eucalypt.Syntax.Error
 import Eucalypt.Syntax.ParseCommon
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
--- | The target of an interpolation request, either an implicit
--- parameter ("anaphor"), numbered or otherwise or a name referring to
--- value in appropriate block.
-data Target
-  = Anaphor (Maybe Int) -- empty anaphor or indexed anaphor
-  | Reference String -- reference to value from block (or environment)
-  deriving (Eq, Show)
-
--- | The interpolation request
---
--- A target and string governing how to format it
-data InterpolationRequest = InterpolationRequest
-  { refTarget :: Target
-  , refFormat :: Maybe String
-  } deriving (Eq, Show)
-
--- | A string element is either literal content or an interpolation
--- request
-data StringElement
-  = LiteralContent String
-  | Interpolation InterpolationRequest
-  deriving (Eq, Show)
 
 -- | Parse the target of an interpolation request (empty, 0-9 or ref)
 target :: Parser Target
@@ -44,16 +23,25 @@ target =
   (Reference <$> normalIdentifier) <|>
   (Anaphor <$> optional (digitToInt <$> digitChar))
 
+
 -- | Parse the format string
 format :: Parser String
-format = some (notChar '}')
+format = some (satisfy $ \ c -> c /= '}' && c /= ':')
+
+
+-- | Parse the conversion string
+conversion :: Parser String
+conversion = some (notChar '}')
+
 
 -- | Parse an interpolation request
 interpolationRequest :: Parser InterpolationRequest
 interpolationRequest = braces $ do
   t <- target
   f <- optional (colon >> format)
-  return $ InterpolationRequest t f
+  c <- optional (colon >> conversion)
+  return $ InterpolationRequest t f c
+
 
 -- | Text with braces escaped. '{{...}}' gives literal content '{...}'
 escapedBracesText :: Parser String
@@ -63,24 +51,24 @@ escapedBracesText = do
   text <- manyTill anyChar (count n (char '}'))
   return $ replicate (n - 1) '{' ++ text ++ replicate (n - 1) '}'
 
+
 -- | Parse literal content up to next '{'
 literalContent :: Parser String
-literalContent = some $ notChar '{'
+literalContent = some (satisfy $ \c -> c /= '{' && c /= '"')
 
 
 -- | Parse a chunk of the string literal content
-chunk :: Parser StringElement
+chunk :: Parser StringChunk
 chunk =
   (LiteralContent <$> literalContent) <|>
   try (lookAhead (string "{{") >> LiteralContent <$> escapedBracesText) <|>
   try (lookAhead (char '{') >> Interpolation <$> interpolationRequest)
 
 
-
 -- | Parse content of a string literal (with interpolation syntax)
-stringContent :: Parser [StringElement]
-stringContent = many chunk
+quotedStringContent :: Parser [StringChunk]
+quotedStringContent = many chunk
 
 -- | Parse the string content into either error or chunk list
-parseEucalyptString :: String -> Either SyntaxError [StringElement]
-parseEucalyptString = first MegaparsecError <$> parse stringContent "<<literal>>"
+parseEucalyptString :: String -> Either SyntaxError [StringChunk]
+parseEucalyptString = first MegaparsecError <$> parse quotedStringContent "<<literal>>"

--- a/src/Eucalypt/Syntax/ParseString.hs
+++ b/src/Eucalypt/Syntax/ParseString.hs
@@ -1,0 +1,60 @@
+{-|
+Module      : Eucalypt.Syntax.ParseString
+Description : Parser for the eucalypt string interpolation DSL
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+
+import Eucalypt.Syntax.ParseCommon
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+-- | The target of an interpolation request, either an implicit
+-- parameter ("anaphor"), numbered or otherwise or a name referring to
+-- value in appropriate block.
+data Target
+  = Anaphor (Maybe Int) -- empty anaphor or indexed anaphor
+  | Reference String -- reference to value from block (or environment)
+
+-- | The interpolation request
+--
+-- A target and string governing how to format it
+data InterpolationRequest = InterpolationRequest
+  { refTarget :: Target
+  , refFormat :: (Maybe String)
+  }
+
+-- | A string element is either literal content or an interpolation
+-- request
+data StringElement
+  = LiteralContent String
+  | Interpolation InterpolationRequest
+
+
+-- | Parse the target of an interpolation request (empty, 0-9 or ref)
+parseTarget :: Parser (Maybe Target)
+parseTarget =
+  (Reference <$> normalIdentifier) <|> (Anaphor <$> optional digitChar)
+
+-- | Parse the format string
+parseFormat :: Parser (Maybe String)
+parseFormat = optional $ some (notChar '}')
+
+-- | Parse an interpolation request
+parseInterpolationRequest :: Parser InterpolationRequest
+parseInterpolationRequest = do
+  char '{' << notFollowedBy (char '{')
+  target <- parseTarget
+  format <- optional (colon >> parseFormat)
+  char '}'
+  return $ InterpolationRequest target format
+
+parseLiteralContent :: Parser String
+parseLiteralContent = do
+                         text <- anyTill (char '{')
+
+
+parseStringContent :: Parser [StringElement]
+parseStringContent = undefined

--- a/src/Eucalypt/Syntax/ParseString.hs
+++ b/src/Eucalypt/Syntax/ParseString.hs
@@ -6,7 +6,11 @@ License     :
 Maintainer  : greg@curvelogic.co.uk
 Stability   : experimental
 -}
+module Eucalypt.Syntax.ParseString where
 
+import Data.Bifunctor (first)
+import Data.Char (digitToInt)
+import Eucalypt.Syntax.Error
 import Eucalypt.Syntax.ParseCommon
 import Text.Megaparsec
 import Text.Megaparsec.Char
@@ -17,44 +21,66 @@ import Text.Megaparsec.Char
 data Target
   = Anaphor (Maybe Int) -- empty anaphor or indexed anaphor
   | Reference String -- reference to value from block (or environment)
+  deriving (Eq, Show)
 
 -- | The interpolation request
 --
 -- A target and string governing how to format it
 data InterpolationRequest = InterpolationRequest
   { refTarget :: Target
-  , refFormat :: (Maybe String)
-  }
+  , refFormat :: Maybe String
+  } deriving (Eq, Show)
 
 -- | A string element is either literal content or an interpolation
 -- request
 data StringElement
   = LiteralContent String
   | Interpolation InterpolationRequest
-
+  deriving (Eq, Show)
 
 -- | Parse the target of an interpolation request (empty, 0-9 or ref)
-parseTarget :: Parser (Maybe Target)
-parseTarget =
-  (Reference <$> normalIdentifier) <|> (Anaphor <$> optional digitChar)
+target :: Parser Target
+target =
+  (Reference <$> normalIdentifier) <|>
+  (Anaphor <$> optional (digitToInt <$> digitChar))
 
 -- | Parse the format string
-parseFormat :: Parser (Maybe String)
-parseFormat = optional $ some (notChar '}')
+format :: Parser String
+format = some (notChar '}')
 
 -- | Parse an interpolation request
-parseInterpolationRequest :: Parser InterpolationRequest
-parseInterpolationRequest = do
-  char '{' << notFollowedBy (char '{')
-  target <- parseTarget
-  format <- optional (colon >> parseFormat)
-  char '}'
-  return $ InterpolationRequest target format
+interpolationRequest :: Parser InterpolationRequest
+interpolationRequest = braces $ do
+  t <- target
+  f <- optional (colon >> format)
+  return $ InterpolationRequest t f
 
-parseLiteralContent :: Parser String
-parseLiteralContent = do
-                         text <- anyTill (char '{')
+-- | Text with braces escaped. '{{...}}' gives literal content '{...}'
+escapedBracesText :: Parser String
+escapedBracesText = do
+  opens <- some $ char '{'
+  let n = length opens
+  text <- manyTill anyChar (count n (char '}'))
+  return $ replicate (n - 1) '{' ++ text ++ replicate (n - 1) '}'
+
+-- | Parse literal content up to next '{'
+literalContent :: Parser String
+literalContent = some $ notChar '{'
 
 
-parseStringContent :: Parser [StringElement]
-parseStringContent = undefined
+-- | Parse a chunk of the string literal content
+chunk :: Parser StringElement
+chunk =
+  (LiteralContent <$> literalContent) <|>
+  try (lookAhead (string "{{") >> LiteralContent <$> escapedBracesText) <|>
+  try (lookAhead (char '{') >> Interpolation <$> interpolationRequest)
+
+
+
+-- | Parse content of a string literal (with interpolation syntax)
+stringContent :: Parser [StringElement]
+stringContent = many chunk
+
+-- | Parse the string content into either error or chunk list
+parseEucalyptString :: String -> Either SyntaxError [StringElement]
+parseEucalyptString = first MegaparsecError <$> parse stringContent "<<literal>>"

--- a/test/Eucalypt/Core/DesugarSpec.hs
+++ b/test/Eucalypt/Core/DesugarSpec.hs
@@ -25,6 +25,7 @@ spec = do
   blockSpec
   sampleSpec
   targetsSpec
+  interpolationSpec
 
 -- ? shims
 testDesugarSoup :: [Expression] -> Syn.CoreExpr
@@ -210,3 +211,100 @@ targetsSpec =
     it "finds T and U in larger sample " $
       (truTargets . translateToCore) targetSampleB `shouldBe`
       [TargetSpec "T" "x" ["a", "b"], TargetSpec "U" "y" ["a", "c"]]
+
+
+interpolationSpec:: Spec
+interpolationSpec =
+  describe "string interpolation" $ do
+    it "decomposes pattern \"{foo}bar\"" $
+      testDesugar <$>
+      parseExpression "\"{foo}bar\"" "test" `shouldBe`
+      Right
+        (Syn.app
+           (Syn.bif "JOIN")
+           [ Syn.CoreList
+               [Syn.app (Syn.bif "STR") [Syn.var "foo"], Syn.str "bar"]
+           , Syn.str ""
+           ])
+    it "decomposes pattern \"{foo}bar\"" $
+      testDesugar <$>
+      parseExpression "\"foo{bar}\"" "test" `shouldBe`
+      Right
+        (Syn.app
+           (Syn.bif "JOIN")
+           [ Syn.CoreList
+               [Syn.str "foo", Syn.app (Syn.bif "STR") [Syn.var "bar"]]
+           , Syn.str ""
+           ])
+    it "decomposes pattern \"{foo}{bar}\"" $
+      testDesugar <$>
+      parseExpression "\"{foo}{bar}\"" "test" `shouldBe`
+      Right
+        (Syn.app
+           (Syn.bif "JOIN")
+           [ Syn.CoreList
+               [ Syn.app (Syn.bif "STR") [Syn.var "foo"]
+               , Syn.app (Syn.bif "STR") [Syn.var "bar"]
+               ]
+           , Syn.str ""
+           ])
+    it "handles empty string \"\"" $
+      testDesugar <$>
+      parseExpression "\"\"" "test" `shouldBe` Right (Syn.str "")
+    it "desugars numbered anaphora" $
+      testDesugar <$>
+      parseExpression "\"{0}{1}\"" "test" `shouldBe`
+      Right
+        (Syn.lam
+           ["x", "y"]
+           (Syn.app
+              (Syn.bif "JOIN")
+              [ Syn.CoreList
+                  [ Syn.app (Syn.bif "STR") [Syn.var "x"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  ]
+              , Syn.str ""
+              ]))
+    it "desugars unnumbered anaphora" $
+      testDesugar <$>
+      parseExpression "\"{}{}\"" "test" `shouldBe`
+      Right
+        (Syn.lam
+           ["x", "y"]
+           (Syn.app
+              (Syn.bif "JOIN")
+              [ Syn.CoreList
+                  [ Syn.app (Syn.bif "STR") [Syn.var "x"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  ]
+              , Syn.str ""
+              ]))
+    it "desugars unnumbered anaphora with free vars" $
+      testDesugar <$>
+      parseExpression "\"{foo}{}\"" "test" `shouldBe`
+      Right
+        (Syn.lam
+           ["y"]
+           (Syn.app
+              (Syn.bif "JOIN")
+              [ Syn.CoreList
+                  [ Syn.app (Syn.bif "STR") [Syn.var "foo"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  ]
+              , Syn.str ""
+              ]))
+    it "desugars both anaphora with free vars" $
+      testDesugar <$>
+      parseExpression "\"{foo}{1}{}\"" "test" `shouldBe`
+      Right
+        (Syn.lam
+           ["x", "y"]
+           (Syn.app
+              (Syn.bif "JOIN")
+              [ Syn.CoreList
+                  [ Syn.app (Syn.bif "STR") [Syn.var "foo"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "y"]
+                  , Syn.app (Syn.bif "STR") [Syn.var "x"]
+                  ]
+              , Syn.str ""
+              ]))

--- a/test/Eucalypt/Core/DesugarSpec.hs
+++ b/test/Eucalypt/Core/DesugarSpec.hs
@@ -40,7 +40,7 @@ testDesugar = (`evalState` initTranslateState) . unTranslate . translate
 coreSpec :: Spec
 coreSpec =
   describe "Core" $ do
-    it "represents literals" $ desugarLiteral (VInt 8) `shouldBe` Syn.CoreInt 8
+    it "represents literals" $ desugarLiteral (VInt 8) `shouldBe` Syn.int 8
     it "processes annotation shortcuts" $
       processAnnotation (Syn.CorePrim (Syn.CoreString "blah")) `shouldBe`
       Syn.CoreBlock

--- a/test/Eucalypt/Syntax/ParseExprSpec.hs
+++ b/test/Eucalypt/Syntax/ParseExprSpec.hs
@@ -7,6 +7,7 @@ module Eucalypt.Syntax.ParseExprSpec
 import Data.Void
 import Eucalypt.Reporting.Location
 import Eucalypt.Syntax.Ast
+import Eucalypt.Syntax.ParseCommon
 import Eucalypt.Syntax.ParseExpr
 import Test.Hspec
 import Test.Hspec.Megaparsec
@@ -40,7 +41,7 @@ operatorStart = "!@£%^&*|></+=-~"
 
 operatorCont = "!@£$%^&*|></?+=-~"
 
-identifierStart = lower ++ upper ++ digits ++ idStartPunc
+identifierStart = lower ++ upper ++ idStartPunc
 
 identifierCont = lower ++ upper ++ digits ++ idContPunc
 

--- a/test/Eucalypt/Syntax/ParseExprSpec.hs
+++ b/test/Eucalypt/Syntax/ParseExprSpec.hs
@@ -115,7 +115,7 @@ primitiveSpec = do
     it "parses shown haskell float" $ property parsesDoubles
   describe "parsing strings" $
     it "parses simple strings" $
-    parseMaybe stringLiteral "\"abc\"" == Just (VStr "abc")
+    testParse stringLiteral "\"abc\"" `shouldParse` str "abc"
   describe "parsing symbols" $ do
     it "parses normal symbols" $ forAll validNormalNames parsesSymbols
     it "parses operator symbols" $ forAll validOperatorNames parsesSymbols

--- a/test/Eucalypt/Syntax/ParseExprSpec.hs
+++ b/test/Eucalypt/Syntax/ParseExprSpec.hs
@@ -113,9 +113,11 @@ primitiveSpec = do
   describe "parsing numbers" $ do
     it "parses shown haskell integers" $ property parsesAnyInteger
     it "parses shown haskell float" $ property parsesDoubles
-  describe "parsing strings" $
+  describe "parsing strings" $ do
     it "parses simple strings" $
-    testParse stringLiteral "\"abc\"" `shouldParse` str "abc"
+      testParse stringLiteral "\"abc\"" `shouldParse` str "abc"
+    it "parses empty string" $
+      testParse stringLiteral "\"\"" `shouldParse` str ""
   describe "parsing symbols" $ do
     it "parses normal symbols" $ forAll validNormalNames parsesSymbols
     it "parses operator symbols" $ forAll validOperatorNames parsesSymbols

--- a/test/Eucalypt/Syntax/ParseStringSpec.hs
+++ b/test/Eucalypt/Syntax/ParseStringSpec.hs
@@ -1,0 +1,64 @@
+module Eucalypt.Syntax.ParseStringSpec
+  ( main
+  , spec
+  ) where
+
+import Data.Void
+import Eucalypt.Syntax.ParseString
+import Test.Hspec
+import Test.Hspec.Megaparsec
+import Text.Megaparsec
+
+main :: IO ()
+main = hspec spec
+
+anaphor :: StringElement
+anaphor =
+  Interpolation $
+  InterpolationRequest {refTarget = Anaphor Nothing, refFormat = Nothing}
+
+anaphor1 :: StringElement
+anaphor1 =
+  Interpolation $
+  InterpolationRequest {refTarget = Anaphor (Just 1), refFormat = Nothing}
+
+refer :: String -> StringElement
+refer v =
+  Interpolation $
+  InterpolationRequest {refTarget = Reference v, refFormat = Nothing}
+
+testParse :: String -> Either (ParseError Char Void) [StringElement]
+testParse = parse stringContent "<<test>>"
+
+
+spec :: Spec
+spec =
+  describe "string parsing" $ do
+    it "reads simple content - \"foo\"" $
+      testParse "foo" `shouldParse`
+      [LiteralContent "foo"]
+    it "handles escaped braces - \"{{foo}}\"" $
+      testParse "{{foo}}" `shouldParse`
+      [LiteralContent "{foo}"]
+    it "handles blank anaphor - \"{}\"" $
+      testParse "{}" `shouldParse` [anaphor]
+    it "handles numeric anaphor - \"{1}\"" $
+      testParse "{1}" `shouldParse` [anaphor1]
+    it "handles interpolation ref - \"{foo}\"" $
+      testParse "{foo}" `shouldParse` [refer "foo"]
+    it "handles mixture - \"x{}y{}z{}a{foo}b{bar}c{baz}{{txt}}\"" $
+      testParse "x{}y{}z{}a{foo}b{bar}c{baz}{{txt}}" `shouldParse`
+      [ LiteralContent "x"
+      , anaphor
+      , LiteralContent "y"
+      , anaphor
+      , LiteralContent "z"
+      , anaphor
+      , LiteralContent "a"
+      , refer "foo"
+      , LiteralContent "b"
+      , refer "bar"
+      , LiteralContent "c"
+      , refer "baz"
+      , LiteralContent "{txt}"
+      ]

--- a/test/Eucalypt/Syntax/ParseStringSpec.hs
+++ b/test/Eucalypt/Syntax/ParseStringSpec.hs
@@ -4,6 +4,7 @@ module Eucalypt.Syntax.ParseStringSpec
   ) where
 
 import Data.Void
+import Eucalypt.Syntax.Ast
 import Eucalypt.Syntax.ParseString
 import Test.Hspec
 import Test.Hspec.Megaparsec
@@ -12,23 +13,35 @@ import Text.Megaparsec
 main :: IO ()
 main = hspec spec
 
-anaphor :: StringElement
+anaphor :: StringChunk
 anaphor =
   Interpolation $
-  InterpolationRequest {refTarget = Anaphor Nothing, refFormat = Nothing}
+  InterpolationRequest
+    { refTarget = Anaphor Nothing
+    , refParseOrFormat = Nothing
+    , refConversion = Nothing
+    }
 
-anaphor1 :: StringElement
+anaphor1 :: StringChunk
 anaphor1 =
   Interpolation $
-  InterpolationRequest {refTarget = Anaphor (Just 1), refFormat = Nothing}
+  InterpolationRequest
+    { refTarget = Anaphor (Just 1)
+    , refParseOrFormat = Nothing
+    , refConversion = Nothing
+    }
 
-refer :: String -> StringElement
+refer :: String -> StringChunk
 refer v =
   Interpolation $
-  InterpolationRequest {refTarget = Reference v, refFormat = Nothing}
+  InterpolationRequest
+    { refTarget = Reference v
+    , refParseOrFormat = Nothing
+    , refConversion = Nothing
+    }
 
-testParse :: String -> Either (ParseError Char Void) [StringElement]
-testParse = parse stringContent "<<test>>"
+testParse :: String -> Either (ParseError Char Void) [StringChunk]
+testParse = parse quotedStringContent "<<test>>"
 
 
 spec :: Spec


### PR DESCRIPTION
## Analysis Needed: Block anaphora to fancy underbracket

### Current Understanding
- Eucalypt has anaphora (implicit argument) support: `_`, `_1`, `_2`, etc.
- Implementation in `src/core/anaphora.rs`
- This issue seems to request extending anaphora for blocks with "fancy underbracket" notation

### Questions Requiring Discussion
1. **What is "fancy underbracket"?** - Need specific syntax examples
2. **Current block anaphora**: How does it work today vs. desired behavior?
3. **Use cases**: What problems would this solve?
4. **Implementation scope**: Parser changes, semantic changes, both?

### Initial Investigation Needed
- Examine `harness/test/031_block_anaphora.eu` for current behavior
- Review existing anaphora documentation
- Understand specific enhancement being requested

### Priority
**Requires discussion** - language feature enhancement

### Status
**Needs clarification of:**
- Specific syntax and semantics for "fancy underbracket"
- Current limitations that this would address
- Priority relative to other language features
- Implementation complexity assessment