### PR TITLE
Error: include OS reason in file-not-found error messages

### DIFF
--- a/src/driver/error.rs
+++ b/src/driver/error.rs
@@ -29,8 +29,20 @@ pub enum EucalyptError {
     Io(#[from] io::Error),
     #[error("unknown resource {0}")]
     UnknownResource(String),
-    #[error("path {0} could not be read")]
-    FileCouldNotBeRead(String),
+    /// A file could not be read.
+    ///
+    /// The first field is the path. The optional second field is the
+    /// OS-level reason (e.g. "No such file or directory", "Permission denied").
+    #[error("{}", format_file_could_not_be_read(.0, .1.as_deref()))]
+    FileCouldNotBeRead(String, Option<String>),
+}
+
+/// Format a "file could not be read" error message including the OS reason when available.
+fn format_file_could_not_be_read(path: &str, reason: Option<&str>) -> String {
+    match reason {
+        Some(r) => format!("could not read '{path}': {r}"),
+        None => format!("could not read '{path}'"),
+    }
 }
 
 fn default_diagnostic<E>(e: &E) -> Diagnostic<usize>

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -180,10 +180,10 @@ impl SourceLoader {
             Locator::Fs(p) => self.resolve_fs_path(p)?,
             Locator::StdIn => "-".to_string(),
             _ => {
-                return Err(EucalyptError::FileCouldNotBeRead(format!(
-                    "streaming not supported for locator: {}",
-                    input.locator()
-                )))
+                return Err(EucalyptError::FileCouldNotBeRead(
+                    format!("streaming not supported for locator: {}", input.locator()),
+                    None,
+                ))
             }
         };
 
@@ -215,6 +215,7 @@ impl SourceLoader {
         }
         Err(EucalyptError::FileCouldNotBeRead(
             path.to_string_lossy().to_string(),
+            None,
         ))
     }
 
@@ -501,24 +502,24 @@ impl SourceLoader {
     }
 
     /// Read text from the filesystem, using lib-path to resolve the
-    /// filesnames.
+    /// filenames.
     fn read_fs_input(&mut self, path: &Path) -> Result<String, EucalyptError> {
         for libdir in &self.lib_path {
             let mut filename = libdir.to_path_buf();
             filename.push(path);
-            if let Ok(text) = fs::read_to_string(filename) {
+            if let Ok(text) = fs::read_to_string(&filename) {
                 return Ok(text);
             }
         }
 
         // lastly - absolute files are ok with empty lib path
-        if let Ok(text) = fs::read_to_string(path) {
-            return Ok(text);
+        match fs::read_to_string(path) {
+            Ok(text) => Ok(text),
+            Err(e) => Err(EucalyptError::FileCouldNotBeRead(
+                path.to_string_lossy().to_string(),
+                Some(e.to_string()),
+            )),
         }
-
-        Err(EucalyptError::FileCouldNotBeRead(
-            path.to_string_lossy().to_string(),
-        ))
     }
 
     /// Read source from stdin

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -52,9 +52,10 @@ pub fn error_test(opt: &EucalyptOptions) -> Result<i32, EucalyptError> {
             return Ok(0);
         }
         Err(e) => {
-            return Err(EucalyptError::FileCouldNotBeRead(format!(
-                "failed to load .expect sidecar: {e}"
-            )));
+            return Err(EucalyptError::FileCouldNotBeRead(
+                "failed to load .expect sidecar".to_string(),
+                Some(e.to_string()),
+            ));
         }
     };
 
@@ -76,9 +77,10 @@ pub fn resolve_input(opt: &EucalyptOptions, input: &Input) -> Result<PathBuf, Eu
         }
         Err(EucalyptError::FileCouldNotBeRead(
             path.to_string_lossy().to_string(),
+            None,
         ))
     } else {
-        Err(EucalyptError::FileCouldNotBeRead(format!("{input}")))
+        Err(EucalyptError::FileCouldNotBeRead(format!("{input}"), None))
     }
 }
 


### PR DESCRIPTION
## Error message: FileCouldNotBeRead — missing OS reason

### Scenario
Running `eu nonexistent.eu` where the file does not exist, or passing any path that cannot be read from the filesystem.

### Before
```
error: path /tmp/nonexistent_clarion.eu could not be read
```

### After
```
error: could not read '/tmp/nonexistent_clarion.eu': No such file or directory (os error 2)
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The "before" message inverts the natural English phrasing ("path X could not be read" vs "could not read 'X'") and, crucially, discards the OS reason. When a file fails to open, the reason matters: "No such file or directory" tells the user to check the path, while "Permission denied" tells them to check permissions. Without it, both cases look identical.

### Change
- `EucalyptError::FileCouldNotBeRead` gains a second field `Option<String>` for the OS-level reason.
- A `format_file_could_not_be_read()` helper renders the message with or without the reason.
- `read_fs_input()` in `src/driver/source.rs` now matches on `fs::read_to_string` and forwards the `io::Error` as the second field instead of silently discarding it.
- Other call sites (streaming locator path, lib-path resolution, tester resolve) pass `None` where no OS error is available.

### Risks
- The `FileCouldNotBeRead` enum variant gains a second field; any exhaustive matches elsewhere would need updating, but there are none outside the changed files.
- The phrasing change from "path X could not be read" to "could not read 'X'" may affect any scripts parsing eucalypt stderr, though this is an unlikely usage pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)