### PR TITLE
feat(eu-bscw): redesign STG pretty-printer

### DIFF
--- a/src/eval/stg/pretty.rs
+++ b/src/eval/stg/pretty.rs
@@ -1,9 +1,32 @@
-//! Export pretty printed version of core.
+//! Export pretty printed version of STG syntax.
+
+use std::convert::TryFrom;
 
 use pretty::{DocAllocator, DocBuilder};
 
 use super::syntax::{LambdaForm, StgSyn};
+use super::tags::DataConstructor;
 use crate::common::prettify::ToPretty;
+use crate::eval::intrinsics;
+
+/// Format a data constructor tag as a readable name where possible.
+fn tag_name(tag: u8) -> String {
+    match DataConstructor::try_from(tag) {
+        Ok(DataConstructor::Unit) => "Unit".to_string(),
+        Ok(DataConstructor::BoolTrue) => "True".to_string(),
+        Ok(DataConstructor::BoolFalse) => "False".to_string(),
+        Ok(DataConstructor::BoxedNumber) => "Num".to_string(),
+        Ok(DataConstructor::BoxedSymbol) => "Sym".to_string(),
+        Ok(DataConstructor::BoxedString) => "Str".to_string(),
+        Ok(DataConstructor::ListNil) => "Nil".to_string(),
+        Ok(DataConstructor::ListCons) => "Cons".to_string(),
+        Ok(DataConstructor::Block) => "Block".to_string(),
+        Ok(DataConstructor::BlockPair) => "Pair".to_string(),
+        Ok(DataConstructor::BlockKvList) => "KvList".to_string(),
+        Ok(DataConstructor::BoxedZdt) => "Zdt".to_string(),
+        Err(()) => format!("#{tag}"),
+    }
+}
 
 impl ToPretty for LambdaForm {
     fn pretty<'b, D, A>(&'b self, allocator: &'b D) -> DocBuilder<'b, D, A>
@@ -14,11 +37,14 @@ impl ToPretty for LambdaForm {
     {
         match self {
             LambdaForm::Lambda { bound, body, .. } => allocator
-                .text(format!("λ{{{bound}}}"))
-                .append(body.pretty(allocator).parens()),
-            LambdaForm::Thunk { body } => {
-                allocator.text("Th").append(body.pretty(allocator).parens())
-            }
+                .text(format!("\u{03bb}{{{bound}}}"))
+                .append(allocator.space())
+                .append(body.pretty(allocator))
+                .group(),
+            LambdaForm::Thunk { body } => allocator
+                .text("thunk ")
+                .append(body.pretty(allocator))
+                .group(),
             LambdaForm::Value { body } => body.pretty(allocator),
         }
     }
@@ -39,25 +65,47 @@ impl ToPretty for StgSyn {
                 fallback,
             } => {
                 let scrutinee_doc = allocator
-                    .text("CASE")
-                    .append(scrutinee.pretty(allocator).parens())
-                    .append(allocator.line());
+                    .text("case ")
+                    .append(scrutinee.pretty(allocator))
+                    .append(allocator.text(" of"));
+
                 let mut branch_docs: Vec<_> = branches
                     .iter()
-                    .map(|(t, c)| allocator.text(format!("{t}: ")).append(c.pretty(allocator)))
+                    .map(|(t, c)| {
+                        allocator
+                            .text(tag_name(*t))
+                            .append(allocator.text(" \u{2192} "))
+                            .append(c.pretty(allocator))
+                            .group()
+                    })
                     .collect();
                 if let Some(fb) = fallback {
-                    branch_docs.push(allocator.text("…: ").append(fb.pretty(allocator)));
+                    branch_docs.push(
+                        allocator
+                            .text("_ \u{2192} ")
+                            .append(fb.pretty(allocator))
+                            .group(),
+                    );
                 }
 
-                let branch_doc = allocator.intersperse(branch_docs, allocator.line()).align();
-                scrutinee_doc.append(branch_doc).hang(2)
+                scrutinee_doc
+                    .append(
+                        allocator
+                            .line()
+                            .append(allocator.intersperse(branch_docs, allocator.line()).align())
+                            .nest(2),
+                    )
+                    .group()
             }
             StgSyn::Cons { tag, args } => {
+                let name = tag_name(*tag);
+                if args.is_empty() {
+                    return allocator.text(name);
+                }
                 let args_docs = args.iter().map(|r| allocator.text(format!("{r}")));
-                allocator.text(format!("DATA[{tag}]")).append(
+                allocator.text(name).append(
                     allocator
-                        .intersperse(args_docs, allocator.text(" "))
+                        .intersperse(args_docs, allocator.text(", "))
                         .parens(),
                 )
             }
@@ -65,82 +113,93 @@ impl ToPretty for StgSyn {
                 let args_docs = args.iter().map(|r| allocator.text(format!("{r}")));
                 allocator.text(format!("{callable}")).append(
                     allocator
-                        .intersperse(args_docs, allocator.text(" "))
+                        .intersperse(args_docs, allocator.text(", "))
                         .parens(),
                 )
             }
             StgSyn::Bif { intrinsic, args } => {
+                let name = intrinsics::intrinsic(*intrinsic as usize).name();
                 let args_docs = args.iter().map(|r| allocator.text(format!("{r}")));
-                allocator.text(format!("BIF[{intrinsic}]")).append(
+                allocator.text(name).append(
                     allocator
-                        .intersperse(args_docs, allocator.text(" "))
+                        .intersperse(args_docs, allocator.text(", "))
                         .parens(),
                 )
             }
             StgSyn::Let { bindings, body } => {
-                let binding_docs = bindings.iter().map(|d| d.pretty(allocator));
-                let body_doc = body.pretty(allocator);
+                let binding_docs = bindings.iter().enumerate().map(|(i, d)| {
+                    allocator
+                        .text(format!("[{i}] "))
+                        .append(d.pretty(allocator))
+                        .group()
+                });
                 allocator
-                    .text("LET")
-                    .append(allocator.space())
+                    .text("let ")
                     .append(
                         allocator
-                            .intersperse(binding_docs, allocator.line())
+                            .intersperse(binding_docs, allocator.text(";").append(allocator.line()))
                             .align(),
                     )
                     .append(allocator.line())
-                    .append(body_doc.parens().indent(2))
+                    .append(allocator.text("in "))
+                    .append(body.pretty(allocator))
+                    .group()
             }
             StgSyn::LetRec { bindings, body } => {
-                let binding_docs = bindings.iter().map(|d| d.pretty(allocator));
-                let body_doc = body.pretty(allocator);
-
+                let binding_docs = bindings.iter().enumerate().map(|(i, d)| {
+                    allocator
+                        .text(format!("[{i}] "))
+                        .append(d.pretty(allocator))
+                        .group()
+                });
                 allocator
-                    .text("LETREC")
-                    .append(allocator.line())
+                    .text("letrec ")
                     .append(
                         allocator
-                            .intersperse(binding_docs, allocator.line())
+                            .intersperse(binding_docs, allocator.text(";").append(allocator.line()))
                             .align(),
                     )
-                    .hang(2)
                     .append(allocator.line())
-                    .append(body_doc)
-                    .hang(2)
+                    .append(allocator.text("in "))
+                    .append(body.pretty(allocator))
+                    .group()
             }
             StgSyn::Ann { smid, body } => allocator
-                .text(format!("♩{smid}:"))
+                .text(format!("@{smid} "))
                 .append(body.pretty(allocator)),
             StgSyn::Meta { meta, body } => allocator
                 .text("`")
                 .append(allocator.text(format!("{meta}")))
+                .append(allocator.text(" "))
                 .append(allocator.text(format!("{body}"))),
             StgSyn::DeMeta {
                 scrutinee,
                 handler,
                 or_else,
             } => {
-                let scrutinee_body = scrutinee.pretty(allocator);
-                let handler_case = allocator
-                    .text("`:")
+                let scrutinee_doc = scrutinee.pretty(allocator);
+                let handler_doc = allocator
+                    .text("meta \u{2192} ")
                     .append(handler.pretty(allocator))
                     .group();
-                let else_case = allocator
-                    .text("•:")
+                let else_doc = allocator
+                    .text("_ \u{2192} ")
                     .append(or_else.pretty(allocator))
                     .group();
 
-                let branch_doc = (handler_case
-                    .append(",")
-                    .append(allocator.line())
-                    .append(else_case))
-                .angles();
-
                 allocator
-                    .text("ƒ")
-                    .append(scrutinee_body.parens())
-                    .append("⑂")
-                    .append(branch_doc)
+                    .text("demeta ")
+                    .append(scrutinee_doc)
+                    .append(allocator.text(" of"))
+                    .append(
+                        allocator
+                            .line()
+                            .append(handler_doc)
+                            .append(allocator.line())
+                            .append(else_doc)
+                            .nest(2),
+                    )
+                    .group()
             }
             StgSyn::BlackHole => allocator.text("HOLE"),
         }


### PR DESCRIPTION
## Summary

- Show intrinsic names (e.g. `LOOKUP`, `RENDER`) instead of raw `u8` indices in `Bif` nodes
- Show data constructor names (e.g. `Cons`, `Nil`, `Block`) instead of raw tag numbers
- Use arrow notation for case branches: `Tag → body`
- Use lowercase keywords: `case`/`of`, `let`/`in`, `letrec`/`in`, `thunk`, `demeta`
- Number let bindings with indices for reference clarity
- Compact lambda and thunk notation without wrapping parens
- Use comma-separated args for consistency

## Test plan

- [x] All 106 harness tests pass (dump format is output-only)
- [x] No clippy warnings
- [x] cargo fmt clean
- [x] Unit tests pass

Generated with [Claude Code](https://claude.com/claude-code)