### PR TITLE
Fix YAML slash escapes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,8 +1652,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "yaml-rust"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+source = "git+https://github.com/curvelogic/yaml-rust?rev=966f2a26245dda59daf605be1983d318db5e46f5#966f2a26245dda59daf605be1983d318db5e46f5"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 lalrpop-util = "0.19.5"
 serde_json = "1.0.64"
-yaml-rust = "0.4.5"
+yaml-rust = { git = "https://github.com/curvelogic/yaml-rust", rev = "966f2a26245dda59daf605be1983d318db5e46f5" }
 unic-ucd-category = "0.9.0"
 itertools = "0.10.0"
 thiserror = "1.0.24"

--- a/harness/test/011_yaml.yaml
+++ b/harness/test/011_yaml.yaml
@@ -3,4 +3,6 @@ y:
   - z: 1
   - z: 2
 
+z: "escaping\/slashes\/works"
+
 RESULT: PASS


### PR DESCRIPTION
- fix: Allow escaped slashes (e.g "\/") in YAML strings