### PR TITLE
feat(eu-t99l): implement incremental LSP range formatting

### DIFF
--- a/src/driver/lsp/formatting.rs
+++ b/src/driver/lsp/formatting.rs
@@ -2,13 +2,19 @@
 //!
 //! Wires up the existing `eu fmt` formatter via the LSP
 //! `textDocument/formatting` and `textDocument/rangeFormatting`
-//! requests. The formatter operates on the full Rowan parse tree so
-//! both requests reformat the entire document, returning a single
-//! `TextEdit` replacing the full text.
+//! requests.
+//!
+//! Full-document formatting reformats the entire file, returning a
+//! single `TextEdit` replacing the full text.
+//!
+//! Range formatting identifies top-level declarations overlapping the
+//! requested range and reformats only those declarations, returning
+//! edits scoped to the affected ranges.
 
 use lsp_types::{Position, Range, TextEdit};
+use rowan::ast::AstNode;
 
-use crate::syntax::export::format::{format_source, FormatterConfig};
+use crate::syntax::export::format::{format_source, Formatter, FormatterConfig};
 
 /// Format an entire document, returning edits to replace the full text.
 ///
@@ -27,15 +33,114 @@ pub fn format_document(source: &str, options: &lsp_types::FormattingOptions) -> 
 
 /// Format a range within a document.
 ///
-/// The eucalypt formatter operates on the whole parse tree, so we
-/// reformat the entire document and return the result. The range
-/// parameter is accepted for protocol compliance but does not restrict
-/// the formatted output — this matches the behaviour of many language
-/// servers whose formatters lack incremental support.
-pub fn format_range(source: &str, options: &lsp_types::FormattingOptions) -> Vec<TextEdit> {
-    // Same as full-document formatting — the formatter is not
-    // incremental, so we format the whole file.
-    format_document(source, options)
+/// Identifies top-level declarations overlapping the given range and
+/// reformats each one individually. Declarations outside the range
+/// are left untouched.
+///
+/// If the source has parse errors, returns an empty edit list.
+pub fn format_range(
+    source: &str,
+    range: &Range,
+    options: &lsp_types::FormattingOptions,
+) -> Vec<TextEdit> {
+    let parse = crate::syntax::rowan::parse_unit(source);
+    if !parse.errors().is_empty() {
+        return vec![];
+    }
+
+    let unit = parse.tree();
+    let config = options_to_config(options);
+    let formatter = Formatter::new(config);
+
+    let request_start = lsp_position_to_offset(source, &range.start);
+    let request_end = lsp_position_to_offset(source, &range.end);
+
+    let mut edits = Vec::new();
+
+    for decl in unit.declarations() {
+        let node_range = decl.syntax().text_range();
+        let node_start = u32::from(node_range.start()) as usize;
+        let node_end = u32::from(node_range.end()) as usize;
+
+        // For overlap checking, extend to include trailing newline
+        let check_end = if node_end < source.len() && source.as_bytes()[node_end] == b'\n' {
+            node_end + 1
+        } else {
+            node_end
+        };
+
+        // Check overlap: declaration range intersects requested range
+        if node_start >= request_end || check_end <= request_start {
+            continue;
+        }
+
+        let original = &source[node_start..node_end];
+        if let Ok(formatted) = formatter.format_declaration(&decl) {
+            if formatted != original {
+                let start_pos = offset_to_lsp_position(source, node_start);
+                let end_pos = offset_to_lsp_position(source, node_end);
+                edits.push(TextEdit {
+                    range: Range {
+                        start: start_pos,
+                        end: end_pos,
+                    },
+                    new_text: formatted,
+                });
+            }
+        }
+    }
+
+    edits
+}
+
+/// Convert an LSP `Position` (line, character in UTF-16 code units)
+/// to a byte offset in the source string.
+fn lsp_position_to_offset(source: &str, position: &Position) -> usize {
+    let mut current_line = 0u32;
+    let mut current_char = 0u32;
+    let mut byte_offset = 0;
+
+    for ch in source.chars() {
+        if current_line == position.line && current_char == position.character {
+            return byte_offset;
+        }
+        if ch == '\n' {
+            if current_line == position.line {
+                // Position is beyond the end of this line; clamp to newline
+                return byte_offset;
+            }
+            current_line += 1;
+            current_char = 0;
+        } else {
+            current_char += ch.len_utf16() as u32;
+        }
+        byte_offset += ch.len_utf8();
+    }
+
+    byte_offset
+}
+
+/// Convert a byte offset to an LSP `Position` (line, character in
+/// UTF-16 code units).
+fn offset_to_lsp_position(source: &str, offset: usize) -> Position {
+    let mut line = 0u32;
+    let mut character = 0u32;
+    let mut byte_offset = 0;
+
+    for ch in source.chars() {
+        if byte_offset >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            character = 0;
+        } else {
+            character += ch.len_utf16() as u32;
+        }
+        byte_offset += ch.len_utf8();
+    }
+
+    Position { line, character }
 }
 
 /// Build a `FormatterConfig` from LSP `FormattingOptions`.
@@ -122,17 +227,6 @@ mod tests {
     }
 
     #[test]
-    fn range_format_delegates_to_full() {
-        let source = "x: 1\ny:   2\n";
-        let full = format_document(source, &default_options());
-        let range = format_range(source, &default_options());
-        assert_eq!(full.len(), range.len());
-        if !full.is_empty() {
-            assert_eq!(full[0].new_text, range[0].new_text);
-        }
-    }
-
-    #[test]
     fn end_of_document_empty() {
         let pos = end_of_document("");
         assert_eq!(pos.line, 0);
@@ -177,5 +271,198 @@ mod tests {
         let pos = end_of_document("😀x");
         assert_eq!(pos.line, 0);
         assert_eq!(pos.character, 3, "emoji (2 UTF-16 units) + x (1) = 3");
+    }
+
+    // ========================================================================
+    // Range formatting tests
+    // ========================================================================
+
+    #[test]
+    fn range_format_single_declaration() {
+        // Second declaration has extra spaces; format range covering only it
+        let source = "x: 1\ny:   2\n";
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 6,
+            },
+        };
+        let edits = format_range(source, &range, &default_options());
+        // Should produce an edit for the second declaration only
+        if !edits.is_empty() {
+            assert_eq!(edits.len(), 1, "should edit only one declaration");
+            assert!(
+                edits[0].range.start.line >= 1,
+                "edit should start at or after line 1"
+            );
+            assert!(
+                edits[0].new_text.contains("y:"),
+                "edit should contain the y declaration"
+            );
+            assert!(
+                !edits[0].new_text.contains("x:"),
+                "edit should not contain the x declaration"
+            );
+        }
+    }
+
+    #[test]
+    fn range_format_leaves_other_declarations_untouched() {
+        let source = "x:   1\ny:   2\nz:   3\n";
+        // Range covers only line 1 (the y declaration)
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 6,
+            },
+        };
+        let edits = format_range(source, &range, &default_options());
+        // Edits should only touch the y declaration, not x or z
+        for edit in &edits {
+            assert!(
+                edit.range.start.line >= 1,
+                "no edit should touch line 0 (x declaration)"
+            );
+            assert!(
+                edit.range.end.line <= 2,
+                "no edit should extend past line 2"
+            );
+        }
+    }
+
+    #[test]
+    fn range_format_spanning_two_declarations() {
+        let source = "x:   1\ny:   2\nz: 3\n";
+        // Range spans lines 0-1 (x and y declarations)
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 6,
+            },
+        };
+        let edits = format_range(source, &range, &default_options());
+        // Should produce edits for both x and y (both have extra spaces)
+        assert!(
+            edits.len() >= 2,
+            "should edit at least two declarations, got {}",
+            edits.len()
+        );
+    }
+
+    #[test]
+    fn range_format_parse_error_returns_empty() {
+        let source = "x: { y: 1\n";
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 10,
+            },
+        };
+        let edits = format_range(source, &range, &default_options());
+        assert!(edits.is_empty(), "no edits when source has parse errors");
+    }
+
+    #[test]
+    fn range_format_already_formatted_returns_empty() {
+        let source = "x: 1\ny: 2\n";
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 4,
+            },
+        };
+        let edits = format_range(source, &range, &default_options());
+        assert!(edits.is_empty(), "no edits for already-formatted source");
+    }
+
+    #[test]
+    fn lsp_position_to_offset_basic() {
+        let source = "abc\ndef\n";
+        assert_eq!(
+            lsp_position_to_offset(
+                source,
+                &Position {
+                    line: 0,
+                    character: 0
+                }
+            ),
+            0
+        );
+        assert_eq!(
+            lsp_position_to_offset(
+                source,
+                &Position {
+                    line: 0,
+                    character: 3
+                }
+            ),
+            3
+        );
+        assert_eq!(
+            lsp_position_to_offset(
+                source,
+                &Position {
+                    line: 1,
+                    character: 0
+                }
+            ),
+            4
+        );
+        assert_eq!(
+            lsp_position_to_offset(
+                source,
+                &Position {
+                    line: 1,
+                    character: 3
+                }
+            ),
+            7
+        );
+    }
+
+    #[test]
+    fn offset_to_lsp_position_basic() {
+        let source = "abc\ndef\n";
+        assert_eq!(
+            offset_to_lsp_position(source, 0),
+            Position {
+                line: 0,
+                character: 0
+            }
+        );
+        assert_eq!(
+            offset_to_lsp_position(source, 4),
+            Position {
+                line: 1,
+                character: 0
+            }
+        );
+        assert_eq!(
+            offset_to_lsp_position(source, 7),
+            Position {
+                line: 1,
+                character: 3
+            }
+        );
     }
 }

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -89,7 +89,7 @@ fn server_capabilities() -> ServerCapabilities {
             },
         )),
         document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
-        document_range_formatting_provider: None,
+        document_range_formatting_provider: Some(lsp_types::OneOf::Left(true)),
         references_provider: Some(lsp_types::OneOf::Left(true)),
         code_action_provider: None,
         inlay_hint_provider: Some(lsp_types::OneOf::Left(true)),
@@ -526,7 +526,7 @@ fn on_range_formatting(
 ) -> Option<Vec<lsp_types::TextEdit>> {
     let uri = &params.text_document.uri;
     let text = store.get(uri)?;
-    let edits = formatting::format_range(text, &params.options);
+    let edits = formatting::format_range(text, &params.range, &params.options);
     Some(edits)
 }
 
@@ -653,9 +653,9 @@ mod tests {
     }
 
     #[test]
-    fn server_capabilities_has_no_range_formatting() {
+    fn server_capabilities_has_range_formatting() {
         let caps = server_capabilities();
-        assert!(caps.document_range_formatting_provider.is_none());
+        assert!(caps.document_range_formatting_provider.is_some());
     }
 
     #[test]

--- a/src/syntax/export/format.rs
+++ b/src/syntax/export/format.rs
@@ -77,6 +77,20 @@ impl Formatter {
         Ok(result)
     }
 
+    /// Format a single top-level declaration.
+    ///
+    /// Returns the formatted text for the declaration (without trailing
+    /// newline). Used by range formatting to reformat individual
+    /// declarations rather than the entire file.
+    pub fn format_declaration(&self, decl: &rowan_ast::Declaration) -> Result<String, String> {
+        let doc = if self.config.reformat {
+            self.reformat_declaration(decl)
+        } else {
+            self.fix_whitespace_violations(decl.syntax())
+        };
+        self.render_doc(doc)
+    }
+
     /// Format a Soup (expression)
     pub fn format_soup(&self, soup: &rowan_ast::Soup) -> Result<String, String> {
         let doc = self.format_soup_doc(soup);


### PR DESCRIPTION
## Summary
- Replace the stub range formatting (which delegated to full-document formatting) with declaration-level incremental formatting
- The server now identifies top-level declarations overlapping the requested LSP range, reformats each individually, and returns scoped TextEdits
- Enable `document_range_formatting_provider` in server capabilities so editors can use format-selection

## Changes
- **`src/driver/lsp/formatting.rs`**: Rewrite `format_range()` to parse the document, find overlapping declarations, and return per-declaration edits. Add `lsp_position_to_offset()` and `offset_to_lsp_position()` utilities. Add 7 new tests.
- **`src/driver/lsp/mod.rs`**: Enable `document_range_formatting_provider`, pass range to `format_range()`, update capability test.
- **`src/syntax/export/format.rs`**: Add `format_declaration()` public method to `Formatter` for single-declaration formatting.

## Test plan
- [x] 16 formatting tests pass (including 7 new range formatting tests)
- [x] 10 LSP capability tests pass (including updated range formatting capability test)
- [x] All 543 library tests pass
- [x] clippy clean with `--all-targets`
- [x] rustfmt clean

Generated with [Claude Code](https://claude.com/claude-code)