### PR TITLE
feat(eu-iy92): add documentation example testing and mark untestable blocks

### DIFF
--- a/doc/appendices/syntax-gotchas.md
+++ b/doc/appendices/syntax-gotchas.md
@@ -14,7 +14,7 @@ catenation (precedence 20), which can lead to unexpected parsing.
 rather than `(objects head).id`.
 
 **Example**:
-```eu
+```eu,notest
 # This doesn't work as expected:
 objects: range(0, 5) map({ id: _ })
 result: objects head.id  # Parsed as: objects (head.id)
@@ -53,7 +53,7 @@ map(λx.x + 1)        # Invalid
 
 **Correct Approach**: Use anaphora (`_`, `_0`, `_1`, etc.) or define
 named functions:
-```eu
+```eu,notest
 # Using anaphora:
 map(_ + 1)
 
@@ -85,7 +85,7 @@ developers might expect `'text'` to be a string literal.
 - String literals use double quotes (`"`) only
 
 **Examples**:
-```eu
+```eu,notest
 # Single quotes create identifiers (variable names):
 'my-file.txt': "content"     # Creates identifier: my-file.txt
 home: {

--- a/doc/guide/anaphora.md
+++ b/doc/guide/anaphora.md
@@ -84,7 +84,7 @@ into a lambda.
 So an expression that refers `_0` and `_1` actually defines a function
 accepting two parameters:
 
-```eu
+```eu,notest
 xs: zip-with(f, [1, 2, 3], [1, 2, 3]) //=> [3, 6, 9]
 
 # or more succinctly
@@ -162,7 +162,7 @@ f(x, y): {x: x y: y }
 An attempt to define this using expression anaphora would fail. This
 defines a block with two identity functions:
 
-```eu
+```eu,notest
 f: {x: _ y: _ }
 ```
 

--- a/doc/guide/date-time-random.md
+++ b/doc/guide/date-time-random.md
@@ -31,7 +31,7 @@ The `t"..."` syntax accepts ISO 8601 formats:
 The `cal` namespace provides functions for working with date-time
 values:
 
-```eu
+```eu,notest
 # Parse from a string
 d: cal.parse("2024-03-15T14:30:00Z")
 
@@ -103,7 +103,7 @@ eu --seed 42 example.eu
 Random functions consume part of the stream and return both a result
 and the remaining stream:
 
-```eu
+```eu,notest
 result: random-int(100, io.random)
 value: result.value   # a number from 0 to 99
 rest: result.rest     # remaining stream
@@ -113,14 +113,14 @@ rest: result.rest     # remaining stream
 
 **Rolling dice:**
 
-```eu
+```eu,notest
 roll: random-int(6, io.random)
 die: roll.value + 1
 ```
 
 **Picking a random element:**
 
-```eu
+```eu,notest
 colours: ["red", "green", "blue"]
 pick: random-choice(colours, io.random)
 colour: pick.value
@@ -128,7 +128,7 @@ colour: pick.value
 
 **Shuffling a list:**
 
-```eu
+```eu,notest
 items: ["a", "b", "c", "d"]
 shuffled: shuffle(items, io.random)
 result: shuffled.value
@@ -136,7 +136,7 @@ result: shuffled.value
 
 **Sampling without replacement:**
 
-```eu
+```eu,notest
 pool: range(1, 50)
 drawn: sample(6, pool, io.random)
 lottery: drawn.value

--- a/doc/reference/cli.md
+++ b/doc/reference/cli.md
@@ -184,7 +184,7 @@ y: 8
 
 b.eu
 
-```eu
+```eu,notest
 z: x + y
 ```
 

--- a/doc/reference/import-formats.md
+++ b/doc/reference/import-formats.md
@@ -12,7 +12,7 @@ from disk or direct from git repositories.
 Imports are specified in declaration metadata and make the names in
 the imported unit available within the declaration that is annotated.
 
-```eu
+```eu,notest
 { import: "config.eu" }
 data: {
   # names from config are available here
@@ -24,7 +24,7 @@ As described in [Syntax Reference](syntax.md), declaration metadata can
 be applied at a unit level simply by including a metadata block as the
 very first thing in a eucalypt file:
 
-```eu
+```eu,notest
 { import: "config.eu" }
 
 # names from config are available here
@@ -37,13 +37,13 @@ x: config-value
 Imports are specified using the key `import` in a declaration metadata
 block. The value may be a single import specification:
 
-```eu
+```eu,notest
 { import: "dep-a.eu"}
 ```
 
 or a list of import specifications:
 
-```eu
+```eu,notest
 { import: ["dep-a.eu", "dep-b.eu"]}
 ```
 
@@ -58,14 +58,14 @@ specified at the command line (see [CLI Reference](cli.md)).
 So you can override the format of the imported file when the file
 extension is misleading:
 
-```eu
+```eu,notest
 { import: "yaml@dep.txt" }
 ```
 
 ...and provide a name under which the imported names will be
 available:
 
-```eu
+```eu,notest
 { import: "cfg=config.eu" }
 
 # names in config.eu are available by lookup in cfg:
@@ -76,7 +76,7 @@ x: cfg.x
 In cases where the import format delivers a list rather than a block
 ("text", "csv", "jsonl", ...) a name is mandatory:
 
-```eu
+```eu,notest
 { import: "txns=transactions.csv" }
 ```
 
@@ -92,7 +92,7 @@ explicitly manage a git working copy and a library path with the
 repeatability of a git SHA. A git import is specified as a block with
 the keys "git", "commit" and "import", all of which are mandatory:
 
-```eu
+```eu,notest
 { import: { git: "https://github.com/gmorpheme/eu.aws"
             commit: "0140232cf882a922bdd67b520ed56f0cddbd0637"
             import: "aws/cloudformation.eu" } }
@@ -325,7 +325,7 @@ eu -e 'data filter(str.matches?("ERROR"))' log=text-stream@app.log
 Streaming imports can also be used via the import syntax in eucalypt
 source files:
 
-```eu
+```eu,notest
 { import: "events=jsonl-stream@events.jsonl" }
 
 recent: events take(100)

--- a/doc/reference/operators-and-identifiers.md
+++ b/doc/reference/operators-and-identifiers.md
@@ -17,7 +17,7 @@ identifier by surrounding them in single quotes. This is the only use
 of single quotes in eucalypt. This can be useful when you want to use
 file paths or other external identifiers as block keys for instance:
 
-```eu
+```eu,notest
 home: {
   '.bashrc': false
   '.emacs.d': false
@@ -70,7 +70,7 @@ y: { z: 100 r: z //=> 100 }
 
 But beware trying to access the outer value:
 
-```eu
+```eu,notest
 name: "foo"
 x: { name: name } //=> infinite recursion
 ```

--- a/doc/reference/prelude/random.md
+++ b/doc/reference/prelude/random.md
@@ -36,7 +36,7 @@ The random functions use a functional random stream pattern. Each
 function consumes some random values and returns both a result and the
 remaining stream in a block with `value` and `rest` keys:
 
-```eu
+```eu,notest
 result: random-int(6, io.random)
 die-roll: result.value    # a number from 0 to 5
 remaining: result.rest    # unconsumed stream for further use
@@ -44,7 +44,7 @@ remaining: result.rest    # unconsumed stream for further use
 
 To chain multiple random operations, thread the `rest` through:
 
-```eu
+```eu,notest
 rolls: {
   first: random-int(6, io.random)
   second: random-int(6, first.rest)
@@ -55,13 +55,13 @@ two-dice: rolls.value
 
 ## Shuffling and Sampling
 
-```eu
+```eu,notest
 deck: range(1, 53)
 shuffled: shuffle(deck, io.random)
 hand: shuffled.value take(5)
 ```
 
-```eu
+```eu,notest
 colours: ["red", "green", "blue", "yellow", "purple"]
 picked: sample(2, colours, io.random)
 two-colours: picked.value
@@ -71,7 +71,7 @@ two-colours: picked.value
 
 For reproducible output (useful in tests), pass a fixed seed:
 
-```eu
+```eu,notest
 stream: random-stream(12345)
 x: random-int(100, stream)
 # x.value is always the same for seed 12345

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -27,7 +27,7 @@ and expressions (from the *expression DSL*) appear in declarations
 Comments can be interspersed throughout. Eucalypt only has line level
 comments.
 
-```eu
+```eu,notest
 foo: bar # Line comments start with '#' and run till the end of the line
 ```
 
@@ -55,7 +55,7 @@ A **block** is surrounded by curly braces:
 
 ...and contains declarations...
 
-```eu
+```eu,notest
 ... {
   a: 1
   b: 2
@@ -65,7 +65,7 @@ A **block** is surrounded by curly braces:
 
 ...which may themselves have blocks as values...
 
-```eu
+```eu,notest
 ... {
   foo: {
     bar: {
@@ -281,7 +281,7 @@ result: 2 increment
 to define simple functions without the song and dance of a function
 declaration:
 
-```eu
+```eu,notest
 f: if(tuesday?, (_ * 32 / 12), (99 / _))
 result: f(3)
 ```
@@ -303,7 +303,7 @@ result: 2 increment (126 /)
 Both styles of function application together with partial application
 and sectioning can all be applied together:
 
-```eu
+```eu,notest
 result: [1, 2, 3] map(+1) filter(odd?) //=> [3]
 ```
 

--- a/doc/welcome/index.md
+++ b/doc/welcome/index.md
@@ -144,7 +144,7 @@ The whole line is a **declaration**. Declarations come in several
 types - this one is a **property declaration**. A **block** is written
 as a sequence of declarations enclosed in braces. For example:
 
-```eu
+```eu,notest
 {
   w: "foo" # a string
   x: 3     # a whole number
@@ -161,7 +161,7 @@ Unlike JSON, commas are not needed to separate declarations. Instead,
 the eucalypt parser determines the declarations mainly based on the
 location of colons. You can write:
 
-```eu
+```eu,notest
 { x: 1 increment negate y: 2 }
 ```
 
@@ -304,7 +304,7 @@ functions in scope when an expression is created are the ones that are
 applied. So if you redefine an `f` like this, in an overriding
 block...
 
-```eu
+```eu,notest
 { f(x): x+1 a: f(2) } { f(x): x-2 }
 ```
 

--- a/scripts/test-doc-examples.py
+++ b/scripts/test-doc-examples.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Test eucalypt code examples extracted from documentation.
+
+Extracts code blocks from markdown files and runs them through the eu
+binary to verify they produce valid output or pass assertions.
+
+Code blocks are identified by their language tag:
+    ```eu          -- testable (default)
+    ```eu,notest   -- explicitly skipped
+    ```eu,seed=42  -- run with --seed flag
+
+Blocks containing //=> assertions are self-checking: the assertion
+panics if the value does not match, causing eu to exit non-zero.
+
+Usage:
+    python3 scripts/test-doc-examples.py [options]
+
+Options:
+    --verbose       Show output from each test
+    --file FILE     Test only examples from FILE
+    --eu PATH       Path to eu binary (default: eu)
+    --list          List all extracted examples without running them
+"""
+
+import re
+import os
+import sys
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class CodeBlock:
+    """A code block extracted from documentation."""
+    source_file: str
+    line_number: int
+    code: str
+    language: str  # "eu", "eu,notest", etc.
+    block_index: int  # index within the file
+
+    @property
+    def skip(self) -> bool:
+        return "notest" in self.language
+
+    @property
+    def seed(self) -> Optional[int]:
+        match = re.search(r'seed=(\d+)', self.language)
+        return int(match.group(1)) if match else None
+
+    @property
+    def has_assertions(self) -> bool:
+        return '//=>' in self.code or '//!' in self.code
+
+    @property
+    def label(self) -> str:
+        rel = os.path.relpath(self.source_file)
+        return f"{rel}:{self.line_number}"
+
+
+def extract_code_blocks(filepath: str) -> list[CodeBlock]:
+    """Extract eu code blocks from a markdown file."""
+    blocks = []
+    with open(filepath, 'r') as f:
+        lines = f.readlines()
+
+    in_block = False
+    block_lines = []
+    block_lang = ""
+    block_start = 0
+    block_index = 0
+
+    for i, line in enumerate(lines, 1):
+        stripped = line.rstrip()
+
+        if not in_block:
+            # Check for opening fence with eu language
+            match = re.match(r'^```(eu\b[^\s]*)$', stripped)
+            if match:
+                in_block = True
+                block_lang = match.group(1)
+                block_start = i
+                block_lines = []
+                continue
+        else:
+            if stripped == '```':
+                # Closing fence
+                code = '\n'.join(block_lines)
+                if code.strip():
+                    blocks.append(CodeBlock(
+                        source_file=filepath,
+                        line_number=block_start,
+                        code=code,
+                        language=block_lang,
+                        block_index=block_index,
+                    ))
+                    block_index += 1
+                in_block = False
+                continue
+            block_lines.append(line.rstrip())
+
+    return blocks
+
+
+def is_likely_fragment(code: str) -> bool:
+    """Heuristic: is this code block likely a fragment that won't run standalone?
+
+    Returns True for blocks that look like they need surrounding context.
+    """
+    stripped = code.strip()
+
+    # Empty or whitespace only
+    if not stripped:
+        return True
+
+    # Single expression without a declaration (no colon)
+    lines = [l.strip() for l in stripped.split('\n') if l.strip()
+             and not l.strip().startswith('#')]
+    if not lines:
+        return True
+
+    # If the first non-comment line doesn't contain a declaration
+    # (name: ...) it's probably a fragment
+    first_line = lines[0]
+
+    # Check for common fragment patterns
+    # - starts with a pipe (shell command)
+    if first_line.startswith('|') or first_line.startswith('$'):
+        return True
+
+    # - is a bare expression (no `:` declaration)
+    # But be careful: `x: 1` is a declaration, `x` alone is not
+    has_declaration = any(':' in l and not l.strip().startswith('#')
+                         for l in lines)
+    if not has_declaration:
+        return True
+
+    return False
+
+
+def run_example(block: CodeBlock, eu_path: str, verbose: bool = False,
+                timeout: int = 10) -> tuple[bool, str]:
+    """Run a code block through eu and return (success, message)."""
+    if block.skip:
+        return True, "SKIP (notest)"
+
+    if is_likely_fragment(block.code):
+        return True, "SKIP (fragment)"
+
+    # Write to temp file
+    with tempfile.NamedTemporaryFile(
+        mode='w', suffix='.eu', prefix='doctest_', delete=False
+    ) as f:
+        f.write(block.code)
+        f.write('\n')
+        tmpfile = f.name
+
+    try:
+        cmd = [eu_path]
+        if block.seed is not None:
+            cmd.extend(['--seed', str(block.seed)])
+        cmd.append(tmpfile)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        if result.returncode == 0:
+            if verbose:
+                return True, f"OK\n{result.stdout.strip()}"
+            return True, "OK"
+        else:
+            err = result.stderr.strip()
+            # Clean ANSI escape codes
+            err = re.sub(r'\x1b\[[0-9;]*m', '', err)
+            return False, f"FAIL (exit {result.returncode})\n{err}"
+
+    except subprocess.TimeoutExpired:
+        return False, f"FAIL (timeout after {timeout}s)"
+    finally:
+        os.unlink(tmpfile)
+
+
+def find_doc_files(doc_dir: str) -> list[str]:
+    """Find all markdown files in the doc directory."""
+    files = []
+    for root, dirs, filenames in os.walk(doc_dir):
+        for name in sorted(filenames):
+            if name.endswith('.md'):
+                files.append(os.path.join(root, name))
+    return sorted(files)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Test eucalypt code examples from documentation"
+    )
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Show output from each test")
+    parser.add_argument("--file", type=str, default=None,
+                        help="Test only examples from this file")
+    parser.add_argument("--eu", type=str, default="eu",
+                        help="Path to eu binary")
+    parser.add_argument("--list", action="store_true",
+                        help="List all extracted examples without running")
+    parser.add_argument("--timeout", type=int, default=10,
+                        help="Timeout in seconds per test (default: 10)")
+
+    args = parser.parse_args()
+
+    # Determine paths
+    script_dir = Path(__file__).parent
+    project_dir = script_dir.parent
+    doc_dir = str(project_dir / "doc")
+
+    # Check eu binary
+    if not args.list:
+        try:
+            subprocess.run([args.eu, "version"], capture_output=True,
+                           timeout=5)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            print(f"Error: eu binary not found at '{args.eu}'",
+                  file=sys.stderr)
+            print("Install eu or specify --eu /path/to/eu", file=sys.stderr)
+            sys.exit(1)
+
+    # Find and extract blocks
+    if args.file:
+        doc_files = [args.file]
+    else:
+        doc_files = find_doc_files(doc_dir)
+
+    all_blocks = []
+    for filepath in doc_files:
+        blocks = extract_code_blocks(filepath)
+        all_blocks.extend(blocks)
+
+    if not all_blocks:
+        print("No eu code blocks found in documentation")
+        sys.exit(0)
+
+    if args.list:
+        print(f"Found {len(all_blocks)} eu code blocks:\n")
+        for block in all_blocks:
+            skip = " [notest]" if block.skip else ""
+            frag = " [fragment]" if is_likely_fragment(block.code) else ""
+            assert_ = " [asserts]" if block.has_assertions else ""
+            seed = f" [seed={block.seed}]" if block.seed else ""
+            print(f"  {block.label}{skip}{frag}{assert_}{seed}")
+            if args.verbose:
+                for line in block.code.split('\n')[:3]:
+                    print(f"    | {line}")
+                if block.code.count('\n') > 3:
+                    print(f"    | ...")
+                print()
+        return
+
+    # Run tests
+    total = 0
+    passed = 0
+    failed = 0
+    skipped = 0
+    failures = []
+
+    print(f"Testing {len(all_blocks)} eu code blocks from documentation...\n")
+
+    for block in all_blocks:
+        total += 1
+        success, message = run_example(block, args.eu, args.verbose,
+                                       args.timeout)
+
+        if "SKIP" in message:
+            skipped += 1
+            if args.verbose:
+                print(f"  SKIP  {block.label}")
+        elif success:
+            passed += 1
+            if args.verbose:
+                print(f"  OK    {block.label}")
+        else:
+            failed += 1
+            failures.append((block, message))
+            print(f"  FAIL  {block.label}")
+            # Show first few lines of code
+            for line in block.code.split('\n')[:5]:
+                print(f"        | {line}")
+            # Show error
+            for line in message.split('\n'):
+                print(f"        {line}")
+            print()
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed, "
+          f"{skipped} skipped, {total} total")
+
+    if failures:
+        print(f"\nFailed tests:")
+        for block, msg in failures:
+            print(f"  {block.label}")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed!")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/test-doc-examples.py` which extracts eu code blocks from markdown documentation and runs them through the eu binary to verify they produce valid output
- Blocks with `//=>` assertions are self-checking (non-zero exit on mismatch)
- Mark 42 code blocks as `eu,notest` across 9 documentation files where examples cannot run standalone (imports, free variables, random stream timeouts, illustrative fragments)
- Result: 72 passed, 0 failed, 42 skipped out of 114 total blocks
- Supersedes PR #237 (rebased on current master to resolve conflicts from PR #236 merge)

## Test plan
- [ ] Run `python3 scripts/test-doc-examples.py --eu /opt/homebrew/bin/eu -v` and verify 0 failures
- [ ] Run `python3 scripts/test-doc-examples.py --list` to review block classification
- [ ] Verify `mdbook build` completes without errors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>