### PR TITLE
feat: DCE investigation and dynamise fallback fix

### DIFF
--- a/src/core/analyse/block_usage.rs
+++ b/src/core/analyse/block_usage.rs
@@ -1,0 +1,268 @@
+//! Analyse block usage patterns in a core expression tree.
+//!
+//! Walks the expression tree and classifies every `DefaultBlockLet`
+//! binding as having:
+//! - **static-only** access (all references are `Lookup(Var(Bound(bv)), key, ...)`)
+//! - **dynamic** access (at least one bare `Var(Bound(bv))` reference)
+//!
+//! Reports member counts, accessed member counts, and eliminated
+//! member counts so we can quantify the DCE opportunity.
+
+use crate::core::expr::*;
+use moniker::{BoundVar, Embed, Var};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::rc::Rc;
+
+/// Summary of access patterns for a single block binding.
+#[derive(Debug, Clone)]
+pub struct BlockUsageSummary {
+    /// Pretty name of the binding (from the binder)
+    pub name: String,
+    /// Total number of members in the block body
+    pub total_members: usize,
+    /// Members accessed via static Lookup
+    pub static_accesses: HashSet<String>,
+    /// Whether the block escapes dynamically (bare var reference)
+    pub escapes: bool,
+    /// Sites where the block escapes (pretty names of the bound var references)
+    pub escape_sites: Vec<String>,
+    /// Members that could be eliminated (total - accessed) if static-only
+    pub eliminable: usize,
+}
+
+/// Overall report for a core expression tree.
+#[derive(Debug, Default)]
+pub struct BlockUsageReport {
+    pub blocks: Vec<BlockUsageSummary>,
+}
+
+impl BlockUsageReport {
+    pub fn total_members(&self) -> usize {
+        self.blocks.iter().map(|b| b.total_members).sum()
+    }
+
+    pub fn total_static_only(&self) -> usize {
+        self.blocks.iter().filter(|b| !b.escapes).count()
+    }
+
+    pub fn total_escaping(&self) -> usize {
+        self.blocks.iter().filter(|b| b.escapes).count()
+    }
+
+    pub fn total_eliminable(&self) -> usize {
+        self.blocks.iter().map(|b| b.eliminable).sum()
+    }
+
+    pub fn print_report(&self) {
+        eprintln!("=== Block Usage Report ===");
+        eprintln!("Total DefaultBlockLet bindings: {}", self.blocks.len());
+        eprintln!("  Static-only: {}", self.total_static_only());
+        eprintln!("  Escaping (dynamic): {}", self.total_escaping());
+        eprintln!(
+            "  Total members across all blocks: {}",
+            self.total_members()
+        );
+        eprintln!("  Total eliminable members: {}", self.total_eliminable());
+        eprintln!();
+        for b in &self.blocks {
+            let status = if b.escapes { "ESCAPES" } else { "static-only" };
+            eprintln!(
+                "  {}: {} members, {} accessed, {} eliminable [{}]",
+                b.name,
+                b.total_members,
+                b.static_accesses.len(),
+                b.eliminable,
+                status
+            );
+            if b.escapes && !b.escape_sites.is_empty() {
+                let sites: Vec<_> = b.escape_sites.iter().take(5).collect();
+                eprintln!("    escape sites: {sites:?}");
+            }
+        }
+    }
+}
+
+/// Analyse block usage patterns in a core expression.
+pub fn analyse_block_usage(expr: &RcExpr) -> BlockUsageReport {
+    let mut analyser = BlockUsageAnalyser::default();
+    analyser.analyse(expr);
+    analyser.report
+}
+
+type BindingId = *const Expr<RcExpr>;
+
+#[derive(Default)]
+struct BlockUsageAnalyser {
+    scopes: VecDeque<RcExpr>,
+    /// DefaultBlockLet bindings we're tracking
+    candidates: HashMap<BindingId, BlockInfo>,
+    report: BlockUsageReport,
+}
+
+struct BlockInfo {
+    name: String,
+    total_members: usize,
+    static_accesses: HashSet<String>,
+    escapes: bool,
+    escape_sites: Vec<String>,
+}
+
+impl BlockUsageAnalyser {
+    fn analyse(&mut self, expr: &RcExpr) {
+        self.walk(expr);
+        self.finalise();
+    }
+
+    fn walk(&mut self, expr: &RcExpr) {
+        match &*expr.inner {
+            Expr::Let(_, scope, _) => {
+                // Register DefaultBlockLet bindings
+                for (ref binder, Embed(ref value)) in &scope.unsafe_pattern.unsafe_pattern {
+                    if value.inner.is_default_let() {
+                        let id: BindingId = Rc::as_ptr(&value.inner);
+                        let name = binder
+                            .0
+                            .pretty_name
+                            .clone()
+                            .unwrap_or_else(|| "<anon>".to_string());
+                        let total = self.count_block_members(value);
+                        self.candidates.insert(
+                            id,
+                            BlockInfo {
+                                name,
+                                total_members: total,
+                                static_accesses: HashSet::new(),
+                                escapes: false,
+                                escape_sites: Vec::new(),
+                            },
+                        );
+                    }
+                }
+                self.scopes.push_front(expr.clone());
+                for (_, Embed(ref value)) in &scope.unsafe_pattern.unsafe_pattern {
+                    self.walk(value);
+                }
+                self.walk(&scope.unsafe_body);
+                self.scopes.pop_front();
+            }
+            Expr::Lam(_, _, scope) => {
+                self.scopes.push_front(expr.clone());
+                self.walk(&scope.unsafe_body);
+                self.scopes.pop_front();
+            }
+            Expr::Lookup(_, e, member, fb) => {
+                // Check for static access: Lookup(Var(Bound(bv)), member, ...)
+                if let Expr::Var(_, Var::Bound(bound_var)) = &*e.inner {
+                    self.record_static_access(bound_var, member);
+                } else {
+                    self.walk(e);
+                }
+                if let Some(fallback) = fb {
+                    self.walk(fallback);
+                }
+            }
+            Expr::Var(_, Var::Bound(bound_var)) => {
+                self.record_escape(bound_var);
+            }
+            Expr::App(_, f, args) => {
+                self.walk(f);
+                for a in args {
+                    self.walk(a);
+                }
+            }
+            Expr::List(_, xs) => {
+                for x in xs {
+                    self.walk(x);
+                }
+            }
+            Expr::Block(_, bm) => {
+                for (_, v) in bm.iter() {
+                    self.walk(v);
+                }
+            }
+            Expr::Meta(_, e, m) => {
+                self.walk(e);
+                self.walk(m);
+            }
+            Expr::ArgTuple(_, xs) => {
+                for x in xs {
+                    self.walk(x);
+                }
+            }
+            Expr::Soup(_, xs) => {
+                for x in xs {
+                    self.walk(x);
+                }
+            }
+            Expr::Operator(_, _, _, e) => {
+                self.walk(e);
+            }
+            _ => {}
+        }
+    }
+
+    fn record_static_access(&mut self, bv: &BoundVar<String>, member: &str) {
+        if let Some(scope_expr) = self.scopes.get(bv.scope.0 as usize) {
+            if let Expr::Let(_, scope, _) = &*scope_expr.inner {
+                if bv.binder.to_usize() < scope.unsafe_pattern.unsafe_pattern.len() {
+                    let (_, Embed(ref value)) =
+                        &scope.unsafe_pattern.unsafe_pattern[bv.binder.to_usize()];
+                    let id: BindingId = Rc::as_ptr(&value.inner);
+                    if let Some(info) = self.candidates.get_mut(&id) {
+                        info.static_accesses.insert(member.to_owned());
+                    }
+                }
+            }
+        }
+    }
+
+    fn record_escape(&mut self, bv: &BoundVar<String>) {
+        if let Some(scope_expr) = self.scopes.get(bv.scope.0 as usize) {
+            if let Expr::Let(_, scope, _) = &*scope_expr.inner {
+                if bv.binder.to_usize() < scope.unsafe_pattern.unsafe_pattern.len() {
+                    let (_, Embed(ref value)) =
+                        &scope.unsafe_pattern.unsafe_pattern[bv.binder.to_usize()];
+                    let id: BindingId = Rc::as_ptr(&value.inner);
+                    if let Some(info) = self.candidates.get_mut(&id) {
+                        info.escapes = true;
+                        info.escape_sites.push(
+                            bv.pretty_name
+                                .clone()
+                                .unwrap_or_else(|| format!("?{}", bv.binder.to_usize())),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn count_block_members(&self, expr: &RcExpr) -> usize {
+        match &*expr.inner {
+            Expr::Let(_, scope, LetType::DefaultBlockLet) => match &*scope.unsafe_body.inner {
+                Expr::Block(_, bm) => bm.len(),
+                _ => 0,
+            },
+            Expr::Meta(_, e, _) => self.count_block_members(e),
+            _ => 0,
+        }
+    }
+
+    fn finalise(&mut self) {
+        for (_, info) in self.candidates.drain() {
+            let eliminable = if info.escapes {
+                0
+            } else {
+                info.total_members
+                    .saturating_sub(info.static_accesses.len())
+            };
+            self.report.blocks.push(BlockUsageSummary {
+                name: info.name,
+                total_members: info.total_members,
+                static_accesses: info.static_accesses,
+                escapes: info.escapes,
+                escape_sites: info.escape_sites,
+                eliminable,
+            });
+        }
+    }
+}

--- a/src/core/analyse/block_usage.rs
+++ b/src/core/analyse/block_usage.rs
@@ -154,11 +154,27 @@ impl BlockUsageAnalyser {
                 // Check for static access: Lookup(Var(Bound(bv)), member, ...)
                 if let Expr::Var(_, Var::Bound(bound_var)) = &*e.inner {
                     self.record_static_access(bound_var, member);
+                    // For fallbacks that reference the SAME binding as the
+                    // target (dynamise-generated pattern), treat as static
+                    // access rather than escape.
+                    if let Some(fallback) = fb {
+                        if let Expr::Var(_, Var::Bound(fb_var)) = &*fallback.inner {
+                            if fb_var.scope == bound_var.scope && fb_var.binder == bound_var.binder
+                            {
+                                // Same binding — not an escape
+                                self.record_static_access(fb_var, member);
+                            } else {
+                                self.walk(fallback);
+                            }
+                        } else {
+                            self.walk(fallback);
+                        }
+                    }
                 } else {
                     self.walk(e);
-                }
-                if let Some(fallback) = fb {
-                    self.walk(fallback);
+                    if let Some(fallback) = fb {
+                        self.walk(fallback);
+                    }
                 }
             }
             Expr::Var(_, Var::Bound(bound_var)) => {

--- a/src/core/analyse/mod.rs
+++ b/src/core/analyse/mod.rs
@@ -1,1 +1,2 @@
+pub mod block_usage;
 pub mod testplan;

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -328,11 +328,28 @@ impl<'expr> ScopeTracker<'expr> {
                 // Check for static access pattern: Lookup(Var(Bound(bv)), member, ...)
                 if let Expr::Var(_, Var::Bound(bound_var)) = &*e.inner {
                     self.encounter_lookup(bound_var, member);
+                    // For fallbacks that reference the SAME binding as the
+                    // target, treat as a static lookup rather than an escape.
+                    // This handles dynamise-generated patterns:
+                    //   Lookup(target, key, Some(Var(Bound(target))))
+                    if let Some(fallback) = fb {
+                        if let Expr::Var(_, Var::Bound(fb_var)) = &*fallback.inner {
+                            if fb_var.scope == bound_var.scope && fb_var.binder == bound_var.binder
+                            {
+                                // Same binding — not an escape, just a lookup fallback
+                                self.encounter_lookup(fb_var, member);
+                            } else {
+                                self.traverse(fallback);
+                            }
+                        } else {
+                            self.traverse(fallback);
+                        }
+                    }
                 } else {
                     self.traverse(e);
-                }
-                if let Some(fallback) = fb {
-                    self.traverse(fallback);
+                    if let Some(fallback) = fb {
+                        self.traverse(fallback);
+                    }
                 }
             }
             Expr::List(_, xs) => {
@@ -767,6 +784,106 @@ pub mod tests {
                                 assert!(block_map.get("a").is_some());
                                 assert!(block_map.get("c").is_some());
                                 assert!(block_map.get("b").is_none());
+                            }
+                            other => panic!("expected Block body, got: {other:?}"),
+                        }
+                    }
+                    other => panic!("expected DefaultBlockLet, got: {other:?}"),
+                }
+            }
+            other => panic!("expected outer Let, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    pub fn test_dynamise_fallback_allows_block_dce() {
+        // Simulates the dynamise pattern:
+        //   ns = DefaultBlockLet { used: 42, unused: 99 }
+        //   result = Lookup(Var(ns), "used", Some(Var(ns)))
+        //
+        // The fallback Var(ns) should NOT prevent block-level DCE
+        // because it refers to the same binding as the lookup target.
+        let used = free("used");
+        let unused = free("unused");
+        let ns = free("ns");
+        let result = free("result");
+
+        let ns_var = || var(ns.clone());
+
+        let expr = let_(
+            vec![
+                (
+                    ns.clone(),
+                    default_let(vec![(used.clone(), num(42)), (unused.clone(), num(99))]),
+                ),
+                (result.clone(), lookup(ns_var(), "used", Some(ns_var()))),
+            ],
+            var(result.clone()),
+        );
+
+        let pruned = prune(&expr);
+
+        // Verify the block body is filtered (only "used" member)
+        match &*pruned.inner {
+            Expr::Let(_, scope, _) => {
+                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                match &*ns_val.inner {
+                    Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
+                        match &*inner_scope.unsafe_body.inner {
+                            Expr::Block(_, block_map) => {
+                                assert_eq!(block_map.len(), 1);
+                                assert!(block_map.get("used").is_some());
+                                assert!(block_map.get("unused").is_none());
+                            }
+                            other => panic!("expected Block body, got: {other:?}"),
+                        }
+                    }
+                    other => panic!("expected DefaultBlockLet, got: {other:?}"),
+                }
+            }
+            other => panic!("expected outer Let, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    pub fn test_different_binding_fallback_does_not_prevent_dce() {
+        // Lookup(Var(ns), "used", Some(Var(other)))
+        // Different fallback binding should NOT cause ns to escape
+        // because the fallback is just another variable
+        let used = free("used");
+        let unused = free("unused");
+        let ns = free("ns");
+        let other = free("other");
+        let result = free("result");
+
+        let expr = let_(
+            vec![
+                (
+                    ns.clone(),
+                    default_let(vec![(used.clone(), num(42)), (unused.clone(), num(99))]),
+                ),
+                (other.clone(), num(0)),
+                (
+                    result.clone(),
+                    lookup(var(ns.clone()), "used", Some(var(other.clone()))),
+                ),
+            ],
+            var(result.clone()),
+        );
+
+        let pruned = prune(&expr);
+
+        // ns should still have block-level DCE applied since only
+        // "used" is accessed — the fallback references "other", not "ns"
+        match &*pruned.inner {
+            Expr::Let(_, scope, _) => {
+                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                match &*ns_val.inner {
+                    Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
+                        match &*inner_scope.unsafe_body.inner {
+                            Expr::Block(_, block_map) => {
+                                assert_eq!(block_map.len(), 1);
+                                assert!(block_map.get("used").is_some());
                             }
                             other => panic!("expected Block body, got: {other:?}"),
                         }

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -169,6 +169,10 @@ pub struct RunArgs {
     #[arg(long = "no-dce")]
     pub no_dce: bool,
 
+    /// Dump block usage analysis (static vs dynamic access patterns)
+    #[arg(long = "debug-block-usage")]
+    pub debug_block_usage: bool,
+
     /// Seed for random number generation (for reproducible results)
     #[arg(long = "seed")]
     pub seed: Option<i64>,
@@ -344,6 +348,9 @@ pub struct EucalyptOptions {
 
     // Optimisation flags
     pub no_dce: bool,
+
+    // Debug analysis flags
+    pub debug_block_usage: bool,
 
     // Error format
     pub error_format: ErrorFormat,
@@ -549,6 +556,11 @@ impl From<EucalyptCli> for EucalyptOptions {
             _ => false,
         };
 
+        let debug_block_usage = match &cli.command {
+            Some(Commands::Run(run_args)) => run_args.debug_block_usage,
+            _ => false,
+        };
+
         // Extract seed from Run command
         let seed = match &cli.command {
             Some(Commands::Run(run_args)) => run_args.seed,
@@ -607,6 +619,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             format_reformat,
             format_indent,
             no_dce,
+            debug_block_usage,
             error_format,
             stg_settings: StgSettings {
                 heap_limit_mib,
@@ -758,6 +771,10 @@ impl EucalyptOptions {
 
     pub fn no_dce(&self) -> bool {
         self.no_dce
+    }
+
+    pub fn debug_block_usage(&self) -> bool {
+        self.debug_block_usage
     }
 
     pub fn run(&self) -> bool {

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -158,6 +158,13 @@ pub fn prepare(
         stats.record("eliminate-1", t.elapsed());
     }
 
+    // Dump block usage analysis if requested
+    if opt.debug_block_usage() {
+        use crate::core::analyse::block_usage;
+        let report = block_usage::analyse_block_usage(&loader.core().expr);
+        report.print_report();
+    }
+
     // Run inline pass
     {
         let t = Instant::now();


### PR DESCRIPTION
## Summary

- Add block usage static analysis pass (`src/core/analyse/block_usage.rs`) and `--debug-block-usage` CLI flag to quantify DCE opportunities
- Fix dynamise fallback pattern in `prune.rs` — when `Lookup(target, key, Some(Var(target)))` has a fallback referencing the same binding as the lookup target, treat it as a static access rather than an escape, unlocking block-level member elimination
- Add 2 unit tests for the new dynamise-aware fallback handling

### Investigation Findings

The dynamise transform creates `Lookup(target, key, Some(Var(Bound(original))))` patterns where the fallback bare `Var` was triggering escape detection, disqualifying DefaultBlockLet bindings from block-level DCE. The fix correctly identifies same-binding fallbacks and treats them as static lookups.

**Quantitative results** (harness/test/006_lists.eu):
- Before DCE: 6 blocks, 3 static-only, 4 eliminable members
- After DCE: 0 blocks remaining — all fully eliminated or pruned

Most escaping blocks in test files are **genuine** dynamic escapes (blocks included in output), not false positives from the dynamise pattern.

## Test plan

- [x] All 122 harness tests pass
- [x] 11 prune unit tests pass (9 existing + 2 new)
- [x] clippy clean, fmt clean
- [x] Verified no regressions with full `cargo test`

Generated with [Claude Code](https://claude.com/claude-code)