### PR TITLE
feat(eu-1j9u): create curl-installable install script

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -267,6 +267,10 @@ jobs:
           cp eu_darwin eucalypt-aarch64-osx/eu
           tar -cvzf eucalypt-aarch64-osx.tgz eucalypt-aarch64-osx
 
+      - name: Generate SHA256SUMS
+        run: |
+          sha256sum *.tgz > SHA256SUMS
+
       - name: Query binary for version number
         run: |
           chmod +x eu_amd64
@@ -283,5 +287,6 @@ jobs:
             eucalypt-x86_64-linux.tgz
             eucalypt-aarch64-linux.tgz
             eucalypt-aarch64-osx.tgz
+            SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# install.sh - Install eucalypt binary from GitHub releases
+#
+# Usage:
+#   curl -sSf https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+#
+# Environment variables:
+#   EUCALYPT_VERSION     - Pin a specific version (default: latest release)
+#   EUCALYPT_INSTALL_DIR - Override install location (default: ~/.local/bin)
+
+set -eu
+
+REPO="curvelogic/eucalypt"
+DEFAULT_INSTALL_DIR="$HOME/.local/bin"
+
+main() {
+    install_dir="${EUCALYPT_INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+
+    detect_platform
+    determine_version
+    download_and_verify
+    install_binary
+    check_path
+}
+
+detect_platform() {
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux)
+            case "$arch" in
+                x86_64)
+                    tarball="eucalypt-x86_64-linux.tgz"
+                    platform_dir="eucalypt-x86_64-linux"
+                    ;;
+                aarch64)
+                    tarball="eucalypt-aarch64-linux.tgz"
+                    platform_dir="eucalypt-aarch64-linux"
+                    ;;
+                *)
+                    unsupported "$os" "$arch"
+                    ;;
+            esac
+            sha_cmd="sha256sum"
+            ;;
+        Darwin)
+            case "$arch" in
+                arm64)
+                    tarball="eucalypt-aarch64-osx.tgz"
+                    platform_dir="eucalypt-aarch64-osx"
+                    ;;
+                *)
+                    unsupported "$os" "$arch"
+                    ;;
+            esac
+            sha_cmd="shasum -a 256"
+            ;;
+        *)
+            unsupported "$os" "$arch"
+            ;;
+    esac
+
+    printf "Detected platform: %s/%s\n" "$os" "$arch"
+}
+
+unsupported() {
+    printf "eucalypt does not provide prebuilt binaries for %s/%s.\n" "$1" "$2"
+    printf "Build from source: cargo install --git https://github.com/%s\n" "$REPO"
+    exit 1
+}
+
+determine_version() {
+    if [ -n "${EUCALYPT_VERSION:-}" ]; then
+        version="$EUCALYPT_VERSION"
+        printf "Using specified version: %s\n" "$version"
+    else
+        printf "Querying latest release...\n"
+        version="$(curl -sSf "https://api.github.com/repos/$REPO/releases/latest" \
+            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"
+        if [ -z "$version" ]; then
+            printf "Error: could not determine latest release version.\n" >&2
+            exit 1
+        fi
+        printf "Latest version: %s\n" "$version"
+    fi
+
+    base_url="https://github.com/$REPO/releases/download/$version"
+}
+
+download_and_verify() {
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    printf "Downloading %s...\n" "$tarball"
+    curl -sSfL -o "$tmp_dir/$tarball" "$base_url/$tarball"
+
+    printf "Downloading SHA256SUMS...\n"
+    curl -sSfL -o "$tmp_dir/SHA256SUMS" "$base_url/SHA256SUMS"
+
+    printf "Verifying integrity...\n"
+    expected="$(grep "$tarball" "$tmp_dir/SHA256SUMS" | awk '{print $1}')"
+    if [ -z "$expected" ]; then
+        printf "Error: %s not found in SHA256SUMS.\n" "$tarball" >&2
+        exit 1
+    fi
+
+    actual="$(cd "$tmp_dir" && $sha_cmd "$tarball" | awk '{print $1}')"
+    if [ "$expected" != "$actual" ]; then
+        printf "Error: SHA256 verification failed.\n" >&2
+        printf "  Expected: %s\n" "$expected" >&2
+        printf "  Actual:   %s\n" "$actual" >&2
+        exit 1
+    fi
+
+    printf "Integrity verified.\n"
+
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+}
+
+install_binary() {
+    mkdir -p "$install_dir"
+    cp "$tmp_dir/$platform_dir/eu" "$install_dir/eu"
+    chmod +x "$install_dir/eu"
+    printf "Installed eu to %s/eu\n" "$install_dir"
+}
+
+check_path() {
+    case ":${PATH}:" in
+        *":${install_dir}:"*)
+            printf "eu is ready to use.\n"
+            ;;
+        *)
+            printf "\nWarning: %s is not on your PATH.\n" "$install_dir"
+            printf "Add it to your shell profile:\n\n"
+            printf "  export PATH=\"%s:\$PATH\"\n\n" "$install_dir"
+            printf "Then restart your shell or run the export command above.\n"
+            ;;
+    esac
+}
+
+main


### PR DESCRIPTION
## Summary

- Add POSIX-compatible `install.sh` for single-line installation: `curl -sSf .../install.sh | sh`
- Platform detection for x86_64-linux, aarch64-linux, and aarch64-darwin (Apple Silicon)
- SHA256 hash verification via `SHA256SUMS` release asset
- Configurable version (`EUCALYPT_VERSION`) and install directory (`EUCALYPT_INSTALL_DIR`, default `~/.local/bin`)
- PATH check with instructions if install directory is not on PATH
- Clear error message for unsupported platforms directing users to build from source
- Release workflow updated to generate and attach `SHA256SUMS` file

## Dependencies

This PR is based on #216 (eu-epe4: aarch64-linux release binary) and should be merged after it.

## Test plan

- [ ] Verify YAML syntax is valid (done locally)
- [ ] Verify shellcheck passes (done locally, no warnings)
- [ ] Verify install script is POSIX-compatible (uses `#!/bin/sh`, no bashisms)
- [ ] Test script on Linux x86_64 after a release is published
- [ ] Test script on macOS ARM after a release is published
- [ ] Verify SHA256SUMS appears in draft release assets after merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)