### PR TITLE
Detect duplicate anonymous expression anaphora at compile time

### DIFF
--- a/harness/test/errors/037_double_anaphora.eu
+++ b/harness/test/errors/037_double_anaphora.eu
@@ -1,0 +1,2 @@
+# Error: using _ more than once creates multiple parameters
+result: [1,2,3] map(_ + _)

--- a/harness/test/errors/037_double_anaphora.eu.expect
+++ b/harness/test/errors/037_double_anaphora.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "used more than once"

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -142,6 +142,24 @@ impl Cooker {
 
     /// Wrap a lambda around an expr-anaphoric expression
     fn process_expr_anaphora(&mut self, expr: RcExpr) -> Result<RcExpr, CoreError> {
+        // Detect multiple bare '_' in a single expression — each introduces
+        // a separate parameter which is almost never the user's intent.
+        let anonymous_count = self
+            .pending_expr_anaphora
+            .keys()
+            .filter(|a| matches!(a, Anaphor::ExplicitAnonymous(_)))
+            .count();
+        if anonymous_count > 1 {
+            let smid = self
+                .pending_expr_anaphora
+                .keys()
+                .find_map(|a| match a {
+                    Anaphor::ExplicitAnonymous(s) => Some(*s),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            return Err(CoreError::DuplicateAnonymousAnaphor(smid));
+        }
         let binders = anaphora::to_binding_pattern(&self.pending_expr_anaphora)?;
         self.pending_expr_anaphora.clear();
         Ok(core::lam(expr.smid(), binders, succ::succ(&expr)?))

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -19,6 +19,8 @@ pub enum CoreError {
     TooFewOperands(Smid),
     #[error("cannot mix anaphora types (numberless, numbered and section)")]
     MixedAnaphora(Smid),
+    #[error("'_' used more than once in a single expression")]
+    DuplicateAnonymousAnaphor(Smid),
     #[error("found temporary pseudo-operators remaining in evaluand")]
     UneliminatedPseudoOperators,
     #[error("found operator soup within unresolved precedence")]
@@ -48,6 +50,7 @@ impl HasSmid for CoreError {
             InvalidEmbedding(_, s) => s,
             TooFewOperands(s) => s,
             MixedAnaphora(s) => s,
+            DuplicateAnonymousAnaphor(s) => s,
             UnresolvedVariable(s, _) => s,
             RedeclaredVariable(s, _) => s,
             _ => Smid::default(),
@@ -58,6 +61,13 @@ impl HasSmid for CoreError {
 impl CoreError {
     pub fn to_diagnostic(&self, source_map: &SourceMap) -> Diagnostic<usize> {
         match self {
+            CoreError::DuplicateAnonymousAnaphor(_) => {
+                source_map.diagnostic(self).with_notes(vec![
+                    "each '_' in an expression introduces a separate parameter".to_string(),
+                    "use numbered anaphora (_0, _1) for multiple parameters, or a named function"
+                        .to_string(),
+                ])
+            }
             CoreError::InvalidMergeBase() => source_map.diagnostic(self).with_notes(vec![
                 "some input formats (csv, text, etc.) that read as lists need to be assigned names"
                     .to_string(),

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -637,6 +637,11 @@ pub fn test_error_036() {
 }
 
 #[test]
+pub fn test_error_037() {
+    run_error_test(&error_opts("037_double_anaphora.eu"));
+}
+
+#[test]
 pub fn test_error_040() {
     run_error_test(&error_opts("040_json_error_format.eu"));
 }


### PR DESCRIPTION
## Summary

- Detects `_` used more than once in a single expression (e.g. `_ + _`) at compile time
- Each bare `_` introduces a separate parameter, which is almost never the user's intent
- Reports a clear error with the exact source location of the duplicate `_`
- Suggests using numbered anaphora (`_0`, `_1`) or named functions instead
- Only affects expression anaphora (`_`), not block anaphora (`bullet`) which legitimately appear multiple times

## Before

```
error: expected a value but found an annotated expression
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
```

## After

```
error: '_' used more than once in a single expression
  --> test.eu:1:25
  |
1 | result: [1,2,3] map(_ + _)
  |                         ^
  |
  = each '_' in an expression introduces a separate parameter
  = use numbered anaphora (_0, _1) for multiple parameters, or a named function
```

## Test plan

- [x] All 35 error tests pass (including new 037_double_anaphora)
- [x] Harness tests using anaphora (022, 031, 053) still pass
- [x] Clippy clean with `--all-targets -- -D warnings`
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)