### PR TITLE
Improve NoBranchForNative error with type and location

### DIFF
--- a/harness/test/errors/002_lists.eu.expect
+++ b/harness/test/errors/002_lists.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "no branch for native"
+stderr: "received a .* where a structured value"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -270,8 +270,8 @@ pub enum ExecutionError {
     ExpectedBranchContinuation,
     #[error("type mismatch: expected {}, found {}", display_expected_tags(.2), display_data_tag(*.1))]
     NoBranchForDataTag(Smid, u8, Vec<u8>),
-    #[error("no branch for native")]
-    NoBranchForNative,
+    #[error("type mismatch: received a {1} where a structured value (block or list) was expected")]
+    NoBranchForNative(Smid, String),
     #[error("{}", format_cannot_return_fun(.1))]
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
@@ -336,6 +336,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,
+            ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -449,7 +449,10 @@ impl MachineState {
                             )?,
                         );
                     } else {
-                        return Err(ExecutionError::NoBranchForNative);
+                        return Err(ExecutionError::NoBranchForNative(
+                            self.annotation,
+                            value.type_description().to_string(),
+                        ));
                     }
                 }
                 Continuation::Update { environment, index } => {


### PR DESCRIPTION
## Summary

- Improves the cryptic "no branch for native" error to include the actual native type and source location
- The error now reads: "type mismatch: received a <type> where a structured value (block or list) was expected"
- Adds Smid to the error variant for source location tracking

## Before

```
error: no branch for native
```

## After

```
error: type mismatch: received a string where a structured value (block or list) was expected
```

## Test plan

- [x] All 34 error tests pass (updated 002_lists.eu.expect for new message format)
- [x] Clippy clean with `--all-targets -- -D warnings`
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)