### PR TITLE
feat(eu-fti1): Phase 2 trace machinery improvements

### DIFF
--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -48,6 +48,9 @@ pub trait IntrinsicMachine {
 
     /// Mutable access to the symbol pool for interning new symbols
     fn symbol_pool_mut(&mut self) -> &mut SymbolPool;
+
+    /// Current source annotation for error reporting
+    fn annotation(&self) -> Smid;
 }
 
 /// All intrinsics have an STG syntax wrapper

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -671,6 +671,11 @@ impl IntrinsicMachine for MachineState {
     fn symbol_pool_mut(&mut self) -> &mut SymbolPool {
         &mut self.symbol_pool
     }
+
+    /// Current source annotation for error reporting
+    fn annotation(&self) -> Smid {
+        self.annotation
+    }
 }
 
 /// MachineState contains all the garbage collection roots

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -746,9 +746,10 @@ impl ProtoSyntax for ProtoLambda {
             body = dsl::ann(self.annotation, body);
         }
 
-        Ok(dsl::lambda(
+        Ok(dsl::annotated_lambda(
             args.try_into().or(Err(CompileError::MaxLambdaArgs))?,
             body,
+            self.annotation,
         ))
     }
 }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -30,7 +30,7 @@ pub fn num_arg(
     if let Native::Num(n) = native {
         Ok(n)
     } else {
-        Err(ExecutionError::NotEvaluatedNumber(Smid::default()))
+        Err(ExecutionError::NotEvaluatedNumber(machine.annotation()))
     }
 }
 
@@ -44,7 +44,7 @@ pub fn str_arg(
     if let Native::Str(s) = native {
         Ok((*view.scoped(s)).as_str().to_string())
     } else {
-        Err(ExecutionError::NotEvaluatedString(Smid::default()))
+        Err(ExecutionError::NotEvaluatedString(machine.annotation()))
     }
 }
 
@@ -58,7 +58,7 @@ pub fn sym_arg(
     if let Native::Sym(id) = native {
         Ok(machine.symbol_pool().resolve(id).to_string())
     } else {
-        Err(ExecutionError::NotEvaluatedString(Smid::default()))
+        Err(ExecutionError::NotEvaluatedString(machine.annotation()))
     }
 }
 
@@ -72,7 +72,7 @@ pub fn zdt_arg(
     if let Native::Zdt(dt) = native {
         Ok(dt)
     } else {
-        Err(ExecutionError::NotEvaluatedZdt(Smid::default()))
+        Err(ExecutionError::NotEvaluatedZdt(machine.annotation()))
     }
 }
 
@@ -277,13 +277,13 @@ pub fn resolve_native_unboxing(
                     Ok(native)
                 }
                 _ => Err(ExecutionError::NotValue(
-                    Smid::default(),
+                    machine.annotation(),
                     "non-boxed constructor".to_string(),
                 )),
             }
         }
         _ => Err(ExecutionError::NotValue(
-            Smid::default(),
+            machine.annotation(),
             "expected native value".to_string(),
         )),
     }


### PR DESCRIPTION
## Summary

Four commits implementing error message Phase 2 trace improvements:

- **Phase 2D (eu-cckb)**: Map intrinsic names to user-facing names in stack traces. Internal names like `ADD`, `LETTERS` become `+`, `str.letters`. Internal machinery (`SATURATED`, `AND`, `RENDER`, etc.) is filtered out.
- **Phase 2A**: Use `annotated_lambda` for user function lambda forms so user-defined functions appear in stack traces with their source locations.
- **Phase 2C (eu-5na7)**: Propagate source annotations to intrinsic errors. Adds `annotation()` method to `IntrinsicMachine` trait so `num_arg`, `str_arg`, `sym_arg`, `zdt_arg` report actual source locations instead of `Smid::default()`.
- **Phase 2B**: Add annotation to `ApplyTo` continuations. Function application sites now appear in stack traces, and `NotCallable` errors report the correct source location.

### Files changed

- `src/common/sourcemap.rs` — `intrinsic_display_name()` mapping function
- `src/eval/stg/compiler.rs` — `annotated_lambda` in `ProtoLambda`
- `src/eval/machine/intrinsic.rs` — `annotation()` trait method
- `src/eval/machine/vm.rs` — `annotation()` impl + ApplyTo annotation field
- `src/eval/machine/cont.rs` — `ApplyTo` annotation field
- `src/eval/stg/support.rs` — `machine.annotation()` in error constructors

## Test plan

- [x] All 108 harness tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] No regressions in existing error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)