### PR TITLE
perf: reuse existing Atom closure in return_native

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -423,7 +423,11 @@ impl MachineState {
         Ok(())
     }
 
-    /// Return a native value into continuation or terminate
+    /// Return a native value into continuation or terminate.
+    ///
+    /// The current closure already wraps the native in an Atom on the
+    /// heap, so we reuse that closure when building the env frame for
+    /// Branch/DeMeta fallbacks instead of allocating a fresh Atom.
     fn return_native(
         &mut self,
         view: MutatorHeapView<'_>,
@@ -440,13 +444,12 @@ impl MachineState {
                 } => {
                     // case fallbacks can handle natives
                     if let Some(fb) = fallback {
+                        // Reuse the existing closure (already an Atom
+                        // wrapping the native value) instead of allocating
+                        // a new HeapSyn::Atom via from_args.
                         self.closure = SynClosure::new(
                             fb,
-                            view.from_args(
-                                &[Ref::vref(value.clone())],
-                                environment,
-                                self.annotation,
-                            )?,
+                            view.from_closure(self.closure.clone(), environment, self.annotation)?,
                         );
                     } else {
                         return Err(ExecutionError::NoBranchForNative);
@@ -466,10 +469,10 @@ impl MachineState {
                     environment,
                     ..
                 } => {
-                    // demeta or_else can accept natives
+                    // Reuse existing Atom closure as above
                     self.closure = SynClosure::new(
                         or_else,
-                        view.from_args(&[Ref::vref(value.clone())], environment, self.annotation)?,
+                        view.from_closure(self.closure.clone(), environment, self.annotation)?,
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- When `return_native` passes a native value to a Branch or DeMeta fallback, reuse the existing `Atom` closure already on the heap instead of allocating a fresh one via `from_args`
- Replaces `from_args(&[Ref::vref(value)])` with `from_closure(self.closure.clone(), ...)` which saves one `HeapSyn::Atom` allocation per native return into a case fallback
- Heap block allocations reduced by ~8% on naive_fib (476K -> 437K blocks)

## Benchmark results (stg-execute, min of 3 runs)

| Benchmark | Before | After | Change |
|---|---|---|---|
| 001_naive_fib | 8.74s | 8.09s | **-7.4%** |
| 002_thunk_updates | 0.82s | 0.83s | noise |
| 004_generations | 0.51s | 0.51s | unchanged |
| 005_drop_cons | 0.17s | 0.16s | -3% |
| 007_short_lived | 0.24s | 0.23s | -4% |
| 008_long_lived_graph | 0.19s | 0.18s | -5% |
| 009_fragmentation | 0.17s | 0.16s | -5% |

## Test plan

- [x] All 551 unit tests pass
- [x] All 121 harness tests pass
- [x] No benchmark regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)