### PR TITLE
Improve numeric error messages with help context

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -281,9 +281,9 @@ pub enum ExecutionError {
     NotScalar(Smid),
     #[error("unknown format ({0})")]
     UnknownFormat(String),
-    #[error("cannot combine numbers ({0}, {1}) into same numeric domain")]
+    #[error("cannot combine numbers ({0}, {1}) into same numeric domain\n  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision")]
     NumericDomainError(Number, Number),
-    #[error("out of range error operating on numbers ({0}, {1})")]
+    #[error("numeric overflow: result of operating on {0} and {1} is out of range\n  help: the result exceeds the representable range for this numeric type")]
     NumericRangeError(Number, Number),
     #[error("{}", format_division_by_zero(.0))]
     DivisionByZero(String),


### PR DESCRIPTION
## Summary

- Improves `NumericRangeError` from "out of range error operating on numbers" to "numeric overflow: result of operating on X and Y is out of range" with help about representable range
- Improves `NumericDomainError` with help about mixing integer and floating-point arithmetic

## Before

```
error: out of range error operating on numbers (999999999999999999, 999999999999999999)
```

## After

```
error: numeric overflow: result of operating on 999999999999999999 and 999999999999999999 is out of range
  help: the result exceeds the representable range for this numeric type
```

## Test plan

- [x] All 36 error tests pass
- [x] Clippy clean with `--all-targets -- -D warnings`
- [x] `cargo fmt` clean

Generated with [Claude Code](https://claude.com/claude-code)