### PR TITLE
feat(eu-fti1): Phase 1 error message improvements

### DIFF
--- a/harness/test/errors/006_div_by_zero.eu
+++ b/harness/test/errors/006_div_by_zero.eu
@@ -1,5 +1,2 @@
-#!/usr/bin/env eu
-
-(l/r):__DIV(l,r)
-
-bomb: 1.0 / 0.0
+# Division by zero
+bomb: 1 / 0

--- a/harness/test/errors/006_div_by_zero.eu.expect
+++ b/harness/test/errors/006_div_by_zero.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "division by zero"

--- a/harness/test/errors/012_bad_value.eu.expect
+++ b/harness/test/errors/012_bad_value.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "EmptyExpression"
+stderr: "empty expression where a value was expected"

--- a/harness/test/errors/013_bad_nested_value.eu.expect
+++ b/harness/test/errors/013_bad_nested_value.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "EmptyExpression"
+stderr: "empty expression where a value was expected"

--- a/harness/test/errors/014_unterm_strlit.eu.expect
+++ b/harness/test/errors/014_unterm_strlit.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "UnclosedDoubleQuote"
+stderr: "unterminated string literal"

--- a/harness/test/errors/015_missing_argtuple_close.eu.expect
+++ b/harness/test/errors/015_missing_argtuple_close.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "InvalidParenExpr"
+stderr: "invalid parenthesised expression"

--- a/harness/test/errors/016_empty_brackets.eu.expect
+++ b/harness/test/errors/016_empty_brackets.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "EmptyExpression"
+stderr: "empty expression where a value was expected"

--- a/harness/test/errors/017_too_many_args.eu.expect
+++ b/harness/test/errors/017_too_many_args.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "call of not callable"
+stderr: "tried to call a value that is not a function"

--- a/harness/test/errors/019_no_such_key.eu.expect
+++ b/harness/test/errors/019_no_such_key.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "infinite loop detected"

--- a/harness/test/errors/023_arg_types.eu.expect
+++ b/harness/test/errors/023_arg_types.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "no branch for data tag"
+stderr: "type mismatch: unexpected number"

--- a/harness/test/errors/024_invalid_zdt_literal.eu.expect
+++ b/harness/test/errors/024_invalid_zdt_literal.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "InvalidZdtLiteral"

--- a/harness/test/errors/024_invalid_zdt_literal.eu.expect
+++ b/harness/test/errors/024_invalid_zdt_literal.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "InvalidZdtLiteral"
+stderr: "invalid date/time literal"

--- a/harness/test/errors/025_malformed_zdt_literal.eu.expect
+++ b/harness/test/errors/025_malformed_zdt_literal.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "InvalidZdtLiteral"

--- a/harness/test/errors/025_malformed_zdt_literal.eu.expect
+++ b/harness/test/errors/025_malformed_zdt_literal.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "InvalidZdtLiteral"
+stderr: "invalid date/time literal"

--- a/harness/test/errors/026_empty_zdt_literal.eu.expect
+++ b/harness/test/errors/026_empty_zdt_literal.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "InvalidZdtLiteral"

--- a/harness/test/errors/026_empty_zdt_literal.eu.expect
+++ b/harness/test/errors/026_empty_zdt_literal.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "InvalidZdtLiteral"
+stderr: "invalid date/time literal"

--- a/harness/test/errors/029_type_mismatch_num.eu
+++ b/harness/test/errors/029_type_mismatch_num.eu
@@ -1,0 +1,2 @@
+# Type mismatch: pass number where string expected
+x: str.letters(42)

--- a/harness/test/errors/029_type_mismatch_num.eu.expect
+++ b/harness/test/errors/029_type_mismatch_num.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "no branch for data tag"

--- a/harness/test/errors/029_type_mismatch_num.eu.expect
+++ b/harness/test/errors/029_type_mismatch_num.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "no branch for data tag"
+stderr: "type mismatch: unexpected number"

--- a/harness/test/errors/030_type_mismatch_str.eu
+++ b/harness/test/errors/030_type_mismatch_str.eu
@@ -1,0 +1,2 @@
+# Type mismatch: pass string where number expected
+x: 1 + "hello"

--- a/harness/test/errors/030_type_mismatch_str.eu.expect
+++ b/harness/test/errors/030_type_mismatch_str.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "no branch for data tag"
+stderr: "type mismatch: unexpected string"

--- a/harness/test/errors/030_type_mismatch_str.eu.expect
+++ b/harness/test/errors/030_type_mismatch_str.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "no branch for data tag"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -1,12 +1,22 @@
 //! Execution errors
 use crate::common::sourcemap::{HasSmid, Smid, SourceMap};
+use crate::eval::stg::tags::DataConstructor;
 use crate::eval::types::IntrinsicType;
 use codespan_reporting::diagnostic::Diagnostic;
 use serde_json::Number;
+use std::convert::TryFrom;
 use std::io;
 use thiserror::Error;
 
 use super::{memory::bump, stg::compiler::CompileError};
+
+/// Convert a data tag number to a human-readable type name for error messages
+fn display_data_tag(tag: u8) -> String {
+    match DataConstructor::try_from(tag) {
+        Ok(dc) => dc.to_string(),
+        Err(()) => format!("unknown type (tag {tag})"),
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum ExecutionError {
@@ -77,7 +87,7 @@ pub enum ExecutionError {
     DivisionByZero,
     #[error("expected branch continuation")]
     ExpectedBranchContinuation,
-    #[error("no branch for data tag {0}")]
+    #[error("type mismatch: unexpected {}", display_data_tag(*.0))]
     NoBranchForDataTag(u8),
     #[error("no branch for native")]
     NoBranchForNative,

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -37,7 +37,7 @@ pub enum ExecutionError {
     TypeMismatch(Smid, IntrinsicType, IntrinsicType),
     #[error("unknown intrinsic {1}")]
     UnknownIntrinsic(Smid, String),
-    #[error("call of not callable")]
+    #[error("tried to call a value that is not a function")]
     NotCallable(Smid),
     #[error("intrinsic {1} expected value in strict position")]
     NotValue(Smid, String),

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -73,6 +73,8 @@ pub enum ExecutionError {
     NumericDomainError(Number, Number),
     #[error("out of range error operating on numbers ({0}, {1})")]
     NumericRangeError(Number, Number),
+    #[error("division by zero")]
+    DivisionByZero,
     #[error("expected branch continuation")]
     ExpectedBranchContinuation,
     #[error("no branch for data tag {0}")]

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -48,6 +48,9 @@ pub trait IntrinsicMachine {
 
     /// Mutable access to the symbol pool for interning new symbols
     fn symbol_pool_mut(&mut self) -> &mut SymbolPool;
+
+    /// Current source annotation for error reporting
+    fn annotation(&self) -> Smid;
 }
 
 /// All intrinsics have an STG syntax wrapper

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -671,6 +671,11 @@ impl IntrinsicMachine for MachineState {
     fn symbol_pool_mut(&mut self) -> &mut SymbolPool {
         &mut self.symbol_pool
     }
+
+    /// Current source annotation for error reporting
+    fn annotation(&self) -> Smid {
+        self.annotation
+    }
 }
 
 /// MachineState contains all the garbage collection roots

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -26,6 +26,11 @@ use super::{
     tags::DataConstructor,
 };
 
+/// Check if a number is zero
+fn is_zero(n: &Number) -> bool {
+    n.as_i64() == Some(0) || n.as_u64() == Some(0) || n.as_f64() == Some(0.0)
+}
+
 /// ADD(l, r) - add l to r
 pub struct Add;
 
@@ -170,6 +175,10 @@ impl StgIntrinsic for Div {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
 
+        if is_zero(&y) {
+            return Err(ExecutionError::DivisionByZero);
+        }
+
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
             let result = l
                 .checked_div(r)
@@ -211,6 +220,10 @@ impl StgIntrinsic for Mod {
     ) -> Result<(), crate::eval::error::ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
+
+        if is_zero(&y) {
+            return Err(ExecutionError::DivisionByZero);
+        }
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
             let product = l

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -746,9 +746,10 @@ impl ProtoSyntax for ProtoLambda {
             body = dsl::ann(self.annotation, body);
         }
 
-        Ok(dsl::lambda(
+        Ok(dsl::annotated_lambda(
             args.try_into().or(Err(CompileError::MaxLambdaArgs))?,
             body,
+            self.annotation,
         ))
     }
 }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -30,7 +30,7 @@ pub fn num_arg(
     if let Native::Num(n) = native {
         Ok(n)
     } else {
-        Err(ExecutionError::NotEvaluatedNumber(Smid::default()))
+        Err(ExecutionError::NotEvaluatedNumber(machine.annotation()))
     }
 }
 
@@ -44,7 +44,7 @@ pub fn str_arg(
     if let Native::Str(s) = native {
         Ok((*view.scoped(s)).as_str().to_string())
     } else {
-        Err(ExecutionError::NotEvaluatedString(Smid::default()))
+        Err(ExecutionError::NotEvaluatedString(machine.annotation()))
     }
 }
 
@@ -58,7 +58,7 @@ pub fn sym_arg(
     if let Native::Sym(id) = native {
         Ok(machine.symbol_pool().resolve(id).to_string())
     } else {
-        Err(ExecutionError::NotEvaluatedString(Smid::default()))
+        Err(ExecutionError::NotEvaluatedString(machine.annotation()))
     }
 }
 
@@ -72,7 +72,7 @@ pub fn zdt_arg(
     if let Native::Zdt(dt) = native {
         Ok(dt)
     } else {
-        Err(ExecutionError::NotEvaluatedZdt(Smid::default()))
+        Err(ExecutionError::NotEvaluatedZdt(machine.annotation()))
     }
 }
 
@@ -277,13 +277,13 @@ pub fn resolve_native_unboxing(
                     Ok(native)
                 }
                 _ => Err(ExecutionError::NotValue(
-                    Smid::default(),
+                    machine.annotation(),
                     "non-boxed constructor".to_string(),
                 )),
             }
         }
         _ => Err(ExecutionError::NotValue(
-            Smid::default(),
+            machine.annotation(),
             "expected native value".to_string(),
         )),
     }

--- a/src/eval/stg/tags.rs
+++ b/src/eval/stg/tags.rs
@@ -1,6 +1,7 @@
 //! Predefined data tags and arities
 
 use std::convert::TryFrom;
+use std::fmt;
 
 /// Datatype tag
 pub type Tag = u8;
@@ -30,6 +31,25 @@ pub enum DataConstructor {
     BlockKvList = 10,
     /// Boxed zoned datetime
     BoxedZdt = 11,
+}
+
+impl fmt::Display for DataConstructor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DataConstructor::Unit => write!(f, "null"),
+            DataConstructor::BoolTrue => write!(f, "true"),
+            DataConstructor::BoolFalse => write!(f, "false"),
+            DataConstructor::BoxedNumber => write!(f, "number"),
+            DataConstructor::BoxedSymbol => write!(f, "symbol"),
+            DataConstructor::BoxedString => write!(f, "string"),
+            DataConstructor::ListNil => write!(f, "empty list"),
+            DataConstructor::ListCons => write!(f, "list"),
+            DataConstructor::Block => write!(f, "block"),
+            DataConstructor::BlockPair => write!(f, "key-value pair"),
+            DataConstructor::BlockKvList => write!(f, "key-value list"),
+            DataConstructor::BoxedZdt => write!(f, "datetime"),
+        }
+    }
 }
 
 impl DataConstructor {

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -23,7 +23,7 @@ where
         let errors: Vec<String> = parse_result
             .errors()
             .iter()
-            .map(|e| format!("{e:?}"))
+            .map(|e| format!("{e}"))
             .collect();
         return Err(ParserError::Syntax(
             crate::syntax::error::SyntaxError::InvalidInputFormat(
@@ -52,7 +52,7 @@ where
         let errors: Vec<String> = parse_result
             .errors()
             .iter()
-            .map(|e| format!("{e:?}"))
+            .map(|e| format!("{e}"))
             .collect();
         return Err(ParserError::Syntax(
             crate::syntax::error::SyntaxError::InvalidInputFormat(

--- a/src/syntax/rowan/error.rs
+++ b/src/syntax/rowan/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use rowan::TextRange;
 
 use super::kind::SyntaxKind;
@@ -60,4 +62,45 @@ pub enum ParseError {
     InvalidZdtLiteral {
         range: TextRange,
     },
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::UnexpectedToken {
+                expected, actual, ..
+            } => write!(f, "expected {expected:?}, found {actual:?}"),
+            ParseError::UnclosedSingleQuote { .. } => {
+                write!(f, "unterminated single-quoted string")
+            }
+            ParseError::UnclosedDoubleQuote { .. } => write!(f, "unterminated string literal"),
+            ParseError::InvalidParenExpr { .. } => {
+                write!(f, "invalid parenthesised expression")
+            }
+            ParseError::UnterminatedBlock { .. } => write!(f, "unterminated block (missing '}}')"),
+            ParseError::EmptyDeclarationBody { .. } => {
+                write!(f, "empty declaration body where a value was expected")
+            }
+            ParseError::MissingDeclarationColon { .. } => {
+                write!(f, "missing ':' after declaration head")
+            }
+            ParseError::MalformedDeclarationHead { .. } => {
+                write!(f, "malformed declaration head")
+            }
+            ParseError::InvalidFormalParameter { .. } => {
+                write!(f, "invalid formal parameter in function definition")
+            }
+            ParseError::InvalidOperatorName { .. } => write!(f, "invalid operator name"),
+            ParseError::InvalidPropertyName { .. } => write!(f, "invalid property name"),
+            ParseError::SurplusContent { .. } => write!(f, "unexpected content after expression"),
+            ParseError::ReservedCharacter { .. } => write!(f, "reserved character"),
+            ParseError::EmptyExpression { .. } => {
+                write!(f, "empty expression where a value was expected")
+            }
+            ParseError::UnclosedStringInterpolation { .. } => {
+                write!(f, "unterminated string interpolation (missing '}}')")
+            }
+            ParseError::InvalidZdtLiteral { .. } => write!(f, "invalid date/time literal"),
+        }
+    }
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -570,3 +570,13 @@ pub fn test_error_027() {
 pub fn test_error_028() {
     run_error_test(&error_opts("028_mutual_cycle.eu"));
 }
+
+#[test]
+pub fn test_error_029() {
+    run_error_test(&error_opts("029_type_mismatch_num.eu"));
+}
+
+#[test]
+pub fn test_error_030() {
+    run_error_test(&error_opts("030_type_mismatch_str.eu"));
+}


### PR DESCRIPTION
## Summary

- **Phase 0 (eu-dohu)**: Expand error test coverage baseline -- fix 006_div_by_zero.eu broken syntax, add .expect sidecars for 5 tests, add 2 new type mismatch test cases
- **Phase 1A (eu-l7e1)**: Human-readable data tag names -- "no branch for data tag 5" becomes "type mismatch: unexpected string"
- **Phase 1B (eu-dcio)**: Recognise division by zero -- "out of range error operating on numbers" becomes "division by zero"
- **Phase 1C (eu-bdnd)**: Clean up parse error formatting -- raw Rust Debug format replaced with human-readable messages
- **Phase 1D (eu-cb4b)**: Remove Smid values from messages -- strip `[3700]`-style references
- **Phase 1E (eu-h1kp)**: Improve "not callable" message -- "call of not callable" becomes "tried to call a value that is not a function"
- **Phase 1F (eu-wkpj)**: Drop environment trace from output -- remove unhelpful "environment trace:" note

## Test plan

- [x] All 27 error tests pass with updated .expect files
- [x] Full test suite (108 tests) passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)