### PR TITLE
Ignore target if `-e` specified

### DIFF
--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -306,6 +306,10 @@ impl EucalyptCommandOption {
 }
 
 impl EucalyptOptions {
+    pub fn evaluand(&self) -> Option<&String> {
+        self.evaluate.as_ref()
+    }
+
     pub fn explain(&self) -> bool {
         self.command.explain
     }

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -71,7 +71,7 @@ pub fn prepare(
 
         if let Some(target) = opt.target() {
             loader.retarget(target)?;
-        } else if loader.core().has_target("main") {
+        } else if loader.core().has_target("main") && opt.evaluand().is_none() {
             loader.retarget("main")?;
         }
 


### PR DESCRIPTION
- fix: Targets `-t` (and :main targets )  overriding evaluand `-e`. Now fixed. `-e` takes priority.