### PR TITLE
feat: auto-generate prelude reference from source (eu-wr4u)

### DIFF
--- a/doc/reference/prelude/blocks.md
+++ b/doc/reference/prelude/blocks.md
@@ -1,77 +1,76 @@
 # Blocks
 
-## Construction
+## Block Construction and Merging
 
 | Function | Description |
 |----------|-------------|
-| `block(kvs)` | Construct block from list of `[key, value]` pairs |
-| `pair(k, v)` | Create a `[key, value]` pair |
-| `sym(s)` | Create symbol from string `s` |
-| `tongue(ks, v)` | Create nested block from key path to value |
-| `zip-kv(ks, vs)` | Create block by zipping keys and values |
-| `with-keys(ks)` | Alias for `zip-kv` |
-| `map-as-block(f, syms)` | Map symbols and create block |
+| `sym` | Create symbol with name given by string `s` |
+| `merge` | Shallow merge block `b2` on top of `b1` |
+| `deep-merge` | Deep merge block `b2` on top of `b1`, merges nested blocks but not lists |
+| `block?` | True if and only if `v` is a block |
+| `list?` | True if and only if `v` is a list |
+| `elements` | Expose list of elements of block `b` |
+| `block` | (re)construct block from list `kvs` of elements |
+| `has(s, b)` | True if and only if block `b` has key (symbol) `s` |
+| `lookup(s, b)` | Look up symbol `s` in block `b`, error if not found |
+| `lookup-in(b, s)` | Look up symbol `s` in block `b`, error if not found |
+| `lookup-or(s, d, b)` | Look up symbol `s` in block `b`, default `d` if not found |
+| `lookup-or-in(b, s, d)` | Look up symbol `s` in block `b`, default `d` if not found |
+| `lookup-alts(syms, d, b)` | Look up symbols `syms` in turn in block `b` until a value is found, default `d` if none |
+| `lookup-across(s, d, bs)` | Look up symbol `s` in turn in each of blocks `bs` until a value is found, default `d` if none |
+| `lookup-path(ks, b)` | Look up value at key path `ks` in block `b` |
 
-## Access
-
-| Function | Description |
-|----------|-------------|
-| `lookup(s, b)` | Look up symbol `s` in block (error if missing) |
-| `lookup-in(b, s)` | Same as `lookup` with swapped args |
-| `lookup-or(s, d, b)` | Look up with default `d` if missing |
-| `lookup-or-in(b, s, d)` | Same with swapped args |
-| `lookup-alts(syms, d, b)` | Try symbols in order until found |
-| `lookup-across(s, d, bs)` | Look up in sequence of blocks |
-| `lookup-path(ks, b)` | Look up nested key path |
-| `has(s, b)` | True if block has key `s` |
-| `elements(b)` | List of `[key, value]` pairs |
-| `keys(b)` | List of keys |
-| `values(b)` | List of values |
-| `key(pr)` | Key from a pair |
-| `value(pr)` | Value from a pair |
-
-## Merging
+## Block Utilities
 
 | Function | Description |
 |----------|-------------|
-| `merge(b1, b2)` | Shallow merge `b2` onto `b1` |
-| `deep-merge(b1, b2)` | Deep merge (nested blocks) |
-| `l << r` | Operator for deep merge |
-| `merge-all(bs)` | Merge list of blocks |
-| `merge-at(ks, v, b)` | Merge `v` at key path `ks` |
+| `merge-all(bs)` | Merge all blocks in list `bs` together, later overriding earlier |
+| `key` | Return key in a block element / pair |
+| `value` | Return key in a block element / pair |
+| `keys(b)` | Return keys of block |
+| `values(b)` | Return values of block |
+| `sort-keys(b)` | Return block `b` with keys sorted alphabetically |
+| `bimap(f, g, pr)` | Apply f to first item of pair and g to second, return pair |
+| `map-first(f, prs)` | Apply f to first elements of all pairs in list of pairs `prs` |
+| `map-second(f, prs)` | Apply f to second elements of all pairs in list of pairs `prs` |
+| `map-kv(f, b)` | Apply `f(k, v)` to each key / value pair in block `b`, returning list |
+| `map-as-block(f, syms)` | Map each symbol in `syms` and create block mapping `syms` to mapped values |
+| `pair(k, v)` | Form a block element from key (symbol) `k` and value `v` |
+| `zip-kv(ks, vs)` | Create a block by zipping together keys `ks` and values `vs` |
+| `with-keys` | Create block from list of values by assigning list of keys `ks` against them |
+| `map-values(f, b)` | Apply `f(v)` to each value in block `b` |
+| `map-keys(f, b)` | Apply `f(k)` to each key in block `b` |
+| `filter-items(f, b)` | Return items from block `b` which match item match function `f` |
+| `by-key(p?)` | Return item match function that checks predicate `p?` against the (symbol) key |
+| `by-key-name(p?)` | Return item match function that checks predicate `p?` against string representation of the key |
+| `by-key-match(re)` | Return item match function that checks string representation of the key matches regex `re` |
+| `by-value(p?)` | Return item match runction that checks predicate `p?` against the item value |
+| `match-filter-values(re, b)` | Return list of values from block `b` with keys matching regex `re` |
+| `filter-values(p?, b)` | Return items from block `b` where values match predicate `p?` |
 
-## Transformation
+## Block Alteration
 
 | Function | Description |
 |----------|-------------|
-| `map-values(f, b)` | Apply `f` to each value |
-| `map-keys(f, b)` | Apply `f` to each key |
-| `map-kv(f, b)` | Apply `f(k, v)` to each pair, return list |
-| `filter-items(f, b)` | Filter items by predicate on pairs |
-| `filter-values(p?, b)` | Values matching predicate |
-| `match-filter-values(re, b)` | Values with keys matching regex |
-
-## Item Predicates
-
-| Function | Description |
-|----------|-------------|
-| `by-key(p?)` | Predicate on key |
-| `by-key-name(p?)` | Predicate on key as string |
-| `by-key-match(re)` | Predicate matching key against regex |
-| `by-value(p?)` | Predicate on value |
+| `alter-value(k, v, b)` | Alter `b.k` to value `v` |
+| `update-value(k, f, b)` | Update  `b.k` to `f(b.k)` |
+| `alter(ks, v, b)` | In nested block `b` alter value to value `v` at path-of-keys `ks` |
+| `update(ks, f, b)` | In nested block `b` applying `f` to value at path-of-keys `ks` |
+| `update-value-or(k, f, d, b)` | Set `b.k` to `f(v)` where v is current value, otherwise add with default value `d` |
+| `set-value(k, v)` | Set `b.k` to `v`, adding if absent |
+| `tongue(ks, v)` | Construct block with a single nested path-of-keys `ks` down to value `v` |
+| `merge-at(ks, v, b)` | Shallow merge block `v` into block value at path-of-keys `ks` |
 
 ## Deep Find and Query
 
-These functions search recursively through nested block structures.
-
 | Function | Description |
 |----------|-------------|
-| `deep-find(k, b)` | All values for key `k` at any depth, depth-first |
-| `deep-find-first(k, d, b)` | First value for key `k`, or default `d` |
-| `deep-find-paths(k, b)` | Key paths to all occurrences of key `k` |
-| `deep-query(pattern, b)` | Query using dot-separated pattern string |
-| `deep-query-first(pattern, d, b)` | First match for pattern, or default `d` |
-| `deep-query-paths(pattern, b)` | Key paths matching pattern |
+| `deep-find(k, b)` | Return list of all values for key `k` at any depth in block `b`, depth-first |
+| `deep-find-first(k, d, b)` | Return first value for key `k` at any depth in block `b`, or default `d` |
+| `deep-find-paths(k, b)` | Return list of key paths to all occurrences of key `k` at any depth in block `b` |
+| `deep-query(pattern, b)` | Query block `b` using dot-separated pattern string. `*` matches one level, `**` matches any depth. Bare `foo` is sugar for `**.foo` |
+| `deep-query-first(pattern, d, b)` | Return first match for `pattern` in block `b`, or default `d` |
+| `deep-query-paths(pattern, b)` | Return list of key paths matching `pattern` in block `b` |
 
 ### Deep Find
 
@@ -107,14 +106,3 @@ hosts: data deep-query("config.host")  # ["us.example.com", "eu.example.com"]
 # Wildcard: any key at one level, then host
 hosts: data deep-query("*.config.host")
 ```
-
-## Mutation
-
-| Function | Description |
-|----------|-------------|
-| `alter-value(k, v, b)` | Set `b.k` to `v` |
-| `update-value(k, f, b)` | Apply `f` to `b.k` |
-| `alter(ks, v, b)` | Set value at nested key path |
-| `update(ks, f, b)` | Apply `f` at nested key path |
-| `update-value-or(k, f, d, b)` | Update or add with default |
-| `set-value(k, v, b)` | Set value, adding if absent |

--- a/doc/reference/prelude/booleans.md
+++ b/doc/reference/prelude/booleans.md
@@ -1,51 +1,29 @@
 # Booleans and Comparison
 
-## Constants
-
-- `true` -- Boolean true
-- `false` -- Boolean false
-- `null` -- Null value (exports as `null` in JSON, `~` in YAML)
-- `nil` -- Empty list `[]`
-
-## Control Flow
+## Essentials
 
 | Function | Description |
 |----------|-------------|
-| `if(c, t, f)` | If `c` is true return `t`, else `f` |
-| `then(t, f, c)` | Pipeline-friendly if: `x? then(t, f)` |
-| `when(p?, f, x)` | When `x` satisfies `p?`, apply `f`, else pass through |
-| `cond(l, d)` | Select first true condition from list of `[condition, value]` pairs, else default `d` |
+| `null` | A null value. To export as `null` in JSON or ~ in YAML |
+| `true` | Constant logical true |
+| `false` | Constant logical false |
+| `if` | If `c` is `true`, return `t` else `f` |
+| `then(t, f, c)` | For pipeline if: - `x? then(t, f)` |
+| `when(p?, f, x)` | When `x` satisfies `p?` apply `f` else pass through unchanged |
 
-## Error Handling
-
-| Function | Description |
-|----------|-------------|
-| `panic(s)` | Raise runtime error with message `s` |
-| `assert(c, s, v)` | If `c` is true return `v`, else error with message `s` |
-
-## Boolean Functions
+## Error and Debug Support
 
 | Function | Description |
 |----------|-------------|
-| `not(b)` | Toggle boolean |
-| `and(l, r)` | Logical and |
-| `or(l, r)` | Logical or |
+| `panic` | Raise runtime error with message string `s` |
+| `assert(c, s, v)` | If `c` is true then value `v` otherwise error with message `s` |
 
-## Boolean Operators
+## Boolean Logic
 
-| Operator | Description |
+| Function | Description |
 |----------|-------------|
-| `!x` or `¬x` | Not (prefix) |
-| `l && r` or `l ∧ r` | And |
-| `l \|\| r` or `l ∨ r` | Or |
-
-## Equality and Comparison
-
-| Operator | Description |
-|----------|-------------|
-| `l = r` | Equality |
-| `l != r` | Inequality |
-| `l < r` | Less than |
-| `l > r` | Greater than |
-| `l <= r` | Less than or equal |
-| `l >= r` | Greater than or equal |
+| `not` | Toggle boolean |
+| `(! b)` | Not x, toggle boolean |
+| `(¬ b)` | Not x, toggle boolean |
+| `and` | True if and only if `l` and `r` are true |
+| `or` | True if and only if `l` or `r` is true |

--- a/doc/reference/prelude/calendar.md
+++ b/doc/reference/prelude/calendar.md
@@ -1,13 +1,11 @@
 # Calendar
 
-The `cal` namespace provides date/time functions:
+## Date and Time Functions
 
 | Function | Description |
 |----------|-------------|
-| `cal.now` | Current time as fields block |
-| `cal.epoch` | Unix epoch as fields block |
-| `cal.zdt(y,m,d,H,M,S,Z)` | Create zoned datetime |
-| `cal.datetime(b)` | Create from block with defaults |
-| `cal.parse(s)` | Parse ISO8601 string |
-| `cal.format(t)` | Format as ISO8601 |
-| `cal.fields(t)` | Decompose to `{y,m,d,H,M,S,Z}` block |
+| `cal.zdt` | Create zoned date time from datetime components and timezone string (e.g. '+0100') |
+| `cal.datetime(b)` | Convert block of time fields to zoned datetime (defaults: y=1, m=1, d=1, H=0, M=0, S=0, Z=UTC) |
+| `cal.parse` | Parse an ISO8601 formatted date string into a zoned date time |
+| `cal.format` | Format a zoned date time as ISO8601 |
+| `cal.fields` | Decompose a zoned date time into a block of its component fields (y,m,d,H,M,S,Z) |

--- a/doc/reference/prelude/combinators.md
+++ b/doc/reference/prelude/combinators.md
@@ -1,27 +1,23 @@
 # Combinators
 
-| Function | Description |
-|----------|-------------|
-| `identity(v)` | Return `v` unchanged |
-| `const(k)` | Function that always returns `k` |
-| `-> k` | Operator form of `const` |
-| `compose(f, g, x)` | Apply `f` to `g(x)` |
-| `f ∘ g` | Composition: `g` then `f` |
-| `f ; g` | Composition: `f` then `g` |
-| `l @ r` | Application: `l(r)` |
-| `apply(f, xs)` | Apply `f` to args in list |
-| `flip(f)` | Swap argument order |
-| `complement(p?)` | Invert predicate |
-| `curry(f)` | Convert `f([x,y])` to `f(x,y)` |
-| `uncurry(f)` | Convert `f(x,y)` to `f([x,y])` |
-| `juxt(f, g, x)` | Return `[f(x), g(x)]` |
-| `fnil(f, v, x)` | Replace null with `v` before applying `f` |
-
-## Pairs
+## Combinators
 
 | Function | Description |
 |----------|-------------|
-| `pair(k, v)` | Create pair `[k, v]` |
-| `bimap(f, g, pr)` | Apply `f` to first, `g` to second |
-| `map-first(f, prs)` | Apply `f` to first elements |
-| `map-second(f, prs)` | Apply `f` to second elements |
+| `identity(v)` | Identity function, return value `v` |
+| `const(k, _)` | Return single arg function that always returns `k` |
+| `(-> k)` | Const; return single arg function that always returns `k` |
+| `compose(f, g, x)` | Apply function `f` to `g(x)` |
+| `apply(f, xs)` | Apply function `f` to arguments in list `xs` |
+| `flip(f, x, y)` | Flip arguments of function `f`, flip(f)(x, y) == f(y, x) |
+| `complement(p?)` | Invert truth value of predicate function |
+| `curry(f, x, y)` | Turn f([x, y]) into f' of two parameters (x, y) |
+| `uncurry(f, l)` | Turn f(x, y) into f' that expects [x, y] as a list |
+| `cond(l, d)` | In list `l` of [condition, value] select first true condition, returning value, else default `d` |
+| `juxt(f, g, x)` | `juxt(f, g) - return function of `x` returning list of `f(x)` and g(x)` |
+
+## Utilities
+
+| Function | Description |
+|----------|-------------|
+| `fnil(f, v, x)` | Return a function equivalent to f except it sees `x` instead of `null` when null is passed |

--- a/doc/reference/prelude/index.md
+++ b/doc/reference/prelude/index.md
@@ -9,14 +9,16 @@ in the prelude).
 
 ## Categories
 
-- [Lists](lists.md) -- list construction, transformation, folding, sorting
-- [Blocks](blocks.md) -- block construction, access, merging, transformation
-- [Strings](strings.md) -- string manipulation, regex, formatting
-- [Numbers and Arithmetic](numbers.md) -- numeric operations and predicates
-- [Booleans and Comparison](booleans.md) -- boolean logic and comparison operators
-- [Combinators](combinators.md) -- function composition, application, utilities
-- [Calendar](calendar.md) -- date and time functions
-- [Sets](sets.md) -- set operations
-- [Random Numbers](random.md) -- random number generation
-- [Metadata](metadata.md) -- metadata and assertion functions
-- [IO](io.md) -- environment, time, and argument access
+- [Lists](lists.md) -- list construction, transformation, folding, sorting (64 entries)
+- [Blocks](blocks.md) -- block construction, access, merging, transformation (52 entries)
+- [Strings](strings.md) -- string manipulation, regex, formatting (26 entries)
+- [Numbers and Arithmetic](numbers.md) -- numeric operations and predicates (14 entries)
+- [Booleans and Comparison](booleans.md) -- boolean logic and comparison operators (13 entries)
+- [Combinators](combinators.md) -- function composition, application, utilities (12 entries)
+- [Calendar](calendar.md) -- date and time functions (5 entries)
+- [Sets](sets.md) -- set operations (11 entries)
+- [Random Numbers](random.md) -- random number generation (5 entries)
+- [Metadata](metadata.md) -- metadata and assertion functions (7 entries)
+- [IO](io.md) -- environment, time, and argument access (9 entries)
+
+*218 documented entries in total.*

--- a/doc/reference/prelude/io.md
+++ b/doc/reference/prelude/io.md
@@ -1,12 +1,25 @@
 # IO
 
-## `eu` namespace
+## Prelude Versioning
 
-- `eu.prelude.version` -- Version of the standard prelude
-- `eu.build` -- Build metadata for the eucalypt executable
+| Function | Description |
+|----------|-------------|
+| `eu.prelude` | Metadata about this version of the standard prelude |
+| `eu.build` | Metadata about this version of the eucalypt executable |
+| `eu.requires` | Assert that the eucalypt version satisfies the given semver constraint (e.g. '>=0.2.0') |
 
-## `io` namespace
+## IO Functions
 
-- `io.env` -- Block of environment variables at launch time
-- `io.epoch-time` -- Unix timestamp at launch time
-- `io.args` -- List of command-line arguments passed after `--` separator
+| Function | Description |
+|----------|-------------|
+| `io.env` | Read access to environent variables at time of launch |
+| `io.args` | Line arguments passed after -- separator |
+| `io.RANDOM_SEED` | Seed for random number generation (from --seed or system time) |
+| `io.random` | Infinite lazy stream of random floats in [0,1), seeded from system entropy or --seed flag |
+
+## Other
+
+| Function | Description |
+|----------|-------------|
+| `alter?(k?, v!, k, v)` | If `k` satisfies `k?` then `v!` else `v` |
+| `update?(k?, f, k, v)` | If `k` satisfies `k?` then `v!` else `v` |

--- a/doc/reference/prelude/lists.md
+++ b/doc/reference/prelude/lists.md
@@ -4,103 +4,101 @@
 
 | Function | Description |
 |----------|-------------|
-| `cons(h, t)` | Prepend item `h` to list `t` |
-| `head(xs)` | First item of list (error if empty) |
-| `↑xs` | Tight-binding prefix form of `head` (prec 95) |
-| `head-or(d, xs)` | First item or default `d` if empty |
-| `tail(xs)` | List without first item (error if empty) |
-| `tail-or(d, xs)` | List without first item or `d` if empty |
-| `first(xs)` | Alias for `head` |
-| `second(xs)` | Second item of list |
-| `second-or(d, xs)` | Second item or default `d` |
-| `last(l)` | Last element of list |
-| `nil?(xs)` | True if list is empty |
-| `nth(n, l)` | Return `n`th item (0-indexed) |
-| `l !! n` | Operator form of `nth` |
-| `count(l)` | Number of items in list |
+| `cons` | Construct new list by prepending item `h` to list `t` |
+| `head` | Return the head item of list `xs`, panic if empty |
+| `(↑ xs)` | Return first element of list `xs`. Tight-binding prefix operator |
+| `nil?` | `true` if list `xs` is empty, `false` otherwise |
+| `head-or(d, xs)` | Return the head item of list `xs` or default `d` if empty |
+| `tail` | Return list `xs` without the head item. [] causes error |
+| `tail-or(d, xs)` | Return list `xs` without the head item or `d` for empty list |
+| `nil` | Identical to `[]`, the empty list |
+| `first` | Return first item of list `xs` - error if the list is empty |
+| `second(xs)` | Return second item of list - error if there is none |
+| `second-or(d, xs)` | Return second item of list - default `d` if there is none |
 
 ## List Construction
 
 | Function | Description |
 |----------|-------------|
-| `repeat(i)` | Infinite list of item `i` |
-| `ints-from(n)` | Infinite list of integers from `n` upwards |
-| `range(b, e)` | List of integers from `b` to `e` (exclusive) |
-| `cycle(l)` | Infinite list cycling elements of `l` |
-| `iterate(f, i)` | List of `i`, `f(i)`, `f(f(i))`, ... |
+| `repeat(i)` | Return infinite list of instances of item `i` |
+| `iterate(f, i)` | Return list of `i` with subsequent repeated applications of `f` to `i` |
+| `ints-from(n)` | Return infinite list of integers from `n` upwards |
+| `range(b, e)` | Return list of ints from `b` to `e` (not including `e`) |
+| `cycle(l)` | Create infinite list by cycling elements of list `l` |
 
 ## Transformations
 
 | Function | Description |
 |----------|-------------|
-| `map(f, l)` | Apply `f` to each element |
-| `f <$> l` | Operator form of `map` |
-| `map2(f, l1, l2)` | Map `f` over two lists in parallel |
-| `filter(p?, l)` | Keep elements satisfying predicate `p?` |
-| `remove(p?, l)` | Remove elements satisfying predicate `p?` |
-| `reverse(l)` | Reverse list |
-| `take(n, l)` | First `n` elements |
-| `drop(n, l)` | List after dropping `n` elements |
-| `take-while(p?, l)` | Initial elements while `p?` is true |
-| `take-until(p?, l)` | Initial elements while `p?` is false |
-| `drop-while(p?, l)` | Skip elements while `p?` is true |
-| `drop-until(p?, l)` | Skip elements while `p?` is false |
+| `take(n, l)` | Return initial segment of integer `n` elements from list `l` |
+| `drop(n, l)` | Return result of dropping integer `n` elements from list `l` |
+| `take-while(p?, l)` | Initial elements of list `l` while `p?` is true |
+| `take-until(p?)` | Initial elements of list `l` while `p?` is false |
+| `drop-while(p?, l)` | Skip initial elements of list `l` while `p?` is true |
+| `drop-until(p?)` | Skip initial elements of list `l` while `p?` is false |
+| `map(f, l)` | Map function `f` over list `l` |
+| `map2(f, l1, l2)` | Map function `f` over lists `l1` and `l2`, until the shorter is exhausted |
+| `cross(f, xs, ys)` | Apply `f` to every combination of elements from `xs` and `ys` (cartesian product) |
+| `filter(p?, l)` | Return list of elements of list `l` that satisfy predicate `p?` |
+| `remove(p?, l)` | Return list of elements of list `l` that do not satisfy predicate `p?` |
+| `reverse(l)` | Reverse list `l` |
 
 ## Combining Lists
 
 | Function | Description |
 |----------|-------------|
-| `append(l1, l2)` | Concatenate two lists |
-| `l1 ++ l2` | Operator form of `append` |
-| `prepend(l1, l2)` | Concatenate with `l1` after `l2` |
-| `concat(ls)` | Concatenate list of lists |
-| `mapcat(f, l)` | Map then concatenate results |
-| `zip(l1, l2)` | List of pairs from two lists |
-| `zip-with(f, l1, l2)` | Apply `f` to parallel elements |
-| `zip-apply(fs, vs)` | Apply functions to corresponding values |
+| `zip-with` | Map function `f` over lists `l1` and `l2`, until the shorter is exhausted |
+| `zip` | List of pairs of elements  `l1` and `l2`, until the shorter is exhausted |
+| `append(l1, l2)` | Concatenate two lists `l1` and `l2` |
+| `prepend` | Concatenate two lists with `l1` after `l2` |
+| `concat(ls)` | Concatenate all lists in `ls` together |
+| `mapcat(f)` | Map items in l with `f` and concatenate the resulting lists |
+| `zip-apply(fs, vs)` | Apply fns in list `fs` to corresponding values in list `vs`, until shorter is exhausted |
 
 ## Splitting Lists
 
 | Function | Description |
 |----------|-------------|
-| `split-at(n, l)` | Split at index `n`, return pair |
-| `split-after(p?, l)` | Split where `p?` becomes false |
-| `split-when(p?, l)` | Split where `p?` becomes true |
-| `window(n, step, l)` | Sliding windows of size `n` with offset `step` |
-| `partition(n, l)` | Non-overlapping segments of size `n` |
-| `discriminate(pred, xs)` | Split into [matches, non-matches] |
+| `split-at(n, l)` | Split list in to at `n`th item and return pair |
+| `split-after(p?, l)` | Split list where `p?` becomes false and return pair |
+| `split-when(p?, l)` | Split list where `p?` becomes true and return pair |
+| `window(n, step, l)` | List of lists of sliding windows over list `l` of size `n` and offest `step` |
+| `partition(n)` | List of lists of non-overlapping segments of list `l` of size `n` |
+| `discriminate(pred, xs)` | Return pair of `xs` for which `pred(_)` is true and `xs` for which `pred(_)` is false |
 
 ## Folds and Scans
 
 | Function | Description |
 |----------|-------------|
-| `foldl(op, i, l)` | Left fold with initial value `i` |
-| `foldr(op, i, l)` | Right fold with final value `i` |
-| `scanl(op, i, l)` | Left scan (intermediate fold values) |
-| `scanr(op, i, l)` | Right scan |
+| `foldl(op, i, l)` | Left fold operator `op` over list `l` starting from value `i`  |
+| `foldr(op, i, l)` | Right fold operator `op` over list `l` ending with value `i`  |
+| `scanl(op, i, l)` | Left scan operator `op` over list `l` starting from value `i`  |
+| `scanr(op, i, l)` | Right scan operator `op` over list `l` ending with value `i`  |
 
 ## Predicates
 
 | Function | Description |
 |----------|-------------|
-| `all(p?, l)` | True if all elements satisfy `p?` |
-| `all-true?(l)` | True if all elements are true |
-| `any(p?, l)` | True if any element satisfies `p?` |
-| `any-true?(l)` | True if any element is true |
+| `all-true?(l)` | True if and only if all items in list `l` are true |
+| `all(p?, l)` | True if and only if all items in list `l` satisfy predicate `p?` |
+| `any-true?(l)` | True if and only if any items in list `l` are true |
+| `any(p?, l)` | True if and only if any items in list `l` satisfy predicate `p?` |
 
 ## Sorting
 
 | Function | Description |
 |----------|-------------|
-| `qsort(lt, xs)` | Sort using less-than function `lt` |
-| `sort-nums(xs)` | Sort numbers ascending |
-| `sort-strs(xs)` | Sort strings/symbols ascending |
-| `sort-zdts(xs)` | Sort zoned date-times ascending |
-| `sort-by(key-fn, cmp, xs)` | Sort by key extracted with `key-fn` using comparator `cmp` |
-| `sort-by-num(key-fn, xs)` | Sort ascending by numeric key |
-| `sort-by-str(key-fn, xs)` | Sort ascending by string key |
-| `sort-by-zdt(key-fn, xs)` | Sort ascending by date-time key |
-| `group-by(k, xs)` | Group by key function, returns block |
+| `group-by(k, xs)` | Group xs by key function returning block of key to subgroups, maintains order |
+| `qsort(lt, xs)` | Sort `xs` using 'less-than' function `lt` |
+| `sort-nums(xs)` | Sort list of numbers ascending |
+| `sort-strs(xs)` | Sort list of strings or symbols ascending |
+| `sort-zdts(xs)` | Sort list of zoned date-times ascending |
+| `sort-by(key-fn, cmp, xs)` | Sort list `xs` by key extracted with `key-fn` using comparator `cmp` |
+| `sort-by-num(key-fn)` | Sort list `xs` ascending by numeric key extracted with `key-fn` |
+| `sort-by-str(key-fn)` | Sort list `xs` ascending by string key extracted with `key-fn` |
+| `sort-by-zdt(key-fn)` | Sort list `xs` ascending by zoned date-time key extracted with `key-fn` |
+
+### Sorting Examples
 
 ```eu
 nums: [3, 1, 4, 1, 5] sort-nums          # [1, 1, 3, 4, 5]
@@ -115,5 +113,9 @@ by-age: people sort-by-num(_.age)         # sorted by age
 
 | Function | Description |
 |----------|-------------|
-| `over-sliding-pairs(f, l)` | Apply binary `f` to overlapping pairs |
-| `differences(l)` | Differences between adjacent numbers |
+| `nth(n, l)` | Return `n`th item of list if it exists, otherwise panic |
+| `(l !! n)` | Return `n`th item of list if it exists, otherwise error |
+| `count(l)` | Return count of items in list `l` |
+| `last` | Return last element of list `l` |
+| `over-sliding-pairs(f, l)` | Apply binary fn `f` to each overlapping pair in `l` to form new list |
+| `differences` | Calculate difference between each overlapping pair in list of numbers `l` |

--- a/doc/reference/prelude/numbers.md
+++ b/doc/reference/prelude/numbers.md
@@ -1,35 +1,25 @@
 # Numbers and Arithmetic
 
-## Operators
-
-| Operator | Description |
-|----------|-------------|
-| `l + r` | Addition |
-| `l - r` | Subtraction |
-| `l * r` | Multiplication |
-| `l / r` | Division |
-| `l % r` | Modulus |
-| `∸ n` | Unary minus (negate) |
-
-## Functions
+## Arithmetic Operators
 
 | Function | Description |
 |----------|-------------|
-| `inc(x)` | Increment by 1 |
-| `dec(x)` | Decrement by 1 |
-| `negate(n)` | Negate number |
-| `num(s)` | Parse number from string |
-| `floor(n)` | Round down to integer |
-| `ceiling(n)` | Round up to integer |
-| `max(l, r)` | Maximum of two numbers |
-| `min(l, r)` | Minimum of two numbers |
-| `max-of(l)` | Maximum in list |
-| `min-of(l)` | Minimum in list |
+| `(∸ n)` | Unary minus; negate |
 
-## Predicates
+## Numeric Functions
 
 | Function | Description |
 |----------|-------------|
-| `zero?(n)` | True if `n` is 0 |
-| `pos?(n)` | True if `n` is positive |
-| `neg?(n)` | True if `n` is negative |
+| `inc` | Increment number `x` by 1 |
+| `dec` | Decrement number `x` by 1 |
+| `negate` | Negate number `n` |
+| `zero?` | Return true if and only if number `n` is 0 |
+| `pos?` | Return true if and only if number `n` is strictly positive |
+| `neg?` | Return true if and only if number `n` is strictly negative |
+| `num` | Parse number from string |
+| `floor` | Round number downwards to nearest integer |
+| `ceiling` | Round number upwards to nearest integer |
+| `max(l, r)` | Return max of numbers `l` and `r` |
+| `max-of(l)` | `max-of(l) - return max element in list of numbers `l` - error if empty` |
+| `min(l, r)` | Return min of numbers `l` and `r` |
+| `min-of(l)` | `min-of(l) - return min element in list of numbers `l` - error if empty` |

--- a/doc/reference/prelude/random.md
+++ b/doc/reference/prelude/random.md
@@ -20,15 +20,15 @@ results:
 eu --seed 42 example.eu
 ```
 
-## Core Functions
+## Random Number Generation
 
 | Function | Description |
 |----------|-------------|
-| `random-stream(seed)` | Infinite lazy list of floats in `[0, 1)` from integer seed |
-| `random-int(n, stream)` | Random integer in `[0, n)` from stream. Returns `{ value, rest }` |
-| `random-choice(list, stream)` | Pick a random element from list. Returns `{ value, rest }` |
-| `shuffle(list, stream)` | Randomly reorder list. Returns `{ value, rest }` |
-| `sample(n, list, stream)` | Pick `n` elements without replacement. Returns `{ value, rest }` |
+| `random-stream(seed)` | Infinite lazy stream of random floats in [0,1), seeded by the given integer |
+| `random-int(n, stream)` | Generate a random integer in [0, n) from the stream. Returns block with value and rest |
+| `random-choice(list, stream)` | Choose a random element from a list. Returns block with value and rest |
+| `shuffle(list, stream)` | Shuffle a list using repeated selection. Returns block with value and rest |
+| `sample(n, list, stream)` | Sample n elements from a list without replacement. Returns block with value and rest |
 
 ## Usage Pattern
 

--- a/doc/reference/prelude/sets.md
+++ b/doc/reference/prelude/sets.md
@@ -1,46 +1,27 @@
 # Sets
 
-The `set` namespace provides operations on sets of primitive values
-(numbers, strings, symbols). Sets are unordered collections of unique
-elements.
+## Set Operations
 
-## Creating Sets
-
-| Expression | Description |
-|------------|-------------|
-| `set.from-list(xs)` | Create a set from a list of values |
-| `∅` | The empty set (Option-O on Mac, or use `set.from-list([])`) |
+| Function | Description |
+|----------|-------------|
+| `set.from-list(xs)` | Create a set from list `xs` of primitive values |
+| `set.to-list` | Return sorted list of elements in set `s` |
+| `set.add` | Add element `e` to set `s` |
+| `set.remove` | Remove element `e` from set `s` |
+| `set.contains?` | True if set `s` contains element `e` |
+| `set.size` | Return number of elements in set `s` |
+| `set.empty?(s)` | True if set `s` has no elements |
+| `set.union` | Return union of sets `a` and `b` |
+| `set.intersect` | Return intersection of sets `a` and `b` |
+| `set.diff` | Return elements in set `a` that are not in set `b` |
+| `(∅)` | The empty set |
 
 ```eu
 s: set.from-list([1, 2, 3, 2, 1])
 # s contains {1, 2, 3} (duplicates removed)
 ```
 
-## Operations
-
-| Function | Description |
-|----------|-------------|
-| `set.add(e, s)` | Add element `e` to set `s` |
-| `set.remove(e, s)` | Remove element `e` from set `s` |
-| `set.contains?(e, s)` | True if set `s` contains element `e` |
-| `set.size(s)` | Number of elements in set `s` |
-| `set.empty?(s)` | True if set `s` has no elements |
-| `set.to-list(s)` | Sorted list of elements in set `s` |
-
-```eu
-s: set.from-list([3, 1, 4, 1, 5])
-has-three: s set.contains?(3)        # true
-count: s set.size                     # 4 (duplicates removed)
-elems: s set.to-list                  # [1, 3, 4, 5]
-```
-
 ## Set Algebra
-
-| Function | Description |
-|----------|-------------|
-| `set.union(a, b)` | Elements in either set |
-| `set.intersect(a, b)` | Elements in both sets |
-| `set.diff(a, b)` | Elements in `a` but not in `b` |
 
 ```eu
 a: set.from-list([1, 2, 3])

--- a/doc/reference/prelude/strings.md
+++ b/doc/reference/prelude/strings.md
@@ -1,42 +1,35 @@
 # Strings
 
-The `str` namespace contains string functions:
+## String Processing
 
 | Function | Description |
 |----------|-------------|
-| `str.of(e)` | Convert to string |
-| `str.split(s, re)` | Split string on regex |
-| `str.split-on(re, s)` | Split (pipeline-friendly) |
-| `str.join(l, s)` | Join list with separator |
-| `str.join-on(s, l)` | Join (pipeline-friendly) |
-| `str.match(s, re)` | Match regex, return captures |
-| `str.match-with(re, s)` | Match (pipeline-friendly) |
-| `str.matches(s, re)` | All matches of regex |
-| `str.matches-of(re, s)` | All matches (pipeline-friendly) |
-| `str.matches?(re, s)` | True if regex matches full string |
-| `str.extract(re, s)` | Extract single capture |
-| `str.extract-or(re, d, s)` | Extract with default |
-| `str.suffix(b, a)` | Suffix `b` onto `a` |
-| `str.prefix(b, a)` | Prefix `b` onto `a` |
-| `str.letters(s)` | List of characters |
-| `str.len(s)` | String length |
-| `str.fmt(x, spec)` | Printf-style formatting |
-| `str.to-upper(s)` | Convert to upper case |
-| `str.to-lower(s)` | Convert to lower case |
-
-## Encoding and Hashing
-
-| Function | Description |
-|----------|-------------|
-| `str.base64-encode(s)` | Encode string `s` as base64 |
-| `str.base64-decode(s)` | Decode base64 string `s` |
-| `str.sha256(s)` | SHA-256 hash of string `s` as lowercase hex |
-
-```eu
-encoded: "hello" str.base64-encode    # "aGVsbG8="
-decoded: "aGVsbG8=" str.base64-decode # "hello"
-hash: "hello" str.sha256              # "2cf24dba5fb0a30e..."
-```
+| `str.of` | Convert `e` to string |
+| `str.split` | Split string `s` on separators matching regex `re` |
+| `str.split-on` | Split string `s` on separators matching regex `re` |
+| `str.join` | Join list of strings `l` by interposing string s |
+| `str.join-on` | Join list of strings `l` by interposing string s |
+| `str.match` | Match string `s` using regex `re`, return list of full match then capture groups |
+| `str.match-with` | Match string `s` using regex `re`, return list of full match then capture groups |
+| `str.extract(re)` | Use regex `re` (with single capture) to extract substring of s - or error |
+| `str.extract-or(re, d, s)` | Use regex `re` (with single capture) to extract substring of `s` - or default `d` |
+| `str.matches` | Return list of all matches in string `s` of regex `re` |
+| `str.matches-of` | Return list of all matches in string `s` of regex `re` |
+| `str.matches?(re, s)` | Return true if `re` matches full string `s` |
+| `str.suffix(b, a)` | Return string `b` suffixed onto `a` |
+| `str.prefix(b, a)` | Return string `b` prefixed onto `a` |
+| `str.letters` | Return individual letters of `s` as list of strings |
+| `str.len` | Return length of string in characters |
+| `str.fmt` | Format `x` using printf-style format `spec` |
+| `str.to-upper` | Convert string `s` to upper case |
+| `str.to-lower` | Convert string `s` to lower case |
+| `str.lt(a, b)` | True if string `a` is lexicographically less than `b` |
+| `str.gt(a, b)` | True if string `a` is lexicographically greater than `b` |
+| `str.lte(a, b)` | True if string `a` is lexicographically less than or equal to `b` |
+| `str.gte(a, b)` | True if string `a` is lexicographically greater than or equal to `b` |
+| `str.base64-encode` | Encode string `s` as base64 |
+| `str.base64-decode` | Decode base64 string `s` back to its original string |
+| `str.sha256` | Return the SHA-256 hash of string `s` as lowercase hex |
 
 ## Character Constants
 
@@ -45,3 +38,11 @@ The `ch` namespace provides special characters:
 - `ch.n` -- Newline
 - `ch.t` -- Tab
 - `ch.dq` -- Double quote
+
+### Encoding and Hashing Examples
+
+```eu
+encoded: "hello" str.base64-encode    # "aGVsbG8="
+decoded: "aGVsbG8=" str.base64-decode # "hello"
+hash: "hello" str.sha256              # "2cf24dba5fb0a30e..."
+```

--- a/doc/reference/prelude/supplements/blocks/deep-find-and-query.md
+++ b/doc/reference/prelude/supplements/blocks/deep-find-and-query.md
@@ -1,0 +1,34 @@
+### Deep Find
+
+Searches for a key at any nesting level:
+
+```eu
+config: {
+  server: { host: "localhost" port: 8080 }
+  db: { host: "db.local" port: 5432 }
+}
+
+hosts: config deep-find("host")  # ["localhost", "db.local"]
+first-host: config deep-find-first("host", "unknown")  # "localhost"
+```
+
+### Deep Query
+
+Queries using dot-separated patterns with wildcards:
+
+- Bare name `foo` is sugar for `**.foo` (find at any depth)
+- `*` matches one level
+- `**` matches any depth
+
+```eu
+data: {
+  us: { config: { host: "us.example.com" } }
+  eu: { config: { host: "eu.example.com" } }
+}
+
+# Find all hosts under any config
+hosts: data deep-query("config.host")  # ["us.example.com", "eu.example.com"]
+
+# Wildcard: any key at one level, then host
+hosts: data deep-query("*.config.host")
+```

--- a/doc/reference/prelude/supplements/lists/sorting.md
+++ b/doc/reference/prelude/supplements/lists/sorting.md
@@ -1,0 +1,10 @@
+### Sorting Examples
+
+```eu
+nums: [3, 1, 4, 1, 5] sort-nums          # [1, 1, 3, 4, 5]
+words: ["banana", "apple", "cherry"] sort-strs  # ["apple", "banana", "cherry"]
+
+people: [{name: "Zara" age: 30}, {name: "Alice" age: 25}]
+by-name: people sort-by-str(_.name)       # sorted by name
+by-age: people sort-by-num(_.age)         # sorted by age
+```

--- a/doc/reference/prelude/supplements/metadata/default.md
+++ b/doc/reference/prelude/supplements/metadata/default.md
@@ -1,23 +1,3 @@
-# Metadata
-
-Metadata is a powerful mechanism for attaching auxiliary information to
-any eucalypt expression. It is used for documentation, export control,
-import declarations, operator definitions, and testing assertions.
-
-## Attaching and Reading Metadata
-
-## Metadata Basics
-
-| Function | Description |
-|----------|-------------|
-| `with-meta` | Add metadata block `m` to expression `e` |
-| `meta` | Retrieve expression metadata for e |
-| `raw-meta` | Retrieve immediate metadata of e without recursing into inner layers |
-| `merge-meta(m, e)` | Merge block `m` into `e`'s metadata |
-| `validator(v)` | Find the validator for a value `v` in its metadata |
-| `check(v)` | True if v is valid according to assert metadata |
-| `checked(v)` | Panic if value doesn't satisfy its validator |
-
 ## Documentation Metadata
 
 The backtick (`` ` ``) before a declaration attaches metadata. When the

--- a/doc/reference/prelude/supplements/metadata/top.md
+++ b/doc/reference/prelude/supplements/metadata/top.md
@@ -1,0 +1,5 @@
+Metadata is a powerful mechanism for attaching auxiliary information to
+any eucalypt expression. It is used for documentation, export control,
+import declarations, operator definitions, and testing assertions.
+
+## Attaching and Reading Metadata

--- a/doc/reference/prelude/supplements/random/default.md
+++ b/doc/reference/prelude/supplements/random/default.md
@@ -1,0 +1,52 @@
+## Usage Pattern
+
+The random functions use a functional random stream pattern. Each
+function consumes some random values and returns both a result and the
+remaining stream in a block with `value` and `rest` keys:
+
+```eu
+result: random-int(6, io.random)
+die-roll: result.value    # a number from 0 to 5
+remaining: result.rest    # unconsumed stream for further use
+```
+
+To chain multiple random operations, thread the `rest` through:
+
+```eu
+rolls: {
+  first: random-int(6, io.random)
+  second: random-int(6, first.rest)
+  value: [first.value + 1, second.value + 1]
+}
+two-dice: rolls.value
+```
+
+## Shuffling and Sampling
+
+```eu
+deck: range(1, 53)
+shuffled: shuffle(deck, io.random)
+hand: shuffled.value take(5)
+```
+
+```eu
+colours: ["red", "green", "blue", "yellow", "purple"]
+picked: sample(2, colours, io.random)
+two-colours: picked.value
+```
+
+## Deterministic Seeds
+
+For reproducible output (useful in tests), pass a fixed seed:
+
+```eu
+stream: random-stream(12345)
+x: random-int(100, stream)
+# x.value is always the same for seed 12345
+```
+
+Or use `--seed` on the command line, which sets `io.RANDOM_SEED`:
+
+```sh
+eu --seed 42 my-template.eu
+```

--- a/doc/reference/prelude/supplements/random/top.md
+++ b/doc/reference/prelude/supplements/random/top.md
@@ -1,0 +1,19 @@
+Eucalypt provides pseudo-random number generation through the `io.random`
+stream and a set of prelude functions.
+
+## The Random Stream
+
+The `io.random` binding is an infinite lazy list of random floats in
+`[0, 1)`, seeded from system entropy or the `--seed` command-line flag.
+
+```eu
+first-random: io.random head
+```
+
+Because `io.random` is seeded from the system clock by default, it
+produces different values on each run. Use `--seed` for reproducible
+results:
+
+```sh
+eu --seed 42 example.eu
+```

--- a/doc/reference/prelude/supplements/sets/default.md
+++ b/doc/reference/prelude/supplements/sets/default.md
@@ -1,0 +1,14 @@
+```eu
+s: set.from-list([1, 2, 3, 2, 1])
+# s contains {1, 2, 3} (duplicates removed)
+```
+
+## Set Algebra
+
+```eu
+a: set.from-list([1, 2, 3])
+b: set.from-list([2, 3, 4])
+u: set.union(a, b) set.to-list       # [1, 2, 3, 4]
+i: set.intersect(a, b) set.to-list   # [2, 3]
+d: set.diff(a, b) set.to-list        # [1]
+```

--- a/doc/reference/prelude/supplements/strings/character-constants.md
+++ b/doc/reference/prelude/supplements/strings/character-constants.md
@@ -1,0 +1,5 @@
+The `ch` namespace provides special characters:
+
+- `ch.n` -- Newline
+- `ch.t` -- Tab
+- `ch.dq` -- Double quote

--- a/doc/reference/prelude/supplements/strings/default.md
+++ b/doc/reference/prelude/supplements/strings/default.md
@@ -1,0 +1,7 @@
+### Encoding and Hashing Examples
+
+```eu
+encoded: "hello" str.base64-encode    # "aGVsbG8="
+decoded: "aGVsbG8=" str.base64-decode # "hello"
+hash: "hello" str.sha256              # "2cf24dba5fb0a30e..."
+```

--- a/scripts/extract-prelude-docs.py
+++ b/scripts/extract-prelude-docs.py
@@ -1,0 +1,840 @@
+#!/usr/bin/env python3
+"""Extract documentation from lib/prelude.eu and generate markdown reference pages.
+
+Usage:
+    python3 scripts/extract-prelude-docs.py --summary    # Show extraction summary
+    python3 scripts/extract-prelude-docs.py --check      # Check coverage
+    python3 scripts/extract-prelude-docs.py --generate   # Generate reference pages
+"""
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class PreludeEntry:
+    """A single documented declaration from the prelude."""
+    name: str
+    signature: str
+    description: str
+    section: str
+    namespace: str = ""
+    is_operator: bool = False
+    is_suppressed: bool = False
+    precedence: Optional[str] = None
+    associates: Optional[str] = None
+    line_number: int = 0
+
+
+# ── Section to category mapping ──────────────────────────────────────────
+
+SECTION_TO_CATEGORY = {
+    "Prelude versioning and run metadata": "io",
+    "Random number generation": "random",
+    "Error / debug support": "booleans",
+    "Essentials": "booleans",
+    "List basics": "lists",
+    "Blocks / merge": "blocks",
+    "Deep find — recursive key search": "blocks",
+    "Deep query — pattern-based data querying": "blocks",
+    "Boolean": "booleans",
+    "Polymorphic equality": "booleans",
+    "Arithmetic": "numbers",
+    "Text and regexes": "strings",
+    "Combinators": "combinators",
+    "Sets": "sets",
+}
+
+# Namespace to category mapping
+NAMESPACE_TO_CATEGORY = {
+    "eu": "io",
+    "io": "io",
+    "str": "strings",
+    "ch": "strings",
+    "cal": "calendar",
+    "set": "sets",
+    "assertions": "metadata",
+}
+
+# Single-line section (#) to category mapping
+SINGLE_SECTION_TO_CATEGORY = {
+    "Utilities": "combinators",
+    "Metadata basics": "metadata",
+    "List library functions, maps and folds": "lists",
+    "Block library functions": "blocks",
+    "By property alteration of blocks": "blocks",
+}
+
+# Known namespaces that open with name: {
+KNOWN_NAMESPACES = {"eu", "io", "str", "cal", "set", "ch", "assertions", "_block"}
+
+
+# ── Parsing ──────────────────────────────────────────────────────────────
+
+def parse_doc_string(lines: list[str], start: int) -> tuple[dict, int]:
+    """Parse a backtick doc string starting at line `start`.
+
+    Returns (metadata_dict, next_line_index).
+    metadata_dict has at least 'doc' key if documentation found.
+    """
+    line = lines[start].strip()
+    if not line.startswith('`'):
+        return {}, start
+
+    # Content after the backtick
+    content = line[1:].strip()
+
+    # Simple string doc: ` "..."
+    if content.startswith('"'):
+        # Single-line string
+        match = re.match(r'^"((?:[^"\\]|\\.)*)"', content)
+        if match:
+            return {"doc": match.group(1)}, start + 1
+        # Multi-line string - keep collecting
+        doc_text = content[1:]  # strip opening quote
+        idx = start + 1
+        while idx < len(lines):
+            l = lines[idx]
+            if '"' in l:
+                doc_text += " " + l.strip().rstrip('"')
+                return {"doc": doc_text.strip()}, idx + 1
+            doc_text += " " + l.strip()
+            idx += 1
+        return {"doc": doc_text.strip()}, idx
+
+    # Block metadata: ` { ... }
+    if content.startswith('{'):
+        block_text = content
+        idx = start
+        brace_depth = content.count('{') - content.count('}')
+        while brace_depth > 0 and idx + 1 < len(lines):
+            idx += 1
+            block_text += " " + lines[idx].strip()
+            brace_depth += lines[idx].count('{') - lines[idx].count('}')
+
+        meta = {}
+        # Extract doc
+        doc_match = re.search(r'doc:\s*"((?:[^"\\]|\\.)*)"', block_text)
+        if doc_match:
+            # Collapse whitespace in multi-line doc strings
+            doc = doc_match.group(1)
+            doc = re.sub(r'\s+', ' ', doc).strip()
+            meta["doc"] = doc
+        # Extract export
+        exp_match = re.search(r'export:\s*:(\w+)', block_text)
+        if exp_match:
+            meta["export"] = exp_match.group(1)
+        # Extract precedence
+        prec_match = re.search(r'precedence:\s*:?([\w-]+)', block_text)
+        if prec_match:
+            meta["precedence"] = prec_match.group(1)
+        # Extract associates
+        assoc_match = re.search(r'associates:\s*:(\w+)', block_text)
+        if assoc_match:
+            meta["associates"] = assoc_match.group(1)
+        return meta, idx + 1
+
+    return {}, start
+
+
+def parse_declaration(line: str) -> tuple[str, str, bool]:
+    """Parse a declaration line.
+
+    Returns (name, signature, is_operator).
+    """
+    stripped = line.strip()
+
+    # Operator: (l op r): ... or (op x): ...
+    op_match = re.match(r'^\(([^)]+)\)\s*:', stripped)
+    if op_match:
+        sig = op_match.group(1).strip()
+        # Extract operator symbol
+        parts = sig.split()
+        if len(parts) == 3:
+            name = parts[1]
+        elif len(parts) == 2:
+            name = parts[0]
+        else:
+            name = sig
+        return name, f"({sig})", True
+
+    # Regular: name(args): ... or name: ...
+    decl_match = re.match(r'^([a-zA-Z_∅][\w?!∅.-]*(?:\([^)]*\))?)\s*:', stripped)
+    if decl_match:
+        sig = decl_match.group(1)
+        name = sig.split('(')[0]
+        return name, sig, False
+
+    return "", "", False
+
+
+def parse_prelude(prelude_path: str) -> list[PreludeEntry]:
+    """Parse the entire prelude file and extract documented entries."""
+    with open(prelude_path) as f:
+        lines = [l.rstrip('\n') for l in f.readlines()]
+
+    entries = []
+    current_section = ""
+    current_namespace = ""
+    namespace_stack = []  # list of (name, brace_depth_at_open)
+    brace_depth = 0
+    pending_doc = None
+    pending_meta = {}
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Skip empty lines
+        if not stripped:
+            i += 1
+            continue
+
+        # ── Section comment detection ──
+
+        # Double-hash section headers: ## ... ##
+        if stripped == '##':
+            # Collect multi-line section comment
+            section_lines = []
+            j = i + 1
+            while j < len(lines):
+                sl = lines[j].strip()
+                if sl == '##':
+                    break
+                if sl.startswith('##'):
+                    section_lines.append(sl[2:].strip())
+                j += 1
+            if section_lines:
+                current_section = "\n".join(section_lines)
+                # Normalise known multi-line section names
+                for known in SECTION_TO_CATEGORY:
+                    if current_section.startswith(known):
+                        current_section = known
+                        break
+            i = j + 1
+            continue
+
+        # Single-hash section comment: # Section Name
+        single_section_match = re.match(r'^#\s+(.+)$', stripped)
+        if single_section_match and not stripped.startswith('##'):
+            sec_name = single_section_match.group(1).strip()
+            if sec_name in SINGLE_SECTION_TO_CATEGORY:
+                current_section = sec_name
+            i += 1
+            continue
+
+        # ── Brace depth tracking (exclude strings) ──
+        line_for_braces = re.sub(r'"[^"]*"', '', line)
+        open_b = line_for_braces.count('{')
+        close_b = line_for_braces.count('}')
+
+        # ── Backtick doc string ──
+        if stripped.startswith('`') and not stripped.startswith('`_'):
+            pending_meta, next_i = parse_doc_string(lines, i)
+            pending_doc = pending_meta.get("doc", "")
+            i = next_i
+            continue
+
+        # ── Namespace detection ──
+        ns_match = re.match(r'^(\w[\w-]*)\s*:\s*\{', stripped)
+        if ns_match and ns_match.group(1) in KNOWN_NAMESPACES:
+            ns_name = ns_match.group(1)
+            namespace_stack.append((ns_name, brace_depth))
+            current_namespace = ns_name
+            brace_depth += (open_b - close_b)
+            # Consume the namespace-level doc string
+            pending_doc = None
+            pending_meta = {}
+            i += 1
+            continue
+
+        # Update brace depth
+        brace_depth += (open_b - close_b)
+
+        # Check if we've exited namespaces
+        while namespace_stack and brace_depth <= namespace_stack[-1][1]:
+            namespace_stack.pop()
+            current_namespace = (
+                namespace_stack[-1][0] if namespace_stack else ""
+            )
+
+        # ── Internal helper (starts with _), skip ──
+        if stripped.startswith('_') and not stripped.startswith('('):
+            pending_doc = None
+            pending_meta = {}
+            i += 1
+            continue
+
+        # ── Declaration detection ──
+        if pending_doc is not None and stripped and not stripped.startswith('#'):
+            name, sig, is_op = parse_declaration(stripped)
+            if name:
+                entry = PreludeEntry(
+                    name=name,
+                    signature=sig,
+                    description=pending_doc,
+                    section=current_section,
+                    namespace=current_namespace,
+                    is_operator=is_op,
+                    is_suppressed=pending_meta.get("export") == "suppress",
+                    precedence=pending_meta.get("precedence"),
+                    associates=pending_meta.get("associates"),
+                    line_number=i + 1,
+                )
+                entries.append(entry)
+                pending_doc = None
+                pending_meta = {}
+                i += 1
+                continue
+
+        i += 1
+
+    return entries
+
+
+# ── Categorisation ───────────────────────────────────────────────────────
+
+def categorise_entries(
+    entries: list[PreludeEntry],
+) -> dict[str, list[PreludeEntry]]:
+    """Group entries by category."""
+    categories: dict[str, list[PreludeEntry]] = {}
+
+    for entry in entries:
+        # Determine category
+        if entry.namespace:
+            cat = NAMESPACE_TO_CATEGORY.get(entry.namespace, "io")
+        elif entry.section in SECTION_TO_CATEGORY:
+            cat = SECTION_TO_CATEGORY[entry.section]
+        elif entry.section in SINGLE_SECTION_TO_CATEGORY:
+            cat = SINGLE_SECTION_TO_CATEGORY[entry.section]
+        else:
+            cat = "io"  # fallback
+
+        if cat not in categories:
+            categories[cat] = []
+        categories[cat].append(entry)
+
+    return categories
+
+
+# ── Formatting ───────────────────────────────────────────────────────────
+
+def format_signature(entry: PreludeEntry) -> str:
+    """Format signature for display in a markdown table cell."""
+    sig = entry.signature
+
+    if entry.namespace and entry.namespace not in ("assertions", "_block"):
+        if not entry.is_operator:
+            sig = f"{entry.namespace}.{sig}"
+
+    # Escape pipe for markdown tables
+    sig = sig.replace('|', '\\|')
+
+    return f"`{sig}`"
+
+
+def format_description(entry: PreludeEntry) -> str:
+    """Format description for display in a markdown table cell.
+
+    Strips leading signature prefix patterns like `name(args) -` from
+    the doc string, since the signature is shown in its own column.
+    """
+    doc = entry.description
+    if not doc:
+        return ""
+
+    # Strip single leading backtick only if it's unmatched
+    if doc.startswith('`'):
+        if doc.count('`') % 2 == 1:
+            doc = doc[1:].strip()
+
+    # Strip backtick-quoted signature prefix: `name(args)` - description
+    doc = re.sub(r'^`[^`]*`\s*[-\u2014\u2013]\s*', '', doc)
+
+    # Strip signature prefix: name(args) - description
+    prefix_re = re.compile(
+        r"^'?"                              # optional leading quote
+        r"[a-zA-Z_∅∸¬↑!][\w?!∅.,-]*"       # name (incl ! prefix)
+        r"(?:\([^)]*\))?"                   # optional (args)
+        r"`?"                               # optional trailing backtick
+        r"\s*[-\u2014\u2013]\s*"            # dash separator
+    )
+    doc = prefix_re.sub('', doc)
+
+    # Also handle operator prefix: (l op r) - description
+    op_prefix_re = re.compile(
+        r"^`?\([^)]+\)`?\s*[-\u2014\u2013]\s*"
+    )
+    doc = op_prefix_re.sub('', doc)
+
+    # Strip trailing unmatched backtick
+    if doc.endswith('`') and doc.count('`') % 2 == 1:
+        doc = doc[:-1].strip()
+
+    # Capitalise first letter
+    if doc and doc[0].islower():
+        doc = doc[0].upper() + doc[1:]
+
+    # Escape pipe for markdown tables
+    doc = doc.replace('|', '\\|')
+
+    # Remove trailing period
+    doc = doc.rstrip('.')
+
+    return doc
+
+
+# ── Supplement system ────────────────────────────────────────────────────
+
+def section_slug(display_name: str) -> str:
+    """Convert a section display name to a slug for supplement lookup."""
+    slug = display_name.lower()
+    slug = re.sub(r'[^a-z0-9]+', '-', slug)
+    slug = slug.strip('-')
+    return slug
+
+
+def load_supplement(category: str, slug: str, supplements_dir: str) -> str:
+    """Load a supplement file if it exists."""
+    path = os.path.join(supplements_dir, category, f"{slug}.md")
+    if os.path.exists(path):
+        with open(path) as f:
+            content = f.read().strip()
+        return content
+    return ""
+
+
+# ── Page generation ──────────────────────────────────────────────────────
+
+PAGE_CONFIG = {
+    "lists": {
+        "title": "Lists",
+        "sections": [
+            {"display": "Basic Operations",
+             "sources": ["List basics"]},
+            {"display": "List Construction",
+             "filter": lambda e: e.name in {
+                 "repeat", "ints-from", "range", "cycle", "iterate", "nil",
+             }},
+            {"display": "Transformations",
+             "filter": lambda e: e.name in {
+                 "map", "<$>", "map2", "filter", "remove", "reverse",
+                 "take", "drop", "take-while", "take-until",
+                 "drop-while", "drop-until", "cross",
+             }},
+            {"display": "Combining Lists",
+             "filter": lambda e: e.name in {
+                 "append", "++", "prepend", "concat", "mapcat",
+                 "zip", "zip-with", "zip-apply",
+             }},
+            {"display": "Splitting Lists",
+             "filter": lambda e: e.name in {
+                 "split-at", "split-after", "split-when",
+                 "window", "partition", "discriminate",
+             }},
+            {"display": "Folds and Scans",
+             "filter": lambda e: e.name in {
+                 "foldl", "foldr", "scanl", "scanr",
+             }},
+            {"display": "Predicates",
+             "filter": lambda e: e.name in {
+                 "all", "all-true?", "any", "any-true?",
+             }},
+            {"display": "Sorting",
+             "filter": lambda e: e.name in {
+                 "qsort", "sort-nums", "sort-strs", "sort-zdts",
+                 "sort-by", "sort-by-num", "sort-by-str", "sort-by-zdt",
+                 "group-by",
+             }},
+            {"display": "Other",
+             "filter": lambda e: e.name in {
+                 "over-sliding-pairs", "differences", "count", "last",
+                 "nth", "!!",
+             }},
+        ],
+    },
+    "blocks": {
+        "title": "Blocks",
+        "sections": [
+            {"display": "Block Construction and Merging",
+             "sources": ["Blocks / merge"]},
+            {"display": "Block Utilities",
+             "sources": ["Block library functions"]},
+            {"display": "Block Alteration",
+             "sources": ["By property alteration of blocks"]},
+            {"display": "Deep Find and Query",
+             "sources": [
+                 "Deep find — recursive key search",
+                 "Deep query — pattern-based data querying",
+             ]},
+        ],
+    },
+    "strings": {
+        "title": "Strings",
+        "sections": [
+            {"display": "String Processing",
+             "filter": lambda e: e.namespace == "str"},
+            {"display": "Character Constants",
+             "filter": lambda e: e.namespace == "ch"},
+        ],
+    },
+    "numbers": {
+        "title": "Numbers and Arithmetic",
+        "sections": [
+            {"display": "Arithmetic Operators",
+             "filter": lambda e: e.is_operator},
+            {"display": "Numeric Functions",
+             "filter": lambda e: not e.is_operator},
+        ],
+    },
+    "booleans": {
+        "title": "Booleans and Comparison",
+        "sections": [
+            {"display": "Essentials",
+             "sources": ["Essentials"]},
+            {"display": "Error and Debug Support",
+             "sources": ["Error / debug support"]},
+            {"display": "Boolean Logic",
+             "sources": ["Boolean"]},
+            {"display": "Equality and Comparison",
+             "sources": ["Polymorphic equality"]},
+        ],
+    },
+    "combinators": {
+        "title": "Combinators",
+        "sections": [
+            {"display": "Combinators",
+             "sources": ["Combinators"]},
+            {"display": "Utilities",
+             "sources": ["Utilities"]},
+        ],
+    },
+    "calendar": {
+        "title": "Calendar",
+        "sections": [
+            {"display": "Date and Time Functions",
+             "filter": lambda _: True},
+        ],
+    },
+    "sets": {
+        "title": "Sets",
+        "sections": [
+            {"display": "Set Operations",
+             "filter": lambda _: True},
+        ],
+    },
+    "random": {
+        "title": "Random Numbers",
+        "sections": [
+            {"display": "Random Number Generation",
+             "filter": lambda _: True},
+        ],
+    },
+    "metadata": {
+        "title": "Metadata",
+        "sections": [
+            {"display": "Metadata Basics",
+             "sources": ["Metadata basics"]},
+            {"display": "Assertions",
+             "filter": lambda e:
+                e.namespace == "assertions" or e.name.startswith("//")},
+        ],
+    },
+    "io": {
+        "title": "IO",
+        "sections": [
+            {"display": "Prelude Versioning",
+             "filter": lambda e: e.namespace == "eu"},
+            {"display": "IO Functions",
+             "filter": lambda e: e.namespace == "io"},
+        ],
+    },
+}
+
+
+def entries_for_section(
+    all_entries: list[PreludeEntry],
+    section_config: dict,
+) -> list[PreludeEntry]:
+    """Select entries that belong to a section based on its config."""
+    if "sources" in section_config:
+        sources = section_config["sources"]
+        return [e for e in all_entries if e.section in sources]
+    elif "filter" in section_config:
+        return [e for e in all_entries if section_config["filter"](e)]
+    return []
+
+
+def generate_table(entries: list[PreludeEntry]) -> str:
+    """Generate a markdown table from a list of entries."""
+    if not entries:
+        return ""
+
+    lines = ["| Function | Description |", "|----------|-------------|"]
+    for entry in entries:
+        sig = format_signature(entry)
+        desc = format_description(entry)
+        lines.append(f"| {sig} | {desc} |")
+
+    return "\n".join(lines)
+
+
+def generate_page(
+    category: str,
+    all_entries: list[PreludeEntry],
+    supplements_dir: str,
+) -> str:
+    """Generate a complete markdown page for a category."""
+    config = PAGE_CONFIG[category]
+    parts = [f"# {config['title']}"]
+
+    # Top-level supplement (preamble)
+    top_supp = load_supplement(category, "top", supplements_dir)
+    if top_supp:
+        parts.append("")
+        parts.append(top_supp)
+
+    # Track which entries have been assigned to a section
+    used_entries: set[int] = set()
+
+    for section_config in config["sections"]:
+        display = section_config["display"]
+        section_entries = entries_for_section(all_entries, section_config)
+
+        # Filter to public (non-suppressed) entries
+        public_entries = [e for e in section_entries if not e.is_suppressed]
+
+        # Deduplicate by (name, line) and track used entries
+        seen = set()
+        unique_entries = []
+        for e in public_entries:
+            key = (e.name, e.line_number)
+            if key not in seen and id(e) not in used_entries:
+                seen.add(key)
+                unique_entries.append(e)
+                used_entries.add(id(e))
+
+        # Check for section supplement even if no entries
+        slug = section_slug(display)
+        supp = load_supplement(category, slug, supplements_dir)
+
+        if not unique_entries and not supp:
+            continue
+
+        parts.append("")
+        parts.append(f"## {display}")
+        parts.append("")
+
+        if unique_entries:
+            table = generate_table(unique_entries)
+            parts.append(table)
+
+        if supp:
+            if unique_entries:
+                parts.append("")
+            parts.append(supp)
+
+    # Default supplement (bottom of page)
+    default_supp = load_supplement(category, "default", supplements_dir)
+    if default_supp:
+        parts.append("")
+        parts.append(default_supp)
+
+    # Remaining entries not assigned to any section
+    remaining = [
+        e for e in all_entries
+        if id(e) not in used_entries and not e.is_suppressed
+    ]
+    if remaining:
+        parts.append("")
+        parts.append("## Other")
+        parts.append("")
+        parts.append(generate_table(remaining))
+
+    parts.append("")
+    return "\n".join(parts)
+
+
+def generate_index(categories: dict[str, list[PreludeEntry]]) -> str:
+    """Generate the prelude index page."""
+    parts = [
+        "# Prelude Reference",
+        "",
+        "The eucalypt **prelude** is a standard library of functions, operators,",
+        "and constants that is automatically loaded before your code runs.",
+        "",
+        "You can suppress the prelude with `-Q` if needed, though this leaves",
+        "a very bare environment (even `true`, `false`, and `if` are defined",
+        "in the prelude).",
+        "",
+        "## Categories",
+        "",
+    ]
+
+    category_info = [
+        ("lists", "Lists", "list construction, transformation, folding, sorting"),
+        ("blocks", "Blocks", "block construction, access, merging, transformation"),
+        ("strings", "Strings", "string manipulation, regex, formatting"),
+        ("numbers", "Numbers and Arithmetic", "numeric operations and predicates"),
+        ("booleans", "Booleans and Comparison",
+         "boolean logic and comparison operators"),
+        ("combinators", "Combinators",
+         "function composition, application, utilities"),
+        ("calendar", "Calendar", "date and time functions"),
+        ("sets", "Sets", "set operations"),
+        ("random", "Random Numbers", "random number generation"),
+        ("metadata", "Metadata", "metadata and assertion functions"),
+        ("io", "IO", "environment, time, and argument access"),
+    ]
+
+    for cat_key, cat_title, cat_desc in category_info:
+        count = len([
+            e for e in categories.get(cat_key, [])
+            if not e.is_suppressed
+        ])
+        parts.append(
+            f"- [{cat_title}]({cat_key}.md) -- {cat_desc} ({count} entries)"
+        )
+
+    total = sum(
+        len([e for e in entries if not e.is_suppressed])
+        for entries in categories.values()
+    )
+    parts.append("")
+    parts.append(f"*{total} documented entries in total.*")
+    parts.append("")
+
+    return "\n".join(parts)
+
+
+# ── Coverage check ───────────────────────────────────────────────────────
+
+def check_coverage(
+    entries: list[PreludeEntry],
+    categories: dict[str, list[PreludeEntry]],
+):
+    """Check and report documentation coverage."""
+    public = [e for e in entries if not e.is_suppressed]
+    documented = [e for e in public if e.description]
+    undocumented = [e for e in public if not e.description]
+
+    print(f"Total entries extracted: {len(entries)}")
+    print(f"Public entries: {len(public)}")
+    print(f"Suppressed entries: {len(entries) - len(public)}")
+    print(f"Documented: {len(documented)}")
+    print(f"Undocumented: {len(undocumented)}")
+    print()
+
+    if undocumented:
+        print("UNDOCUMENTED entries:")
+        for e in undocumented:
+            ns = f"{e.namespace}." if e.namespace else ""
+            print(
+                f"  - {ns}{e.name} (line {e.line_number},"
+                f" section: {e.section})"
+            )
+    else:
+        print("All public entries are documented.")
+
+    print()
+    print("Coverage by category:")
+    for cat_key in PAGE_CONFIG:
+        cat_entries = categories.get(cat_key, [])
+        cat_public = [e for e in cat_entries if not e.is_suppressed]
+        cat_doc = [e for e in cat_public if e.description]
+        print(f"  {cat_key}: {len(cat_doc)}/{len(cat_public)} documented")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract and generate prelude documentation"
+    )
+    parser.add_argument(
+        "--summary", action="store_true",
+        help="Show extraction summary",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Check documentation coverage",
+    )
+    parser.add_argument(
+        "--generate", action="store_true",
+        help="Generate markdown reference pages",
+    )
+    parser.add_argument(
+        "--root", default=None,
+        help="Project root directory (default: auto-detect)",
+    )
+    args = parser.parse_args()
+
+    if not (args.summary or args.check or args.generate):
+        parser.print_help()
+        sys.exit(1)
+
+    # Find project root
+    if args.root:
+        root = Path(args.root)
+    else:
+        root = Path(__file__).resolve().parent.parent
+
+    prelude_path = root / "lib" / "prelude.eu"
+    output_dir = root / "doc" / "reference" / "prelude"
+    supplements_dir = output_dir / "supplements"
+
+    if not prelude_path.exists():
+        print(f"Error: prelude not found at {prelude_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse
+    entries = parse_prelude(str(prelude_path))
+    categories = categorise_entries(entries)
+
+    if args.summary:
+        print(f"Extracted {len(entries)} entries from {prelude_path}")
+        public = [e for e in entries if not e.is_suppressed]
+        print(f"Public: {len(public)}, Suppressed: {len(entries) - len(public)}")
+        print()
+        for cat_key in PAGE_CONFIG:
+            cat_entries = categories.get(cat_key, [])
+            cat_public = [e for e in cat_entries if not e.is_suppressed]
+            print(f"  {cat_key}: {len(cat_public)} public entries")
+
+    if args.check:
+        check_coverage(entries, categories)
+
+    if args.generate:
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Generate category pages
+        for cat_key in PAGE_CONFIG:
+            cat_entries = categories.get(cat_key, [])
+            page = generate_page(cat_key, cat_entries, str(supplements_dir))
+            outpath = output_dir / f"{cat_key}.md"
+            with open(outpath, 'w') as f:
+                f.write(page)
+            public_count = len([
+                e for e in cat_entries if not e.is_suppressed
+            ])
+            print(f"  Generated {outpath.name} ({public_count} public entries)")
+
+        # Generate index
+        index = generate_index(categories)
+        index_path = output_dir / "index.md"
+        with open(index_path, 'w') as f:
+            f.write(index)
+        print(f"  Generated {index_path.name}")
+
+        print(f"\nDone. Generated pages in {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add Python extraction script (`scripts/extract-prelude-docs.py`) that parses `lib/prelude.eu` backtick doc strings and generates markdown reference pages
- 247 entries extracted (218 public, 29 suppressed) across 11 categories with 100% documentation coverage
- Supplement system for hand-written examples (deep find/query, sorting, random usage, set algebra, metadata keys, character constants) injected alongside auto-generated tables
- Script supports `--check` (coverage verification), `--summary`, and `--generate` modes

## Test plan

- [x] `python3 scripts/extract-prelude-docs.py --check` reports 218/218 documented, 0 undocumented
- [x] `python3 scripts/extract-prelude-docs.py --generate` produces all 11 category pages + index
- [x] `mdbook build` succeeds with no warnings
- [ ] Visual review of generated HTML pages in browser

Generated with [Claude Code](https://claude.ai/code)