### PR TITLE
--collect-as and --name-inputs

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -145,12 +145,107 @@ When several inputs are listed, names from earlier inputs become
 available to later inputs, but the content that will be rendered is
 that of the final input.
 
-The common use case is a final input which contains logic to inspect
-or process data provided by the previous inputs (potentially coming in
-from previous processing on stdin).
+So for instance:
 
-If you want to render contents of earlier inputs verbatim, you need a
-named input to provide a name for that content which you can then use.
+a.eu
+```eu
+x: 4
+y: 8
+```
+
+b.eu
+
+```eu
+z: x + y
+```
+
+```sh
+eu a.eu b.eu
+```
+
+will output
+
+```yaml
+z: 12
+```
+
+The common use cases are:
+- a final input containing logic to inspect or process data
+  provided by previous inputs
+- a final input which uses functions defined in earlier inputs to
+  process data provided in previous inputs
+
+If you want to __render_ contents of earlier inputs, you need a named
+input to provide a name for that content which you can then use.
+
+For instance:
+
+```sh
+eu r=a.eu b.eu -e r
+```
+
+will render:
+
+```yaml
+x: 4
+y: 8
+```
+
+#### `--collect-as` and `--name-inputs`
+
+Occasionally it is useful to aggregate data from an arbitrary number
+of sources files, typically specified by shell wildcards. To refer to
+this data we need to introduce a name for the collection of data.
+
+This is what the command line switch `--collect-as` / `-C` is for.
+
+```sh
+eu --collect-as inputs *.eu
+```
+
+...will render:
+
+```yaml
+inputs:
+  - x: 4
+	y: 8
+  - z: 12
+```
+
+It is common to use `-e` to select an item to render:
+
+```sh
+eu -C *.eu -e 'inputs head'
+```
+
+...renders:
+
+```yaml
+x: 4
+y: 8
+```
+
+If you are likely to need to refer to inputs by name, you can add
+`--name-inputs` / `-N` to pass inputs as a block instead of a list:
+
+```sh
+eu --collect-as inputs *.eu
+```
+
+...renders:
+
+```yaml
+inputs:
+  a.eu:
+	x: 4
+	y: 8
+  b.eu:
+	z: 12
+```
+
+This makes it possible to easier to invoke specific functions from
+named inputs although you will need single-quote name syntax to use
+the generated names which contain '.'s.
 
 ## Outputs
 

--- a/src/core/doc.rs
+++ b/src/core/doc.rs
@@ -12,3 +12,16 @@ pub struct DeclarationDocumentation {
     /// Documentation metadata
     pub doc: String,
 }
+
+impl DeclarationDocumentation {
+    /// Construct a documentation item one level deeper under a named
+    /// root
+    pub fn under(&self, root: &str) -> Self {
+        let mut path = vec![root.to_string()];
+        path.extend(self.path.clone());
+        Self {
+            path,
+            ..self.clone()
+        }
+    }
+}

--- a/src/core/target.rs
+++ b/src/core/target.rs
@@ -66,4 +66,14 @@ impl Target {
     pub fn path(&self) -> &Vec<String> {
         &self.path
     }
+
+    /// Return a version of the target where the path is
+    pub fn under(&self, root: &str) -> Self {
+        let mut path = vec![root.to_string()];
+        path.extend(self.path.clone());
+        Self {
+            path,
+            ..self.clone()
+        }
+    }
 }

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -15,7 +15,7 @@ use super::statistics::{Statistics, Timings};
 
 pub fn test(opt: &EucalyptOptions) -> Result<i32, EucalyptError> {
     let cwd = Input::from(Locator::Fs(PathBuf::from(".")));
-    let input = opt.inputs().last().unwrap_or(&cwd);
+    let input = opt.explicit_inputs().last().unwrap_or(&cwd);
     let path = resolve_input(opt, input)?;
 
     if path.is_dir() {
@@ -100,7 +100,7 @@ pub fn run_suite(opt: &EucalyptOptions, dir: &Path) -> Result<i32, EucalyptError
         let input = Input::from_str(&test.to_string_lossy())?;
         let test_opts = opt
             .clone()
-            .with_inputs(vec![input])
+            .with_explicit_inputs(vec![input])
             .with_lib_path(lib_path.clone());
         if run_test(&test_opts, &test)? > 0 {
             exit = 1;
@@ -294,7 +294,7 @@ impl Tester for InProcessTester {
         // An invocation to run the validation and generate yaml report
         let report_file = plan.report_file_name();
         let report_opts = EucalyptOptions::default()
-            .with_inputs(inputs)
+            .with_explicit_inputs(inputs)
             .with_output(report_file)
             .build();
         let mut loader = SourceLoader::new(vec![]);
@@ -312,7 +312,7 @@ impl Tester for InProcessTester {
         // Then finally, one more to check for success
         let report_input = Input::from(Locator::Fs(plan.report_file_name()));
         let check_opts = EucalyptOptions::default()
-            .with_inputs(vec![report_input])
+            .with_explicit_inputs(vec![report_input])
             .with_export_type("text".to_string())
             .to_evaluate(script)
             .build();

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -9,7 +9,7 @@ pub fn opts(filename: &str) -> EucalyptOptions {
     let path = format!("harness/test/{}", filename);
 
     EucalyptOptions::default()
-        .with_inputs(vec![Input::from_str(&path).unwrap()])
+        .with_explicit_inputs(vec![Input::from_str(&path).unwrap()])
         .with_lib_path(lib_path)
         .build()
 }
@@ -17,7 +17,7 @@ pub fn opts(filename: &str) -> EucalyptOptions {
 /// Parse and desugar the test files and analyse for expectations,
 /// then run and assert success.
 fn run_test(opt: &EucalyptOptions) {
-    let input = opt.inputs().last().unwrap();
+    let input = opt.explicit_inputs().last().unwrap();
     let filename = resolve_input(opt, &input).unwrap();
 
     let exit_code = tester::run_test(opt, &filename).unwrap();


### PR DESCRIPTION
- feature: New flags `--collect-as` and `--name-inputs` have been implemented to aggregate data from arbitrary numbers of inputs (e.g. using shell wildcard syntax).