### PR TITLE
Enable did-you-mean suggestions for static key lookups

### DIFF
--- a/harness/test/errors/034_did_you_mean.eu.expect
+++ b/harness/test/errors/034_did_you_mean.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "key 'bax' not found in block"
+stderr: "similar keys:"

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1375,15 +1375,12 @@ impl CallGlobal1 for IsBlock {}
 
 /// Compile a lookup failure for a statically known missing key.
 ///
-/// Generates a PANIC("key 'X' not found in block") call. This produces
-/// a clearer error message than the previous generic "Key not found".
-pub fn lookup_fail(key: &str, _obj: super::syntax::Ref) -> Rc<StgSyn> {
+/// Uses the LookupFail intrinsic so that the runtime can collect
+/// block keys and offer "did you mean?" suggestions via edit distance.
+pub fn lookup_fail(key: &str, obj: super::syntax::Ref) -> Rc<StgSyn> {
     use dsl::*;
 
-    let_(
-        vec![value(box_str(format!("key '{key}' not found in block")))],
-        Panic.global(lref(0)),
-    )
+    LookupFail.global(sym(key), obj)
 }
 
 /// Compile a panic for a missing key (legacy fallback, kept for tests)


### PR DESCRIPTION
## Summary

- Changes static `.key` lookup failures from `PANIC` to `LookupFail` intrinsic
- The LookupFail intrinsic collects available block keys at runtime and computes edit-distance suggestions
- Static lookups now show "did you mean?" suggestions just like dynamic lookups
- Updated test 034 to validate suggestions are shown

## Before

```
error: panic: key 'bax' not found in block
```

## After

```
error: key 'bax' not found in block
  help: similar keys: 'bar', 'baz'
```

## Test plan

- [x] All 35 error tests pass (including 034_did_you_mean with suggestions validation)
- [x] All 76 harness tests pass
- [x] Clippy clean with `--all-targets -- -D warnings`
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)