### PR TITLE
Fix missing __UPPER & __LOWER intrinsics.

### DIFF
--- a/harness/test/016_string_fns.eu
+++ b/harness/test/016_string_fns.eu
@@ -53,6 +53,11 @@ checks4: {
   trues: [ip-components = ["192", "168", "0", "1"]]
 }
 
-pass: checks.trues ++ checks2.trues ++ checks3.trues ++ checks4.trues  all-true?
+case-tests: {
+  α: "hello" str.to-upper //= "HELLO"
+  β: "GOODBYE" str.to-lower //= "goodbye"
+}
 
-RESULT: if(pass, :PASS, :FAIL)
+RESULT: checks.trues ++ checks2.trues ++ checks3.trues ++ checks4.trues ++ (case-tests values)
+        all-true?
+        then(:PASS, :FAIL)

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -106,6 +106,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(string::Fmt));
     rt.add(Box::new(string::Letters));
     rt.add(Box::new(string::Dq));
+    rt.add(Box::new(string::Upper));
+    rt.add(Box::new(string::Lower));
     rt.add(Box::new(force::SeqStrList));
     rt.add(Box::new(meta::Meta));
     rt.add(Box::new(meta::WithMeta));

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -450,3 +450,43 @@ impl StgIntrinsic for Dq {
 }
 
 impl CallGlobal0 for Dq {}
+
+/// __UPPER(s) - convert to upper case
+pub struct Upper;
+
+impl StgIntrinsic for Upper {
+    fn name(&self) -> &str {
+        "UPPER"
+    }
+
+    fn execute<'guard>(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'guard>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let string = str_arg(machine, view, &args[0])?;
+        machine_return_str(machine, view, string.to_uppercase())
+    }
+}
+
+/// __LOWER(s) - convert to lower case
+pub struct Lower;
+
+impl StgIntrinsic for Lower {
+    fn name(&self) -> &str {
+        "LOWER"
+    }
+
+    fn execute<'guard>(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'guard>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let string = str_arg(machine, view, &args[0])?;
+        machine_return_str(machine, view, string.to_lowercase())
+    }
+}


### PR DESCRIPTION
- fix: fixed `to-upper` and `to-lower` prelude functions broken since 0.2