### PR TITLE
perf: avoid Vec allocation and redundant heap allocs in return_data

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -466,6 +466,46 @@ impl MachineState {
         Ok(())
     }
 
+    /// Build an env frame from data constructor args, resolving refs
+    /// directly without an intermediate Vec allocation.
+    ///
+    /// For `Ref::L` and `Ref::G`, reuses the existing closure from
+    /// the current environment. For `Ref::V`, allocates a minimal
+    /// atom closure. This avoids the heap allocation that
+    /// `HeapNavigator::resolve` performs for value refs.
+    #[inline]
+    fn env_from_data_args(
+        &self,
+        view: MutatorHeapView<'_>,
+        args: &[Ref],
+        next: RefPtr<EnvFrame>,
+    ) -> Result<RefPtr<EnvFrame>, ExecutionError> {
+        let local_env = view.scoped(self.closure.env());
+        let global_env = view.scoped(self.globals);
+
+        let mut array = Array::with_capacity(&view, args.len());
+        for r in args {
+            let closure = match r {
+                Ref::L(index) => (*local_env)
+                    .get(&view, *index)
+                    .ok_or(ExecutionError::BadEnvironmentIndex(*index))?,
+                Ref::G(index) => (*global_env)
+                    .get(&view, *index)
+                    .ok_or(ExecutionError::BadGlobalIndex(*index))?,
+                Ref::V(_) => SynClosure::new(
+                    view.alloc(HeapSyn::Atom {
+                        evaluand: r.clone(),
+                    })?
+                    .as_ptr(),
+                    self.closure.env(),
+                ),
+            };
+            array.push(&view, closure);
+        }
+
+        view.from_saturation(array, next, self.annotation)
+    }
+
     /// Return data into an appropriate branch handler
     ///
     /// Data is destructured for tag handlers but not for the default
@@ -492,17 +532,7 @@ impl MachineState {
                             // 0-arity constructor: reuse parent env directly
                             environment
                         } else {
-                            let closures = args
-                                .iter()
-                                .map(|r| self.nav(view).resolve(r))
-                                .collect::<Result<Vec<SynClosure>, ExecutionError>>()?;
-                            let len = closures.len();
-                            view.from_closures(
-                                closures.into_iter(),
-                                len,
-                                environment,
-                                self.annotation,
-                            )?
+                            self.env_from_data_args(view, args, environment)?
                         };
                         // When a case branch directly enters a local
                         // reference, suppress the Update on the next


### PR DESCRIPTION
## Summary

- Replaces the `resolve()` + `collect()` + `from_closures()` pattern in `return_data`'s branch matching with a direct `env_from_data_args()` method that builds the environment frame inline
- Eliminates intermediate `Vec<SynClosure>` allocation per constructor return into a case branch
- For `Ref::L` and `Ref::G`, reuses existing closures directly instead of going through `HeapNavigator::resolve` (which constructs a new `HeapNavigator` per ref)
- For `Ref::V` (native values), avoids the empty `EnvFrame` heap allocation that `resolve()` performs

## Benchmarks (before -> after)

| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| 001_naive_fib (150M ticks) | 10.02s | 8.83s | **12%** |
| 002_thunk_updates | 0.86s | 0.80s | **7%** |
| 005_drop_cons | 0.17s | 0.16s | **6%** |
| 007_short_lived | 0.27s | 0.23s | **13%** |
| 008_long_lived_graph | 0.20s | 0.18s | **7%** |
| 009_fragmentation | 0.19s | 0.16s | **12%** |

## Test plan

- [x] All 119 harness tests pass
- [x] All 548 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Benchmarks show consistent improvement across multiple runs

## Profiling context

Identified via macOS `sample` profiler on `001_naive_fib`. The `return_data -> resolve()` path accounted for ~9.3% of all samples, dominated by heap allocation in `HeapNavigator::resolve` for `Ref::V` cases and the `Vec` collection overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)