### PR TITLE
feat: improve runtime stack traces and error context

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -169,8 +169,8 @@ pub enum ExecutionError {
     DivisionByZero,
     #[error("expected branch continuation")]
     ExpectedBranchContinuation,
-    #[error("type mismatch: expected {}, found {}", display_expected_tags(.1), display_data_tag(*.0))]
-    NoBranchForDataTag(u8, Vec<u8>),
+    #[error("type mismatch: expected {}, found {}", display_expected_tags(.2), display_data_tag(*.1))]
+    NoBranchForDataTag(Smid, u8, Vec<u8>),
     #[error("no branch for native")]
     NoBranchForNative,
     #[error("cannot return function into case table without default")]
@@ -236,6 +236,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NotCallable(s) => *s,
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
+            ExecutionError::NoBranchForDataTag(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/machine/cont.rs
+++ b/src/eval/machine/cont.rs
@@ -43,6 +43,8 @@ pub enum Continuation {
         fallback: Option<RefPtr<HeapSyn>>,
         /// Environment of case statement
         environment: RefPtr<EnvFrame>,
+        /// Source annotation at the point the case was pushed
+        annotation: Smid,
     },
     /// Update thunk in environment at index i
     Update {


### PR DESCRIPTION
## Summary

- Filter internal machinery names (emit/render pipeline, saturation, internal helpers) from user-visible stack traces so only meaningful entries are shown
- Add user-facing display names for date/time, encoding, set, and stream intrinsics in trace output
- Add annotation field to `Branch` continuation for better error attribution when type mismatches occur in case expressions
- Add `Smid` to `NoBranchForDataTag` error variant for source location context
- Show "in <function>" diagnostic note for errors with synthetic BIF annotations
- Set BIF annotation before intrinsic execution for direct BIF errors
- Add `nearest_stack_annotation` fallback to search the stack for call context when the immediate continuation has no annotation

## Technical Details

The `intrinsic_display_name` function in `sourcemap.rs` now comprehensively maps internal BIF names to user-facing names and filters out all internal machinery (emit pipeline, render pipeline, saturation helpers, internal block/list operations, data constructors).

The `Branch` continuation now carries an `annotation: Smid` field (similar to `ApplyTo`) that captures the source annotation at `Case` push time. This improves stack trace extraction and error attribution.

## Limitations

Type mismatch errors from inlined BIF wrappers (e.g. `"hello" + 1`) do not yet show "in (+)" context because the STG compiler inlines wrapper code and the inner Case closures lose the BIF annotation. A future improvement could annotate Cases at STG compilation time.

## Test plan

- [x] All 111 harness tests pass
- [x] All 543 unit tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Existing type mismatch error tests (031-033) still pass

Generated with [Claude Code](https://claude.com/claude-code)