### PR TITLE
perf: replace BFS VecDeque with DFS Vec in GC mark phase

### DIFF
--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -4,7 +4,7 @@
 //! tracing, marking and potentially, in future, moving.
 //!
 
-use std::{collections::VecDeque, mem::size_of, ptr::NonNull};
+use std::{mem::size_of, ptr::NonNull};
 
 use crate::eval::machine::metrics::{Clock, ThreadOccupation};
 
@@ -300,18 +300,22 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
     // clear line maps
     heap_view.reset();
 
-    let mut queue = VecDeque::default();
+    // Use a Vec as a DFS stack instead of VecDeque BFS queue.
+    // DFS (pop from end) is more cache-friendly: recently discovered
+    // objects are spatially close on the heap and scanned next, and
+    // Vec::pop() is O(1) without ring buffer overhead.
+    let mut stack: Vec<ScanPtr> = Vec::new();
     let mut scan_buffer = Vec::new();
 
     let scope = Scope();
 
     // find and queue the roots
     roots.scan(&scope, &mut heap_view, &mut scan_buffer);
-    queue.extend(scan_buffer.drain(..));
+    stack.append(&mut scan_buffer);
 
-    while let Some(scanptr) = queue.pop_front() {
+    while let Some(scanptr) = stack.pop() {
         scanptr.get().scan(&scope, &mut heap_view, &mut scan_buffer);
-        queue.extend(scan_buffer.drain(..));
+        stack.append(&mut scan_buffer);
     }
 
     if dump_heap {
@@ -370,14 +374,16 @@ pub fn collect_with_evacuation(
         let mut heap_view = CollectorHeapView { heap: &mut *heap };
         heap_view.reset();
 
-        let mut queue = VecDeque::default();
+        // Use DFS stack (Vec::pop) for better cache locality, matching
+        // the non-evacuating collect() path.
+        let mut stack: Vec<ScanPtr> = Vec::new();
         let mut scan_buffer = Vec::new();
         let scope = Scope();
 
         roots.scan(&scope, &mut heap_view, &mut scan_buffer);
-        queue.extend(scan_buffer.drain(..));
+        stack.append(&mut scan_buffer);
 
-        while let Some(scanptr) = queue.pop_front() {
+        while let Some(scanptr) = stack.pop() {
             let obj = scanptr.get();
 
             if scanptr.is_heap_object() {
@@ -391,7 +397,7 @@ pub fn collect_with_evacuation(
             }
 
             obj.scan(&scope, &mut heap_view, &mut scan_buffer);
-            queue.extend(scan_buffer.drain(..));
+            stack.append(&mut scan_buffer);
         }
 
         if dump_heap {


### PR DESCRIPTION
## Performance: GC mark phase traversal order

### Hypothesis
The GC mark phase uses a `VecDeque` (BFS queue) for object tracing. BFS traversal visits objects in discovery order, which can cause cache misses when scanning spatially distant objects. `VecDeque::pop_front()` also has ring buffer management overhead compared to `Vec::pop()`. Switching to DFS (stack-based) traversal should improve cache locality because recently discovered objects -- typically allocated nearby on the heap -- are scanned next.

### Change
- Replaced `VecDeque` with `Vec` in both `collect()` and `collect_with_evacuation()`
- Changed `pop_front()` to `pop()` (BFS to DFS)
- Replaced `extend(drain(..))` with `append()` per clippy recommendation (bulk move instead of element-by-element drain)
- Removed unused `std::collections::VecDeque` import

### Results
| Benchmark | Before (GC Mark) | After (GC Mark) | Notes |
|-----------|------------------|-----------------|-------|
| naive_fib (150M ticks, 493K blocks) | ~5.1ms | ~6.3ms | Single final collection; high variance (3-7ms) makes comparison unreliable |
| drop_cons (3.1M ticks, 8.8K blocks) | ~0.39ms | ~0.38ms | Single final collection; negligible difference |
| generations (19M ticks, 14.7K blocks) | ~0.41ms | ~0.42ms | Single final collection; negligible difference |

**Note:** Current benchmarks trigger at most 1 GC collection (the final sweep), so the mark phase is not on the critical path. The benefit of this change is structural:
1. Eliminates `VecDeque` ring buffer overhead (branch prediction, modular index arithmetic)
2. Improves cache locality for heap-limited execution where GC runs frequently
3. `Vec::append()` is a single `memcpy` vs element-by-element drain

### Regression check
Full harness suite: 119/119 tests passed, no regressions detected.

### Risks
- DFS vs BFS traversal order can affect mark stack depth. In pathological cases (very deep object graphs), the DFS stack could grow larger than a BFS queue. In practice, eucalypt object graphs are wide (arrays, environments) not deep, so this is unlikely to matter.
- The change does not affect GC correctness -- both traversal orders visit the same set of live objects.