### PR TITLE
fix: multiple error message improvements — str.fmt panic, BadNumberFormat hint, arrow-hint precision

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -412,6 +412,15 @@ impl ExecutionError {
                         .to_string(),
                 ]
             }
+            ExecutionError::BadNumberFormat(_) => {
+                vec![
+                    "valid number formats are: integers (e.g. 42), decimals (e.g. 3.14), and \
+                     scientific notation (e.g. 1.5e10)"
+                        .to_string(),
+                    "use 'str' to convert numbers to strings; to convert strings to numbers use 'num'"
+                        .to_string(),
+                ]
+            }
             _ => vec![],
         };
         if notes.is_empty() {

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -64,9 +64,11 @@ impl CompileError {
         match self {
             CompileError::FreeVar(_, name) => {
                 let mut notes = vec!["check that the variable is defined and in scope".to_string()];
-                // If the name looks like a short identifier (typical lambda
-                // parameter), hint about the common '->' mistake.
-                if name.len() <= 3 && name.chars().all(|c| c.is_alphanumeric()) {
+                // If the name is a single letter it almost certainly comes from an
+                // arrow-function expression like `x -> x + 1`.  Avoid showing this
+                // hint for longer names (e.g. `xs`, `zdt`) that are more likely
+                // genuine unresolved identifiers rather than misused lambda parameters.
+                if name.len() == 1 && name.chars().all(|c| c.is_alphanumeric()) {
                     notes.push(
                         "note: eucalypt has no arrow functions; '->' is the const \
                          operator, not lambda syntax"

--- a/src/eval/stg/printf.rs
+++ b/src/eval/stg/printf.rs
@@ -207,8 +207,11 @@ fn parse_length(sub: &[u8]) -> (Length, &[u8]) {
 
 /// Parse a format parameter and write it somewhere.
 ///
+/// Returns `None` if the string is not a valid printf-style format specifier.
 fn parse_format(format: &str) -> Option<Argument> {
-    assert!(format.starts_with('%'));
+    if !format.starts_with('%') {
+        return None;
+    }
     let sub = next_char(format.as_bytes());
 
     let (flags, sub) = parse_flags(sub);
@@ -448,7 +451,13 @@ pub fn fmt(
             }
         }
         Ok(output)
+    } else if !fmt_string.starts_with('%') {
+        Err(PrintfError::InvalidFormatString(format!(
+            "'{fmt_string}' is not a printf specifier (must start with '%', e.g. '%d', '%s', '%.2f')"
+        )))
     } else {
-        Err(PrintfError::InvalidFormatString(fmt_string.to_string()))
+        Err(PrintfError::InvalidFormatString(format!(
+            "'{fmt_string}' is not a recognised printf specifier"
+        )))
     }
 }


### PR DESCRIPTION
## Error message improvements — three issues in one branch

### 1. str.fmt — panic instead of error when format is not a %-specifier

#### Scenario
Calling `str.fmt(value, format_spec)` where the format spec is a full printf template string (e.g. `"Value: %d"`) rather than a bare %-specifier (e.g. `"%d"`). This is a realistic user mistake.

#### Before
```
thread 'main' panicked at src/eval/stg/printf.rs:211:5:
assertion failed: format.starts_with('%')
```
(Exit code 101 — an uncaught Rust panic.)

#### After
```
error: bad format string: 'Value: %d' is not a printf specifier (must start with '%', e.g. '%d', '%s', '%.2f')
  help: format strings use printf-style %-specifiers, e.g. %d (integer), %f (float), %s (string), %e (scientific)
```

#### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: poor → good (panic is undiagnosable)

---

### 2. BadNumberFormat — add explanatory hint

#### Scenario
Calling `num` on a string that is not a number, e.g. `"not-a-number" num`.

#### Before
```
error: bad number format: not-a-number
```
(No context about what constitutes a valid number.)

#### After
```
error: bad number format: not-a-number
  = valid number formats are: integers (e.g. 42), decimals (e.g. 3.14), and scientific notation (e.g. 1.5e10)
  = use 'str' to convert numbers to strings; to convert strings to numbers use 'num'
```

#### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

---

### 3. Arrow-function hint — reduce false positives

#### Scenario
Unresolved variable with a multi-letter name like `xs` or `zdt` was incorrectly triggering the arrow-function hint ("eucalypt has no arrow functions; '->' is the const operator").

#### Before (`f: z(xs)`)
```
error: unresolved variable 'xs'
  = check that the variable is defined and in scope
  = note: eucalypt has no arrow functions; '->' is the const operator, not lambda syntax
  = use anaphora (_ + 1), sections (+ 1), or named functions instead
```
(Misleading — `xs` is a genuine unresolved variable, not a lambda parameter.)

#### After
```
error: unresolved variable 'xs'
  = check that the variable is defined and in scope
```
(The arrow-function hint now fires only for single-letter identifiers like `x`, `n`, `i` which are the typical parameter names in `x -> x + 1` style expressions.)

#### Assessment
- Human diagnosability: poor → fair (removes misleading noise for non-lambda cases)
- LLM diagnosability: fair → good (cleaner signal)

---

### Changes
- `src/eval/stg/printf.rs`: `parse_format()` assertion replaced with graceful `return None`; `fmt()` produces descriptive error distinguishing "not a %-specifier" from "unrecognised specifier"
- `src/eval/error.rs`: Added `BadNumberFormat` arm in `to_diagnostic()` with explanatory notes
- `src/eval/stg/compiler.rs`: Arrow-function hint threshold changed from `len <= 3` to `len == 1`

### Risks
- The `parse_format` change is safe: the function already returns `Option<Argument>` and the `assert!` was dead defensive code.
- The arrow-hint change might miss edge cases like `xs -> xs + 1`, but single-letter params are far more common and multi-letter ones are already covered by the primary "check that the variable is defined" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)