### PR TITLE
List supported formats in unknown format error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -196,6 +196,14 @@ fn format_division_by_zero(operation: &str) -> String {
     }
 }
 
+/// Format an unknown format error message listing valid export formats
+fn format_unknown_format(name: &str) -> String {
+    format!(
+        "unknown export format '{name}'\n  \
+         help: supported formats are: yaml, json, toml, text, edn, html"
+    )
+}
+
 /// Format a bad format string error message with help about valid specifiers
 fn format_bad_format_string(detail: &str) -> String {
     format!(
@@ -279,7 +287,7 @@ pub enum ExecutionError {
     FormatError(String, Number),
     #[error("expected scalar value")]
     NotScalar(Smid),
-    #[error("unknown format ({0})")]
+    #[error("{}", format_unknown_format(.0))]
     UnknownFormat(String),
     #[error("cannot combine numbers ({0}, {1}) into same numeric domain\n  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision")]
     NumericDomainError(Number, Number),


### PR DESCRIPTION
## Summary

- When an unrecognised export format is requested (e.g. `eu -x xml`), the error now lists valid options
- Previously: `unknown format (xml)`
- Now: `unknown export format 'xml'` with help listing yaml, json, toml, text, edn, html

### Before
```
error: unknown format (xml)
```

### After
```
error: unknown export format 'xml'
  help: supported formats are: yaml, json, toml, text, edn, html
```

## Test plan
- [x] All 36 error tests pass
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean