### PR TITLE
default stdin input to yaml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@
 This is a prototype Haskell implementation of the Eucalypt language
 for generating, templating, rendering and processing structured data
 formats like YAML and JSON.
+
+**Health warning**
+
+This implementation is currently a very crude substitutional
+interpreter for experimenting with the shape of the Eucalypt language.
+It has many shortcuts and shortcomings. It's not complete, nor
+necessarily even ready for casual use.

--- a/src/Eucalypt/Driver/Options.hs
+++ b/src/Eucalypt/Driver/Options.hs
@@ -281,7 +281,7 @@ defaultStdInput opts = do
   istty <- queryTerminal stdInput
   if istty
     then return opts
-    else return $ appendInputs opts [ (fromJust . parseInputFromString) "-" ]
+    else return $ appendInputs opts [ (fromJust . parseInputFromString) "yaml@-" ]
 
 
 


### PR DESCRIPTION
## Analysis Needed: 0-arity operators

### Current State
**Operator Arity Support (Current Parser):**
- `Fixity` enum in `src/core/expr.rs` supports:
  - `UnaryPrefix`, `UnaryPostfix` (arity 1)  
  - `InfixLeft`, `InfixRight` (arity 2)
- **No support for arity 0 (nullary) operators**

### What are 0-arity Operators?
**Definition:** Operators that take no arguments - essentially constants that look like operators.

**Potential examples:**
- Mathematical constants: `π`, `∞`, `ε`
- Special values: `⊥` (bottom), `⊤` (top), `∅` (empty)
- Context-dependent: `now`, `here`, `self`

### Rowan Parser Status
According to user: 0-arity operators are already parsed by the in-progress Rowan parser on `origin/refactor/rowan` branch.

### Implementation Considerations
Would require:
1. Extending `Fixity` enum with `Nullary` variant
2. Updating shunting yard algorithm in `src/core/cook/shunt.rs`
3. Handling in both current and Rowan parsers for consistency

### Priority
**Requires discussion** - language feature completing operator system

### Status
**Needs detailed discussion of:**
- Priority relative to other language features
- Implementation approach (current parser vs Rowan-first)
- Specific nullary operators to support initially
- Syntax for declaring user-defined nullary operators