### PR TITLE
Fix expression anaphora paren scope and block anaphor closure bugs

### DIFF
--- a/harness/test/031_block_anaphora.eu
+++ b/harness/test/031_block_anaphora.eu
@@ -31,6 +31,15 @@ with-expr-anaphora: {
 #   α: { t: •1 * •1 }(0, 2)
 # }
 
-RESULT: [unnumbered, numbered, lambdas, with-expr-anaphora]
+# Block anaphor with outer scope variable in infix (eu-dobu)
+n: 10
+outer-scope: {
+  γ: [1, 2, 3] map({k: •}.(k + n)) //= [11, 12, 13]
+  δ: [5, 10, 15] map({k: •}.(k - n)) //= [-5, 0, 5]
+  ε: [2, 3, 4] map({k: •}.(k * n)) //= [20, 30, 40]
+  ζ: [1, 2, 3] map({k: •}.(n + k)) //= [11, 12, 13]
+}
+
+RESULT: [unnumbered, numbered, lambdas, with-expr-anaphora, outer-scope]
           all(all-true? ∘ values)
           then(:PASS, :FAIL)

--- a/harness/test/086_expr_anaphora_parens.eu
+++ b/harness/test/086_expr_anaphora_parens.eu
@@ -1,0 +1,28 @@
+# Expression anaphora inside parenthesised sub-expressions
+# Bug eu-mi8d: parens truncate anaphora infection
+
+# Basic case: binary op after paren group
+α: zip-with((_0 + _1) / 2, [2, 4, 6], [4, 8, 12]) //= [3, 6, 9]
+
+# Multiplication after paren group
+β: zip-with((_0 + _1) * 2, [1, 2, 3], [4, 5, 6]) //= [10, 14, 18]
+
+# Subtraction after paren group
+γ: zip-with((_0 + _1) - 1, [1, 2, 3], [4, 5, 6]) //= [4, 6, 8]
+
+# Single anaphor in parens with outer operator
+δ: [10, 20, 30] map((_0) + 1) //= [11, 21, 31]
+
+# Deeply nested parens
+ε: zip-with(((_0 + _1)) / 2, [2, 4], [4, 8]) //= [3, 6]
+
+# Outer-scope variable with paren anaphor
+c: 2
+ζ: zip-with((_0 + _1) / c, [2, 4, 6], [4, 8, 12]) //= [3, 6, 9]
+
+# Mixed: one anaphor at outer level, one in parens (already works, regression check)
+η: zip-with(_0 * (_1 + 2), [1, 2, 3], [4, 5, 6]) //= [6, 14, 24]
+
+RESULT: [α, β, γ, δ, ε, ζ, η]
+          all-true?
+          then(:PASS, :FAIL)

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -6,7 +6,7 @@ use crate::core::error::CoreError;
 use crate::core::expr::*;
 use crate::core::transform::succ;
 use moniker::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub mod fill;
 pub mod fixity;
@@ -52,14 +52,16 @@ impl Cooker {
         fixity::distribute(expr)
     }
 
-    /// Check whether an expression tree contains explicit ExprAnaphor
-    /// nodes, recursing only through Soup nodes (from paren groups).
-    /// Other constructs (ArgTuple, Let, List, Block) remain scope
-    /// boundaries and are not traversed.
-    fn contains_expr_anaphora(expr: &RcExpr) -> bool {
+    /// Check whether an expression tree contains explicitly numbered
+    /// ExprAnaphor nodes (`_0`, `_1`, etc.), recursing only through
+    /// Soup nodes (from paren groups). Anonymous `_` and implicit
+    /// section anaphora are NOT detected — they should resolve within
+    /// their own paren scope. Other constructs (ArgTuple, Let, List,
+    /// Block) remain scope boundaries and are not traversed.
+    fn contains_numbered_expr_anaphora(expr: &RcExpr) -> bool {
         match &*expr.inner {
-            Expr::ExprAnaphor(_, _) => true,
-            Expr::Soup(_, xs) => xs.iter().any(Self::contains_expr_anaphora),
+            Expr::ExprAnaphor(_, Anaphor::ExplicitNumbered(_)) => true,
+            Expr::Soup(_, xs) => xs.iter().any(Self::contains_numbered_expr_anaphora),
             _ => false,
         }
     }
@@ -107,10 +109,11 @@ impl Cooker {
 
     /// Resolve precedence and handle expression anaphora
     fn cook_soup(&mut self, exprs: &[RcExpr]) -> Result<RcExpr, CoreError> {
-        // Pre-scan for explicit anaphora in nested sub-expressions
-        // BEFORE fill_gaps, so implicit section anaphora are not detected.
+        // Pre-scan for explicitly numbered anaphora (_0, _1, etc.) in
+        // nested sub-expressions (paren groups) BEFORE fill_gaps, so
+        // implicit section anaphora and anonymous _ are not detected.
         let has_deep_anaphora =
-            !self.in_expr_anaphor_scope && exprs.iter().any(Self::contains_expr_anaphora);
+            !self.in_expr_anaphor_scope && exprs.iter().any(Self::contains_numbered_expr_anaphora);
 
         let (filled, naked_anaphora) = self.insert_anaphora(exprs);
 
@@ -165,10 +168,50 @@ impl Cooker {
         Ok(core::lam(expr.smid(), binders, succ::succ(&expr)?))
     }
 
-    /// Wrap a lambda around an block-anaphoric expression
+    /// Wrap a lambda around a block-anaphoric expression, collapsing
+    /// redundant inner lets where possible.
+    ///
+    /// When a single block anaphor like `{k: •}` is used with a dot
+    /// lookup, desugaring produces `let k = • in body`. After cooking,
+    /// this becomes `let k = _b_a in body`. Wrapping naively gives
+    /// `lam(_b_a, succ(let k = _b_a in body))` which has a redundant
+    /// let scope that confuses STG compilation of outer-scope variable
+    /// references. We collapse to `lam(_b_a, body)` when the single
+    /// let binding is a simple alias of the anaphor var.
     fn process_block_anaphora(&mut self, expr: RcExpr) -> Result<RcExpr, CoreError> {
         let binders = anaphora::to_binding_pattern(&self.pending_block_anaphora)?;
+        let anaphora_vars: HashSet<String> = self
+            .pending_block_anaphora
+            .values()
+            .filter_map(|v| v.pretty_name.clone())
+            .collect();
         self.pending_block_anaphora.clear();
+
+        // Try to collapse: if the expression is a Let with a single
+        // binding whose value is our anaphor var, eliminate the let
+        // and bind directly as a lambda parameter.
+        if let Expr::Let(_, scope, _) = &*expr.inner {
+            let bindings = &scope.unsafe_pattern.unsafe_pattern;
+            let body = &scope.unsafe_body;
+
+            let all_alias = bindings.iter().all(|(_, Embed(val))| {
+                if let Expr::Var(_, Var::Free(fv)) = &*val.inner {
+                    fv.pretty_name
+                        .as_ref()
+                        .is_some_and(|n| anaphora_vars.contains(n))
+                } else {
+                    false
+                }
+            });
+
+            if all_alias && bindings.len() == 1 && binders.len() == 1 {
+                // Single binding: the lambda directly replaces the let
+                // scope, so the body's bound variable indices are already
+                // correct (scope 0 index 0 targets the one lambda param).
+                return Ok(core::lam(expr.smid(), binders, body.clone()));
+            }
+        }
+
         Ok(core::lam(expr.smid(), binders, succ::succ(&expr)?))
     }
 }
@@ -458,31 +501,47 @@ pub mod tests {
     }
 
     #[test]
-    pub fn test_contains_expr_anaphora_scan() {
-        // ExprAnaphor at top level
-        assert!(Cooker::contains_expr_anaphora(&core::expr_anaphor(
-            Smid::fake(1),
-            Some(0)
-        )));
+    pub fn test_contains_numbered_expr_anaphora_scan() {
+        // Numbered ExprAnaphor (_0) at top level
+        assert!(Cooker::contains_numbered_expr_anaphora(
+            &core::expr_anaphor(Smid::fake(1), Some(0))
+        ));
 
-        // ExprAnaphor nested in Soup (paren group)
+        // Numbered ExprAnaphor nested in Soup (paren group)
         let inner = soup(vec![
             core::expr_anaphor(Smid::fake(2), Some(0)),
             core::infixl(Smid::fake(3), 50, bif("ADD")),
             core::expr_anaphor(Smid::fake(4), Some(1)),
         ]);
-        assert!(Cooker::contains_expr_anaphora(&inner));
+        assert!(Cooker::contains_numbered_expr_anaphora(&inner));
 
         // Plain number — no anaphora
-        assert!(!Cooker::contains_expr_anaphora(&num(42)));
+        assert!(!Cooker::contains_numbered_expr_anaphora(&num(42)));
 
         // Soup without anaphora
-        let plain = soup(vec![num(1), core::infixl(Smid::fake(5), 50, bif("ADD")), num(2)]);
-        assert!(!Cooker::contains_expr_anaphora(&plain));
+        let plain = soup(vec![
+            num(1),
+            core::infixl(Smid::fake(5), 50, bif("ADD")),
+            num(2),
+        ]);
+        assert!(!Cooker::contains_numbered_expr_anaphora(&plain));
 
         // ArgTuple is a scope boundary — anaphora inside should NOT be detected
         let arg = arg_tuple(vec![core::expr_anaphor(Smid::fake(6), Some(0))]);
-        assert!(!Cooker::contains_expr_anaphora(&arg));
+        assert!(!Cooker::contains_numbered_expr_anaphora(&arg));
+
+        // Anonymous ExprAnaphor (_) should NOT be detected
+        assert!(!Cooker::contains_numbered_expr_anaphora(
+            &core::expr_anaphor(Smid::fake(7), None)
+        ));
+
+        // Anonymous _ nested in Soup should NOT be detected
+        let anon_inner = soup(vec![
+            core::expr_anaphor(Smid::fake(8), None),
+            core::infixl(Smid::fake(9), 50, bif("COMPOSE")),
+            bif("F"),
+        ]);
+        assert!(!Cooker::contains_numbered_expr_anaphora(&anon_inner));
     }
 
     #[test]

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -107,9 +107,15 @@ impl Cooker {
 
     /// Resolve precedence and handle expression anaphora
     fn cook_soup(&mut self, exprs: &[RcExpr]) -> Result<RcExpr, CoreError> {
+        // Pre-scan for explicit anaphora in nested sub-expressions
+        // BEFORE fill_gaps, so implicit section anaphora are not detected.
+        let has_deep_anaphora =
+            !self.in_expr_anaphor_scope && exprs.iter().any(Self::contains_expr_anaphora);
+
         let (filled, naked_anaphora) = self.insert_anaphora(exprs);
 
-        let wrap_lambda = !self.in_expr_anaphor_scope && !naked_anaphora.is_empty();
+        let wrap_lambda =
+            !self.in_expr_anaphor_scope && (!naked_anaphora.is_empty() || has_deep_anaphora);
 
         if wrap_lambda {
             self.in_expr_anaphor_scope = true;

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -484,4 +484,64 @@ pub mod tests {
         let arg = arg_tuple(vec![core::expr_anaphor(Smid::fake(6), Some(0))]);
         assert!(!Cooker::contains_expr_anaphora(&arg));
     }
+
+    #[test]
+    pub fn test_anaphora_through_parens() {
+        // Simulates (_0 + _1) / 2 where parens create a nested Soup
+        let l50 = core::infixl(Smid::fake(1), 50, bif("ADD"));
+        let l60 = core::infixl(Smid::fake(2), 60, bif("DIV"));
+        let ana0 = free("_e_n0");
+        let ana1 = free("_e_n1");
+
+        // Inner soup: _0 + _1 (from parens)
+        let inner = soup(vec![
+            core::expr_anaphor(Smid::fake(3), Some(0)),
+            l50.clone(),
+            core::expr_anaphor(Smid::fake(4), Some(1)),
+        ]);
+
+        // Outer soup: (inner) / 2
+        let outer = soup(vec![inner, l60, num(2)]);
+
+        // Should produce: lam([_0, _1], DIV(ADD(_0, _1), 2))
+        let result = cook(outer).unwrap();
+        assert_term_eq!(
+            result,
+            lam(
+                vec![ana0.clone(), ana1.clone()],
+                app(
+                    bif("DIV"),
+                    vec![app(bif("ADD"), vec![var(ana0), var(ana1)]), num(2)]
+                )
+            )
+        );
+    }
+
+    #[test]
+    pub fn test_section_contained_by_parens() {
+        // Simulates (+ 1) / 2 — section should stay inside parens
+        let l50 = core::infixl(Smid::fake(1), 50, bif("ADD"));
+        let l60 = core::infixl(Smid::fake(2), 60, bif("DIV"));
+        let ana0 = free("_e_i_l0");
+
+        // Inner soup: + 1 (section — fill_gaps adds implicit anaphor)
+        let inner = soup(vec![l50, num(1)]);
+
+        // Outer soup: (inner) / 2
+        let outer = soup(vec![inner, l60, num(2)]);
+
+        // Should produce: DIV(lam([_0], ADD(_0, 1)), 2)
+        // The section lambda stays inside — NOT lam([_0], DIV(ADD(_0, 1), 2))
+        let result = cook(outer).unwrap();
+        assert_term_eq!(
+            result,
+            app(
+                bif("DIV"),
+                vec![
+                    lam(vec![ana0.clone()], app(bif("ADD"), vec![var(ana0), num(1)])),
+                    num(2)
+                ]
+            )
+        );
+    }
 }

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -52,6 +52,18 @@ impl Cooker {
         fixity::distribute(expr)
     }
 
+    /// Check whether an expression tree contains explicit ExprAnaphor
+    /// nodes, recursing only through Soup nodes (from paren groups).
+    /// Other constructs (ArgTuple, Let, List, Block) remain scope
+    /// boundaries and are not traversed.
+    fn contains_expr_anaphora(expr: &RcExpr) -> bool {
+        match &*expr.inner {
+            Expr::ExprAnaphor(_, _) => true,
+            Expr::Soup(_, xs) => xs.iter().any(Self::contains_expr_anaphora),
+            _ => false,
+        }
+    }
+
     /// Infer anaphora in gaps and insert them explicitly.
     ///
     /// e.g.

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -450,4 +450,32 @@ pub mod tests {
             )
         );
     }
+
+    #[test]
+    pub fn test_contains_expr_anaphora_scan() {
+        // ExprAnaphor at top level
+        assert!(Cooker::contains_expr_anaphora(&core::expr_anaphor(
+            Smid::fake(1),
+            Some(0)
+        )));
+
+        // ExprAnaphor nested in Soup (paren group)
+        let inner = soup(vec![
+            core::expr_anaphor(Smid::fake(2), Some(0)),
+            core::infixl(Smid::fake(3), 50, bif("ADD")),
+            core::expr_anaphor(Smid::fake(4), Some(1)),
+        ]);
+        assert!(Cooker::contains_expr_anaphora(&inner));
+
+        // Plain number — no anaphora
+        assert!(!Cooker::contains_expr_anaphora(&num(42)));
+
+        // Soup without anaphora
+        let plain = soup(vec![num(1), core::infixl(Smid::fake(5), 50, bif("ADD")), num(2)]);
+        assert!(!Cooker::contains_expr_anaphora(&plain));
+
+        // ArgTuple is a scope boundary — anaphora inside should NOT be detected
+        let arg = arg_tuple(vec![core::expr_anaphor(Smid::fake(6), Some(0))]);
+        assert!(!Cooker::contains_expr_anaphora(&arg));
+    }
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -420,11 +420,6 @@ pub fn test_harness_084() {
 }
 
 #[test]
-pub fn test_harness_085() {
-    run_test(&opts("085_deep_merge_dynamic.eu"));
-}
-
-#[test]
 pub fn test_harness_086() {
     run_test(&opts("086_expr_anaphora_parens.eu"));
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -420,6 +420,16 @@ pub fn test_harness_084() {
 }
 
 #[test]
+pub fn test_harness_085() {
+    run_test(&opts("085_deep_merge_dynamic.eu"));
+}
+
+#[test]
+pub fn test_harness_086() {
+    run_test(&opts("086_expr_anaphora_parens.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- **Expression anaphora paren scope (eu-mi8d)**: Numbered expression anaphora (`_0`, `_1`) inside parenthesised groups now correctly propagate to the enclosing expression scope. Previously `(_0 + _1) / 2` would try to resolve the anaphora at the paren boundary instead of the outer expression. Fixed by adding a pre-scan (`contains_numbered_expr_anaphora`) that detects numbered anaphora through nested `Soup` nodes before `fill_gaps` runs.

- **Block anaphor closure (eu-dobu)**: Block anaphora with outer-scope variables in infix expressions now work correctly. `{k: bullet}.(k + n)` where `n` is an outer-scope binding no longer fails with type mismatch. Root cause was a redundant inner `let` that created an extra scope level confusing STG compilation. Fixed by collapsing the single-binding let into the lambda in `process_block_anaphora`.

## Test plan

- [x] New harness test `086_expr_anaphora_parens.eu` covering numbered anaphora in parens
- [x] Extended `031_block_anaphora.eu` with outer-scope variable test cases
- [x] Unit tests for pre-scan helper and anaphora propagation through parens
- [x] All 121 harness tests pass
- [x] All 553 unit tests pass
- [x] Clippy clean (`--all-targets -D warnings`)
- [x] Formatting clean (`cargo fmt --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)