### PR TITLE
feat(eu-ul5g): convert iterator panics to proper errors

### DIFF
--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -974,11 +974,13 @@ impl StgIntrinsic for Merge {
         let mut merge: IndexMap<String, SynClosure> = IndexMap::new();
 
         for item in l {
+            let item = item?;
             let (k, kv) = deconstruct(view, machine.symbol_pool(), &item)?;
             merge.insert(k, kv);
         }
 
         for item in r {
+            let item = item?;
             let (k, kv) = deconstruct(view, machine.symbol_pool(), &item)?;
             merge.insert(k, kv);
         }
@@ -1077,11 +1079,13 @@ impl StgIntrinsic for MergeWith {
         let mut merge: IndexMap<String, SynClosure> = IndexMap::new();
 
         for item in l {
+            let item = item?;
             let (key, value) = deconstruct(view, machine.symbol_pool(), &item)?;
             merge.insert(key, value);
         }
 
         for item in r {
+            let item = item?;
             let (key, nv) = deconstruct(view, machine.symbol_pool(), &item)?;
             if let Some(ov) = merge.get_mut(&key) {
                 let args = [ov.clone(), nv];

--- a/src/eval/stg/set.rs
+++ b/src/eval/stg/set.rs
@@ -58,7 +58,8 @@ impl StgIntrinsic for SetFromList {
     ) -> Result<(), ExecutionError> {
         let iter = data_list_arg(machine, view, args[0].clone())?;
         let mut primitives = Vec::new();
-        for item_closure in iter {
+        for item_result in iter {
+            let item_closure = item_result?;
             let code = view.scoped(item_closure.code());
             match &*code {
                 HeapSyn::Atom { evaluand } => {

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -33,7 +33,6 @@ use super::{
     tags::DataConstructor,
 };
 
-use itertools::Itertools;
 use regex::Regex;
 use serde_json::Number;
 
@@ -170,7 +169,9 @@ impl StgIntrinsic for Join {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let sep = str_arg(machine, view, &args[1])?;
-        let result = str_list_arg(machine, view, args[0].clone())?.join(&sep);
+        let strings: Vec<String> =
+            str_list_arg(machine, view, args[0].clone())?.collect::<Result<Vec<_>, _>>()?;
+        let result = strings.join(&sep);
         machine_return_str(machine, view, result)
     }
 }


### PR DESCRIPTION
## Summary
- Convert `DataIterator` and `StrListIterator` from panicking on malformed data to returning `Result` errors
- `DataIterator::Item` changed from `SynClosure` to `Result<SynClosure, ExecutionError>`
- `StrListIterator::Item` changed from `String` to `Result<String, ExecutionError>`
- Updated all call sites in `block.rs` (Merge, MergeWith), `set.rs` (SetFromList), and `string.rs` (Join) to propagate errors
- Non-string items in StrListIterator now produce a `TypeMismatch` error with expected/actual types

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --test harness_test` — 111 tests pass
- [x] `cargo test --lib` — 543 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)