### PR TITLE
Add ability to read core syntax embedded in eu.

### DIFF
--- a/harness/test/048_parse_embed_core.eu
+++ b/harness/test/048_parse_embed_core.eu
@@ -1,0 +1,32 @@
+ { parse-embed: :CORE }
+
+` { embedding: :core }
+CORE: [:c-let, {
+   i: [:c-lam, ["x"], [:c-var, "x"]]
+   k: [:c-lam, ["x", "y"], [:c-var, "x"]]
+   k1: [:c-lam, ["x", "y"], [:c-var, "y"]]
+   s: [:c-lam, ["f", "g", "x"], [:c-app, [:c-app, [:c-var, "f"], [[:c-var, "x"]]], [[:c-app, [:c-var, "g"], [[:c-var, "x"]]]]]]
+   compose: [:c-lam, ["f", "g", "x"], [:c-app, [:c-var, "f"], [[:c-app, [:c-var, "g"], [[:c-var, "x"]]]]]]
+   twice: [:c-lam, ["f"], [:c-app, [:c-var, "compose"], [[:c-var, "f"], [:c-var, "f"]]]]
+   box: [:c-let, { value: [:c-app, [:c-var, "i"], [[:c-lit, 5]]] }, [:c-block, {
+       value: [:c-var, "value"]
+     }]]
+   box2: [:c-let, {
+      value: [:c-app, [:c-app, [:c-var, "s"], [[:c-var, "k"], [:c-var, "k"]]], [[:c-lit, 5]]]
+    }, [:c-block, { value: [:c-var, "value"] }]]
+   RESULT: [:c-app, [:c-bif, :IF], [[:c-app, [:c-bif, :EQ], [[:c-lookup, [:c-var, "box"], "value"], [:c-lookup, [:c-var, "box2"], "value"]]], [:c-lit, :PASS], [:c-lit, :FAIL]]]
+ }, [:c-block, {
+    i: [:c-var, "i"]
+    k: [:c-var, "k"]
+    k1: [:c-var, "k1"]
+    s: [:c-var, "s"]
+    compose: [:c-var, "compose"]
+    twice: [:c-var, "twice"]
+    box: [:c-var, "box"]
+    box2: [:c-var, "box2"]
+    RESULT: [:c-var, "RESULT"]
+  }]]
+
+
+
+

--- a/src/Eucalypt/Core/Desugar.hs
+++ b/src/Eucalypt/Core/Desugar.hs
@@ -238,10 +238,7 @@ checkImports annot = do
 -- the unit contents with the result of consuming the embedding at the
 -- specified key.
 checkParseEmbed :: CoreExpr -> Translate ()
-checkParseEmbed annot =
-  case determineParseEmbed annot of
-    Just pe -> recordParseEmbed pe
-    Nothing -> return ()
+checkParseEmbed annot = forM_ (determineParseEmbed annot) recordParseEmbed
 
 
 

--- a/src/Eucalypt/Core/Desugar.hs
+++ b/src/Eucalypt/Core/Desugar.hs
@@ -37,6 +37,7 @@ import Eucalypt.Core.Import
 import Eucalypt.Core.Syn as Syn
 import Eucalypt.Core.SourceMap
 import Eucalypt.Core.Metadata
+import Eucalypt.Core.ParseEmbed (translateEmbedded)
 import Eucalypt.Core.Target
 import Eucalypt.Core.Unit
 import Eucalypt.Reporting.Location
@@ -53,6 +54,8 @@ data TranslateState = TranslateState
     -- ^ maintain stack of keys to calculate target "paths"
   , trImports :: [Input]
     -- ^ imports discovered
+  , trParseEmbed :: Maybe CoreBindingName
+    -- ^ a parse-embed key
   , trSourceMap :: SourceMap
     -- ^ map of source map IDs to source locations
   , trActions :: [IO ()]
@@ -79,7 +82,7 @@ initTranslateState ::
      SMID           -- ^ source map ID to start from
   -> ImportHandler  -- ^ for reading imports
   -> TranslateState -- ^ initial state
-initTranslateState = TranslateState [] [] [] mempty mempty
+initTranslateState = TranslateState [] [] [] mempty mempty mempty
 
 -- | Push a key onto the stack to track where we are, considering
 -- statically declared blocks as namespaces
@@ -127,6 +130,13 @@ recordImports imports =
 recordActions :: [IO ()] -> Translate ()
 recordActions actions =
   modify $ \s@TranslateState {trActions = old} -> s {trActions = old ++ actions}
+
+
+
+-- | Record a parse-embed key read from unit metadata
+recordParseEmbed :: CoreBindingName -> Translate ()
+recordParseEmbed key =
+  modify $ \s -> s {trParseEmbed = Just key }
 
 
 
@@ -224,6 +234,17 @@ checkImports annot = do
 
 
 
+-- | Check for a parse-embed directive that indicates we must replace
+-- the unit contents with the result of consuming the embedding at the
+-- specified key.
+checkParseEmbed :: CoreExpr -> Translate ()
+checkParseEmbed annot =
+  case determineParseEmbed annot of
+    Just pe -> recordParseEmbed pe
+    Nothing -> return ()
+
+
+
 -- | Description of all declaration details for producing the combined
 -- core let / block which represents the AST block.
 data DeclarationFields = DeclarationFields
@@ -276,7 +297,11 @@ unifiedDeclarations blk =
           checkImports annot
           return $ splitAnnotationMetadata annot
         Nothing -> return (Nothing, Nothing)
-    expr <- translateDeclarationForm a k (content d)
+    let embedding = a >>= determineEmbedding
+    expr <- case embedding of
+      Just EmbedCore -> translateEmbedded $ extractPropValue d
+      Just EmbedAST -> undefined
+      Nothing -> translateDeclarationForm a k (content d)
     popKey
     return $ DeclarationFields declMeta k valMeta expr
   where
@@ -289,6 +314,13 @@ unifiedDeclarations blk =
               (LeftOperatorDecl k _ _) -> k
               (RightOperatorDecl k _ _) -> k
        in atomicName name
+    extractPropValue Annotated {content = Located {locatee = decl}} =
+      case decl of
+        (PropertyDecl _ v) -> v
+        (FunctionDecl _ _ v) -> v
+        (OperatorDecl _ _ _ v) -> v
+        (LeftOperatorDecl _ _ v) -> v
+        (RightOperatorDecl _ _ v) -> v
 
 
 
@@ -449,10 +481,16 @@ translateUnit Located { location = l
       m <- translate annot
       checkImports m
       checkTarget m
-      e >>= mint2 CoreMeta l m
+      checkParseEmbed m
+      parseEmbed <- gets trParseEmbed
+      case parseEmbed of
+        Nothing -> e >>= mint2 CoreMeta l m
+        Just k -> e >>= (return . selectEmbedding k)
     Nothing -> e
   where
     e = translate Located {location = l, locatee = EBlock b}
+    selectEmbedding key expr =
+      instantiateLet $ rebody expr (anon Syn.var key)
 
 
 

--- a/src/Eucalypt/Core/Metadata.hs
+++ b/src/Eucalypt/Core/Metadata.hs
@@ -41,7 +41,7 @@ splitAnnotationMetadata (CoreBlock smid (CoreList _ items)) =
   bimap maybeBlock maybeBlock $ partitionEithers $ map classify items
   where
     classify item@(CoreList _ [CorePrim _ (CoreSymbol k), _]) =
-      if k == "import"
+      if k == "import" || k == "embedding"
         then Right item
         else Left item
     classify item = Left item
@@ -143,3 +143,23 @@ determineTarget meta = (, doc, format) <$> target
     target = join $ readUnevaluatedMetadata "target" meta symbolName
     doc = fromMaybe "" $ join $ readUnevaluatedMetadata "doc" meta stringContent
     format = join $ readUnevaluatedMetadata "format" meta symbolName
+
+
+-- | Check (unevaluated) metadata for parse-embed annotation
+determineParseEmbed :: CoreExpr -> Maybe String
+determineParseEmbed meta =
+  join $ readUnevaluatedMetadata "parse-embed" meta symbolName
+
+
+-- | The internal language which is quote-embedded
+data Embedding = EmbedCore | EmbedAST
+
+-- | Check (unevaluated) metadata for parse-embed annotation
+determineEmbedding :: CoreExpr -> Maybe Embedding
+determineEmbedding meta =
+   (join $ readUnevaluatedMetadata "embedding" meta symbolName)
+   >>= embedding
+   where
+     embedding "core" = Just EmbedCore
+     embedding "ast" = Just EmbedAST
+     embedding _ = Nothing

--- a/src/Eucalypt/Core/Metadata.hs
+++ b/src/Eucalypt/Core/Metadata.hs
@@ -157,9 +157,9 @@ data Embedding = EmbedCore | EmbedAST
 -- | Check (unevaluated) metadata for parse-embed annotation
 determineEmbedding :: CoreExpr -> Maybe Embedding
 determineEmbedding meta =
-   (join $ readUnevaluatedMetadata "embedding" meta symbolName)
-   >>= embedding
-   where
-     embedding "core" = Just EmbedCore
-     embedding "ast" = Just EmbedAST
-     embedding _ = Nothing
+  join (readUnevaluatedMetadata "embedding" meta symbolName)
+  >>= embedding
+  where
+    embedding "core" = Just EmbedCore
+    embedding "ast" = Just EmbedAST
+    embedding _ = Nothing

--- a/src/Eucalypt/Core/ParseEmbed.hs
+++ b/src/Eucalypt/Core/ParseEmbed.hs
@@ -1,0 +1,217 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
+{-|
+Module      : Eucalypt.Core.ParseEmbed
+Description : Parse quoted core directly into core without desugaring
+Copyright   : (c) Greg Hawkins, 2018
+License     :
+Maintainer  : greg@curvelogic.co.uk
+Stability   : experimental
+-}
+
+module Eucalypt.Core.ParseEmbed
+  (translateEmbedded)
+where
+
+import Eucalypt.Core.Syn as Syn
+import Eucalypt.Syntax.Ast as Ast
+import Eucalypt.Core.SourceMap
+import Eucalypt.Reporting.Location
+import Debug.Trace
+
+-- | Desugar quote-embedded core so we can reconstruct core that is
+-- described directly in AST
+translateEmbedded :: MonadSupplySMID m => Expression -> m CoreExpr
+translateEmbedded Located{..} =
+  translateExpr locatee
+  where
+    translateExpr (EList ((Located{locatee=(ELiteral(VSym s))}):xs)) = dispatch s xs
+    translateExpr (EOpSoup _ (x:_)) = translateEmbedded x
+    translateExpr e = traceShow e $ error "bad parse-embed core content"
+    dispatch "c-var" (x:[]) = cvar x
+    dispatch "c-let" (decls:body:[]) = clet decls body
+    dispatch "c-bif" (n:[]) = cbif n
+    dispatch "c-lit" (v:[]) = clit v
+    dispatch "c-lookup" (t:n:fb:[]) = clookup t n $ Just fb
+    dispatch "c-lookup" (t:n:[]) = clookup t n Nothing
+    dispatch "c-name" (n:[]) = cname n
+    dispatch "c-list" xs = clist xs
+    dispatch "c-block" (b:[]) = cblock b
+    dispatch "c-meta" (e:m:[]) = cmeta e m
+    dispatch "c-args" xs = cargs xs
+    dispatch "c-lam" (xs:body:[]) = clam xs body
+    dispatch "c-app" (f:xs:[]) = capp f xs
+    dispatch "c-soup" xs = csoup xs
+    dispatch "c-op" (f:p:e:[]) = cop f p e
+    dispatch "c-bk-ana" (i:[]) = cbkana i
+    dispatch "c-ex-ana" (a:[]) = cexana a
+    dispatch "e-unresolved" (n:[]) = eunresolved n
+    dispatch "e-redeclared" (n:[]) = eredeclared n
+    dispatch "e-eliminated" [] = eeliminated
+    dispatch "e-pseudodot" [] = epseudodot
+    dispatch "e-pseudocall" [] = epseudocall
+    dispatch "e-pseudocat" [] = epseudocat
+    dispatch _ _ = undefined
+
+-- | Translate embedded [:c-var n]
+cvar :: MonadSupplySMID m => Expression -> m CoreExpr
+cvar Located{locatee=(ELiteral (VStr varname)), location=loc} =
+  mint Syn.var loc varname
+cvar _ = error "bad c-var"
+
+-- | Translate embedded [:c-let {} body]
+clet :: MonadSupplySMID m => Expression -> Expression -> m CoreExpr
+clet Located{locatee = (EBlock declblock), location=loc} body = do
+  bindings <- sequenceA $ map binding $ declarations declblock
+  value <- translateEmbedded body
+  mint2 Syn.letexp loc bindings value
+  where
+    declarations Located{locatee=Block elts} =
+      map (\ (Located{locatee=(Declaration (Annotated{content=c}))}) -> c) elts
+    binding Located{locatee=PropertyDecl k v} = do
+      expr <- translateEmbedded v
+      return (atomicName k, expr)
+clet _ _ = error "bad c-let"
+
+
+-- | Translate embedded [:c-bif n]
+cbif :: MonadSupplySMID m => Expression -> m CoreExpr
+cbif Located{locatee=(ELiteral (VSym bifname)), location=loc} =
+  mint Syn.bif loc bifname
+cbif _ = error "bad c-bif"
+
+
+-- | Translate embedded [:c-lit _]
+clit :: MonadSupplySMID m => Expression -> m CoreExpr
+clit Located{locatee=(ELiteral prim), location=loc} =
+  mint CorePrim loc $
+  case prim of
+    VInt i -> CoreInt i
+    VFloat f -> CoreFloat f
+    VStr s -> CoreString s
+    VSym s -> CoreSymbol s
+clit _ = error "bad c-lit"
+
+
+-- | Translate embedded [:c-lookup _ n _?]
+clookup :: MonadSupplySMID m => Expression -> Expression -> Maybe Expression -> m CoreExpr
+clookup target (Located{ locatee = (ELiteral (VStr n)) }) (Just fallback) = do
+  tgt <- translateEmbedded target
+  fb <- translateEmbedded fallback
+  return $ anon Syn.dynlookup tgt n fb
+clookup target (Located{locatee=(ELiteral (VStr n))}) Nothing = do
+  tgt <- translateEmbedded target
+  return $ anon Syn.corelookup tgt n
+clookup _ _ _ = error "bad c-lookup"
+
+
+-- | Translate embedded [:c-name n]
+cname :: MonadSupplySMID m => Expression -> m CoreExpr
+cname Located{locatee=(ELiteral (VStr namename)), location=loc} =
+  mint Syn.corename loc namename
+cname _ = error "bad c-name"
+
+
+-- | Translate embedded [:c-list _ _ _ _ ..._]
+clist :: MonadSupplySMID m => [Expression] -> m CoreExpr
+clist exprs = anon corelist <$> traverse translateEmbedded exprs
+
+
+-- | Translate embedded [:c-block {}]
+cblock :: MonadSupplySMID m => Expression -> m CoreExpr
+cblock Located{locatee=(EBlock (Located{locatee=(Block elements)}))} =
+  (anon Syn.block) <$> (sequenceA $ map toElement elements)
+  where
+    propDecl Annotated{content=Located{locatee=(PropertyDecl n expr)}} = (n, expr)
+    toElement (Located{locatee=((Declaration dform)), location=loc}) = do
+      let (n, expr) = propDecl dform
+      val <- translateEmbedded expr
+      mint corelist loc [anon Syn.sym $ atomicName n, val]
+cblock _ = error "bad c-block"
+
+
+-- | Translate embedded [:c-meta e m]
+cmeta :: MonadSupplySMID m => Expression -> Expression -> m CoreExpr
+cmeta expr meta = do
+  e <- translateEmbedded expr
+  m <- translateEmbedded meta
+  return $ anon withMeta m e
+
+
+-- | Translate embedded [:c-args _ _ _ _ ..._]
+cargs :: MonadSupplySMID m => [Expression] -> m CoreExpr
+cargs exprs = anon args <$> traverse translateEmbedded exprs
+
+
+-- | Translate embedded [:c-lam [x, y, z] body]
+clam :: MonadSupplySMID m => Expression -> Expression -> m CoreExpr
+clam bound impl = do
+  let boundVars = extractBoundVars bound
+  body <- translateEmbedded impl
+  return $ anon lam boundVars body
+  where
+    extractBoundVars (Located{locatee=EList vars}) = map varName vars
+    varName (Located{locatee=ELiteral (VStr n)}) = n
+
+
+-- | Translate embedded [:c-app f xs]
+capp :: MonadSupplySMID m => Expression -> Expression -> m CoreExpr
+capp f xs = do
+  applicable <- translateEmbedded f
+  arguments <- sequenceA $ extractArgs xs
+  return $ anon app applicable arguments
+  where
+    extractArgs (Located{locatee=EList vs}) = map translateEmbedded vs
+
+
+-- | Translate embedded [:c-soup _ _ _ _ ..._]
+csoup :: MonadSupplySMID m => [Expression] -> m CoreExpr
+csoup exprs = anon soup <$> traverse translateEmbedded exprs
+
+
+-- | Translate embedded [:c-op f p expr]
+cop :: MonadSupplySMID m => Expression -> Expression -> Expression -> m CoreExpr
+cop f p e = do
+  let fixity = extractFixity f
+  let precedence = extractPrecedence p
+  expr <- translateEmbedded e
+  return $ anon CoreOperator fixity precedence expr
+  where
+    extractFixity Located{locatee=(ELiteral (VSym "unary-prefix"))} = UnaryPrefix
+    extractFixity Located{locatee=(ELiteral (VSym "unary-postfix"))} = UnaryPostfix
+    extractFixity Located{locatee=(ELiteral (VSym "infix-left"))} = InfixLeft
+    extractFixity Located{locatee=(ELiteral (VSym "infix-right"))} = InfixRight
+    extractPrecedence Located{locatee=(ELiteral (VInt prec))} = fromIntegral prec
+
+
+cbkana :: Expression -> m CoreExpr
+cbkana = undefined
+
+cexana :: Expression -> m CoreExpr
+cexana = undefined
+
+eunresolved :: Expression -> m CoreExpr
+eunresolved _ = undefined
+
+
+eredeclared :: Expression -> m CoreExpr
+eredeclared _ = undefined
+
+
+eeliminated :: m CoreExpr
+eeliminated = undefined
+
+
+epseudocall :: m CoreExpr
+epseudocall = undefined
+
+
+epseudocat :: m CoreExpr
+epseudocat = undefined
+
+
+epseudodot :: m CoreExpr
+epseudodot = undefined

--- a/test/Eucalypt/Core/ParseEmbedSpec.hs
+++ b/test/Eucalypt/Core/ParseEmbedSpec.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 module Eucalypt.Core.ParseEmbedSpec
   ( main
   , spec
@@ -24,5 +22,5 @@ main = hspec spec
 spec :: Spec
 spec = describe "samples" $ do
   it "parses c-var" $
-    testParseEmbed <$> (parseExpression "[:c-var, \"x\"]" "test") `shouldBe`
+    testParseEmbed <$> parseExpression "[:c-var, \"x\"]" "test" `shouldBe`
     Right (Syn.var 1 "x")

--- a/test/Eucalypt/Core/ParseEmbedSpec.hs
+++ b/test/Eucalypt/Core/ParseEmbedSpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Eucalypt.Core.ParseEmbedSpec
+  ( main
+  , spec
+  ) where
+
+import Control.Monad.State.Strict
+import Eucalypt.Core.ParseEmbed
+import Eucalypt.Core.Desugar
+import Eucalypt.Core.Import
+import qualified Eucalypt.Core.Syn as Syn
+import Eucalypt.Syntax.Ast
+import Eucalypt.Syntax.ParseExpr
+import Test.Hspec
+
+testParseEmbed :: Expression -> Syn.CoreExpr
+testParseEmbed =
+  (`evalState` initTranslateState 1 nullImportHandler) . unTranslate . translateEmbedded
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "samples" $ do
+  it "parses c-var" $
+    testParseEmbed <$> (parseExpression "[:c-var, \"x\"]" "test") `shouldBe`
+    Right (Syn.var 1 "x")


### PR DESCRIPTION
This is primarily to test the upcoming rust rewrite of eucalypt.

Core syntax generated by the rust implementation can be embedded
directly in surface AST in .eu files (as per 048 test) and consumed
directly by the desugar phase of the haskell implementation ready for
execution by the STG.