### PR TITLE
feat: improve MixedAnaphora error message with actionable hint

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -17,7 +17,15 @@ pub enum CoreError {
     NoParsedAstFor(Box<Input>),
     #[error("too few operands available for operator")]
     TooFewOperands(Smid),
-    #[error("cannot mix anaphora types (numberless, numbered and section)")]
+    /// Anaphora of different kinds ('_', '_0', sections) were mixed in one expression.
+    ///
+    /// The three anaphora kinds are:
+    /// - *Numberless*: `_` — creates a single anonymous parameter
+    /// - *Numbered*: `_0`, `_1`, `_2`, … — creates explicitly-indexed parameters
+    /// - *Section*: `(+ 1)`, `(< 5)` — creates an operator section
+    #[error(
+        "mixed anaphora: cannot use '_', '_0'/'_N', and section expressions in the same expression"
+    )]
     MixedAnaphora(Smid),
     #[error("'_' used more than once in a single expression")]
     DuplicateAnonymousAnaphor(Smid),
@@ -61,6 +69,15 @@ impl HasSmid for CoreError {
 impl CoreError {
     pub fn to_diagnostic(&self, source_map: &SourceMap) -> Diagnostic<usize> {
         match self {
+            CoreError::MixedAnaphora(_) => source_map.diagnostic(self).with_notes(vec![
+                "each kind of anaphora creates a different sort of anonymous function".to_string(),
+                "'_' creates a single-parameter function; '_0', '_1', … create multi-parameter \
+                 functions; sections like (+ 1) create operator partials"
+                    .to_string(),
+                "to use two parameters, switch to numbered anaphora: e.g. `_0 > _1` instead \
+                 of `_0 > _`"
+                    .to_string(),
+            ]),
             CoreError::DuplicateAnonymousAnaphor(_) => {
                 source_map.diagnostic(self).with_notes(vec![
                     "each '_' in an expression introduces a separate parameter".to_string(),


### PR DESCRIPTION
## Error message: mixed anaphora types — unhelpful internal terminology

### Scenario

A user mistakenly mixes anaphora types in a single expression — for example combining numbered anaphora `_0` with numberless anaphora `_`. This is a common beginner mistake when trying to write a two-parameter anonymous function.

Perturbation applied: `[1, 2, 3] filter(_0 > _)` — mixing numbered `_0` with numberless `_` in the filter predicate.

### Before

```
error: cannot mix anaphora types (numberless, numbered and section)
  --> test.eu:1:31
   |
 1 | result: [1, 2, 3] filter(_0 > _)
   |                               ^
```

The words "numberless, numbered and section" are internal implementation terminology. A user seeing this for the first time has no idea what these mean or how to fix the problem.

### After

```
error: mixed anaphora: cannot use '_', '_0'/'_N', and section expressions in the same expression
  --> test.eu:1:31
   |
 1 | result: [1, 2, 3] filter(_0 > _)
   |                               ^
   |
   = each kind of anaphora creates a different sort of anonymous function
   = '_' creates a single-parameter function; '_0', '_1', … create multi-parameter functions; sections like (+ 1) create operator partials
   = to use two parameters, switch to numbered anaphora: e.g. `_0 > _1` instead of `_0 > _`
```

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

The improved message:
- Replaces internal terminology with concrete syntax examples (`'_'`, `'_0'/'_N'`, `(+ 1)`)
- Explains what each anaphora kind does in plain terms
- Gives a direct repair action with a concrete before/after example

### Change

Updated `CoreError::MixedAnaphora` in `src/core/error.rs`:
1. The error string now names the three syntaxes explicitly rather than using internal labels
2. Added a `MixedAnaphora` arm in `to_diagnostic()` with three explanatory notes covering what each anaphora kind is, and a concrete example of the repair (`_0 > _1` instead of `_0 > _`)

### Risks

No functional change. All existing error tests pass. The `MixedAnaphora` variant has no dedicated `.expect` sidecar file to update.