### PR TITLE
fix: improve NotValue error message for unevaluated expressions

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -85,6 +85,23 @@ fn format_lookup_failure(key: &str, suggestions: &[String]) -> String {
     msg
 }
 
+/// Format a "not a value" error message when a non-value expression is found
+/// where a primitive value was expected.
+fn format_not_value(context: &str) -> String {
+    if context.is_empty() {
+        "expected a value but found an unevaluated expression\n  \
+         help: this can occur when a function or structured value appears \
+         where a primitive (number, string, etc.) was expected"
+            .to_string()
+    } else {
+        format!(
+            "expected a value but found {context}\n  \
+             help: this can occur when a function or structured value appears \
+             where a primitive (number, string, etc.) was expected"
+        )
+    }
+}
+
 /// Format a "not callable" error message with the actual type of value found
 fn format_not_callable(actual_type: &str) -> String {
     if actual_type.is_empty() {
@@ -173,7 +190,7 @@ pub enum ExecutionError {
     UnknownIntrinsic(Smid, String),
     #[error("{}", format_not_callable(.1))]
     NotCallable(Smid, String),
-    #[error("intrinsic {1} expected value in strict position")]
+    #[error("{}", format_not_value(.1))]
     NotValue(Smid, String),
     #[error("bad regex ({0})")]
     BadRegex(String),

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -119,7 +119,21 @@ impl HeapNavigator<'_> {
             scoped_code = self.view.scoped(closure.code());
         }
 
-        Err(ExecutionError::NotValue(Smid::default(), "".to_string()))
+        let description = match &*scoped_code {
+            HeapSyn::Cons { .. } => "a data constructor (e.g. block or list)",
+            HeapSyn::App { .. } => "a function application",
+            HeapSyn::Bif { .. } => "an intrinsic function call",
+            HeapSyn::Case { .. } => "a case expression",
+            HeapSyn::Let { .. } | HeapSyn::LetRec { .. } => "a let binding",
+            HeapSyn::Meta { .. } | HeapSyn::DeMeta { .. } => "a metadata expression",
+            HeapSyn::BlackHole => "an uninitialised value (possible cycle)",
+            HeapSyn::Ann { .. } => "an annotated expression",
+            HeapSyn::Atom { .. } => "an atom",
+        };
+        Err(ExecutionError::NotValue(
+            Smid::default(),
+            description.to_string(),
+        ))
     }
 
     pub fn env_trace(&self) -> Vec<Smid> {


### PR DESCRIPTION
## Summary
- Replaces the cryptic `intrinsic  expected value in strict position` error with a descriptive message that explains what was actually found (e.g. "a function application", "a data constructor")
- Adds a help hint explaining that the issue occurs when a function or structured value appears where a primitive was expected
- Improves `resolve_native` in the VM to describe the specific HeapSyn variant encountered

## Before
```
error: intrinsic  expected value in strict position
```

## After
```
error: expected a value but found a function application
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
```

## Test plan
- [x] All 33 existing error tests pass
- [x] Clippy clean
- [x] Manual testing with various error-triggering inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)