### PR TITLE
Suggest list-targets in target-not-found error

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -35,7 +35,7 @@ pub enum CoreError {
     EmptyMerge(),
     #[error("merge base was not valid for merge")]
     InvalidMergeBase(),
-    #[error("target {0} not found")]
+    #[error("target '{0}' not found\n  help: use 'eu list-targets' to see available targets")]
     TargetNotFound(String),
     #[error("target {0} could not be referenced")]
     BadTarget(String),


### PR DESCRIPTION
## Summary

- When a nonexistent target is specified with `-t`, the error now suggests using `eu list-targets` to see available targets
- Helps new users discover the list-targets subcommand

### Before
```
error: target nonexistent not found
```

### After
```
error: target 'nonexistent' not found
  help: use 'eu list-targets' to see available targets
```

## Test plan
- [x] All error tests pass
- [x] clippy clean (`--all-targets -D warnings`)
- [x] rustfmt clean