### PR TITLE
feat: add block pinning API to GC heap (eu-skjg)

### DIFF
--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -194,6 +194,11 @@ impl CollectorHeapView<'_> {
         }
     }
 
+    /// Check whether the block containing `ptr` is currently pinned.
+    pub fn is_pinned<T>(&self, ptr: NonNull<T>) -> bool {
+        self.heap.is_ptr_in_pinned_block(ptr)
+    }
+
     /// Check whether an object resides in a candidate block.
     pub fn is_in_candidate_block<T>(&self, ptr: NonNull<T>, candidates: &[usize]) -> bool {
         self.heap.is_in_candidate_block(ptr, candidates)
@@ -499,6 +504,10 @@ fn try_evacuate(heap_view: &mut CollectorHeapView<'_>, data_ptr: *const u8, cand
         return;
     };
     if !heap_view.is_in_candidate_block(ptr, candidates) {
+        return;
+    }
+    // Skip evacuation for pinned blocks
+    if heap_view.is_pinned(ptr) {
         return;
     }
     // Evacuate: copy header + payload, set forwarding pointer in old header
@@ -1061,5 +1070,64 @@ pub mod tests {
         assert!(stats_a.recycled < stats_b.recycled,
                "Second collection should recycle more blocks after removing let_ptr root. stats_a.recycled ({}) < stats_b.recycled ({})",
                stats_a.recycled, stats_b.recycled);
+    }
+    /// Test that a pinned block is NOT evacuated during collection.
+    #[test]
+    pub fn test_pinned_block_not_evacuated() {
+        let mut heap = Heap::new();
+        let mut clock = Clock::default();
+        clock.switch(ThreadOccupation::Mutator);
+
+        let pinned_ptr = {
+            let view = MutatorHeapView::new(&heap);
+            let _garbage: Vec<_> = repeat_with(|| -> LambdaForm {
+                LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default())
+            })
+            .take(512)
+            .collect();
+            let pinned = view.atom(Ref::L(42)).unwrap().as_ptr();
+            let _others: Vec<_> = repeat_with(|| -> LambdaForm {
+                LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default())
+            })
+            .take(256)
+            .collect();
+            pinned
+        };
+
+        let original_addr = pinned_ptr.as_ptr() as usize;
+
+        let _pin_guard = {
+            let view = MutatorHeapView::new(&heap);
+            view.pin(pinned_ptr)
+        };
+
+        collect(&mut vec![pinned_ptr], &mut heap, &mut clock, false);
+        heap.flush_unswept();
+
+        let rest_count = heap.rest_block_count();
+        if rest_count > 0 {
+            let candidates: Vec<usize> = (0..rest_count + 2).collect();
+            collect_with_evacuation(
+                &mut vec![pinned_ptr],
+                &mut heap,
+                &mut clock,
+                &candidates,
+                false,
+            );
+        }
+
+        let final_addr = pinned_ptr.as_ptr() as usize;
+        assert_eq!(
+            original_addr, final_addr,
+            "pinned object should not have been evacuated"
+        );
+
+        let obj: &HeapSyn = unsafe { &*pinned_ptr.as_ptr() };
+        match obj {
+            HeapSyn::Atom {
+                evaluand: Ref::L(42),
+            } => {}
+            other => panic!("pinned object has wrong data: {:?}", other),
+        }
     }
 }

--- a/src/eval/memory/header.rs
+++ b/src/eval/memory/header.rs
@@ -77,7 +77,8 @@ impl HeaderBits {
 ///  - a mark bit (for mark phase)
 ///  - a forwarded bit (to support evacuation)
 ///  - forwarding pointer (to support evacuation)
-///  - optionally a pinning bit (which we don't support)
+///  - pinning (supported at the block level via Heap::pin_block /
+///    Heap::unpin_block, not per-object)
 #[derive(Default, Debug)]
 pub struct AllocHeader {
     /// Header bits for object state

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -25,7 +25,7 @@
 //! - Header is always at `object_ptr - size_of::<AllocHeader>()`
 //! - Allocations are properly aligned for their types
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
@@ -1028,6 +1028,8 @@ pub struct Heap {
     emergency_state: UnsafeCell<EmergencyState>,
     /// GC performance metrics and telemetry
     gc_metrics: UnsafeCell<GCMetrics>,
+    /// Pin counts by block base address.
+    pin_counts: UnsafeCell<HashMap<usize, usize>>,
 }
 
 #[cfg(test)]
@@ -1492,6 +1494,7 @@ impl Heap {
             mark_state: AtomicBool::new(false),
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
+            pin_counts: UnsafeCell::new(HashMap::new()),
         }
     }
 
@@ -1504,6 +1507,7 @@ impl Heap {
             mark_state: AtomicBool::new(false),
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
+            pin_counts: UnsafeCell::new(HashMap::new()),
         }
     }
 
@@ -1526,6 +1530,36 @@ impl Heap {
     /// Flip the mark state for this heap (called after each collection)
     pub fn flip_mark_state(&self) {
         self.mark_state.fetch_xor(true, SeqCst);
+    }
+
+    /// Increment the pin count for the block containing `ptr`.
+    pub fn pin_block<T>(&self, ptr: NonNull<T>) {
+        let base = bump::block_base_of(ptr);
+        let pin_counts = unsafe { &mut *self.pin_counts.get() };
+        *pin_counts.entry(base).or_insert(0) += 1;
+    }
+
+    /// Decrement the pin count for the block at `base_address`.
+    pub fn unpin_block(&self, base_address: usize) {
+        let pin_counts = unsafe { &mut *self.pin_counts.get() };
+        if let Some(count) = pin_counts.get_mut(&base_address) {
+            *count -= 1;
+            if *count == 0 {
+                pin_counts.remove(&base_address);
+            }
+        }
+    }
+
+    /// Check whether a block is currently pinned.
+    pub fn is_block_pinned(&self, base_address: usize) -> bool {
+        let pin_counts = unsafe { &*self.pin_counts.get() };
+        pin_counts.contains_key(&base_address)
+    }
+
+    /// Check whether the block containing `ptr` is pinned.
+    pub fn is_ptr_in_pinned_block<T>(&self, ptr: NonNull<T>) -> bool {
+        let base = bump::block_base_of(ptr);
+        self.is_block_pinned(base)
     }
 
     /// Bump-allocate into the evacuation target block during collection.
@@ -1636,7 +1670,23 @@ impl Heap {
                 if fragmented_blocks.is_empty() {
                     CollectionStrategy::MarkInPlace
                 } else {
-                    CollectionStrategy::SelectiveEvacuation(fragmented_blocks)
+                    // Exclude pinned blocks from evacuation candidates
+                    let unpinned_candidates: Vec<usize> = fragmented_blocks
+                        .into_iter()
+                        .filter(|&idx| {
+                            let base = match idx {
+                                0 => heap_state.head.as_ref().map(|b| b.base_address()),
+                                1 => heap_state.overflow.as_ref().map(|b| b.base_address()),
+                                n => heap_state.rest.get(n - 2).map(|b| b.base_address()),
+                            };
+                            base.is_none_or(|addr| !self.is_block_pinned(addr))
+                        })
+                        .collect();
+                    if unpinned_candidates.is_empty() {
+                        CollectionStrategy::MarkInPlace
+                    } else {
+                        CollectionStrategy::SelectiveEvacuation(unpinned_candidates)
+                    }
                 }
             }
 
@@ -3118,5 +3168,32 @@ pub mod tests {
 
         // Should be capped at the limit
         assert_eq!(state.recycled_lobs.len(), 16);
+    }
+    #[test]
+    pub fn test_pin_and_unpin_block() {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let ptr = view.atom(Ref::L(0)).unwrap().as_ptr();
+        let base = crate::eval::memory::bump::block_base_of(ptr);
+        assert!(!heap.is_block_pinned(base));
+        let guard = view.pin(ptr);
+        assert!(heap.is_block_pinned(base));
+        drop(guard);
+        assert!(!heap.is_block_pinned(base));
+    }
+
+    #[test]
+    pub fn test_pin_ref_counting() {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let ptr = view.atom(Ref::L(0)).unwrap().as_ptr();
+        let base = crate::eval::memory::bump::block_base_of(ptr);
+        let guard1 = view.pin(ptr);
+        let guard2 = view.pin(ptr);
+        assert!(heap.is_block_pinned(base));
+        drop(guard1);
+        assert!(heap.is_block_pinned(base));
+        drop(guard2);
+        assert!(!heap.is_block_pinned(base));
     }
 }

--- a/src/eval/memory/mutator.rs
+++ b/src/eval/memory/mutator.rs
@@ -17,6 +17,25 @@ use crate::{
 
 use super::{string::HeapString, syntax::Native};
 
+/// RAII guard that keeps a heap block pinned (non-evacuatable).
+pub struct PinGuard {
+    base_address: usize,
+    heap: *const super::heap::Heap,
+}
+
+impl Drop for PinGuard {
+    fn drop(&mut self) {
+        let heap = unsafe { &*self.heap };
+        heap.unpin_block(self.base_address);
+    }
+}
+
+impl std::fmt::Debug for PinGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PinGuard(block @ {:#x})", self.base_address)
+    }
+}
+
 /// A view onto the heap for code that needs mutator access (as
 /// opposed to collector access)
 ///
@@ -48,6 +67,15 @@ impl<'guard> MutatorHeapView<'guard> {
         let mut array = Array::with_capacity(&self, 1);
         array.push(&self, object);
         array
+    }
+
+    /// Pin the block containing `ptr`, preventing evacuation.
+    pub fn pin<T>(&self, ptr: std::ptr::NonNull<T>) -> PinGuard {
+        self.heap.pin_block(ptr);
+        PinGuard {
+            base_address: super::bump::block_base_of(ptr),
+            heap: self.heap as *const super::heap::Heap,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add ref-counted pin map (`HashMap<usize, usize>`) to `Heap` for tracking pinned blocks by base address
- Add `PinGuard` RAII type that automatically decrements pin count on drop
- Add `MutatorHeapView::pin()` method that returns a `PinGuard` for any heap pointer
- Evacuation skips pinned blocks in `try_evacuate()` and candidate selection filters them out
- Unit tests for pin/unpin basics, ref-counting, and verifying pinned blocks survive evacuation

## Context

This is Phase 2a of the string intrinsics optimisation (eu-skjg). Block pinning is foundational for the upcoming `str_arg_ref()` zero-copy heap string borrowing (eu-7flw), which needs to hold `&str` references across allocations without the underlying block being evacuated.

### Design decisions

- **Block-level pinning** (not per-object): simpler, no header layout change, sufficient for the string borrowing use case
- **Ref-counted**: multiple borrows from the same block naturally stack
- **Raw pointer in PinGuard**: avoids lifetime entanglement with `MutatorHeapView`, allowing the guard to be held while allocating

## Files changed

| File | Changes |
|------|---------|
| `src/eval/memory/heap.rs` | `pin_counts` field, `pin_block()`, `unpin_block()`, `is_block_pinned()`, `is_ptr_in_pinned_block()`, candidate filtering, tests |
| `src/eval/memory/mutator.rs` | `PinGuard` struct, `MutatorHeapView::pin()` method |
| `src/eval/memory/collect.rs` | `CollectorHeapView::is_pinned()`, `try_evacuate()` guard, evacuation test |
| `src/eval/memory/header.rs` | Doc comment update (pinning is now supported) |

## Test plan

- [x] `test_pin_and_unpin_block` - basic pin/unpin lifecycle
- [x] `test_pin_ref_counting` - multiple pins on same block
- [x] `test_pinned_block_not_evacuated` - pinned objects survive evacuation
- [x] Full test suite passes (119/119 harness tests, all unit tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)