### PR TITLE
EDN import and export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bigdecimal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +359,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "edn-format"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c462f3c16bda8581446b1432b3182e8f2964dd5fcf900e7715cb0543898540"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "internship",
+ "itertools",
+ "num-bigint",
+ "ordered-float",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +403,7 @@ dependencies = [
  "criterion",
  "csv",
  "dirs",
+ "edn-format",
  "html5ever",
  "indexmap",
  "itertools",
@@ -385,6 +413,7 @@ dependencies = [
  "lru",
  "matches",
  "moniker",
+ "ordered-float",
  "petgraph 0.6.0",
  "pretty",
  "pretty-hex",
@@ -530,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "internship"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75b80c06d9124692b2927086ed75c8721d4061f9c159d9675d3f6d63729b597"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -707,6 +745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +795,15 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.4",
  "once_cell",
  "version_check",
 ]
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-set"
@@ -92,9 +92,9 @@ checksum = "303cec55cd9c5fde944b061b902f142b52a8bb5438cc822481ea1e3ebc96bbcb"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -104,21 +104,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "cast"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
@@ -144,13 +138,13 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c01c1c607d25c71bbaa67c113d6c6b36c434744b4fd66691d711b5b1bc0c8b"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf 0.10.0",
+ "phf 0.10.1",
 ]
 
 [[package]]
@@ -160,15 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
 dependencies = [
  "parse-zoneinfo",
- "phf 0.10.0",
+ "phf 0.10.1",
  "phf_codegen 0.10.0",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -236,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -246,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -257,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -270,11 +264,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
- "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -293,7 +286,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -416,9 +409,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "form_urlencoded"
@@ -432,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
@@ -453,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -464,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -479,18 +472,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -504,9 +497,9 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -522,43 +515,58 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lalrpop"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
 dependencies = [
  "ascii-canvas",
  "atty",
@@ -579,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
 dependencies = [
  "regex",
 ]
@@ -594,15 +602,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -615,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
  "hashbrown",
 ]
@@ -650,15 +667,15 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -710,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -720,15 +737,40 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "parse-zoneinfo"
@@ -746,15 +788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +803,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
- "fixedbitset 0.4.0",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -785,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
  "phf_shared 0.10.0",
 ]
@@ -829,7 +862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.4",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -853,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7afeb98c5a10e0bffcc7fc16e105b04d06729fac5fd6384aebf7ff5cb5a67d"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "plotters"
@@ -872,24 +905,24 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "precomputed-hash"
@@ -920,9 +953,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "version_check",
 ]
 
@@ -932,8 +965,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "version_check",
 ]
 
@@ -948,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -975,11 +1008,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
- "proc-macro2 1.0.26",
+ "proc-macro2 1.0.36",
 ]
 
 [[package]]
@@ -992,20 +1025,19 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
  "rand_pcg",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1043,7 +1075,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.4",
 ]
 
 [[package]]
@@ -1053,15 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1100,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -1113,7 +1136,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.4",
  "redox_syscall",
 ]
 
@@ -1130,12 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1145,24 +1165,24 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -1181,33 +1201,21 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -1215,41 +1223,48 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "string_cache"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
+checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "phf_shared 0.8.0",
+ "parking_lot",
+ "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
 ]
@@ -1262,8 +1277,8 @@ checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
 ]
 
 [[package]]
@@ -1274,9 +1289,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1291,9 +1306,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1309,12 +1324,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
  "unicode-xid 0.2.2",
 ]
 
@@ -1385,9 +1400,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1422,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1450,12 +1465,6 @@ name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uncased"
@@ -1510,33 +1519,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1574,7 +1580,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.4",
  "serde",
 ]
 
@@ -1586,9 +1592,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1615,9 +1621,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1625,53 +1631,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.15",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
- "proc-macro2 1.0.26",
- "quote 1.0.9",
- "syn 1.0.72",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "eucalypt"
 version = "0.2.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 lalrpop = { version = "0.19.6", features = ["lexer"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ uuid = { version = "0.8.2", features = ["serde", "v4"] }
 webbrowser = "0.5.5"
 bitmaps = "3.1.0"
 pretty-hex = "0.2.1"
+edn-format = "3.2.2"
+ordered-float = "2.10.0"
 
 [[bench]]
 harness = false

--- a/benches/alloc.rs
+++ b/benches/alloc.rs
@@ -22,7 +22,7 @@ use eucalypt::{
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn box_one<'guard>(view: MutatorHeapView<'guard>, empty: RefPtr<EnvFrame>) -> Closure {
+fn box_one(view: MutatorHeapView, empty: RefPtr<EnvFrame>) -> Closure {
     Closure::new(
         view.data(
             DataConstructor::BoxedString.tag(),
@@ -34,16 +34,7 @@ fn box_one<'guard>(view: MutatorHeapView<'guard>, empty: RefPtr<EnvFrame>) -> Cl
     )
 }
 
-fn identity<'guard>(view: MutatorHeapView<'guard>, empty: RefPtr<EnvFrame>) -> RefPtr<Closure> {
-    view.alloc(Closure::close(
-        &LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default()),
-        empty,
-    ))
-    .unwrap()
-    .as_ptr()
-}
-
-fn fake_bindings<'guard>(view: MutatorHeapView<'guard>, width: usize) -> Vec<LambdaForm> {
+fn fake_bindings(view: MutatorHeapView, width: usize) -> Vec<LambdaForm> {
     iter::repeat_with(|| {
         LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default())
     })
@@ -51,8 +42,8 @@ fn fake_bindings<'guard>(view: MutatorHeapView<'guard>, width: usize) -> Vec<Lam
     .collect()
 }
 
-fn fake_env_stack<'guard>(
-    view: MutatorHeapView<'guard>,
+fn fake_env_stack(
+    view: MutatorHeapView,
     empty: RefPtr<EnvFrame>,
     width: usize,
     height: usize,
@@ -68,8 +59,8 @@ fn fake_env_stack<'guard>(
 }
 
 /// Allocate a letrec of identify function bindings
-fn alloc_let<'guard>(
-    view: MutatorHeapView<'guard>,
+fn alloc_let(
+    view: MutatorHeapView,
     empty: RefPtr<EnvFrame>,
     bindings: &[LambdaForm],
 ) -> RefPtr<EnvFrame> {
@@ -77,8 +68,8 @@ fn alloc_let<'guard>(
 }
 
 /// Allocate a letrec of identify function bindings
-fn alloc_letrec<'guard>(
-    view: MutatorHeapView<'guard>,
+fn alloc_letrec(
+    view: MutatorHeapView,
     empty: RefPtr<EnvFrame>,
     bindings: &[LambdaForm],
 ) -> RefPtr<EnvFrame> {
@@ -86,30 +77,21 @@ fn alloc_letrec<'guard>(
 }
 
 /// Access deep closure
-fn access<'guard>(
-    view: MutatorHeapView<'guard>,
-    env: RefPtr<EnvFrame>,
-    depth: usize,
-) -> Option<Closure> {
+fn access(view: MutatorHeapView, env: RefPtr<EnvFrame>, depth: usize) -> Option<Closure> {
     let e = view.scoped(env);
     (*e).get(&view, depth)
 }
 
 /// Update deep closure with a new value
-fn update<'guard>(
-    view: MutatorHeapView<'guard>,
-    empty: RefPtr<EnvFrame>,
-    env: RefPtr<EnvFrame>,
-    depth: usize,
-) {
+fn update(view: MutatorHeapView, empty: RefPtr<EnvFrame>, env: RefPtr<EnvFrame>, depth: usize) {
     let e = view.scoped(env);
     let value = box_one(view, empty);
     (*e).update(&view, depth, value).unwrap();
 }
 
 /// Create an identity lambda and saturate it
-fn create_and_saturate_lambda<'guard>(view: MutatorHeapView<'guard>, empty: RefPtr<EnvFrame>) {
-    let mut lambda = Closure::close(
+fn create_and_saturate_lambda(view: MutatorHeapView, empty: RefPtr<EnvFrame>) {
+    let lambda = Closure::close(
         &LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default()),
         empty,
     );
@@ -118,11 +100,8 @@ fn create_and_saturate_lambda<'guard>(view: MutatorHeapView<'guard>, empty: RefP
 }
 
 /// Create an identity lambda and saturate it
-fn create_partially_apply_and_saturate_lambda<'guard>(
-    view: MutatorHeapView<'guard>,
-    empty: RefPtr<EnvFrame>,
-) {
-    let mut lambda = Closure::close(
+fn create_partially_apply_and_saturate_lambda(view: MutatorHeapView, empty: RefPtr<EnvFrame>) {
+    let lambda = Closure::close(
         &LambdaForm::new(2, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default()),
         empty,
     );

--- a/harness/test/050_edn.edn
+++ b/harness/test/050_edn.edn
@@ -1,0 +1,5 @@
+{:k "foo"
+ :k1 "bar"
+ :α :blah
+ :quux [:x :y :z]
+ :RESULT :PASS}

--- a/src/core/anaphora.rs
+++ b/src/core/anaphora.rs
@@ -227,15 +227,12 @@ pub mod tests {
 
     #[test]
     pub fn test_to_binding_pattern() {
-        let _0 = free("_0");
-        let _1 = free("_1");
+        let ana0 = free("_0");
+        let ana1 = free("_1");
 
         let mut hm: HashMap<Anaphor<Smid, i32>, FreeVar<String>> = HashMap::new();
-        hm.insert(Anaphor::ExplicitNumbered(0), _0.clone());
-        hm.insert(Anaphor::ExplicitNumbered(1), _1.clone());
-        assert_eq!(
-            to_binding_pattern(&hm).unwrap(),
-            vec![_0.clone(), _1.clone()]
-        );
+        hm.insert(Anaphor::ExplicitNumbered(0), ana0.clone());
+        hm.insert(Anaphor::ExplicitNumbered(1), ana1.clone());
+        assert_eq!(to_binding_pattern(&hm).unwrap(), vec![ana0, ana1]);
     }
 }

--- a/src/core/cook/fill.rs
+++ b/src/core/cook/fill.rs
@@ -159,7 +159,7 @@ pub mod tests {
 
         assert_term_eq!(
             soup(fill(&[ana.clone(), plus.clone(), var(x.clone())])),
-            soup(vec![ana.clone(), plus.clone(), var(x.clone())])
+            soup(vec![ana, plus, var(x)])
         );
     }
 }

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -126,8 +126,8 @@ pub mod tests {
         );
 
         let expected = let_(
-            vec![(plus.clone(), bif("FOO")), (minus.clone(), bif("BAR"))],
-            soup(vec![num(1), infixl(50, var(plus.clone())), num(2)]),
+            vec![(plus.clone(), bif("FOO")), (minus, bif("BAR"))],
+            soup(vec![num(1), infixl(50, var(plus)), num(2)]),
         );
 
         assert_term_eq!(distribute(expr).unwrap(), expected);
@@ -149,8 +149,8 @@ pub mod tests {
         let expected = let_(
             vec![(plus.clone(), bif("FOO"))],
             let_(
-                vec![(minus.clone(), bif("BAR"))],
-                soup(vec![num(1), infixl(50, var(plus.clone())), num(2)]),
+                vec![(minus, bif("BAR"))],
+                soup(vec![num(1), infixl(50, var(plus)), num(2)]),
             ),
         );
 
@@ -171,8 +171,8 @@ pub mod tests {
         );
 
         let expected = let_(
-            vec![(plus.clone(), bif("FOO")), (minus.clone(), bif("BAR"))],
-            soup(vec![num(1), infixr(90, var(minus.clone())), num(2)]),
+            vec![(plus, bif("FOO")), (minus.clone(), bif("BAR"))],
+            soup(vec![num(1), infixr(90, var(minus)), num(2)]),
         );
 
         assert_term_eq!(distribute(expr).unwrap(), expected);

--- a/src/core/desugar/ast.rs
+++ b/src/core/desugar/ast.rs
@@ -552,13 +552,6 @@ pub mod tests {
     }
 
     impl Fixture {
-        pub fn new() -> Self {
-            let source_map = SourceMap::new();
-            let files = SimpleFiles::<String, String>::new();
-
-            Fixture { source_map, files }
-        }
-
         pub fn desugar(mut self, ast: impl Desugarable) -> RcExpr {
             let file_id = self.files.add("<test>".to_string(), "".into());
             let mut hm: HashMap<Input, Content> = HashMap::new();
@@ -571,25 +564,34 @@ pub mod tests {
         }
     }
 
+    impl Default for Fixture {
+        fn default() -> Self {
+            let source_map = SourceMap::new();
+            let files = SimpleFiles::<String, String>::new();
+
+            Fixture { source_map, files }
+        }
+    }
+
     #[test]
     pub fn test_literals() {
         assert_eq!(
-            Fixture::new().desugar(ast::str("blah")),
+            Fixture::default().desugar(ast::str("blah")),
             core::str(Smid::from(1), "blah")
         );
         assert_eq!(
-            Fixture::new().desugar(ast::sym("blah")),
+            Fixture::default().desugar(ast::sym("blah")),
             core::sym(Smid::from(1), "blah")
         );
         assert_eq!(
-            Fixture::new().desugar(ast::num(900)),
+            Fixture::default().desugar(ast::num(900)),
             core::num(Smid::from(1), 900)
         );
     }
 
     #[test]
     pub fn test_inserts_call_operator() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::default();
 
         let soup = vec![
             ast::lit(ast::num(5)),
@@ -617,7 +619,7 @@ pub mod tests {
 
     #[test]
     pub fn test_handles_iterated_calls() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::default();
 
         let soup = vec![
             ast::name(ast::normal("f")),
@@ -638,7 +640,7 @@ pub mod tests {
 
     #[test]
     pub fn test_handles_relative_names() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::default();
 
         let soup = vec![
             ast::name(ast::normal("x")),
@@ -661,7 +663,7 @@ pub mod tests {
 
     #[test]
     pub fn test_creates_var_for_lonely_names() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::default();
 
         let block = ast::block(
             None,
@@ -679,7 +681,7 @@ pub mod tests {
 
     #[test]
     pub fn test_handles_built_ins() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::default();
 
         let block = ast::block(
             None,
@@ -694,7 +696,7 @@ pub mod tests {
 
         let core_block = acore::default_let(vec![
             (null.clone(), acore::bif("NULL")),
-            (a.clone(), acore::var(null.clone())),
+            (a, acore::var(null)),
         ]);
 
         assert_term_eq!(bound(fixture.desugar(block)), bound(core_block));
@@ -715,22 +717,22 @@ pub mod tests {
         let t = free("t");
 
         let core_expr = acore::soup(vec![
-            acore::var(eq.clone()),
+            acore::var(eq),
             acore::call(),
             acore::arg_tuple(vec![
                 acore::soup(vec![
-                    acore::var(or.clone()),
+                    acore::var(or),
                     acore::call(),
                     acore::arg_tuple(vec![
-                        acore::var(f.clone()),
+                        acore::var(f),
                         acore::soup(vec![
-                            acore::var(and.clone()),
+                            acore::var(and),
                             acore::call(),
                             acore::arg_tuple(vec![acore::var(t.clone()), acore::var(t.clone())]),
                         ]),
                     ]),
                 ]),
-                acore::var(t.clone()),
+                acore::var(t),
             ]),
         ]);
 
@@ -796,9 +798,9 @@ pub mod tests {
         let x = FreeVar::fresh_named("x");
 
         let core_expr = acore::soup(vec![
-            acore::var(f.clone()),
+            acore::var(f),
             acore::call(),
-            acore::arg_tuple(vec![acore::var(x.clone())]),
+            acore::arg_tuple(vec![acore::var(x)]),
             acore::dot(),
             acore::name("v"),
         ]);

--- a/src/core/export/embed.rs
+++ b/src/core/export/embed.rs
@@ -217,9 +217,9 @@ pub mod tests {
         let x = FreeVar::fresh_named("x");
 
         let core_expr = acore::soup(vec![
-            acore::var(f.clone()),
+            acore::var(f),
             acore::call(),
-            acore::arg_tuple(vec![acore::var(x.clone())]),
+            acore::arg_tuple(vec![acore::var(x)]),
             acore::dot(),
             acore::name("v"),
         ]);
@@ -247,7 +247,7 @@ pub mod tests {
             acore::soup(vec![
                 acore::var(x.clone()),
                 acore::op(Fixity::InfixLeft, 40, acore::bif("__ADD")),
-                acore::var(x.clone()),
+                acore::var(x),
             ]),
         );
 

--- a/src/core/export/embed.rs
+++ b/src/core/export/embed.rs
@@ -5,9 +5,12 @@ use crate::syntax::ast::*;
 use crate::syntax::export::embed::Embed;
 use crate::syntax::export::pretty;
 
-/// Embed the core expression as AST then render as parse-embed unit.
+/// Embed a representation of the core expression in an AST then
+/// render as parse-embed unit.
 ///
-/// The core emitted can be consumed by `parse-embed` functionality.
+/// The core emitted can be consumed by `parse-embed` functionality
+/// which reads such a representation out of the AST to build core,
+/// instead of using the normal translation process.
 pub fn quote_embed_core_unit(expr: &RcExpr) -> String {
     format!(
         " {{ parse-embed: :CORE }}

--- a/src/core/export/pretty.rs
+++ b/src/core/export/pretty.rs
@@ -271,7 +271,7 @@ pub mod tests {
                         vec![list(vec![num(1), num(2), num(3)]), bif("HEAD")],
                     ),
                     app(
-                        pseudocat.clone(),
+                        pseudocat,
                         vec![list(vec![num(1), num(2), num(3)]), bif("TAIL")],
                     ),
                 ],

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -345,7 +345,7 @@ where
     /// Block (in contrast to the haskell implementation we're storing
     /// an ordered record right here)
     Block(Smid, BlockMap<T>),
-    /// Metadata annotation (span, expr, meta) - TODO: struct?
+    /// Metadata annotation (span, expr, meta)
     Meta(Smid, T, T),
     /// Tuple of arguments to apply
     ArgTuple(Smid, Vec<T>),
@@ -880,10 +880,12 @@ where
     }
 }
 
-/// Extract data from an expression using only basic inline /
+/// Extract data from a core expression.
+///
+/// Implementations are used to read processing-time metadata from
+/// core representations and therefore using only basic inline /
 /// substitution techniques such as are available during core
-/// processing and transformation. These require mutable self as
-/// transformations applied are kept.
+/// processing and transformation.
 pub trait Extract<T> {
     fn extract(&self) -> Option<T>;
 }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1403,8 +1403,8 @@ pub mod tests {
 
         assert_term_eq!(
             lam(vec![a.clone(), b.clone(), c.clone()], var(d.clone()))
-                .substs(&[(d.clone(), var(e.clone()))]),
-            lam(vec![a.clone(), b.clone(), c.clone()], var(e.clone())),
+                .substs(&[(d, var(e.clone()))]),
+            lam(vec![a, b, c], var(e)),
         );
     }
 
@@ -1421,8 +1421,8 @@ pub mod tests {
         let sub = |n: &str| if n == "d" { Some(var(e.clone())) } else { None };
 
         assert_term_eq!(
-            lam(vec![a.clone(), b.clone(), c.clone()], var(d.clone())).substs_free(&sub),
-            lam(vec![a.clone(), b.clone(), c.clone()], var(e.clone())),
+            lam(vec![a.clone(), b.clone(), c.clone()], var(d)).substs_free(&sub),
+            lam(vec![a, b, c], var(e)),
         );
     }
 
@@ -1434,12 +1434,9 @@ pub mod tests {
         let y = free("y");
 
         let original = default_let(vec![(x.clone(), num(22)), (y.clone(), num(23))]);
-        let expected = let_(
-            vec![(x.clone(), num(22)), (y.clone(), num(23))],
-            var(y.clone()),
-        );
+        let expected = let_(vec![(x, num(22)), (y.clone(), num(23))], var(y.clone()));
 
-        assert_term_eq!(original.rebody(var(y.clone())), expected);
+        assert_term_eq!(original.rebody(var(y)), expected);
     }
 
     #[test]
@@ -1455,11 +1452,11 @@ pub mod tests {
             default_let(vec![(z.clone(), num(24))]),
         );
         let expected = let_(
-            vec![(x.clone(), num(22)), (y.clone(), num(23))],
-            let_(vec![(z.clone(), num(24))], var(x.clone())),
+            vec![(x.clone(), num(22)), (y, num(23))],
+            let_(vec![(z, num(24))], var(x.clone())),
         );
 
-        assert_term_eq!(original.rebody(var(x.clone())), expected);
+        assert_term_eq!(original.rebody(var(x)), expected);
     }
 
     #[test]
@@ -1530,9 +1527,9 @@ pub mod tests {
             vec![
                 (a.clone(), num(1)),
                 (b.clone(), var(a.clone())),
-                (c.clone(), var(y_other.clone())),
+                (c.clone(), var(y_other)),
             ],
-            var(x_other.clone()),
+            var(x_other),
         );
 
         let unit_c = unit_a.merge_in(unit_b);
@@ -1540,15 +1537,8 @@ pub mod tests {
         let expected = let_(
             vec![(x.clone(), num(22)), (y.clone(), var(x.clone()))],
             let_(
-                vec![(z.clone(), num(24))],
-                let_(
-                    vec![
-                        (a.clone(), num(1)),
-                        (b.clone(), var(a.clone())),
-                        (c.clone(), var(y.clone())),
-                    ],
-                    var(x.clone()),
-                ),
+                vec![(z, num(24))],
+                let_(vec![(a.clone(), num(1)), (b, var(a)), (c, var(y))], var(x)),
             ),
         );
 
@@ -1579,25 +1569,18 @@ pub mod tests {
             vec![
                 (a.clone(), num(1)),
                 (b.clone(), var(a.clone())),
-                (c.clone(), var(y_other.clone())),
+                (c.clone(), var(y_other)),
             ],
-            var(x_other.clone()),
+            var(x_other),
         );
 
         let unit_c = unit_a.merge_in(unit_b);
 
         let expected = let_(
-            vec![(x.clone(), num(22)), (y.clone(), var(a_other.clone()))],
+            vec![(x.clone(), num(22)), (y.clone(), var(a_other))],
             let_(
-                vec![(z.clone(), num(24))],
-                let_(
-                    vec![
-                        (a.clone(), num(1)),
-                        (b.clone(), var(a.clone())),
-                        (c.clone(), var(y.clone())),
-                    ],
-                    var(x.clone()),
-                ),
+                vec![(z, num(24))],
+                let_(vec![(a.clone(), num(1)), (b, var(a)), (c, var(y))], var(x)),
             ),
         );
 
@@ -1626,23 +1609,20 @@ pub mod tests {
         );
 
         let unit_b = let_(
-            vec![(a.clone(), num(2)), (b.clone(), var(x_other.clone()))],
+            vec![(a.clone(), num(2)), (b.clone(), var(x_other))],
             var(a.clone()),
         );
 
         let unit_c = let_(
-            vec![(m.clone(), num(3)), (n.clone(), var(b_other.clone()))],
-            var(y_other.clone()),
+            vec![(m.clone(), num(3)), (n.clone(), var(b_other))],
+            var(y_other),
         );
 
         let expected = let_(
             vec![(x.clone(), num(1)), (y.clone(), var(x.clone()))],
             let_(
-                vec![(a.clone(), num(2)), (b.clone(), var(x.clone()))],
-                let_(
-                    vec![(m.clone(), num(3)), (n.clone(), var(b.clone()))],
-                    var(y.clone()),
-                ),
+                vec![(a, num(2)), (b.clone(), var(x))],
+                let_(vec![(m, num(3)), (n, var(b))], var(y)),
             ),
         );
 

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -115,13 +115,7 @@ pub mod tests {
             app(var(f.clone()), vec![num(22), num(23)]),
         );
 
-        let expected = let_(
-            vec![(
-                f.clone(),
-                inline(vec![x.clone(), y.clone()], var(y.clone())),
-            )],
-            num(23),
-        );
+        let expected = let_(vec![(f, inline(vec![x, y.clone()], var(y)))], num(23));
 
         assert_term_eq!(inline_pass(&original).unwrap(), expected);
     }
@@ -167,12 +161,9 @@ pub mod tests {
         );
         let expected = let_(
             vec![
+                (z.clone(), app(var(compose.clone()), vec![var(n), var(m)])),
                 (
-                    z.clone(),
-                    app(var(compose.clone()), vec![var(n.clone()), var(m.clone())]),
-                ),
-                (
-                    compose.clone(),
+                    compose,
                     inline(
                         vec![f.clone(), g.clone(), x.clone()],
                         app(
@@ -182,23 +173,20 @@ pub mod tests {
                     ),
                 ),
                 (
-                    r.clone(),
+                    r,
                     inline(
                         vec![j.clone(), k.clone()],
                         app(
                             inline(
                                 vec![f.clone(), g.clone(), x.clone()],
-                                app(
-                                    var(f.clone()),
-                                    vec![app(var(g.clone()), vec![var(x.clone())])],
-                                ),
+                                app(var(f), vec![app(var(g), vec![var(x)])]),
                             ),
-                            vec![var(j.clone()), var(k.clone())],
+                            vec![var(j), var(k)],
                         ),
                     ),
                 ),
             ],
-            var(z.clone()),
+            var(z),
         );
 
         assert_term_eq!(inline_pass(&original).unwrap(), expected);
@@ -281,22 +269,19 @@ pub mod tests {
                                     let_(
                                         vec![(
                                             d.clone(),
-                                            app(
-                                                var(compose.clone()),
-                                                vec![var(n.clone()), var(m.clone())],
-                                            ),
+                                            app(var(compose.clone()), vec![var(n), var(m)]),
                                         )],
-                                        block(iter::once(("d".to_string(), var(d.clone())))),
+                                        block(iter::once(("d".to_string(), var(d)))),
                                     ),
                                 )],
-                                block(iter::once(("c".to_string(), var(c.clone())))),
+                                block(iter::once(("c".to_string(), var(c)))),
                             ),
                         )],
-                        block(iter::once(("b".to_string(), var(b.clone())))),
+                        block(iter::once(("b".to_string(), var(b)))),
                     ),
                 ),
                 (
-                    compose.clone(),
+                    compose,
                     inline(
                         vec![f.clone(), g.clone(), x.clone()],
                         app(
@@ -306,23 +291,20 @@ pub mod tests {
                     ),
                 ),
                 (
-                    r.clone(),
+                    r,
                     inline(
                         vec![j.clone(), k.clone()],
                         app(
                             inline(
                                 vec![f.clone(), g.clone(), x.clone()],
-                                app(
-                                    var(f.clone()),
-                                    vec![app(var(g.clone()), vec![var(x.clone())])],
-                                ),
+                                app(var(f), vec![app(var(g), vec![var(x)])]),
                             ),
-                            vec![var(j.clone()), var(k.clone())],
+                            vec![var(j), var(k)],
                         ),
                     ),
                 ),
             ],
-            var(a.clone()),
+            var(a),
         );
 
         let inlined = inline_pass(&original).unwrap();

--- a/src/core/inline/tag.rs
+++ b/src/core/inline/tag.rs
@@ -64,10 +64,10 @@ pub mod tests {
                 f.clone(),
                 inline(
                     vec![y.clone(), z.clone()],
-                    app(bif("F"), vec![var(y.clone()), var(z.clone())]),
+                    app(bif("F"), vec![var(y), var(z)]),
                 ),
             )],
-            app(var(f.clone()), vec![num(22), num(23)]),
+            app(var(f), vec![num(22), num(23)]),
         );
 
         assert_term_eq!(tag_combinators(&original).unwrap(), expected);

--- a/src/core/simplify/compress.rs
+++ b/src/core/simplify/compress.rs
@@ -153,23 +153,20 @@ pub mod tests {
                 (
                     a.clone(),
                     let_(
-                        vec![
-                            (d.clone(), RcExpr::from(Expr::ErrEliminated)),
-                            (e.clone(), num(2)),
-                        ],
+                        vec![(d, RcExpr::from(Expr::ErrEliminated)), (e.clone(), num(2))],
                         var(e.clone()),
                     ),
                 ),
-                (b.clone(), RcExpr::from(Expr::ErrEliminated)),
+                (b, RcExpr::from(Expr::ErrEliminated)),
             ],
             var(a.clone()),
         );
 
         let expected = let_(
-            vec![(a.clone(), let_(vec![(e.clone(), num(2))], var(e.clone())))],
-            var(a.clone()),
+            vec![(a.clone(), let_(vec![(e.clone(), num(2))], var(e)))],
+            var(a),
         );
 
-        assert_term_eq!(compress(&sample.clone()).unwrap(), expected);
+        assert_term_eq!(compress(&sample).unwrap(), expected);
     }
 }

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -354,14 +354,11 @@ pub mod tests {
         );
 
         let expected = let_(
-            vec![
-                (x.clone(), num(1)),
-                (y.clone(), RcExpr::from(Expr::ErrEliminated)),
-            ],
-            var(x.clone()),
+            vec![(x.clone(), num(1)), (y, RcExpr::from(Expr::ErrEliminated))],
+            var(x),
         );
 
-        assert_term_eq!(prune(&simple.clone()), expected)
+        assert_term_eq!(prune(&simple), expected)
     }
 
     #[test]
@@ -380,20 +377,17 @@ pub mod tests {
         );
 
         let expected = let_(
-            vec![
-                (x.clone(), num(1)),
-                (y.clone(), RcExpr::from(Expr::ErrEliminated)),
-            ],
+            vec![(x.clone(), num(1)), (y, RcExpr::from(Expr::ErrEliminated))],
             let_(
                 vec![
-                    (z.clone(), RcExpr::from(Expr::ErrEliminated)),
-                    (v.clone(), RcExpr::from(Expr::ErrEliminated)),
+                    (z, RcExpr::from(Expr::ErrEliminated)),
+                    (v, RcExpr::from(Expr::ErrEliminated)),
                 ],
-                var(x.clone()),
+                var(x),
             ),
         );
 
-        assert_term_eq!(prune(&nested.clone()), expected)
+        assert_term_eq!(prune(&nested), expected)
     }
 
     #[test]
@@ -417,7 +411,7 @@ pub mod tests {
                 (b.clone(), num(2)),
                 (c, RcExpr::from(Expr::ErrEliminated)),
             ],
-            app(bif("BLAH"), vec![var(a), var(b.clone())]),
+            app(bif("BLAH"), vec![var(a), var(b)]),
         );
 
         assert_term_eq!(prune(&expr), expected)
@@ -453,9 +447,9 @@ pub mod tests {
                         var(e),
                     ),
                 ),
-                (b.clone(), RcExpr::from(Expr::ErrEliminated)),
+                (b, RcExpr::from(Expr::ErrEliminated)),
             ],
-            var(a.clone()),
+            var(a),
         );
 
         assert_term_eq!(prune(&expr), expected)

--- a/src/core/transform/dynamise.rs
+++ b/src/core/transform/dynamise.rs
@@ -132,7 +132,7 @@ pub mod tests {
         let original = var(x.clone());
         let expected = lam(
             vec![implicit.clone()],
-            lookup(var(implicit.clone()), "x", Some(var(x.clone()))),
+            lookup(var(implicit), "x", Some(var(x))),
         );
 
         assert_term_eq!(dynamise(&original).unwrap(), expected);
@@ -146,8 +146,8 @@ pub mod tests {
         let implicit = free("implicit");
 
         let original = let_(
-            vec![(x.clone(), num(22)), (y.clone(), num(23))],
-            let_(vec![(z.clone(), num(24))], var(x.clone())),
+            vec![(x.clone(), num(22)), (y, num(23))],
+            let_(vec![(z.clone(), num(24))], var(x)),
         );
 
         assert_term_eq!(dynamise(&original).unwrap(), original);
@@ -157,9 +157,9 @@ pub mod tests {
             let expected = lam(
                 vec![implicit.clone()],
                 let_(
-                    vec![(z.clone(), num(24))],
+                    vec![(z, num(24))],
                     lookup(
-                        var(implicit.clone()),
+                        var(implicit),
                         "x",
                         Some(RcExpr::from(Expr::Var(
                             Smid::default(),

--- a/src/driver/error.rs
+++ b/src/driver/error.rs
@@ -7,7 +7,6 @@ use crate::syntax::error::ParserError;
 use crate::syntax::error::SyntaxError;
 use crate::syntax::import::ImportError;
 use codespan_reporting::diagnostic::Diagnostic;
-use codespan_reporting::files;
 use std::fmt::Display;
 use std::io;
 use thiserror::Error;
@@ -28,8 +27,6 @@ pub enum EucalyptError {
     Execution(#[from] ExecutionError),
     #[error(transparent)]
     Io(#[from] io::Error),
-    #[error(transparent)]
-    Files(#[from] files::Error),
     #[error("unknown resource {0}")]
     UnknownResource(String),
     #[error("path {0} could not be read")]

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -498,6 +498,8 @@ impl EucalyptOptions {
                     Some("yaml") | Some("yml") => Some("yaml".to_string()),
                     Some("json") => Some("json".to_string()),
                     Some("txt") => Some("text".to_string()),
+                    Some("edn") => Some("edn".to_string()),
+                    Some("toml") => Some("toml".to_string()),
                     _ => None,
                 };
                 self.export_type = format;

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -427,12 +427,9 @@ pub mod tests {
         ]);
 
         for f in eu_paths() {
-            match loader.load_eucalypt(&Locator::Fs(f.clone())) {
-                Err(e) => {
-                    let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                    panic!("Failed to parse {:?}.\n{}", &f, diag);
-                }
-                Ok(_) => {}
+            if let Err(e) = loader.load_eucalypt(&Locator::Fs(f.clone())) {
+                let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
+                panic!("Failed to parse {:?}.\n{}", &f, diag);
             }
         }
     }
@@ -444,20 +441,14 @@ pub mod tests {
         for f in eu_paths() {
             let loc = Locator::Fs(f.clone());
 
-            match loader.load_tree(&Input::from(loc.clone())) {
-                Err(e) => {
-                    let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                    panic!("Failed to parse {:?}.\n{}", &f, diag);
-                }
-                Ok(_) => {}
+            if let Err(e) = loader.load_tree(&Input::from(loc.clone())) {
+                let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
+                panic!("Failed to parse {:?}.\n{}", &f, diag);
             }
 
-            match loader.translate(&Input::from(loc.clone())) {
-                Err(e) => {
-                    let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                    panic!("Failed to desugar {:?}.\n{}", &f, diag);
-                }
-                Ok(_) => {}
+            if let Err(e) = loader.translate(&Input::from(loc.clone())) {
+                let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
+                panic!("Failed to desugar {:?}.\n{}", &f, diag);
             };
         }
     }

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -1,3 +1,4 @@
+use crate::common::sourcemap::*;
 use crate::core::cook;
 use crate::core::desugar::{Content, Desugarer};
 use crate::core::error::CoreError;
@@ -10,17 +11,16 @@ use crate::core::unit::TranslationUnit;
 use crate::core::verify::content;
 use crate::driver::error::EucalyptError;
 use crate::driver::resources::Resources;
-use crate::import::{csv, text, xml, yaml};
+use crate::import::read_to_core;
 use crate::syntax::ast::*;
 use crate::syntax::import::ImportGraph;
 use crate::syntax::input::Input;
 use crate::syntax::input::Locator;
 use crate::syntax::parser;
-use crate::{common::sourcemap::*, import::toml};
+use codespan_reporting::diagnostic::Diagnostic;
 use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term::emit;
 use codespan_reporting::term::termcolor::{ColorChoice, NoColor, StandardStream};
-use codespan_reporting::{diagnostic::Diagnostic, files::Files};
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
@@ -104,15 +104,29 @@ impl SourceLoader {
 
     /// Load an input (and transitive imports)
     pub fn load(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        match input.format() {
-            "yaml" | "json" => self.load_yaml(input), // direct to core
-            "toml" => self.load_toml(input),
-            "text" => self.load_text(input),
-            "csv" => self.load_csv(input),
-            "xml" => self.load_xml(input),
-            "core" => self.load_core(input), // load pseudoblock
-            _ => self.load_tree(input),      // to ASTs needing desugaring
+        let fmt = input.format();
+
+        if fmt == "eu" {
+            self.load_tree(input)
+        } else if fmt == "core" {
+            self.load_core(input)
+        } else {
+            self.load_simple(input)
         }
+    }
+
+    /// Loads from a data format that does not support imports
+    fn load_simple(&mut self, input: &Input) -> Result<usize, EucalyptError> {
+        let file_id = self.load_source(input.locator())?;
+        let core = read_to_core(
+            input.format(),
+            &mut self.files,
+            &mut self.source_map,
+            file_id,
+        )?;
+        self.imports.add_leaf(input.clone())?;
+        self.cores.insert(input.clone(), core);
+        Ok(file_id)
     }
 
     /// Load and parse import-graph of eucalypt files starting with the one
@@ -150,60 +164,6 @@ impl SourceLoader {
         };
         self.asts.insert(id, ast);
         Ok(id)
-    }
-
-    /// Load YAML
-    ///
-    /// YAML is a special case because of available eu embeddings.
-    fn load_yaml(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let file_id = self.load_source(input.locator())?;
-        // the copy is necessary as yaml needs a mutable files db for
-        // adding embeddings so cannot have immutable ref into it at
-        // the same time
-        let text = self.files.source(file_id)?.to_string();
-        let core = yaml::read_yaml(&mut self.files, &mut self.source_map, file_id, &text)?;
-        self.imports.add_leaf(input.clone())?;
-        self.cores.insert(input.clone(), core);
-        Ok(file_id)
-    }
-
-    /// Load TOML
-    fn load_toml(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let file_id = self.load_source(input.locator())?;
-        let text = self.files.source(file_id)?;
-        let core = toml::read_toml(&mut self.source_map, file_id, text)?;
-        self.imports.add_leaf(input.clone())?;
-        self.cores.insert(input.clone(), core);
-        Ok(file_id)
-    }
-
-    /// Load text as list of lines
-    fn load_text(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let file_id = self.load_source(input.locator())?;
-        let text = self.files.source(file_id)?;
-        let core = text::read_text(&mut self.source_map, file_id, text)?;
-        self.imports.add_leaf(input.clone())?;
-        self.cores.insert(input.clone(), core);
-        Ok(file_id)
-    }
-
-    /// Load text as list of lines
-    fn load_csv(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let file_id = self.load_source(input.locator())?;
-        let text = self.files.source(file_id)?;
-        let core = csv::read_csv(&mut self.source_map, file_id, text)?;
-        self.imports.add_leaf(input.clone())?;
-        self.cores.insert(input.clone(), core);
-        Ok(file_id)
-    }
-
-    fn load_xml(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let file_id = self.load_source(input.locator())?;
-        let text = self.files.source(file_id)?;
-        let core = xml::read_xml(&mut self.source_map, file_id, text)?;
-        self.imports.add_leaf(input.clone())?;
-        self.cores.insert(input.clone(), core);
-        Ok(file_id)
     }
 
     /// Load __io pseudoblock as core

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -125,7 +125,7 @@ fn directory_plans(
         .filter(|f| {
             matches!(
                 f.path().extension().and_then(|s| s.to_str()),
-                Some("eu") | Some("yaml") | Some("json")
+                Some("eu") | Some("yaml") | Some("json") | Some("toml") | Some("edn")
             )
         })
         .map(|f| f.path())

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -813,7 +813,7 @@ impl<'a> Machine<'a> {
 
         if self.state.terminated() {
             if let HeapSyn::Atom { evaluand: r } = &*code {
-                self.nav().resolve_native(&r).ok()
+                self.nav().resolve_native(r).ok()
             } else {
                 None
             }
@@ -831,12 +831,8 @@ impl<'a> Machine<'a> {
 
         if self.state.terminated() {
             if let HeapSyn::Atom { evaluand: r } = &*code {
-                if let Ok(n) = self.nav().resolve_native(&r) {
-                    if let Native::Str(rp) = n {
-                        Some((*view.scoped(rp)).as_str().to_string())
-                    } else {
-                        None
-                    }
+                if let Ok(Native::Str(rp)) = self.nav().resolve_native(r) {
+                    Some((*view.scoped(rp)).as_str().to_string())
                 } else {
                     None
                 }
@@ -879,11 +875,7 @@ impl<'a> Machine<'a> {
 
         if self.state.terminated() {
             if let HeapSyn::Cons { tag, .. } = &*code {
-                if *tag == DataConstructor::Unit.tag() {
-                    true
-                } else {
-                    false
-                }
+                *tag == DataConstructor::Unit.tag()
             } else {
                 false
             }
@@ -955,14 +947,7 @@ pub mod tests {
     fn machine(syn: Rc<StgSyn>) -> Machine<'static> {
         let mut m = Machine::new(Box::new(DebugEmitter::default()), true);
         let blank = m.mutate(Init, ()).unwrap();
-        let closure = m
-            .mutate(
-                Load {
-                    syntax: syn.clone(),
-                },
-                blank,
-            )
-            .unwrap();
+        let closure = m.mutate(Load { syntax: syn }, blank).unwrap();
         m.initialise(blank, blank, closure, vec![]).unwrap();
         m
     }

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -577,13 +577,13 @@ pub mod tests {
         view.nil().unwrap();
         let id = LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default());
         view.let_(
-            view.singleton(id.clone()),
+            view.singleton(id),
             view.app(Ref::L(0), view.singleton(view.sym_ref("foo").unwrap()))
                 .unwrap(),
         )
         .unwrap();
         view.letrec(
-            view.singleton(id.clone()),
+            view.singleton(id),
             view.app(Ref::L(0), view.singleton(view.sym_ref("foo").unwrap()))
                 .unwrap(),
         )

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1095,8 +1095,8 @@ pub mod tests {
         let y = free("y");
 
         let core = acore::let_(
-            vec![(x.clone(), acore::num(2)), (y.clone(), acore::num(3))],
-            acore::var(x.clone()),
+            vec![(x.clone(), acore::num(2)), (y, acore::num(3))],
+            acore::var(x),
         );
 
         assert_eq!(
@@ -1121,11 +1121,11 @@ pub mod tests {
             vec![
                 (
                     x.clone(),
-                    acore::let_(vec![(z.clone(), acore::num(2))], acore::var(y.clone())),
+                    acore::let_(vec![(z, acore::num(2))], acore::var(y.clone())),
                 ),
-                (y.clone(), acore::num(3)),
+                (y, acore::num(3)),
             ],
-            acore::var(x.clone()),
+            acore::var(x),
         );
 
         assert_eq!(
@@ -1153,19 +1153,13 @@ pub mod tests {
 
         let core = acore::let_(
             vec![
-                (
-                    f.clone(),
-                    acore::lam(vec![x.clone(), y.clone()], acore::var(x.clone())),
-                ),
+                (f.clone(), acore::lam(vec![x.clone(), y], acore::var(x))),
                 (
                     z.clone(),
-                    acore::app(
-                        acore::var(f.clone()),
-                        vec![acore::num(999), acore::num(-999)],
-                    ),
+                    acore::app(acore::var(f), vec![acore::num(999), acore::num(-999)]),
                 ),
             ],
-            acore::var(z.clone()),
+            acore::var(z),
         );
 
         let expected = dsl::letrec_(

--- a/src/eval/stg/eq.rs
+++ b/src/eval/stg/eq.rs
@@ -251,8 +251,8 @@ pub mod tests {
     pub fn test_box_nums() {
         let syntax = letrec_(
             vec![
-                value(box_num(Number::from_f64(3.14159265).unwrap())),
-                value(box_num(Number::from_f64(3.14159265).unwrap())),
+                value(box_num(Number::from_f64(std::f64::consts::PI).unwrap())),
+                value(box_num(Number::from_f64(std::f64::consts::PI).unwrap())),
             ],
             Eq.global(lref(0), lref(1)),
         );

--- a/src/eval/stg/testing.rs
+++ b/src/eval/stg/testing.rs
@@ -41,7 +41,7 @@ pub fn runtime(mut bifs: Vec<Box<dyn StgIntrinsic>>) -> Box<dyn Runtime> {
 
 /// Create a machine for standard unit tests equipped with the
 /// specified runtime
-pub fn machine<'r>(runtime: &'r dyn Runtime, syntax: Rc<StgSyn>) -> Machine<'r> {
+pub fn machine(runtime: &dyn Runtime, syntax: Rc<StgSyn>) -> Machine {
     standard_machine(
         &SETTINGS,
         syntax,

--- a/src/export/edn.rs
+++ b/src/export/edn.rs
@@ -18,7 +18,7 @@ impl FromPrimitive for Value {
         match primitive {
             Primitive::Null => Value::Nil,
             Primitive::Bool(b) => Value::Boolean(*b),
-            Primitive::Sym(s) => Value::Keyword(Keyword::from_name(&s)),
+            Primitive::Sym(s) => Value::Keyword(Keyword::from_name(s)),
             Primitive::Str(s) => Value::String(s.clone()),
             Primitive::Num(n) => {
                 if let Some(i) = n.as_i64() {
@@ -65,7 +65,7 @@ impl<'a> Emitter for EdnEmitter<'a> {
     fn emit(&mut self, event: Event) {
         self.accum.consume(event);
         if let Some(result) = self.accum.result() {
-            writeln!(self.out, "{}", emit_str(&result)).unwrap();
+            writeln!(self.out, "{}", emit_str(result)).unwrap();
         }
     }
 }

--- a/src/export/edn.rs
+++ b/src/export/edn.rs
@@ -1,0 +1,71 @@
+//! EDN export
+
+use super::table::{AsKey, FromPairs, FromPrimitive, FromVec, TableAccumulator};
+use crate::eval::emit::{Emitter, Event, RenderMetadata};
+use crate::eval::primitive::Primitive;
+use edn_format::{emit_str, Keyword, Value};
+use ordered_float::OrderedFloat;
+use std::io::Write;
+
+impl AsKey<Value> for Value {
+    fn as_key(&self) -> Value {
+        self.clone()
+    }
+}
+
+impl FromPrimitive for Value {
+    fn from_primitive(_metadata: RenderMetadata, primitive: &Primitive) -> Self {
+        match primitive {
+            Primitive::Null => Value::Nil,
+            Primitive::Bool(b) => Value::Boolean(*b),
+            Primitive::Sym(s) => Value::Keyword(Keyword::from_name(&s)),
+            Primitive::Str(s) => Value::String(s.clone()),
+            Primitive::Num(n) => {
+                if let Some(i) = n.as_i64() {
+                    Value::Integer(i)
+                } else if let Some(f) = n.as_f64() {
+                    Value::Float(OrderedFloat(f))
+                } else {
+                    panic!("unrepresentable number")
+                }
+            }
+            Primitive::ZonedDateTime(dt) => Value::Inst(*dt),
+        }
+    }
+}
+
+impl FromVec<Value> for Value {
+    fn from_vec(_metadata: RenderMetadata, slice: Vec<Value>) -> Self {
+        Value::Vector(slice)
+    }
+}
+
+impl FromPairs<Value, Value> for Value {
+    fn from_pairs(_metadata: RenderMetadata, pairs: Vec<(Value, Value)>) -> Self {
+        Value::Map(pairs.into_iter().collect())
+    }
+}
+
+/// Emitter for EDN
+pub struct EdnEmitter<'a> {
+    accum: TableAccumulator<Value, Value>,
+    out: &'a mut (dyn Write + 'a),
+}
+
+impl<'a> EdnEmitter<'a> {
+    pub fn new(out: &'a mut (dyn Write + 'a)) -> Self {
+        EdnEmitter {
+            accum: Default::default(),
+            out,
+        }
+    }
+}
+
+impl<'a> Emitter for EdnEmitter<'a> {
+    fn emit(&mut self, event: Event) {
+        self.accum.consume(event);
+        if let Some(result) = self.accum.result() {
+            writeln!(self.out, "{}", emit_str(&result)).unwrap();
+        }
+    }
+}

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,3 +1,4 @@
+pub mod edn;
 pub mod error;
 pub mod html;
 pub mod json;
@@ -11,6 +12,7 @@ use self::html::HtmlMarkupSerialiser;
 
 use super::export::toml::TomlEmitter;
 use crate::eval::emit::Emitter;
+use edn::EdnEmitter;
 use html::HtmlEmitter;
 use json::JsonEmitter;
 use std::io::Write;
@@ -29,6 +31,7 @@ pub fn create_emitter<'a, S: AsRef<str>>(
         "toml" => Some(Box::new(TomlEmitter::new(output))),
         "json" => Some(Box::new(JsonEmitter::new(output))),
         "text" => Some(Box::new(TextEmitter::new(output))),
+        "edn" => Some(Box::new(EdnEmitter::new(output))),
         "html" => Some(Box::new(HtmlEmitter::new(HtmlMarkupSerialiser::new(
             output,
         )))),

--- a/src/import/edn.rs
+++ b/src/import/edn.rs
@@ -1,0 +1,110 @@
+//! EDN import
+
+use std::iter;
+
+use super::error::SourceError;
+use crate::{
+    common::sourcemap::SourceMap,
+    core::expr::{acore, RcExpr},
+};
+use codespan::Span;
+use edn_format::{parse_str, Value};
+use serde_json::Number;
+
+/// Read EDN format data
+///
+/// Note that EDN files may have many top-level items, until we
+/// support streaming, we need to read on and return as a list.
+pub fn read_edn<'smap>(
+    _source_map: &'smap mut SourceMap,
+    file_id: usize,
+    text: &'smap str,
+) -> Result<RcExpr, SourceError> {
+    let edn = parse_str(text).map_err(|e| SourceError::InvalidEdn(e, file_id))?;
+    value_to_core(&edn, file_id)
+}
+
+fn value_to_key(edn: &Value, file_id: usize) -> Result<String, SourceError> {
+    match edn {
+        Value::Character(c) => Ok(c.to_string()),
+        Value::String(s) => Ok(s.to_string()),
+        Value::Symbol(sym) => Ok(sym.name().to_string()),
+        Value::Keyword(kw) => Ok(kw.name().to_string()),
+        v => Err(SourceError::InvalidBlockKey(
+            v.to_string(),
+            file_id,
+            Span::default(),
+        )),
+    }
+}
+
+fn value_to_core(edn: &Value, file_id: usize) -> Result<RcExpr, SourceError> {
+    match edn {
+        Value::Nil => Ok(acore::null()),
+        Value::Boolean(b) => Ok(acore::bool_(*b)),
+        Value::Character(c) => Ok(acore::str(c.to_string())),
+        Value::String(s) => Ok(acore::str(s)),
+        Value::Symbol(sym) => Ok(acore::sym(sym.name())),
+        Value::Keyword(kw) => Ok(acore::sym(kw.name())),
+        Value::Integer(i) => Ok(acore::num(*i)),
+        Value::Float(f) => match Number::from_f64(f.into_inner()) {
+            Some(n) => Ok(acore::num(n)),
+            None => Err(SourceError::InvalidNumber(
+                f.to_string(),
+                file_id,
+                Span::default(),
+            )),
+        },
+        Value::BigInt(i) => Err(SourceError::InvalidNumber(
+            i.to_string(),
+            file_id,
+            Span::default(),
+        )),
+        Value::BigDec(d) => Err(SourceError::InvalidNumber(
+            d.to_string(),
+            file_id,
+            Span::default(),
+        )),
+        Value::List(xs) => xs
+            .iter()
+            .map(|v| value_to_core(v, file_id))
+            .collect::<Result<Vec<RcExpr>, SourceError>>()
+            .map(acore::list),
+        Value::Vector(xs) => xs
+            .iter()
+            .map(|v| value_to_core(v, file_id))
+            .collect::<Result<Vec<RcExpr>, SourceError>>()
+            .map(acore::list),
+        Value::Map(m) => m
+            .iter()
+            .map(
+                |(k, v)| match (value_to_key(k, file_id), value_to_core(v, file_id)) {
+                    (Ok(k), Ok(v)) => Ok((k, v)),
+                    (Err(e), _) => Err(e),
+                    (_, Err(e)) => Err(e),
+                },
+            )
+            .collect::<Result<Vec<(String, RcExpr)>, SourceError>>()
+            .map(|entries| acore::block(entries.into_iter())),
+        Value::Set(xs) => xs
+            .iter()
+            .map(|v| value_to_core(v, file_id))
+            .collect::<Result<Vec<RcExpr>, SourceError>>()
+            .map(acore::list),
+        Value::Inst(dt) => Ok(acore::app(
+            acore::bif("ZDT.PARSE"),
+            vec![acore::str(dt.to_string())],
+        )), // TODO core representation of datetime
+        Value::Uuid(uuid) => Ok(acore::meta(
+            acore::str(uuid.to_string()),
+            acore::block(iter::once((
+                "tag".to_string(),
+                acore::str("uuid".to_string()),
+            ))),
+        )),
+        Value::TaggedElement(t, e) => Ok(acore::meta(
+            value_to_core(e, file_id)?,
+            acore::block(iter::once(("tag".to_string(), acore::str(t.name())))),
+        )),
+    }
+}

--- a/src/import/edn.rs
+++ b/src/import/edn.rs
@@ -94,7 +94,7 @@ fn value_to_core(edn: &Value, file_id: usize) -> Result<RcExpr, SourceError> {
         Value::Inst(dt) => Ok(acore::app(
             acore::bif("ZDT.PARSE"),
             vec![acore::str(dt.to_string())],
-        )), // TODO core representation of datetime
+        )), // NB. no core primitive for datetime right now
         Value::Uuid(uuid) => Ok(acore::meta(
             acore::str(uuid.to_string()),
             acore::block(iter::once((

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,6 +1,38 @@
+use codespan_reporting::files::SimpleFiles;
+
+use crate::{common::sourcemap::SourceMap, core::expr::RcExpr};
+use codespan_reporting::files::Files;
+
+use self::error::SourceError;
+
 pub mod csv;
+pub mod edn;
 pub mod error;
 pub mod text;
 pub mod toml;
 pub mod xml;
 pub mod yaml;
+
+/// Read a supported source format into core representation
+pub fn read_to_core<'smap>(
+    format: &str,
+    files: &'smap mut SimpleFiles<String, String>,
+    source_map: &'smap mut SourceMap,
+    file_id: usize,
+) -> Result<RcExpr, SourceError> {
+    match format {
+        "yaml" | "json" => {
+            let text = files.source(file_id)?.to_string();
+            yaml::read_yaml(files, source_map, file_id, &text)
+        }
+        "toml" => toml::read_toml(source_map, file_id, files.source(file_id)?),
+        "text" => text::read_text(source_map, file_id, files.source(file_id)?),
+        "csv" => csv::read_csv(source_map, file_id, files.source(file_id)?),
+        "xml" => xml::read_xml(source_map, file_id, files.source(file_id)?),
+        "edn" => edn::read_edn(source_map, file_id, files.source(file_id)?),
+        _ => Err(SourceError::UnknownSourceFormat(
+            format.to_string(),
+            file_id,
+        )),
+    }
+}

--- a/src/import/yaml.rs
+++ b/src/import/yaml.rs
@@ -413,7 +413,7 @@ z: !!int 1234232353
                 ),
             ),
             (free("x"), acore::str("y")),
-            (free("z"), acore::num(12342323535 as u64)),
+            (free("z"), acore::num(12342323535_u64)),
         ]);
 
         assert_term_eq!(parsed, expected);

--- a/src/syntax/input.rs
+++ b/src/syntax/input.rs
@@ -108,6 +108,7 @@ impl Locator {
             "json" => Some(String::from("json")),
             "txt" => Some(String::from("text")),
             "toml" => Some(String::from("toml")),
+            "edn" => Some(String::from("edn")),
             "yaml" => Some(String::from("yaml")),
             "yml" => Some(String::from("yaml")),
             "csv" => Some(String::from("csv")),

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -230,3 +230,18 @@ pub fn test_harness_046() {
 pub fn test_harness_047() {
     run_test(&opts("047_xml_import.eu"));
 }
+
+#[test]
+pub fn test_harness_048() {
+    run_test(&opts("048_parse_embed_core.eu"));
+}
+
+#[test]
+pub fn test_harness_049() {
+    run_test(&opts("049_tester.eu"));
+}
+
+#[test]
+pub fn test_harness_050() {
+    run_test(&opts("050_edn.edn"));
+}


### PR DESCRIPTION
Adds EDN import and export.

- feature: `eu` now has experimental support import of `.edn` files and export to edn (using `-x edn`). Currently only single top-level forms are supported so, for example, reading streamed logs in edn is not possible. See https://github.com/edn-format/edn for the EDN spec.