### PR TITLE
fix: add helpful hint to NoBranchForNative error for list operations

### DIFF
--- a/harness/test/errors/042_map_non_list.eu
+++ b/harness/test/errors/042_map_non_list.eu
@@ -1,0 +1,3 @@
+# Mistake: applying a list operation (map) to a non-list value
+x: 42
+result: x map((+ 1))

--- a/harness/test/errors/042_map_non_list.eu.expect
+++ b/harness/test/errors/042_map_non_list.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "list operations"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -404,6 +404,16 @@ impl ExecutionError {
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {
                 data_tag_mismatch_notes(*actual, expected)
             }
+            ExecutionError::NoBranchForNative(_, _) => {
+                vec![
+                    "list operations such as 'head', 'tail', '++', 'map', 'filter' require \
+                     list arguments"
+                        .to_string(),
+                    "check that the value is a list before applying list operations; \
+                     use 'nil?' to test for an empty list"
+                        .to_string(),
+                ]
+            }
             ExecutionError::BlackHole(_) => {
                 vec![
                     "a binding that references itself directly or indirectly creates an infinite loop"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -665,3 +665,8 @@ pub fn test_error_040() {
 pub fn test_error_041() {
     run_error_test(&error_opts("041_modulo_by_zero.eu"));
 }
+
+#[test]
+pub fn test_error_042() {
+    run_error_test(&error_opts("042_map_non_list.eu"));
+}


### PR DESCRIPTION
## Error message: NoBranchForNative / list operations applied to non-list values

### Scenario
Perturbation: applied list operations (`map`, `++`, `head`, `tail`, `filter`) to non-list values.

Examples:
- `42 map((+ 1))` — map on a number
- `"hello" ++ "world"` — `++` on strings (only works on lists)
- `[] head` — head on empty list (hits panic path but shows native type error)
- `"hello" filter((> 0))` — filter on a string

### Before
```
error: type mismatch: received a string where a structured value (block or list) was expected
```

The error message correctly identifies the type mismatch but gives no indication of _why_ this happens or how to fix it. A user who wrote `42 map((+ 1))` would not know from this message that `map` requires a list.

### After
```
error: type mismatch: received a string where a structured value (block or list) was expected
 = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
 = check that the value is a list before applying list operations; use 'nil?' to test for an empty list
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The hint names the specific operations that require lists and points to `nil?` as the relevant predicate for checking list type.

### Change
Added a `NoBranchForNative` arm to the `notes` match in `ExecutionError::to_diagnostic()` in `src/eval/error.rs`. Also added harness test `042_map_non_list.eu` to cover this scenario.

### Risks
The hint mentions specific list operations by name. If those function names change in the prelude, the hint would be stale. Low risk since these are stable primitives. The hint is slightly over-broad (it fires even when the cause is not a named list operation), but the guidance is still valid and helpful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)