### PR TITLE
feat(eu-vzv): add text pipeline benchmarks

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,6 +1,7 @@
 pub mod alloc;
 pub mod gc;
 pub mod parse;
+pub mod text;
 
 use criterion::{criterion_group, criterion_main};
 
@@ -8,6 +9,7 @@ criterion_group!(
     benches,
     alloc::criterion_benchmark,
     gc::criterion_benchmark,
-    parse::criterion_benchmark
+    parse::criterion_benchmark,
+    text::criterion_benchmark
 );
 criterion_main!(benches);

--- a/benches/text.rs
+++ b/benches/text.rs
@@ -1,0 +1,69 @@
+//! End-to-end text pipeline benchmarks
+//!
+//! Benchmarks that exercise the full evaluation pipeline (parse, desugar,
+//! cook, inline, compile, execute) on text-heavy workloads. These measure
+//! realistic performance for string operations, regex matching, interpolation,
+//! and text transformation chains.
+
+use std::path::{Path, PathBuf};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use eucalypt::driver::{
+    eval, options::EucalyptOptions, prepare, source::SourceLoader, statistics::Timings,
+};
+use eucalypt::syntax::input::{Input, Locator};
+
+/// Run a benchmark .eu file through the full pipeline, capturing output.
+fn run_bench_file(path: &Path) {
+    let lib_path = vec![path.parent().unwrap().to_path_buf(), PathBuf::from("lib")];
+
+    let input = Input::from(Locator::Fs(path.to_path_buf()));
+    let opts = EucalyptOptions::default()
+        .with_explicit_inputs(vec![input])
+        .with_lib_path(lib_path)
+        .with_export_type("json".to_string())
+        .build();
+
+    let mut loader = SourceLoader::new(opts.lib_path().to_vec());
+    let mut timings = Timings::default();
+    prepare::prepare(&opts, &mut loader, &mut timings).expect("prepare failed");
+
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    let mut executor = eval::Executor::from(loader);
+    executor.capture_output(Box::new(&mut out), Box::new(&mut err));
+
+    let mut stats = eucalypt::driver::statistics::Statistics::default();
+    executor
+        .execute(&opts, &mut stats, "json".to_string())
+        .expect("execution failed");
+}
+
+fn bench_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("harness/test/bench")
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("text_pipelines");
+
+    let bench_files = [
+        ("string_split_join", "011_string_split_join.eu"),
+        ("regex_match", "012_regex_match.eu"),
+        ("interpolation", "013_interpolation.eu"),
+        ("text_transform", "014_text_transform.eu"),
+    ];
+
+    for (name, filename) in &bench_files {
+        let path = bench_dir().join(filename);
+        if path.exists() {
+            group.bench_function(*name, |b| {
+                b.iter(|| run_bench_file(&path));
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/harness/test/bench/011_string_split_join.eu
+++ b/harness/test/bench/011_string_split_join.eu
@@ -1,0 +1,28 @@
+# String split/join benchmark
+#
+# Exercises repeated split and join operations on strings,
+# measuring regex compilation, string allocation, and list processing.
+
+csv-line: "alice,bob,charlie,dave,eve,frank,grace,heidi,ivan,judy"
+
+split-rejoin(sep, line): line str.split-on(sep) str.join-on(sep)
+
+rt-1: split-rejoin(",", csv-line)
+rt-2: split-rejoin(",", rt-1)
+rt-3: split-rejoin(",", rt-2)
+rt-4: split-rejoin(",", rt-3)
+rt-5: split-rejoin(",", rt-4)
+
+words: "the quick brown fox jumps over the lazy dog near the old mill stream"
+word-list: words str.split-on("\s+")
+word-count: word-list count
+
+reassembled: word-list str.join-on("-")
+
+` { target: :bench-string-split-join }
+bench-string-split-join: {
+  preserved: rt-5
+  words: word-count
+  rejoined: reassembled
+  RESULT: if(word-count = 14, :PASS, :FAIL)
+}

--- a/harness/test/bench/012_regex_match.eu
+++ b/harness/test/bench/012_regex_match.eu
@@ -1,0 +1,49 @@
+# Regex match benchmark
+#
+# Exercises regex matching, capture groups, and repeated pattern
+# application across multiple strings. Measures regex cache
+# effectiveness and string processing throughput.
+
+log-lines: [
+  "2024-01-15 10:30:45 INFO  [main] Starting application v2.1.0",
+  "2024-01-15 10:30:46 WARN  [pool-1] Connection timeout after 5000ms",
+  "2024-01-15 10:30:47 ERROR [pool-2] Failed to connect: ECONNREFUSED",
+  "2024-01-15 10:30:48 INFO  [main] Retrying connection attempt 1/3",
+  "2024-01-15 10:30:49 DEBUG [pool-1] Socket opened on port 8080",
+  "2024-01-15 10:30:50 INFO  [main] Connection established successfully",
+  "2024-01-15 10:30:51 WARN  [pool-3] Slow query detected: 2500ms",
+  "2024-01-15 10:30:52 ERROR [pool-2] Query timeout exceeded",
+  "2024-01-15 10:30:53 INFO  [main] Failover to secondary database",
+  "2024-01-15 10:30:54 DEBUG [pool-1] Health check passed",
+  "2024-01-15 10:30:55 INFO  [main] All services healthy",
+  "2024-01-15 10:30:56 WARN  [pool-4] Memory usage above 80%"
+]
+
+# Extract timestamps using match
+extract-ts(line): line str.match-with("^(\d{{4}}-\d{{2}}-\d{{2}} \d{{2}}:\d{{2}}:\d{{2}})") head
+
+# Extract log levels
+extract-level(line): line str.match-with("(INFO|WARN|ERROR|DEBUG)") head
+
+# Extract thread names
+extract-thread(line): line str.match-with("\[([^\]]+)\]") tail head
+
+# Process all lines
+timestamps: log-lines map(extract-ts)
+levels: log-lines map(extract-level)
+threads: log-lines map(extract-thread)
+
+n-timestamps: timestamps count
+n-levels: levels count
+n-threads: threads count
+
+` { target: :bench-regex-match }
+bench-regex-match: {
+  timestamp-count: n-timestamps
+  level-count: n-levels
+  thread-count: n-threads
+  first-ts: timestamps head
+  first-level: levels head
+  first-thread: threads head
+  RESULT: if(n-timestamps = 12, :PASS, :FAIL)
+}

--- a/harness/test/bench/013_interpolation.eu
+++ b/harness/test/bench/013_interpolation.eu
@@ -1,0 +1,61 @@
+# String interpolation benchmark
+#
+# Exercises string interpolation with format specifiers,
+# nested lookups, and template-style string building.
+# Measures the overhead of the interpolation desugaring
+# and runtime string concatenation.
+
+data: {
+  name: "eucalypt"
+  version: "0.4.0"
+  port: 8080
+  host: "localhost"
+  workers: 4
+  timeout: 30
+  retries: 3
+  log-level: "info"
+}
+
+# Simple interpolation
+base-url: "http://{data.host}:{data.port}"
+
+# Multi-field interpolation
+banner-text: "{data.name} v{data.version} on {data.host}:{data.port}"
+
+# Template-style config generation
+mk-config(key, val): "{key} = {val}"
+
+cfg-lines: [
+  mk-config("name", data.name),
+  mk-config("version", data.version),
+  mk-config("host", data.host),
+  mk-config("port", data.port),
+  mk-config("workers", data.workers),
+  mk-config("timeout", data.timeout),
+  mk-config("retries", data.retries),
+  mk-config("log-level", data.log-level)
+]
+
+cfg-text: cfg-lines str.join-on("\n")
+
+# Repeated interpolation in a map
+ids: ["alpha", "beta", "gamma", "delta", "epsilon",
+      "zeta", "eta", "theta", "iota", "kappa"]
+
+prefixed: ids map("svc-{}")
+labeled: ids map("{}: active")
+
+n-cfg: cfg-lines count
+n-prefix: prefixed count
+n-label: labeled count
+
+` { target: :bench-interpolation }
+bench-interpolation: {
+  result-url: base-url
+  result-banner: banner-text
+  result-cfg-count: n-cfg
+  result-prefix-count: n-prefix
+  result-label-count: n-label
+  result-first-prefixed: prefixed head
+  RESULT: if(base-url = "http://localhost:8080", :PASS, :FAIL)
+}

--- a/harness/test/bench/014_text_transform.eu
+++ b/harness/test/bench/014_text_transform.eu
@@ -1,0 +1,31 @@
+# Text transformation pipeline benchmark
+#
+# Exercises case conversion, character-level processing,
+# and chained string transformations. Measures the overhead
+# of multiple string intrinsic calls in sequence.
+
+words: ["hello", "world", "eucalypt", "benchmark", "performance",
+        "string", "processing", "pipeline", "testing", "framework",
+        "alpha", "bravo", "charlie", "delta", "echo",
+        "foxtrot", "golf", "hotel", "india", "juliet"]
+
+# Case conversion pipeline
+upper-words: words map(str.to-upper)
+lower-back: upper-words map(str.to-lower)
+
+# Character processing - count letters per word
+letter-counts: words map(str.letters) map(count)
+
+n-letters: letter-counts foldl({n: • m: •}.(n + m), 0)
+
+# String concatenation
+shouted: words map(str.to-upper) str.join-on(" ")
+whispered: words map(str.to-lower) str.join-on(" ")
+
+` { target: :bench-text-transform }
+bench-text-transform: {
+  letters: n-letters
+  shouted-sample: shouted
+  whispered-sample: whispered
+  RESULT: if(n-letters > 100, :PASS, :FAIL)
+}


### PR DESCRIPTION
## Summary
- Add four end-to-end criterion benchmarks for text processing pipelines
- New `benches/text.rs` module exercises the full evaluation pipeline (parse -> desugar -> cook -> inline -> compile -> execute) on text-heavy workloads
- Benchmark workloads: string split/join (~31ms), regex matching (~31ms), string interpolation (~21ms), text transformation (~21ms)
- Registered in the existing criterion benchmark group alongside alloc, gc, and parse benchmarks

## Test plan
- [x] All four `.eu` benchmark files produce RESULT: PASS
- [x] `cargo bench --bench benches -- text_pipelines` runs successfully
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (527 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)