### PR TITLE
feat(eu-fti1): Phase 1D+1F error message quick wins

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -210,11 +210,6 @@ impl<'a> Executor<'a> {
 
                 let mut notes = vec![];
 
-                if let Some(trace) = e.env_trace() {
-                    let env_trace = self.source_map.format_trace(trace, &self.files);
-                    notes.push(format!("environment trace:\n{env_trace}"));
-                }
-
                 if let Some(trace) = e.stack_trace() {
                     let stack_trace = self.source_map.format_trace(trace, &self.files);
                     notes.push(format!("stack trace:\n{stack_trace}"));

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -31,7 +31,7 @@ use super::{
 /// Errors found during compilation
 #[derive(Debug, Error)]
 pub enum CompileError {
-    #[error("unresolved free variable reference {0}")]
+    #[error("unresolved free variable reference")]
     FreeVar(Smid),
     #[error("unresolvable bound variable reference")]
     BoundVarOverflowsContext,


### PR DESCRIPTION
## Summary

Two Phase 1 quick wins from the error messages implementation plan:

- **1D: Remove Smid values from messages** — Strip `[NNNN]`-style Smid references from `CompileError::FreeVar` display. The source location pointer already conveys this information via the diagnostic.
- **1F: Drop environment trace from output** — Remove the "environment trace:" note from error diagnostic display. The internal `env_trace()` machinery is retained but no longer shown to users, as it adds noise without actionable information.

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (no warnings)
- [x] `cargo fmt --all` applied
- [x] `cargo test --lib` passes (523 tests)
- [x] `cargo test --test harness_test` passes (106 tests)
- [x] No `.expect` files needed updating (none referenced environment trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)