### PR TITLE
Include regex library error details in BadRegex message

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -259,8 +259,8 @@ pub enum ExecutionError {
     NotCallable(Smid, String),
     #[error("{}", format_not_value(.1))]
     NotValue(Smid, String),
-    #[error("bad regex ({0})")]
-    BadRegex(String),
+    #[error("bad regex: {1}\n  help: the pattern '{0}' is not a valid regular expression")]
+    BadRegex(String, String),
     #[error("bad date / time components ({0}, {1}, {2}, {3}, {4}, {5}, {6})")]
     BadDateTimeComponents(Number, Number, Number, Number, Number, Number, String),
     #[error("bad time zone ({0})")]

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -47,8 +47,8 @@ fn cached_regex<T: AsRef<str>>(
     let text_ref = text.as_ref();
 
     if !rcache.contains(text_ref) {
-        let re =
-            Regex::new(text_ref).map_err(|_| ExecutionError::BadRegex(text_ref.to_string()))?;
+        let re = Regex::new(text_ref)
+            .map_err(|e| ExecutionError::BadRegex(text_ref.to_string(), e.to_string()))?;
         rcache.put(text_ref.to_string(), re);
     }
 


### PR DESCRIPTION
## Summary

- When a bad regex pattern is provided (e.g. to `str.split`, `str.match`), the error now includes the detailed parse error from the regex library
- Previously the regex library error was discarded with `map_err(|_|...)`
- Now uses `map_err(|e|...)` to pass the error message through
- `BadRegex` variant updated from single `String` to two `String` fields (pattern + error detail)

### Before
```
error: bad regex (()
```

### After
```
error: bad regex: regex parse error:
    (
    ^
error: unclosed group
  help: the pattern '(' is not a valid regular expression
```

## Test plan
- [x] All 36 error tests pass
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean