### PR TITLE
feat: show accurate source location in parse errors

### DIFF
--- a/src/syntax/error.rs
+++ b/src/syntax/error.rs
@@ -1,3 +1,4 @@
+use crate::syntax::rowan::ParseError as RowanParseError;
 use crate::syntax::span::HasSpan;
 use codespan::{ByteIndex, Span};
 use codespan_reporting::diagnostic::{Diagnostic, Label};
@@ -84,6 +85,42 @@ impl SyntaxError {
     }
 }
 
+/// Convert a `rowan::TextRange` byte offset to a `codespan::ByteIndex`.
+fn text_size_to_byte_index(ts: rowan::TextSize) -> ByteIndex {
+    ByteIndex(u32::from(ts))
+}
+
+/// Convert a `rowan::TextRange` to a `codespan::Span`.
+fn text_range_to_span(range: rowan::TextRange) -> Span {
+    Span::new(
+        text_size_to_byte_index(range.start()),
+        text_size_to_byte_index(range.end()),
+    )
+}
+
+/// Extract the primary text range from a Rowan parse error.
+fn rowan_error_range(error: &RowanParseError) -> Option<rowan::TextRange> {
+    use crate::syntax::rowan::error::ParseError::*;
+    match error {
+        UnexpectedToken { range, .. }
+        | UnclosedSingleQuote { range }
+        | UnclosedDoubleQuote { range }
+        | InvalidParenExpr { range, .. }
+        | UnterminatedBlock { range, .. }
+        | EmptyDeclarationBody { range }
+        | MalformedDeclarationHead { range }
+        | InvalidFormalParameter { range, .. }
+        | InvalidOperatorName { range, .. }
+        | InvalidPropertyName { range, .. }
+        | SurplusContent { range }
+        | ReservedCharacter { range }
+        | EmptyExpression { range }
+        | UnclosedStringInterpolation { range }
+        | InvalidZdtLiteral { range } => Some(*range),
+        MissingDeclarationColon { head_range } => Some(*head_range),
+    }
+}
+
 /// A canonicalised error for all parse related errors, parse, IO,
 /// AST, free of token references.
 #[derive(Debug, Error)]
@@ -92,6 +129,13 @@ pub enum ParserError {
     Io(io::Error),
     #[error(transparent)]
     Syntax(SyntaxError),
+    /// Parse errors from the Rowan parser, with source location information.
+    ///
+    /// Carries the file id and the list of parse errors with their `TextRange`
+    /// positions so that diagnostics can show the actual error location rather
+    /// than defaulting to the start of the file.
+    #[error("{}", .1.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", "))]
+    ParseErrors(usize, Vec<RowanParseError>),
 }
 
 impl ParserError {
@@ -100,6 +144,33 @@ impl ParserError {
         match self {
             ParserError::Syntax(e) => e.to_diagnostic(),
             ParserError::Io(e) => Diagnostic::error().with_message(format!("IO Error: {e}")),
+            ParserError::ParseErrors(file_id, errors) => {
+                if let Some(first) = errors.first() {
+                    let message = first.to_string();
+                    let mut diag = Diagnostic::error().with_message(message);
+                    if let Some(range) = rowan_error_range(first) {
+                        diag = diag
+                            .with_labels(vec![Label::primary(*file_id, text_range_to_span(range))]);
+                    }
+                    // Add secondary labels for additional errors if any
+                    let secondary_labels: Vec<Label<usize>> = errors
+                        .iter()
+                        .skip(1)
+                        .filter_map(|e| {
+                            rowan_error_range(e).map(|r| {
+                                Label::secondary(*file_id, text_range_to_span(r))
+                                    .with_message(e.to_string())
+                            })
+                        })
+                        .collect();
+                    if !secondary_labels.is_empty() {
+                        diag = diag.with_labels(secondary_labels);
+                    }
+                    diag
+                } else {
+                    Diagnostic::error().with_message("parse error")
+                }
+            }
         }
     }
 }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -20,17 +20,7 @@ where
     let parse_result = rowan::parse_unit(text);
 
     if !parse_result.errors().is_empty() {
-        let errors: Vec<String> = parse_result
-            .errors()
-            .iter()
-            .map(|e| format!("{e}"))
-            .collect();
-        return Err(ParserError::Syntax(
-            crate::syntax::error::SyntaxError::InvalidInputFormat(
-                id,
-                format!("Parse errors: {}", errors.join(", ")),
-            ),
-        ));
+        return Err(ParserError::ParseErrors(id, parse_result.errors().clone()));
     }
 
     Ok(parse_result.tree())
@@ -49,17 +39,7 @@ where
     let parse_result = rowan::parse_expr(text);
 
     if !parse_result.errors().is_empty() {
-        let errors: Vec<String> = parse_result
-            .errors()
-            .iter()
-            .map(|e| format!("{e}"))
-            .collect();
-        return Err(ParserError::Syntax(
-            crate::syntax::error::SyntaxError::InvalidInputFormat(
-                id,
-                format!("Parse errors: {}", errors.join(", ")),
-            ),
-        ));
+        return Err(ParserError::ParseErrors(id, parse_result.errors().clone()));
     }
 
     Ok(parse_result.tree())


### PR DESCRIPTION
## Error message: parse errors — inaccurate source location

### Scenario

Any eucalypt source file with a parse error (unterminated string, unterminated block, missing closing parenthesis, etc.) reported the error at line 1, column 1 — always the start of the file — rather than the actual position of the parse mistake. The error message was also wrapped in a redundant `input was not correctly formed: Parse errors:` prefix.

Perturbation applied to various test files:
- `a: "unending` — unterminated string literal
- `x: { a: 1\n  b: 2` — unterminated block
- `x: f(2` — missing closing parenthesis

### Before

```
error: input was not correctly formed: Parse errors: unterminated string literal
  --> test.eu:1:1
   |
 1 | a: "unending
   | ^
```

```
error: input was not correctly formed: Parse errors: unterminated block (missing '}')
  --> test.eu:1:1
   |
 1 | x: {
   | ^
```

```
error: input was not correctly formed: Parse errors: invalid parenthesised expression
  --> test.eu:1:1
   |
 1 | x: f(2
   | ^
```

### After

```
error: unterminated string literal
  --> test.eu:1:4
   |
 1 |   a: "unending
   | ╭────^
 2 | │
   | ╰^
```

```
error: unterminated block (missing '}')
  --> test.eu:1:4
   |
 1 |   x: {
   | ╭────^
 2 | │   a: 1
 3 | │   b: 2
 4 | │
   | ╰^
```

```
error: invalid parenthesised expression
  --> test.eu:1:5
   |
 1 |   x: f(2
   | ╭─────^
 2 | │
   | ╰^
```

### Assessment

- Human diagnosability: poor → excellent
- LLM diagnosability: fair → excellent

The error now:
- Points to the correct line and column (the opening delimiter of the unterminated construct)
- Shows the source span from the opening token to end-of-file
- Removes the redundant double-prefix `input was not correctly formed: Parse errors:`
- Additional errors beyond the first are shown as secondary labels

### Change

Added a `ParseErrors(usize, Vec<RowanParseError>)` variant to `ParserError` in `src/syntax/error.rs`. This variant preserves the `TextRange` data from each Rowan `ParseError`. The `to_diagnostic()` implementation converts `rowan::TextRange` to `codespan::Span` (via `rowan::TextSize` → `u32` → `codespan::ByteIndex`) so that codespan-reporting can render the error at the correct source position.

`src/syntax/parser.rs` was updated to return `ParseErrors` directly instead of wrapping errors in `SyntaxError::InvalidInputFormat`.

The `rowan_error_range()` helper extracts the primary `TextRange` from any `ParseError` variant (matching the existing `error_range()` function in `src/driver/lsp/diagnostics.rs` but using codespan types).

### Risks

- The `SyntaxError::InvalidInputFormat` variant still exists and is used for non-Rowan parse errors (lambda parsing, embedded expressions). Those paths are unchanged.
- Existing error tests all pass; the `.expect` sidecars test for message substrings which remain present in the improved messages.
- No breaking changes to any public API.