### PR TITLE
feat(eu-6lbi): add "did you mean?" infrastructure for lookup errors

### DIFF
--- a/harness/test/errors/020_no_such_key_fn.eu.expect
+++ b/harness/test/errors/020_no_such_key_fn.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "Key not found"
+stderr: "key 'g' not found in block"

--- a/harness/test/errors/034_did_you_mean.eu
+++ b/harness/test/errors/034_did_you_mean.eu
@@ -1,0 +1,2 @@
+ns: { foo: 1 bar: 2 baz: 3 }
+x: ns.bax

--- a/harness/test/errors/034_did_you_mean.eu.expect
+++ b/harness/test/errors/034_did_you_mean.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "key 'bax' not found in block"

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -588,6 +588,11 @@ lazy_static! {
             ty: function(vec![num(), unk()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 109
+            name: "LOOKUP_FAIL",
+            ty: function(vec![sym(), block(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
 
     ];
 }

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -16,7 +16,7 @@ use moniker::{BoundVar, Embed, Var};
 use thiserror::Error;
 
 use super::{
-    block::{panic_key_not_found, LookupOr},
+    block::{lookup_fail, LookupOr},
     constant::KEmptyList,
     optimiser,
     render::{Render, RenderDoc},
@@ -967,10 +967,10 @@ impl<'rt> Compiler<'rt> {
             // the default is unused; if it fails we panic anyway.
             Some(expr) => match self.compile_binding(binder, expr.clone(), annotation, false) {
                 Ok(expr) => Ok(expr),
-                Err(CompileError::FreeVar(_)) => binder.add(panic_key_not_found(key)),
+                Err(CompileError::FreeVar(_)) => binder.add(lookup_fail(key, obj.clone())),
                 Err(e) => Err(e),
             },
-            None => binder.add(panic_key_not_found(key)),
+            None => binder.add(lookup_fail(key, obj.clone())),
         }?;
         Ok(Holder::new(LookupOr(NativeVariant::Unboxed).global(
             dsl::sym(key),

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -150,6 +150,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(prng::PrngNext));
     rt.add(Box::new(prng::PrngFloat));
     rt.add(Box::new(stream_intrinsic::StreamNext));
+    rt.add(Box::new(block::LookupFail));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -595,3 +595,8 @@ pub fn test_error_032() {
 pub fn test_error_033() {
     run_error_test(&error_opts("033_type_mismatch_str_as_num.eu"));
 }
+
+#[test]
+pub fn test_error_034() {
+    run_error_test(&error_opts("034_did_you_mean.eu"));
+}


### PR DESCRIPTION
## Summary
- Add Levenshtein edit distance machinery and suggestion helpers to `error.rs` for "did you mean?" suggestions on lookup failures
- Enhance `LookupFailure` error variant to carry key name and list of suggestions
- Add `LOOKUP_FAIL` BIF that inspects block keys at runtime and produces edit-distance-based suggestions when triggered through the dynamic `LOOKUP` wrapper
- Improve compiled (static) lookup failures from generic "Key not found" to "key 'X' not found in block"
- Update error test 020 expect file for new message format; add error test 034

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 543 unit tests pass
- [x] All 112 harness tests pass (including updated error_020 and new error_034)
- [x] Manual verification: `ns: { f(x): x } x: ns.g(1)` produces `panic: key 'g' not found in block`

🤖 Generated with [Claude Code](https://claude.com/claude-code)