### PR TITLE
Improve NotCallable error with actual type information

### DIFF
--- a/harness/test/errors/017_too_many_args.eu.expect
+++ b/harness/test/errors/017_too_many_args.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "tried to call a value that is not a function"
+stderr: "tried to call a number as a function"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -85,6 +85,18 @@ fn format_lookup_failure(key: &str, suggestions: &[String]) -> String {
     msg
 }
 
+/// Format a "not callable" error message with the actual type of value found
+fn format_not_callable(actual_type: &str) -> String {
+    if actual_type.is_empty() {
+        "tried to call a value that is not a function".to_string()
+    } else {
+        format!(
+            "tried to call a {actual_type} as a function\n  \
+             help: only functions and blocks can be called with arguments"
+        )
+    }
+}
+
 /// Convert a data tag number to a human-readable type name for error messages
 fn display_data_tag(tag: u8) -> String {
     match DataConstructor::try_from(tag) {
@@ -135,8 +147,8 @@ pub enum ExecutionError {
     TypeMismatch(Smid, IntrinsicType, IntrinsicType),
     #[error("unknown intrinsic {1}")]
     UnknownIntrinsic(Smid, String),
-    #[error("tried to call a value that is not a function")]
-    NotCallable(Smid),
+    #[error("{}", format_not_callable(.1))]
+    NotCallable(Smid, String),
     #[error("intrinsic {1} expected value in strict position")]
     NotValue(Smid, String),
     #[error("bad regex ({0})")]
@@ -233,7 +245,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::LookupFailure(s, _, _) => *s,
             ExecutionError::TypeMismatch(s, _, _) => *s,
             ExecutionError::UnknownIntrinsic(s, _) => *s,
-            ExecutionError::NotCallable(s) => *s,
+            ExecutionError::NotCallable(s, _) => *s,
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -84,7 +84,10 @@ impl HeapNavigator<'_> {
         match r {
             Ref::L(index) => self.get(*index),
             Ref::G(index) => self.global(*index),
-            Ref::V(_) => Err(ExecutionError::NotCallable(Smid::default())),
+            Ref::V(n) => Err(ExecutionError::NotCallable(
+                Smid::default(),
+                n.type_description().to_string(),
+            )),
         }
     }
 
@@ -431,7 +434,10 @@ impl MachineState {
                     self.update(view, environment, index)?;
                 }
                 Continuation::ApplyTo { annotation, .. } => {
-                    return Err(ExecutionError::NotCallable(annotation));
+                    return Err(ExecutionError::NotCallable(
+                        annotation,
+                        value.type_description().to_string(),
+                    ));
                 }
                 Continuation::DeMeta {
                     or_else,
@@ -549,7 +555,10 @@ impl MachineState {
                             self.env(view),
                         );
                     } else {
-                        return Err(ExecutionError::NotCallable(annotation));
+                        let type_name = DataConstructor::try_from(tag)
+                            .map(|dc| dc.to_string())
+                            .unwrap_or_else(|()| format!("data (tag {tag})"));
+                        return Err(ExecutionError::NotCallable(annotation, type_name));
                     }
                 }
                 Continuation::DeMeta {

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -64,6 +64,20 @@ impl PartialEq for Native {
 
 impl Eq for Native {}
 
+impl Native {
+    /// Return a human-readable type name for use in error messages
+    pub fn type_description(&self) -> &'static str {
+        match self {
+            Native::Sym(_) => "symbol",
+            Native::Str(_) => "string",
+            Native::Num(_) => "number",
+            Native::Zdt(_) => "datetime",
+            Native::Index(_) => "block index",
+            Native::Set(_) => "set",
+        }
+    }
+}
+
 impl StgObject for Native {}
 
 impl fmt::Display for Native {


### PR DESCRIPTION
## Error message: NotCallable / value used as function

### Scenario
Call a non-function value as if it were a function. For example, calling a number with arguments (`x: 42`, `result: x(1)`), or passing too many arguments to a function so the excess arguments get applied to the numeric result (`f(x,y): x+y`, `result: f(1,2,3)`).

### Before
```
error: tried to call a value that is not a function
```

No type information. No source location. No hint about what went wrong or how to fix it. The message is identical regardless of whether you called a number, string, list, or boolean as a function.

### After
```
error: tried to call a number as a function
  help: only functions and blocks can be called with arguments
```

For a list:
```
error: tried to call a list as a function
  help: only functions and blocks can be called with arguments
```

For a string:
```
error: tried to call a string as a function
  help: only functions and blocks can be called with arguments
```

### Assessment
- Human diagnosability: poor → good. The user now knows what type of value they accidentally tried to call, which immediately narrows down the bug.
- LLM diagnosability: poor → good. An LLM can now confidently identify the issue as an arity mismatch or misuse of a value, rather than guessing from a generic message.

### Change
- Added `type_description()` method to `Native` (memory::syntax) returning a human-readable type name
- Changed `NotCallable(Smid)` to `NotCallable(Smid, String)` to carry the actual type description
- Added `format_not_callable()` helper that produces the improved error message with help hint
- Updated all three call sites in `vm.rs` to provide type information:
  - `resolve_callable()`: extracts type from `Ref::V(native)` 
  - `return_native()`: uses `value.type_description()`
  - `return_data()`: converts `DataConstructor` tag to type name
- Updated error test 017 expectation to match the new message

### Risks
- Low risk. The change is additive (more information, not different control flow).
- The `.expect` file for test 017 needed updating since the error message text changed.
- The fallback case (empty type string) preserves the old generic message for safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)