### PR TITLE
revert: back out stream_advance_one (deferring stream redesign)

### DIFF
--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -86,16 +86,3 @@ pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
         }
     })
 }
-
-/// Advance a stream producer by a single step.
-///
-/// Returns `Some(value)` if the producer yielded an element, or
-/// `None` if the stream is exhausted or the handle is invalid.
-pub fn stream_advance_one(handle: u32) -> Option<Rc<StgSyn>> {
-    STREAM_TABLE.with(|table| {
-        let table = table.borrow();
-        let producer = table.get(handle)?;
-        let value = producer.borrow_mut().next();
-        value
-    })
-}


### PR DESCRIPTION
## Summary
Reverting PR #280 (stream_advance_one helper). The stream memoisation approach needs an architectural redesign — lazy cons cells can't work with the current value-type closure architecture. Deferring until all other 0.4.0 features are in.

Reverts commit 91147f9.

## Test plan
- [x] `cargo test --lib` passes
- [x] No callers of `stream_advance_one` exist in the codebase

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>