### PR TITLE
Add 'too many arguments' hint to NotCallable error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -155,7 +155,8 @@ fn format_not_callable(actual_type: &str) -> String {
     } else {
         format!(
             "tried to call a {actual_type} as a function\n  \
-             help: only functions and blocks can be called with arguments"
+             help: only functions and blocks can be called with arguments\n  \
+             help: this often means too many arguments were passed to a function"
         )
     }
 }


### PR DESCRIPTION
## Summary

- When a non-callable value (e.g. a number or string) is applied as a function, the error now includes a second help line: "this often means too many arguments were passed to a function"
- This is a very common cause of NotCallable errors in pipeline-style eucalypt code

### Before
```
error: tried to call a number as a function
  help: only functions and blocks can be called with arguments
```

### After
```
error: tried to call a number as a function
  help: only functions and blocks can be called with arguments
  help: this often means too many arguments were passed to a function
```

## Test plan
- [x] All 123 harness tests pass
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean