### PR TITLE
Fix CICD release build failures caused by memory management bug

### DIFF
--- a/src/eval/memory/header.rs
+++ b/src/eval/memory/header.rs
@@ -82,7 +82,8 @@ impl HeaderBits {
 pub struct AllocHeader {
     /// Header bits for object state
     bits: HeaderBits,
-    /// Count of allocated bytes (for untyped allocations)
+    /// Count of actual object bytes (excluding header and alignment padding)
+    /// This is the size that should be marked during GC, NOT the total allocation size
     alloc_length: u32,
     /// Forwarding pointer for when object is moved
     forwarded_to: Option<NonNull<()>>,

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -670,13 +670,7 @@ pub fn extract_bound_var<'a>(
 ) -> Result<&'a BoundVar<String>, CompileError> {
     match var {
         Var::Bound(bound_var) => Ok(bound_var),
-        Var::Free(free_var) => {
-            eprintln!("DEBUG MASTER: Unresolved FreeVar: {free_var:?} with smid: {smid:?}");
-            if let Some(ref name) = free_var.pretty_name {
-                eprintln!("DEBUG MASTER: Variable name: {name}");
-            }
-            Err(CompileError::FreeVar(*smid))
-        }
+        Var::Free(_free_var) => Err(CompileError::FreeVar(*smid)),
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes intermittent CICD release build failures that were causing panics during garbage collection with the error "index out of bounds: the len is 2 but the index is 2".

## Root Cause
Objects allocated with `alloc_bytes()` were storing the padded allocation size (including 16-byte alignment) in their headers, but the garbage collector was using this inflated size for marking memory regions. This caused attempts to mark memory beyond block boundaries during GC, leading to index out of bounds errors in the bitmaps crate.

Example failure case:
- Object at offset 30608 with reported size 2176 bytes
- Total: 30608 + 2176 = 32784 > 32768 (block size) ❌

## Technical Details
The bug was in `heap.rs` line 1720:
```rust
// BEFORE (incorrect):
let header = AllocHeader::new_with_mark_state(alloc_size as u32, self.mark_state());

// AFTER (fixed):  
let header = AllocHeader::new_with_mark_state(size_bytes as u32, self.mark_state());
```

The `alloc_size` includes padding from `alloc_size_of()` which adds 16-byte alignment, but `size_bytes` is the actual requested object size.

## Why Only in Release Builds?
- Debug assertions in `mark()` would catch bounds violations in debug builds
- Release builds strip debug assertions, allowing invalid indices to reach the bitmaps crate
- Different optimization characteristics made the race condition more likely in release builds

## Changes Made
- ✅ **Fix core bug**: Store actual requested size in headers, not padded allocation size
- ✅ **Add debug assertions**: Better bounds checking with clear error messages in `mark_region()`
- ✅ **Remove debug output**: Clean up "DEBUG MASTER:" prints that appeared in release builds
- ✅ **Add regression test**: Comprehensive unit test `test_alloc_bytes_header_size_correctness()`
- ✅ **Improve documentation**: Clarify header field purpose

## Test Plan
- [x] Local testing shows harness tests now complete without panics
- [x] Unit test verifies headers store correct sizes
- [x] Debug assertions provide clear diagnostics if issues recur
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)