### PR TITLE
feat: add stream_advance_one helper (eu-45bc)

### DIFF
--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -86,3 +86,16 @@ pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
         }
     })
 }
+
+/// Advance a stream producer by a single step.
+///
+/// Returns `Some(value)` if the producer yielded an element, or
+/// `None` if the stream is exhausted or the handle is invalid.
+pub fn stream_advance_one(handle: u32) -> Option<Rc<StgSyn>> {
+    STREAM_TABLE.with(|table| {
+        let table = table.borrow();
+        let producer = table.get(handle)?;
+        let value = producer.borrow_mut().next();
+        value
+    })
+}


### PR DESCRIPTION
## Summary

- Adds `pub fn stream_advance_one(handle: u32) -> Option<Rc<StgSyn>>` to `src/eval/stg/stream.rs`
- Advances a stream producer by a single step, complementing the existing `stream_drain` which eagerly consumes all values
- Building block for lazy cons cell construction in `StreamNext` (eu-tmv7)

## Details

The function uses the same `STREAM_TABLE` thread-local as `stream_drain` and `register_stream`. It looks up the producer by handle, calls `next()` once, and returns `None` if the stream is exhausted or the handle is invalid.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test --lib` passes (554 tests)
- No new tests needed — the function has no callers yet; it will be exercised by eu-tmv7

🤖 Generated with [Claude Code](https://claude.com/claude-code)