### PR TITLE
perf: reuse pre-allocated global closures for boolean returns

### DIFF
--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1398,7 +1398,13 @@ pub mod tests {
 
     use super::*;
     use crate::eval::stg::{
-        constant::KEmptyList, eq::Eq, panic::Panic, runtime::Runtime, syntax::dsl::*, testing,
+        boolean::{False, True},
+        constant::KEmptyList,
+        eq::Eq,
+        panic::Panic,
+        runtime::Runtime,
+        syntax::dsl::*,
+        testing,
     };
 
     pub fn runtime() -> Box<dyn Runtime> {
@@ -1412,6 +1418,8 @@ pub mod tests {
             Box::new(Panic),
             Box::new(Eq),
             Box::new(KEmptyList),
+            Box::new(True),
+            Box::new(False),
         ])
     }
 

--- a/src/eval/stg/eq.rs
+++ b/src/eval/stg/eq.rs
@@ -228,10 +228,22 @@ pub mod tests {
     use serde_json::Number;
 
     use super::*;
-    use crate::eval::stg::{boolean::And, eq::Eq, panic::Panic, runtime::Runtime, testing};
+    use crate::eval::stg::{
+        boolean::{And, False, True},
+        eq::Eq,
+        panic::Panic,
+        runtime::Runtime,
+        testing,
+    };
 
     pub fn runtime() -> Box<dyn Runtime> {
-        testing::runtime(vec![Box::new(Eq), Box::new(And), Box::new(Panic)])
+        testing::runtime(vec![
+            Box::new(Eq),
+            Box::new(And),
+            Box::new(Panic),
+            Box::new(True),
+            Box::new(False),
+        ])
     }
 
     #[test]

--- a/src/eval/stg/render.rs
+++ b/src/eval/stg/render.rs
@@ -481,6 +481,8 @@ pub mod tests {
             Box::new(panic::Panic),
             Box::new(boolean::And),
             Box::new(boolean::Not),
+            Box::new(boolean::True),
+            Box::new(boolean::False),
         ])
     }
 

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -471,19 +471,24 @@ pub fn machine_return_set(
 }
 
 /// Return boolean from intrinsic
+///
+/// Reuses the pre-allocated TRUE/FALSE global closures rather than
+/// allocating a fresh Cons node on each call, saving one heap
+/// allocation per boolean-returning intrinsic invocation.
 pub fn machine_return_bool(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView,
     b: bool,
 ) -> Result<(), ExecutionError> {
-    machine.set_closure(SynClosure::new(
-        if b {
-            view.t()?.as_ptr()
-        } else {
-            view.f()?.as_ptr()
-        },
-        machine.root_env(),
-    ))
+    use std::sync::OnceLock;
+    static TRUE_IDX: OnceLock<usize> = OnceLock::new();
+    static FALSE_IDX: OnceLock<usize> = OnceLock::new();
+    let idx = if b {
+        *TRUE_IDX.get_or_init(|| crate::eval::intrinsics::index("TRUE").unwrap())
+    } else {
+        *FALSE_IDX.get_or_init(|| crate::eval::intrinsics::index("FALSE").unwrap())
+    };
+    machine.set_closure(machine.nav(view).global(idx)?)
 }
 
 /// Extract f64 values from a concrete (forced) number list.


### PR DESCRIPTION
## Performance: reuse pre-allocated global closures for boolean returns

### Hypothesis

`machine_return_bool` was called on every invocation of a boolean-returning intrinsic (LTE, LT, GTE, GT, EQ, IsBlock, IsList, SetContains, etc.). Each call allocated a fresh `HeapSyn::Cons { tag: BoolTrue/False, args: [] }` node on the heap via `view.t()` or `view.f()`.

The TRUE (index 26) and FALSE (index 27) global closures contain pre-loaded `Cons{BoolTrue/False}` nodes that were already on the heap from initialisation. These can be returned directly as the current closure, eliminating the per-call allocation.

### Change

`machine_return_bool` in `src/eval/stg/support.rs` now retrieves the pre-allocated global closure for TRUE or FALSE (using a `OnceLock`-cached index lookup) rather than allocating a fresh Cons node on each call.

Test runtimes for block, eq, and render unit tests are updated to register the True and False intrinsics so the pre-allocated globals are available when `machine_return_bool` looks them up.

### Results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| bench/001_naive_fib.eu — Heap Blocks Allocated | 436,945 | 429,049 | -1.8% |
| bench/001_naive_fib.eu — stg-execute (median 5 runs) | 8.55s | 8.55s | ~0% |

The heap reduction (7,896 × 32 KB ≈ 246 MB) is meaningful. Wall-clock time is within measurement noise since the benchmark is CPU-bound and GC runs only once.

### Regression check

Full harness suite: no significant regressions detected (124/124 tests pass, 556/556 lib tests pass).

Other bench tests (002–010) show minimal boolean comparison usage so show no change.

### Risks

- The `OnceLock`-cached index is computed from `intrinsics::index("TRUE")` which is a linear scan of the catalogue. This runs at most once per process lifetime (the first time `machine_return_bool` is called), so it is not a hot-path concern.
- The optimisation requires that the runtime has TRUE and FALSE registered. In production this is always the case. Test runtimes that use `machine_return_bool` indirectly now need to include `True` and `False` — the three affected test modules have been updated accordingly.