### PR TITLE
fix: hint for assignment-style declarations and compound operators

### DIFF
--- a/harness/test/errors/043_assignment_syntax.eu
+++ b/harness/test/errors/043_assignment_syntax.eu
@@ -1,0 +1,2 @@
+# Mistake: using = instead of : for declaration (Python/JS style)
+result = 42

--- a/harness/test/errors/043_assignment_syntax.eu.expect
+++ b/harness/test/errors/043_assignment_syntax.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "eucalypt uses ':' for declarations"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -85,6 +85,24 @@ impl CompileError {
                 if name == "==" {
                     notes.push("eucalypt uses '=' for equality, not '=='".to_string());
                 }
+                // Detect assignment-style declarations (e.g. `x = 42`) which
+                // are not valid eucalypt syntax: eucalypt uses `:` for
+                // declarations, not `=`.
+                if name == "=" {
+                    notes.push(
+                        "note: eucalypt uses ':' for declarations, not '='; \
+                         write 'x: 42' instead of 'x = 42'"
+                            .to_string(),
+                    );
+                }
+                // Also handle `+=`, `-=`, etc. from other languages
+                if matches!(name.as_str(), "+=" | "-=" | "*=" | "/=" | "%=") {
+                    notes.push(
+                        "note: eucalypt has no compound assignment operators; \
+                         eucalypt values are immutable — bind a new name with ':'"
+                            .to_string(),
+                    );
+                }
                 diag.with_notes(notes)
             }
             _ => diag,

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -670,3 +670,8 @@ pub fn test_error_041() {
 pub fn test_error_042() {
     run_error_test(&error_opts("042_map_non_list.eu"));
 }
+
+#[test]
+pub fn test_error_043() {
+    run_error_test(&error_opts("043_assignment_syntax.eu"));
+}


### PR DESCRIPTION
## Error message: assignment syntax / unresolved '=' operator

### Scenario
Perturbation: user writes Python/JavaScript-style declarations using '='
instead of ':'.

Examples:
- `result = 42` (Python/JS style)
- `x = 1; y = x + 1` (multi-line Python style)
- `x += 1` (compound assignment)

### Before
```
error: unresolved variable '='
  ┌─ bad_fn_decl2.eu:1:8
  │
1 │ result = 42
  │        ^
  │
  = check that the variable is defined and in scope
```

The error identifies `=` as an unresolved variable (because eucalypt's
equality operator is `=`), but gives no hint that the user might be
using assignment syntax from another language. A user coming from Python
or JavaScript would find this very confusing.

Similarly for `+=` and other compound operators:
```
error: unresolved variable '+='
  ...
  = check that the variable is defined and in scope
```

### After
For `result = 42`:
```
error: unresolved variable '='
  ┌─ bad_fn_decl2.eu:1:8
  │
1 │ result = 42
  │        ^
  │
  = check that the variable is defined and in scope
  = note: eucalypt uses ':' for declarations, not '='; write 'x: 42' instead of 'x = 42'
```

For `x += 1`:
```
error: unresolved variable '+='
  ...
  = check that the variable is defined and in scope
  = note: eucalypt has no compound assignment operators; eucalypt values are immutable — bind a new name with ':'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: poor → good

Users coming from imperative languages will immediately understand what
they need to fix from the new hint.

### Change
Added two new cases to `CompileError::FreeVar::to_diagnostic()` in
`src/eval/stg/compiler.rs`:
1. When the unresolved variable name is `"="`, hint about `:` declarations.
2. When the unresolved variable name is a compound operator (`+=`, `-=`,
   `*=`, `/=`, `%=`), explain that eucalypt is immutable.

Also adds harness test 043 to cover the `=` case.

### Risks
Low risk. The hints are additive notes and only fire for specific
operator names that would be unresolvable in any valid eucalypt program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)