### PR TITLE
feat: add str_arg_ref() zero-copy string borrowing (eu-7flw)

### DIFF
--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -21,7 +21,7 @@ use super::{
     printf::{self, PrintfError},
     support::{
         machine_return_num, machine_return_str, machine_return_str_iter, machine_return_str_list,
-        machine_return_sym, str_arg, str_list_arg,
+        machine_return_sym, str_arg, str_arg_ref, str_list_arg,
     },
     syntax::{
         dsl::{
@@ -195,9 +195,9 @@ impl StgIntrinsic for Match {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let string = str_arg(machine, view, &args[0])?;
-        let regex = str_arg(machine, view, &args[1])?;
-        let re = cached_regex(machine, regex)?;
+        let string = str_arg_ref(machine, view, &args[0])?;
+        let regex = str_arg_ref(machine, view, &args[1])?;
+        let re = cached_regex(machine, &*regex)?;
         let v: Vec<String> = if let Some(captures) = re.captures(&string) {
             captures
                 .iter()
@@ -230,9 +230,9 @@ impl StgIntrinsic for Matches {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let string = str_arg(machine, view, &args[0])?;
-        let regex = str_arg(machine, view, &args[1])?;
-        let re = cached_regex(machine, regex)?;
+        let string = str_arg_ref(machine, view, &args[0])?;
+        let regex = str_arg_ref(machine, view, &args[1])?;
+        let re = cached_regex(machine, &*regex)?;
 
         let v: Vec<String> = re
             .find_iter(&string)
@@ -265,13 +265,13 @@ impl StgIntrinsic for Split {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let string = str_arg(machine, view, &args[0])?;
-        let regex = str_arg(machine, view, &args[1])?;
+        let string = str_arg_ref(machine, view, &args[0])?;
+        let regex = str_arg_ref(machine, view, &args[1])?;
 
         if regex.is_empty() {
-            machine_return_str_list(machine, view, vec![string])
+            machine_return_str_list(machine, view, vec![string.to_string()])
         } else {
-            let re = cached_regex(machine, regex)?;
+            let re = cached_regex(machine, &*regex)?;
             let v: Vec<String> = re.split(&string).map(|it| it.to_string()).collect();
             machine_return_str_iter(machine, view, v.into_iter())
         }
@@ -430,7 +430,7 @@ impl StgIntrinsic for Letters {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let string = str_arg(machine, view, &args[0])?;
+        let string = str_arg_ref(machine, view, &args[0])?;
         let iter = string.chars().map(|c| c.to_string());
         machine_return_str_iter(machine, view, iter)
     }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -70,6 +70,62 @@ pub fn str_arg(
     }
 }
 
+/// A string borrowed directly from the heap with its block pinned.
+///
+/// The `PinGuard` keeps the underlying heap block from being evacuated
+/// during GC, so the `&str` remains valid even across allocations.
+/// Derefs to `&str` for ergonomic use.
+pub struct PinnedString {
+    data: *const str,
+    _guard: crate::eval::memory::mutator::PinGuard,
+}
+
+impl std::ops::Deref for PinnedString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        // SAFETY: The PinGuard keeps the heap block alive and unmoved.
+        // The data pointer was obtained from a valid HeapString on the
+        // heap, and the block cannot be evacuated while pinned.
+        unsafe { &*self.data }
+    }
+}
+
+impl AsRef<str> for PinnedString {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+/// Helper for intrinsics to borrow a str arg directly from the heap.
+///
+/// Returns a `PinnedString` that derefs to `&str` without cloning.
+/// The underlying heap block is pinned for the lifetime of the
+/// returned value, preventing GC evacuation.
+pub fn str_arg_ref(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    arg: &Ref,
+) -> Result<PinnedString, ExecutionError> {
+    let native = machine.nav(view).resolve_native(arg)?;
+    if let Native::Str(s) = native {
+        let guard = view.pin(s);
+        // SAFETY: The scoped pointer dereferences the HeapString on the
+        // heap. We extract a raw pointer to the str slice, which remains
+        // valid because the PinGuard prevents the block from moving.
+        let str_ptr: *const str = (*view.scoped(s)).as_str() as *const str;
+        Ok(PinnedString {
+            data: str_ptr,
+            _guard: guard,
+        })
+    } else {
+        Err(ExecutionError::TypeMismatch(
+            machine.annotation(),
+            IntrinsicType::String,
+            native_type(&native),
+        ))
+    }
+}
+
 /// Helper for intrinsics to access a sym arg
 pub fn sym_arg(
     machine: &mut dyn IntrinsicMachine,


### PR DESCRIPTION
## Summary

- Add `PinnedString` type that wraps a raw `*const str` pointer with a `PinGuard`, providing `Deref<Target=str>` for ergonomic zero-copy string access from the heap
- Add `str_arg_ref()` helper in `support.rs` that resolves a string argument from the heap, pins the block, and returns a `PinnedString` without cloning
- Migrate LETTERS, MATCH, MATCHES, and SPLIT intrinsics to use `str_arg_ref()` for zero intermediate Rust `String` allocations on the input side

## Context

This is Phase 2b of the string intrinsics optimisation (eu-7flw). Depends on the block pinning API from PR #275 (now merged).

Previously, every string intrinsic called `str_arg()` which cloned the heap string into a Rust `String`. With `str_arg_ref()`, the input string is borrowed directly from the heap with the block pinned to prevent GC evacuation. The regex operations and character iteration work directly on the borrowed `&str`.

### Intrinsics migrated

| Intrinsic | Before | After |
|-----------|--------|-------|
| LETTERS | `str_arg` (clone) then `.chars()` | `str_arg_ref` (borrow) then `.chars()` |
| MATCH | `str_arg` x2 (clone) then regex | `str_arg_ref` x2 (borrow) then regex |
| MATCHES | `str_arg` x2 (clone) then regex | `str_arg_ref` x2 (borrow) then regex |
| SPLIT | `str_arg` x2 (clone) then regex | `str_arg_ref` x2 (borrow) then regex |

### Not migrated (intentionally)

SYM, JOIN, NUMPARSE, FMT, UPPER, LOWER — these need the owned `String` for further processing (to_uppercase, parsing, joining, etc.)

## Files changed

| File | Changes |
|------|---------|
| `src/eval/stg/support.rs` | `PinnedString` struct, `str_arg_ref()` function |
| `src/eval/stg/string.rs` | Migrate LETTERS, MATCH, MATCHES, SPLIT to `str_arg_ref()` |

## Test plan

- [x] `test_harness_016` (string functions) passes
- [x] `test_harness_034` (letters) passes
- [x] Full test suite passes (119/119 harness tests + all unit tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)