### PR TITLE
Add string concatenation hint to number/string type mismatch

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -21,7 +21,12 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
                 .to_string(),
         ],
         (Number, String) => {
-            vec!["if you need to convert a string to a number, use 'parse-num'".to_string()]
+            vec![
+                "if you need to convert a string to a number, use 'parse-num'".to_string(),
+                "to concatenate strings, use string interpolation or 'join-on' \
+                 instead of '+'"
+                    .to_string(),
+            ]
         }
         (String, Number) => vec!["if you need to convert a number to a string, use 'str' or \
              string interpolation"
@@ -48,7 +53,12 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
                 .to_string(),
         ]
     } else if is_string && expects_number {
-        vec!["to convert a string to a number, use 'parse-num'".to_string()]
+        vec![
+            "to convert a string to a number, use 'parse-num'".to_string(),
+            "to concatenate strings, use string interpolation or 'join-on' \
+             instead of '+'"
+                .to_string(),
+        ]
     } else if is_number && expects_string {
         vec!["to convert a number to a string, use 'str' or string interpolation".to_string()]
     } else {


### PR DESCRIPTION
## Summary

- When `+` receives a string where a number is expected, the error now includes a second note suggesting string interpolation or `join-on` for concatenation
- Applied to both `TypeMismatch(Number, String)` and `NoBranchForDataTag` (string where number expected) paths
- Users coming from other languages frequently try `"a" + "b"` for string concatenation

### Before
```
error: type mismatch: expected number, found string
 = to convert a string to a number, use 'parse-num'
```

### After
```
error: type mismatch: expected number, found string
 = to convert a string to a number, use 'parse-num'
 = to concatenate strings, use string interpolation or 'join-on' instead of '+'
```

## Test plan
- [x] All 36 error tests pass
- [x] All 123 harness tests pass
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean