### PR TITLE
Tolerate missing PWD var

### DIFF
--- a/harness/test/010_prelude.eu
+++ b/harness/test/010_prelude.eu
@@ -11,7 +11,7 @@ tests: {
   }
 
   environment: {
-    pwd: io.env lookup(:PWD)
+    pwd: io.env lookup-or(:PWD, "/")
     launch-time: io.epoch-time
 
     pass: [ pwd str.matches?(".*/.*")

--- a/harness/test/019_env.eu
+++ b/harness/test/019_env.eu
@@ -1,6 +1,6 @@
 # requires prelude
 
 '~': io.env.HOME
-pwd: io.env.PWD
+shell: io.env.SHELL
 
 RESULT: if((io.env lookup-or(:HOME, "~")) != "~", :PASS, :FAIL)

--- a/harness/test/019_env.eu
+++ b/harness/test/019_env.eu
@@ -1,6 +1,6 @@
 # requires prelude
 
 '~': io.env.HOME
-shell: io.env.SHELL
+lang: io.env.LANG
 
 RESULT: if((io.env lookup-or(:HOME, "~")) != "~", :PASS, :FAIL)


### PR DESCRIPTION
These tests when running in process in the rust impl don't see a PWD var, so let's tolerate that.