### PR TITLE
feat: add Unicode comparison operator aliases (eu-jrrt)

### DIFF
--- a/harness/test/010_prelude.eu
+++ b/harness/test/010_prelude.eu
@@ -94,18 +94,18 @@ tests: {
   }
 
   unicode-comparison: {
-    # \u2260 (not equal)
-    t1: 1 \u2260 2
-    t2: not(1 \u2260 1)
-    t3: "a" \u2260 "b"
-    # \u2264 (less than or equal)
-    t4: 1 \u2264 2
-    t5: 1 \u2264 1
-    t6: not(2 \u2264 1)
-    # \u2265 (greater than or equal)
-    t7: 2 \u2265 1
-    t8: 1 \u2265 1
-    t9: not(1 \u2265 2)
+    # ≠ (not equal)
+    t1: 1 ≠ 2
+    t2: not(1 ≠ 1)
+    t3: "a" ≠ "b"
+    # ≤ (less than or equal)
+    t4: 1 ≤ 2
+    t5: 1 ≤ 1
+    t6: not(2 ≤ 1)
+    # ≥ (greater than or equal)
+    t7: 2 ≥ 1
+    t8: 1 ≥ 1
+    t9: not(1 ≥ 2)
 
     pass: [t1, t2, t3, t4, t5, t6, t7, t8, t9] all-true?
   }

--- a/harness/test/010_prelude.eu
+++ b/harness/test/010_prelude.eu
@@ -93,6 +93,23 @@ tests: {
     pass: [t1, t2, t3, t4, t5, t6, t7] all-true?
   }
 
+  unicode-comparison: {
+    # \u2260 (not equal)
+    t1: 1 \u2260 2
+    t2: not(1 \u2260 1)
+    t3: "a" \u2260 "b"
+    # \u2264 (less than or equal)
+    t4: 1 \u2264 2
+    t5: 1 \u2264 1
+    t6: not(2 \u2264 1)
+    # \u2265 (greater than or equal)
+    t7: 2 \u2265 1
+    t8: 1 \u2265 1
+    t9: not(1 \u2265 2)
+
+    pass: [t1, t2, t3, t4, t5, t6, t7, t8, t9] all-true?
+  }
+
   arithmetic: {
     t1: 4 + 2 = 6
     t2: 9 - 4 - 9 = -4

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -367,11 +367,11 @@ or: __OR
     precedence: :eq }
 (l != r): not(__EQ(l, r))
 
-` { doc: "`l \u2260 r` - `true` if and only if value `l` is not equal to value `r`."
+` { doc: "`l ≠ r` - `true` if and only if value `l` is not equal to value `r`."
     export: :suppress
     associates: :left
     precedence: :eq }
-(l \u2260 r): l != r
+(l ≠ r): l != r
 
 ##
 ## Arithmetic
@@ -437,11 +437,11 @@ or: __OR
     precedence: :cmp }
 (l <= r): __LTE(l, r)
 
-` { doc: "`l \u2264 r` - `true` if `l` is less than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
+` { doc: "`l ≤ r` - `true` if `l` is less than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
     export: :suppress
     associates: :left
     precedence: :cmp }
-(l \u2264 r): l <= r
+(l ≤ r): l <= r
 
 ` { doc: "`l >= r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
     export: :suppress
@@ -449,11 +449,11 @@ or: __OR
     precedence: :cmp }
 (l >= r): __GTE(l, r)
 
-` { doc: "`l \u2265 r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
+` { doc: "`l ≥ r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
     export: :suppress
     associates: :left
     precedence: :cmp }
-(l \u2265 r): l >= r
+(l ≥ r): l >= r
 
 ` "`inc(x)` - increment number `x` by 1."
 inc: _ + 1

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -367,6 +367,12 @@ or: __OR
     precedence: :eq }
 (l != r): not(__EQ(l, r))
 
+` { doc: "`l \u2260 r` - `true` if and only if value `l` is not equal to value `r`."
+    export: :suppress
+    associates: :left
+    precedence: :eq }
+(l \u2260 r): l != r
+
 ##
 ## Arithmetic
 ##
@@ -431,11 +437,23 @@ or: __OR
     precedence: :cmp }
 (l <= r): __LTE(l, r)
 
+` { doc: "`l \u2264 r` - `true` if `l` is less than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
+    export: :suppress
+    associates: :left
+    precedence: :cmp }
+(l \u2264 r): l <= r
+
 ` { doc: "`l >= r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l >= r): __GTE(l, r)
+
+` { doc: "`l \u2265 r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
+    export: :suppress
+    associates: :left
+    precedence: :cmp }
+(l \u2265 r): l >= r
 
 ` "`inc(x)` - increment number `x` by 1."
 inc: _ + 1


### PR DESCRIPTION
## Summary
- Add Unicode comparison operator aliases ≤, ≥, ≠ to the prelude, following the existing pattern of ∧, ∨, ¬
- ≠ aliases `!=`, ≤ aliases `<=`, ≥ aliases `>=` — all with matching precedence and associativity metadata
- Add `unicode-comparison` test section to harness test 010 covering all three operators

## Test plan
- [x] `cargo test test_harness_010` — prelude test passes with new unicode-comparison section
- [x] `cargo test --test harness_test` — all 122 harness tests pass (no regressions)
- [x] `cargo test --lib` — all 548 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatting clean

Closes eu-jrrt (eu-lpv7, eu-v45c, eu-ti3x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)