### PR TITLE
Output heap stats on -S

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -161,6 +161,9 @@ impl<'a> Executor<'a> {
                     stats.set_ticks(machine.metrics().ticks());
                     stats.set_allocs(machine.metrics().allocs());
                     stats.set_max_stack(machine.metrics().max_stack());
+                    let heap_stats = machine.heap_stats();
+                    stats.set_blocks_allocated(heap_stats.blocks_allocated);
+                    stats.set_lobs_allocated(heap_stats.lobs_allocated);
                     ret
                 };
 

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -33,10 +33,18 @@ impl Display for Timings {
 /// The statistics captured during a run
 #[derive(Default, Debug)]
 pub struct Statistics {
+    /// VM ticks
     machine_ticks: u64,
+    /// Allocated object count (i.e. let binding count)
     machine_allocs: u64,
+    /// Max stack height reached
     machine_max_stack: usize,
+    /// Elapsed timings
     timings: Timings,
+    /// Heap blocks allocated
+    blocks_allocated: usize,
+    /// Large object blocks allocated
+    lobs_allocated: usize,
 }
 
 impl Statistics {
@@ -68,19 +76,40 @@ impl Statistics {
         &mut self.timings
     }
 
+    pub fn blocks_allocated(&self) -> usize {
+        self.blocks_allocated
+    }
+
+    pub fn set_blocks_allocated(&mut self, count: usize) {
+        self.blocks_allocated = count
+    }
+
+    pub fn lobs_allocated(&self) -> usize {
+        self.lobs_allocated
+    }
+
+    pub fn set_lobs_allocated(&mut self, count: usize) {
+        self.lobs_allocated = count
+    }
+
     pub fn merge(&mut self, other: Statistics) {
         self.machine_ticks += other.machine_ticks;
         self.machine_allocs += other.machine_allocs;
         self.machine_max_stack = max(self.machine_max_stack, other.machine_max_stack);
         self.timings.merge(other.timings);
+        self.blocks_allocated = max(self.blocks_allocated, other.blocks_allocated);
+        self.lobs_allocated = max(self.lobs_allocated, other.lobs_allocated);
     }
 }
 
 impl Display for Statistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Machine Ticks      : {:10}", self.machine_ticks)?;
-        writeln!(f, "Machine Allocs     : {:10}", self.machine_allocs)?;
-        writeln!(f, "Machine Max Stack  : {:10}", self.machine_max_stack)?;
+        writeln!(f, "Machine Ticks          : {:10}", self.machine_ticks)?;
+        writeln!(f, "Machine Allocs         : {:10}", self.machine_allocs)?;
+        writeln!(f, "Machine Max Stack      : {:10}", self.machine_max_stack)?;
+        writeln!(f, "Machine Max Stack      : {:10}", self.machine_max_stack)?;
+        writeln!(f, "Heap Blocks Allocated  : {:10}", self.blocks_allocated)?;
+        writeln!(f, "Heap LOBs Allocated    : {:10}", self.lobs_allocated)?;
         writeln!(f)?;
         writeln!(f, "{}", self.timings)
     }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -19,7 +19,7 @@ use crate::{
         memory::{
             alloc::{ScopedAllocator, ScopedPtr},
             array::Array,
-            heap::Heap,
+            heap::{Heap, HeapStats},
             mutator::{Mutator, MutatorHeapView},
             syntax::{HeapSyn, Native, Ref, RefPtr, StgBuilder},
         },
@@ -656,6 +656,11 @@ impl<'a> Machine<'a> {
     /// Access the metrics (ticks, allocs, etc.)
     pub fn metrics(&self) -> &Metrics {
         &self.metrics
+    }
+
+    /// Get heap statistics
+    pub fn heap_stats(&self) -> HeapStats {
+        self.heap.stats()
     }
 
     /// Create a mutator heap view for heap access


### PR DESCRIPTION
- feature: `-S` now outputs count of the heap blocks allocated during
  machine execution