### PR TITLE
Add hint for == operator (suggest = for equality)

### DIFF
--- a/harness/test/errors/038_double_equals.eu
+++ b/harness/test/errors/038_double_equals.eu
@@ -1,0 +1,2 @@
+# Error: using == instead of = for equality
+a: 1 == 1

--- a/harness/test/errors/038_double_equals.eu.expect
+++ b/harness/test/errors/038_double_equals.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "eucalypt uses '=' for equality"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -78,6 +78,11 @@ impl CompileError {
                             .to_string(),
                     );
                 }
+                // Suggest eucalypt equivalents for common operators from other
+                // languages.
+                if name == "==" {
+                    notes.push("eucalypt uses '=' for equality, not '=='".to_string());
+                }
                 diag.with_notes(notes)
             }
             _ => diag,

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -647,6 +647,11 @@ pub fn test_error_037() {
 }
 
 #[test]
+pub fn test_error_038() {
+    run_error_test(&error_opts("038_double_equals.eu"));
+}
+
+#[test]
 pub fn test_error_040() {
     run_error_test(&error_opts("040_json_error_format.eu"));
 }


### PR DESCRIPTION
## Summary

- When a user writes `==` (common in C-style languages), the unresolved variable error now hints that eucalypt uses `=` for equality comparison
- Includes new error test (038_double_equals)

### Before
```
error: unresolved variable '=='
 = check that the variable is defined and in scope
```

### After
```
error: unresolved variable '=='
 = check that the variable is defined and in scope
 = eucalypt uses '=' for equality, not '=='
```

## Test plan
- [x] All 37 error tests pass (including new test_error_038)
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean