### PR TITLE
Add source location and help notes to BlackHole error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -279,7 +279,7 @@ pub enum ExecutionError {
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
-    BlackHole,
+    BlackHole(Smid),
     #[error(transparent)]
     Compile(#[from] CompileError),
     #[error(transparent)]
@@ -338,6 +338,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
+            ExecutionError::BlackHole(s) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }
@@ -362,6 +363,14 @@ impl ExecutionError {
             }
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {
                 data_tag_mismatch_notes(*actual, expected)
+            }
+            ExecutionError::BlackHole(_) => {
+                vec![
+                    "a binding that references itself directly or indirectly creates an infinite loop"
+                        .to_string(),
+                    "use a function parameter instead of self-reference, or break the cycle"
+                        .to_string(),
+                ]
             }
             _ => vec![],
         };

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -361,7 +361,7 @@ impl MachineState {
                 )?;
                 self.closure = SynClosure::new(scrutinee, environment);
             }
-            HeapSyn::BlackHole => return Err(ExecutionError::BlackHole),
+            HeapSyn::BlackHole => return Err(ExecutionError::BlackHole(self.annotation)),
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Adds Smid source location to the BlackHole (infinite loop) error for better error positioning
- Adds contextual help notes explaining the cause and suggesting how to fix it
- Changes `BlackHole` from a unit variant to `BlackHole(Smid)`

## Before

```
error: infinite loop detected: binding refers to itself
```

## After

```
error: infinite loop detected: binding refers to itself
  = a binding that references itself directly or indirectly creates an infinite loop
  = use a function parameter instead of self-reference, or break the cycle
```

## Test plan

- [x] All 35 error tests pass
- [x] Clippy clean with `--all-targets -- -D warnings`
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)