### PR TITLE
Fix deprecated chrono APIs and add syntax documentation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(./target/debug/eu --heap-limit-mib 1 --heap-dump-at-gc -e \"[0..100]\")",
       "Bash(find:*)",
       "Bash(rm:*)",
-      "Bash(~/.claude/showme src/eval/memory/heap.rs)"
+      "Bash(~/.claude/showme src/eval/memory/heap.rs)",
+      "Bash(./bench.sh run:*)",
+      "Bash(./bench.sh:*)"
     ],
     "deny": []
   }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.2.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 
+[features]
+default = []
+# Enable comprehensive GC metrics collection in release builds
+# WARNING: May impact performance - only enable for monitoring/debugging
+gc-telemetry = []
+
 [build-dependencies]
 lalrpop = { version = "0.19.8", features = ["lexer"] }
 

--- a/docs/syntax-gotchas.md
+++ b/docs/syntax-gotchas.md
@@ -1,0 +1,83 @@
+# Syntax Gotchas
+
+This document records unintuitive consequences of Eucalypt's syntax design decisions that can lead to subtle bugs or confusion. These are documented here until such time as we can implement a linter or improve error messages to catch them more clearly.
+
+## Operator Precedence Issues
+
+### Field Access vs Catenation
+
+**Problem**: The lookup operator (`.`) has higher precedence (90) than catenation (precedence 20), which can lead to unexpected parsing.
+
+**Gotcha**: Writing `objects head.id` is parsed as `objects (head.id)` rather than `(objects head).id`.
+
+**Example**:
+```eu
+# This doesn't work as expected:
+objects: range(0, 5) map({ id: _ })
+result: objects head.id  # Parsed as: objects (head.id)
+
+# Correct syntax requires parentheses:
+result: (objects head).id  # Explicitly groups the field access
+```
+
+**Error Message**: When this occurs, you may see confusing errors like:
+- `cannot return function into case table without default`
+- `bad index 18446744073709551615 into environment` (under memory pressure)
+
+**Solution**: Always use parentheses to group the expression you want to access fields from:
+- Use `(expression).field` instead of `expression target.field`
+- Be explicit about precedence when combining catenation with field access
+
+**Reference**: Operator precedences are defined in `src/core/metadata.rs:165-186`:
+- `lookup` (`.`): precedence 90
+- `cat` (catenation): precedence 20
+
+## Anaphora and Function Syntax
+
+### Lambda Syntax Does Not Exist
+
+**Problem**: Eucalypt does not have lambda expressions like other functional languages.
+
+**Gotcha**: Attempting to write lambda-style syntax will cause syntax errors.
+
+**Invalid Examples**:
+```eu
+# These syntaxes DO NOT exist in Eucalypt:
+map(\x -> x + 1)     # Invalid
+map(|x| x + 1)       # Invalid  
+map(fn(x) => x + 1)  # Invalid
+map(λx.x + 1)        # Invalid
+```
+
+**Correct Approach**: Use anaphora (`_`, `_0`, `_1`, etc.) or define named functions:
+```eu
+# Using anaphora:
+map(_ + 1)
+
+# Using named function:
+add-one(x): x + 1
+map(add-one)
+
+# Using block with anaphora for complex expressions:
+map({ result: _ + 1, doubled: _ * 2 })
+```
+
+**Reference**: See `docs/anaphora-and-lambdas.md` for detailed explanation of anaphora usage.
+
+## Future Improvements
+
+These gotchas highlight areas where the language could benefit from:
+
+1. **Better Error Messages**: More specific error messages when precedence issues occur
+2. **Linting Rules**: Static analysis to catch common precedence mistakes  
+3. **IDE Support**: Syntax highlighting and warnings for ambiguous expressions
+4. **Documentation**: Better examples showing correct precedence usage
+
+## Contributing
+
+When you encounter a new syntax gotcha, please add it to this document with:
+- A clear description of the problem
+- Example of incorrect usage
+- Example of correct usage  
+- The error message(s) that result
+- Reference to relevant code or documentation

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -264,7 +264,7 @@ pub mod tests {
     pub fn test_per_heap_mark_state_isolation() {
         // Test that each heap has its own independent mark state
         let mut heap1 = Heap::new();
-        let mut heap2 = Heap::new();
+        let heap2 = Heap::new();
         let mut clock = Clock::default();
         clock.switch(ThreadOccupation::Mutator);
 

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1155,24 +1155,25 @@ impl Heap {
     /// Get a snapshot of current GC performance metrics (calculates derived metrics on-demand)
     pub fn gc_metrics(&self) -> GCMetrics {
         let mut metrics = unsafe { (*self.gc_metrics.get()).clone() };
-        
+
         // Calculate derived metrics on-demand to avoid hot path overhead
         let now = Instant::now();
-        metrics.performance_counters.heap_lifetime = now.duration_since(metrics.performance_counters.heap_created_at);
-        
+        metrics.performance_counters.heap_lifetime =
+            now.duration_since(metrics.performance_counters.heap_created_at);
+
         // Calculate allocation rates
         let heap_lifetime_seconds = metrics.performance_counters.heap_lifetime.as_secs_f64();
         if heap_lifetime_seconds > 0.0 {
-            metrics.allocation_stats.allocation_rate_bps = 
+            metrics.allocation_stats.allocation_rate_bps =
                 metrics.allocation_stats.total_bytes_allocated as f64 / heap_lifetime_seconds;
-            metrics.allocation_stats.allocation_rate_ops = 
+            metrics.allocation_stats.allocation_rate_ops =
                 metrics.allocation_stats.total_objects_allocated as f64 / heap_lifetime_seconds;
         }
-        
+
         // Update utilisation and performance metrics
         self.calculate_utilisation_metrics(&mut metrics);
         self.calculate_performance_health(&mut metrics);
-        
+
         metrics
     }
 
@@ -1243,14 +1244,15 @@ impl Heap {
             let total_time = now.duration_since(metrics.performance_counters.heap_created_at);
             if total_time.as_secs_f64() > 0.0 {
                 metrics.performance_counters.gc_overhead_percent =
-                    (metrics.collection_stats.total_gc_time.as_secs_f64() / total_time.as_secs_f64())
+                    (metrics.collection_stats.total_gc_time.as_secs_f64()
+                        / total_time.as_secs_f64())
                         * 100.0;
             }
 
             // Reset allocation burst after collection
             metrics.allocation_stats.current_burst_bytes = 0;
         }
-        
+
         // In release builds, do nothing
         #[cfg(not(debug_assertions))]
         {
@@ -1300,7 +1302,7 @@ impl Heap {
                     total_bytes_freed / metrics.emergency_stats.successful_collections;
             }
         }
-        
+
         // In release builds, do nothing
         #[cfg(not(debug_assertions))]
         {
@@ -1362,7 +1364,6 @@ impl Heap {
 
     /// Calculate performance health indicators on-demand  
     fn calculate_performance_health(&self, metrics: &mut GCMetrics) {
-
         // Calculate memory pressure based on allocation rate and collection frequency
         let allocation_pressure = if metrics.allocation_stats.peak_allocation_rate_bps > 0.0 {
             (metrics.allocation_stats.allocation_rate_bps

--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -421,13 +421,19 @@ pub mod tests {
     pub fn test_tz_parse() {
         assert_eq!(
             offset_from_tz_str("-02:00").unwrap(),
-            FixedOffset::east(2 * 60 * 60)
+            FixedOffset::east_opt(2 * 60 * 60).unwrap()
         );
         assert_eq!(
             offset_from_tz_str("+02:00").unwrap(),
-            FixedOffset::west(2 * 60 * 60)
+            FixedOffset::west_opt(2 * 60 * 60).unwrap()
         );
-        assert_eq!(offset_from_tz_str("UTC").unwrap(), FixedOffset::east(0));
-        assert_eq!(offset_from_tz_str("Z").unwrap(), FixedOffset::east(0));
+        assert_eq!(
+            offset_from_tz_str("UTC").unwrap(),
+            FixedOffset::east_opt(0).unwrap()
+        );
+        assert_eq!(
+            offset_from_tz_str("Z").unwrap(),
+            FixedOffset::east_opt(0).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fix deprecated chrono API usage: replace `FixedOffset::east/west` with `east_opt/west_opt`
- Remove unused `mut` variable in test code  
- Add `docs/syntax-gotchas.md` documenting operator precedence issues discovered during recent stability testing

## Test plan
- [x] All tests pass
- [x] No clippy warnings
- [x] Code properly formatted
- [x] Benchmarks show stable performance

## Context
These are maintenance fixes identified during post-GC-implementation stability testing. The chrono API deprecation warnings needed resolution, and the syntax documentation captures precedence issues that caused confusion during debugging.

🤖 Generated with [Claude Code](https://claude.ai/code)