### PR TITLE
perf: optimise VM execution hot loop

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -202,6 +202,7 @@ impl MachineState {
     }
 
     /// Handle an instruction
+    #[inline]
     fn handle_instruction<'guard>(
         &mut self,
         view: MutatorHeapView<'guard>,
@@ -293,15 +294,22 @@ impl MachineState {
             }
             HeapSyn::Bif { intrinsic, args } => {
                 let bif = intrinsics[intrinsic as usize];
-                // Set annotation to the BIF's own annotation so errors
-                // report the correct intrinsic context (e.g. "in (+)")
-                if let Ok(global_closure) = self.nav(view).global(intrinsic as usize) {
-                    let bif_ann = global_closure.annotation();
-                    if bif_ann.is_valid() {
-                        self.annotation = bif_ann;
-                    }
-                }
-                bif.execute(self, view, emitter, args.as_slice())?;
+                // Defer the BIF annotation lookup to the error path.
+                // Looking up the global closure annotation involves
+                // constructing a HeapNavigator and walking the global
+                // environment chain -- wasted work when the BIF
+                // succeeds (the common case).
+                bif.execute(self, view, emitter, args.as_slice())
+                    .inspect_err(|_| {
+                        // Set annotation to the BIF's own annotation so
+                        // errors report the correct intrinsic context
+                        if let Ok(global_closure) = self.nav(view).global(intrinsic as usize) {
+                            let bif_ann = global_closure.annotation();
+                            if bif_ann.is_valid() {
+                                self.annotation = bif_ann;
+                            }
+                        }
+                    })?;
             }
             HeapSyn::Let { bindings, body } => {
                 metrics.alloc(bindings.len());
@@ -875,6 +883,7 @@ impl<'a> Machine<'a> {
     }
 
     /// Split reference into separate facilities (state, heap)
+    #[inline]
     fn facilities(
         &mut self,
     ) -> (
@@ -927,6 +936,7 @@ impl<'a> Machine<'a> {
     }
 
     /// Execute one step
+    #[inline]
     pub fn step(&mut self) -> Result<(), ExecutionError> {
         let (state, view, emitter, metrics, settings, intrinsics) = self.facilities();
 
@@ -958,7 +968,12 @@ impl<'a> Machine<'a> {
     pub fn run(&mut self, limit: Option<usize>) -> Result<Option<u8>, ExecutionError> {
         self.clock.switch(ThreadOccupation::Mutator);
 
-        let gc_check_freq = 500;
+        // Use a countdown counter instead of modulo check on every
+        // tick. This replaces `ticks % 500 == 0` with a simple
+        // decrement-and-compare, avoiding integer division on every
+        // VM step.
+        let gc_check_freq: u32 = 500;
+        let mut gc_countdown: u32 = gc_check_freq;
 
         while !self.state.terminated {
             if let Some(limit) = limit {
@@ -967,16 +982,18 @@ impl<'a> Machine<'a> {
                 }
             }
 
-            if self.metrics.ticks().is_multiple_of(gc_check_freq)
-                && self.heap().policy_requires_collection()
-            {
-                collect::collect(
-                    &mut self.state,
-                    &mut self.heap,
-                    &mut self.clock,
-                    self.settings.dump_heap,
-                );
-                self.clock.switch(ThreadOccupation::Mutator);
+            gc_countdown -= 1;
+            if gc_countdown == 0 {
+                gc_countdown = gc_check_freq;
+                if self.heap().policy_requires_collection() {
+                    collect::collect(
+                        &mut self.state,
+                        &mut self.heap,
+                        &mut self.clock,
+                        self.settings.dump_heap,
+                    );
+                    self.clock.switch(ThreadOccupation::Mutator);
+                }
             }
 
             self.step()?;


### PR DESCRIPTION
## Summary

Three targeted optimisations to the VM execution hot path that together yield measurable wall-clock time reductions of 2-6% across benchmarks:

1. **`#[inline]` hints** on `step()`, `facilities()`, and `handle_instruction()` — encourages LLVM to inline the hot path, reducing call overhead
2. **Deferred BIF annotation lookup** — moves the global environment lookup for built-in function annotations to the error path only, avoiding unnecessary work on every BIF dispatch
3. **GC countdown counter** — replaces the modulo-based GC check (`ticks % 500 == 0`) with a simple countdown counter, avoiding repeated division

## Benchmark Results

| Benchmark | Ticks | Before | After | Change |
|-----------|-------|--------|-------|--------|
| naive_fib | ~150M | 10.270s | 9.638s | **-6.2%** |
| drop_cons | ~3.1M | 0.188s | 0.180s | **-4.3%** |
| generations | ~19M | 0.554s | 0.540s | **-2.5%** |
| thunk_updates | ~26M | 0.843s | 0.831s | **-1.4%** |

Measurements taken on macOS (Apple Silicon), release build, median of 3 runs.

## Files Changed

- `src/eval/machine/vm.rs` — all three changes in the VM execution loop

## Test Plan

- [x] All 548 library tests pass (`cargo test --lib`)
- [x] All 119 harness tests pass (`cargo test --test harness_test`)
- [x] All 33 error tests pass (`cargo test test_error`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] No correctness regressions — identical output for all test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)