### PR TITLE
Improve CannotReturnFunToCase error with precedence hint

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -97,6 +97,30 @@ fn format_not_callable(actual_type: &str) -> String {
     }
 }
 
+/// Format a "function where value expected" error message.
+///
+/// This error typically occurs when operator precedence causes a
+/// function (e.g. a partially applied operator) to be passed where a
+/// scalar value was expected. The most common trigger is the low
+/// precedence of catenation (juxtaposition) in expressions like
+/// `xs head + 1` which parses as `xs (head + 1)` rather than the
+/// intended `(xs head) + 1`.
+fn format_cannot_return_fun(expected_tags: &[u8]) -> String {
+    let mut msg = if expected_tags.is_empty() {
+        "type mismatch: received a function where a value was expected".to_string()
+    } else {
+        format!(
+            "type mismatch: received a function where {} was expected",
+            display_expected_tags(expected_tags)
+        )
+    };
+    msg.push_str(
+        "\n  help: this often happens due to operator precedence; \
+         try adding parentheses, e.g. `(xs f) + 1` instead of `xs f + 1`",
+    );
+    msg
+}
+
 /// Convert a data tag number to a human-readable type name for error messages
 fn display_data_tag(tag: u8) -> String {
     match DataConstructor::try_from(tag) {
@@ -185,8 +209,8 @@ pub enum ExecutionError {
     NoBranchForDataTag(Smid, u8, Vec<u8>),
     #[error("no branch for native")]
     NoBranchForNative,
-    #[error("cannot return function into case table without default")]
-    CannotReturnFunToCase,
+    #[error("{}", format_cannot_return_fun(.1))]
+    CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
     #[error("machine did not terminate after {0} steps")]
@@ -249,6 +273,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,
+            ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -610,9 +610,11 @@ impl MachineState {
                     }
                 }
                 Continuation::Branch {
+                    min_tag,
+                    branch_table,
                     fallback,
                     environment,
-                    ..
+                    annotation,
                 } => {
                     // In a statically typed STG machine, functions
                     // never enter case continuations. With dynamic
@@ -626,7 +628,16 @@ impl MachineState {
                             view.from_closure(self.closure.clone(), environment, self.annotation)?,
                         );
                     } else {
-                        return Err(ExecutionError::CannotReturnFunToCase);
+                        let expected_tags: Vec<u8> = (0..branch_table.len())
+                            .filter(|i| branch_table.get(*i).flatten().is_some())
+                            .map(|i| min_tag + i as u8)
+                            .collect();
+                        let ann = if annotation.is_valid() {
+                            annotation
+                        } else {
+                            self.nearest_stack_annotation(view)
+                        };
+                        return Err(ExecutionError::CannotReturnFunToCase(ann, expected_tags));
                     }
                 }
                 Continuation::Update { environment, index } => {


### PR DESCRIPTION
## Error message: CannotReturnFunToCase / function where value expected

### Scenario
Write a pipeline expression followed by an infix operator without parentheses. Due to catenation having lower precedence (20) than arithmetic operators (75-80), expressions like `xs head + 1` parse as `xs (head + 1)` rather than the intended `(xs head) + 1`. The `+ 1` gets applied to the function `head`, producing a type error when the operator's case expression tries to inspect the result.

Test cases used:
```eu
xs: [1, 2, 3]
result: xs head + 1
```

```eu
xs: [1, 2, 3]
n: xs foldl((+), 0) + 1
```

### Before
```
error: cannot return function into case table without default
```

This message is completely incomprehensible. It refers to STG machine internals ("case table", "default branch") that have no meaning to a eucalypt user. There is no source location, no indication of what types were involved, and no hint about the likely cause.

### After
```
error: type mismatch: received a function where number was expected
  help: this often happens due to operator precedence; try adding parentheses, e.g. `(xs f) + 1` instead of `xs f + 1`
```

### Assessment
- Human diagnosability: poor → good. The user now knows (a) a function was found where a number was expected, and (b) this is likely a precedence issue with a concrete fix suggestion.
- LLM diagnosability: poor → excellent. An LLM can directly identify the precedence issue and suggest the parenthesisation fix from the error message alone.

### Change
- Changed `CannotReturnFunToCase` from a unit variant to `CannotReturnFunToCase(Smid, Vec<u8>)` carrying source location and expected type tags
- Added `format_cannot_return_fun()` helper that produces user-friendly message with expected types and a precedence hint
- Updated `return_fun()` in vm.rs to extract the `annotation`, `min_tag`, and `branch_table` from the `Branch` continuation, computing the expected tags list (same pattern used by `NoBranchForDataTag`)
- Falls back to `nearest_stack_annotation()` when the branch annotation is invalid
- Added `CannotReturnFunToCase` arm to `HasSmid` implementation for source location propagation

### Risks
- Low risk. No existing error tests reference this error message.
- The change is purely additive: more information, same control flow.
- The expected-tags extraction logic mirrors the existing pattern in `NoBranchForDataTag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)