### PR TITLE
Fix Claude API release notes debugging

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -128,23 +128,51 @@ jobs:
           INPUT_CONTENT=$(cat release_input.txt)
           
           # Generate release notes with Anthropic API
-          curl -X POST https://api.anthropic.com/v1/messages \
+          echo "🔍 Creating API payload..."
+          
+          # Create JSON payload with proper escaping
+          jq -n \
+            --arg prompt "$(cat .github/release-notes-prompt.md)" \
+            --arg input "$(cat release_input.txt)" \
+            '{
+              "model": "claude-3-5-sonnet-20241022",
+              "max_tokens": 4000,
+              "messages": [{
+                "role": "user", 
+                "content": ($prompt + "\n\n" + $input)
+              }]
+            }' > api_payload.json
+          
+          echo "📏 Payload size: $(wc -c < api_payload.json) bytes"
+          
+          # Make API call with debugging
+          echo "🚀 Calling Claude API..."
+          curl -s -X POST https://api.anthropic.com/v1/messages \
             -H "Content-Type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
-            -d "{
-              \"model\": \"claude-3-5-sonnet-20241022\",
-              \"max_tokens\": 4000,
-              \"messages\": [{
-                \"role\": \"user\",
-                \"content\": \"$PROMPT_CONTENT\n\n$INPUT_CONTENT\"
-              }]
-            }" | jq -r '.content[0].text' > CHANGELOG.md || {
-            echo "Claude API failed, falling back to basic git log"
+            -d @api_payload.json \
+            -w "HTTP Status: %{http_code}\n" \
+            -o api_response.json
+          
+          echo "📥 API Response:"
+          cat api_response.json
+          echo ""
+          
+          # Check if response contains expected content
+          if jq -e '.content[0].text' api_response.json > /dev/null 2>&1; then
+            echo "✅ Successfully extracting release notes from API response"
+            jq -r '.content[0].text' api_response.json > CHANGELOG.md
+          else
+            echo "❌ API response missing expected '.content[0].text' structure"
+            echo "🔄 Falling back to basic git log"
             echo "# Release Notes" > CHANGELOG.md
             echo "" >> CHANGELOG.md
             git log latest..HEAD --pretty=format:"- %s" >> CHANGELOG.md
-          }
+          fi
+          
+          echo "📝 Generated CHANGELOG.md:"
+          cat CHANGELOG.md
       - name: Upload changelog
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
Fix the Claude API release notes generation that's currently producing "null" output by adding comprehensive debugging and improving error handling.

## Problem
The Claude API integration is failing silently, producing "null" in CHANGELOG.md instead of proper release notes. The API key is present but something in the request/response handling is broken.

## Changes Made
- **Comprehensive logging**: Added step-by-step debugging output to trace the entire process
- **Proper JSON escaping**: Use `jq` to create API payload instead of string interpolation to avoid JSON syntax errors
- **HTTP status logging**: Show the actual HTTP response code from the API
- **Full response tracing**: Display the complete API response in build logs for debugging
- **Improved error handling**: Clear success/failure messages and proper fallback logic
- **Output verification**: Show the final CHANGELOG.md content for validation

## Debugging Output
The new workflow will show:
- 🔍 Payload creation status
- 📏 Request size in bytes  
- 🚀 API call initiation
- 📥 Complete API response
- ✅/❌ Success/failure status
- 📝 Final generated content

This will help identify whether the issue is authentication, malformed requests, unexpected response format, or parsing problems.

## Test Plan
- [x] Test workflow syntax locally
- [ ] Trigger release build to see full debugging output
- [ ] Analyze API response to identify root cause
- [ ] Apply fix based on debugging results

🤖 Generated with [Claude Code](https://claude.ai/code)