### PR TITLE
feat: block and fixed-length list destructuring in function parameters

### DIFF
--- a/doc/appendices/cheat-sheet.md
+++ b/doc/appendices/cheat-sheet.md
@@ -80,6 +80,9 @@ x: 42 # inline comment
 |------|--------|-------|
 | Property | `name: expr` | Defines a named value |
 | Function | `f(x, y): expr` | Named function with parameters |
+| Block pattern | `f({x y}): expr` | Destructures block argument fields |
+| Block rename | `f({x: a  y: b}): expr` | Destructures with renamed bindings |
+| List pattern | `f([a, b, c]): expr` | Destructures fixed-length list |
 | Binary operator | `(l op r): expr` | Infix operator |
 | Prefix operator | `(op x): expr` | Unary prefix |
 | Postfix operator | `(x op): expr` | Unary postfix |

--- a/doc/guide/functions-and-combinators.md
+++ b/doc/guide/functions-and-combinators.md
@@ -3,6 +3,7 @@
 In this chapter you will learn:
 
 - How to define and call functions
+- How destructuring parameters work
 - How currying and partial application work
 - The standard combinators: `identity`, `const`, `compose`, `flip`
 - How to build functions from other functions without lambdas
@@ -37,6 +38,106 @@ Pipelines](expressions-and-pipelines.md)):
 ```eu
 a: 5 square
 b: 4 add(3)
+```
+
+## Destructuring Parameters
+
+Function parameters can be **destructuring patterns** that extract
+structure from an argument inline, binding its components as named
+variables in the function body.
+
+### Block destructuring
+
+A block pattern binds named fields from a block argument. Shorthand
+form binds the field name directly:
+
+```eu
+sum-of-point({x y}): x + y
+
+p: { x: 3 y: 4 }
+result: sum-of-point(p)
+```
+
+```yaml
+result: 7
+```
+
+A rename form binds a field under a different local name, using a
+colon between the field name and the binding name:
+
+```eu
+scaled({x: a  y: b}, scale): a * scale + b * scale
+
+result: scaled({x: 2  y: 3}, 10)
+```
+
+```yaml
+result: 50
+```
+
+Shorthand and rename can be mixed freely:
+
+```eu
+describe({x  y: height}): "x={x} h={height}"
+
+result: describe({x: 1  y: 5})
+```
+
+```yaml
+result: x=1 h=5
+```
+
+### Fixed-length list destructuring
+
+A list pattern binds positional elements from a list argument:
+
+```eu
+add-pair([a, b]): a + b
+
+result: add-pair([10, 20])
+```
+
+```yaml
+result: 30
+```
+
+Multiple elements at any position are supported:
+
+```eu
+third([a, b, c]): c
+
+result: third([1, 2, 3])
+```
+
+```yaml
+result: 3
+```
+
+### Mixing patterns
+
+Normal parameters and destructuring patterns can be combined in any
+order:
+
+```eu
+weighted-sum(w, [a, b, c]): w * a + w * b + w * c
+
+result: weighted-sum(2, [1, 3, 5])
+```
+
+```yaml
+result: 18
+```
+
+Multiple destructuring parameters are also allowed:
+
+```eu
+combine({x}, [a, b]): x + a + b
+
+result: combine({x: 10}, [3, 7])
+```
+
+```yaml
+result: 20
 ```
 
 ## Functions are Values

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -104,6 +104,35 @@ f(x, y): x + y
 two: f(1, 1)
 ```
 
+Function parameters can be **destructuring patterns** as well as
+simple names. A block pattern extracts named fields from a block
+argument; a list pattern extracts positional elements from a list
+argument:
+
+```eu
+# Block destructuring — shorthand binds field name as variable name
+sum-xy({x y}): x + y
+
+# Block destructuring — rename binds field under a new variable name
+product-ab({x: a  y: b}): a * b
+
+# Mixed shorthand and rename
+mixed({x  y: b}): x + b
+
+# Fixed-length list destructuring
+f-sum([a, b, c]): a + b + c
+f-first([a, b]): a
+```
+
+Destructuring patterns can be mixed with normal parameters:
+
+```eu
+f(n, [a, b]): n * (a + b)
+```
+
+See [Functions and Combinators](../guide/functions-and-combinators.md)
+for more detail on destructuring.
+
 ...and using some brackets and suitable names, you can define
 operators too, either binary:
 

--- a/harness/test/091_destructure_block.eu
+++ b/harness/test/091_destructure_block.eu
@@ -1,0 +1,37 @@
+##
+## 091: Block destructuring in function parameters
+##
+
+f-basic({x y}): x + y
+f-rename({x: a  y: b}): a * b
+f-mixed({x  y: b}): x + b
+
+tests: {
+
+  ` "Basic block destructuring"
+  basic: {
+    ` "sum of fields x and y"
+    a: f-basic({x: 1 y: 2}) //= 3
+    ` "sum with larger values"
+    b: f-basic({x: 10 y: 20}) //= 30
+  }
+
+  ` "Block destructuring with renaming"
+  rename: {
+    ` "product via renamed fields"
+    a: f-rename({x: 3 y: 4}) //= 12
+    ` "product with different values"
+    b: f-rename({x: 5 y: 6}) //= 30
+  }
+
+  ` "Mixed shorthand and rename"
+  mixed: {
+    ` "sum of shorthand x and renamed y"
+    a: f-mixed({x: 10 y: 20}) //= 30
+    ` "sum with different values"
+    b: f-mixed({x: 7 y: 3}) //= 10
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/092_destructure_list.eu
+++ b/harness/test/092_destructure_list.eu
@@ -1,0 +1,29 @@
+##
+## 092: List destructuring in function parameters
+##
+
+f-sum([a, b, c]): a + b + c
+f-first([a, b]): a
+f-second([a, b]): b
+
+tests: {
+
+  ` "Fixed-length list destructuring"
+  fixed: {
+    ` "sum of three elements"
+    a: f-sum([10, 20, 30]) //= 60
+    ` "sum of different values"
+    b: f-sum([1, 2, 3]) //= 6
+  }
+
+  ` "Two-element list"
+  pair: {
+    ` "first element"
+    a: f-first([1, 2]) //= 1
+    ` "second element"
+    b: f-second([1, 2]) //= 2
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -55,6 +55,22 @@ struct DestructureEntry {
     fields: Vec<FieldBinding>,
 }
 
+/// Entry for a single list element binding.
+struct ListElementBinding {
+    /// Zero-based index of the element
+    index: usize,
+    /// FreeVar for the binding name in the body
+    binding_var: moniker::FreeVar<String>,
+}
+
+/// Entry for a destructuring list let: synthetic param + element bindings.
+struct ListDestructureEntry {
+    /// Synthetic parameter name (e.g. `__p0`)
+    synthetic_name: String,
+    /// Element bindings at each position
+    elements: Vec<ListElementBinding>,
+}
+
 /// A parsed parameter pattern in a function declaration
 enum ParamPattern {
     /// Simple identifier: `x`
@@ -65,6 +81,10 @@ enum ParamPattern {
     /// field and binding are both `"x"`. For rename `{x: a}`,
     /// field is `"x"` and binding is `"a"`.
     Block(Vec<(String, String)>),
+    /// Fixed-length list destructuring: `[a, b, c]`.
+    ///
+    /// Contains the binding names for each positional element.
+    List(Vec<String>),
 }
 
 /// Parse a block parameter pattern `{x y}` or `{x: a  y: b}` from a
@@ -131,6 +151,31 @@ fn parse_block_pattern(block: &rowan_ast::Block) -> Result<Vec<(String, String)>
     Ok(fields)
 }
 
+/// Parse a fixed-length list parameter pattern `[a, b, c]` from a
+/// Rowan `List` AST node in a function parameter position.
+///
+/// Each item in the list should be a single normal identifier.
+/// Returns a list of binding names in positional order.
+fn parse_list_pattern(list: &rowan_ast::List) -> Option<Vec<String>> {
+    let mut elements: Vec<String> = Vec::new();
+    for item in list.items() {
+        if let Some(rowan_ast::Element::Name(name)) = item.singleton() {
+            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                elements.push(normal.text().to_string());
+            } else {
+                return None; // Not a normal identifier — invalid pattern
+            }
+        } else {
+            return None; // Not a single name — invalid pattern
+        }
+    }
+    if elements.is_empty() {
+        None // Empty list pattern not valid
+    } else {
+        Some(elements)
+    }
+}
+
 /// Parse a function parameter soup into a `ParamPattern`.
 ///
 /// Returns `None` if the soup is not a valid single-element parameter.
@@ -146,7 +191,25 @@ fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
         Some(rowan_ast::Element::Block(block)) => {
             parse_block_pattern(&block).ok().map(ParamPattern::Block)
         }
+        Some(rowan_ast::Element::List(list)) => parse_list_pattern(&list).map(ParamPattern::List),
         _ => None,
+    }
+}
+
+/// Ordered record of a destructuring let to emit after the body is desugared.
+enum DestructureLet {
+    /// Block destructuring: lookup each field by name.
+    Block(DestructureEntry),
+    /// List destructuring: index each element with LIST.NTH.
+    List(ListDestructureEntry),
+}
+
+impl DestructureLet {
+    fn synthetic_name(&self) -> &str {
+        match self {
+            DestructureLet::Block(e) => &e.synthetic_name,
+            DestructureLet::List(e) => &e.synthetic_name,
+        }
     }
 }
 
@@ -155,6 +218,8 @@ fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
 /// For simple parameter patterns, this behaves like `desugar_declaration_body`.
 /// For block patterns, a synthetic parameter (`__pN`) is introduced as the
 /// lambda binder, and let bindings for each field are added around the body.
+/// For list patterns, the same synthetic-parameter approach is used, with
+/// `LIST.NTH` calls for each positional element.
 ///
 /// Returns `(body_expr, lambda_param_names, lambda_param_vars)`.
 fn desugar_declaration_body_with_patterns(
@@ -168,10 +233,12 @@ fn desugar_declaration_body_with_patterns(
     // which are only binding names for let bindings.
     let mut all_env_names: Vec<String> = Vec::new();
     let mut lambda_param_names: Vec<String> = Vec::new();
-    // For each pattern, record the synthetic param name (if any) and
-    // the field-to-binding mappings (for DestructureBlockLet).
-    let mut destructure_entries: Vec<(String, Vec<(String, String)>)> = Vec::new();
-    // Will be built from destructure_entries after env push
+    // Raw data for block patterns: (synthetic_name, [(field_name, binding_name)])
+    let mut block_raw: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    // Raw data for list patterns: (synthetic_name, [binding_name])
+    let mut list_raw: Vec<(String, Vec<String>)> = Vec::new();
+    // Ordered sequence of lets to emit — preserves argument order for correct nesting.
+    let mut let_order: Vec<DestructureLet> = Vec::new();
     let mut synthetic_counter = 0usize;
 
     for pattern in patterns {
@@ -188,7 +255,27 @@ fn desugar_declaration_body_with_patterns(
                 for (_, binding_name) in fields {
                     all_env_names.push(binding_name.clone());
                 }
-                destructure_entries.push((synthetic_name, fields.clone()));
+                block_raw.push((synthetic_name.clone(), fields.clone()));
+                // Placeholder — resolved after env push
+                let_order.push(DestructureLet::Block(DestructureEntry {
+                    synthetic_name,
+                    fields: Vec::new(),
+                }));
+            }
+            ParamPattern::List(element_names) => {
+                let synthetic_name = format!("__p{}", synthetic_counter);
+                synthetic_counter += 1;
+                all_env_names.push(synthetic_name.clone());
+                lambda_param_names.push(synthetic_name.clone());
+                for binding_name in element_names {
+                    all_env_names.push(binding_name.clone());
+                }
+                list_raw.push((synthetic_name.clone(), element_names.clone()));
+                // Placeholder — resolved after env push
+                let_order.push(DestructureLet::List(ListDestructureEntry {
+                    synthetic_name,
+                    elements: Vec::new(),
+                }));
             }
         }
     }
@@ -204,23 +291,36 @@ fn desugar_declaration_body_with_patterns(
         .map(|name| desugarer.env().get(name).unwrap().clone())
         .collect();
 
-    // Collect FreeVars for binding names (needed for let bindings)
-    let mut destructure_lets: Vec<DestructureEntry> = Vec::new();
-    for (synthetic_name, fields) in &destructure_entries {
-        let field_bindings: Vec<FieldBinding> = fields
-            .iter()
-            .map(|(field_name, binding_name)| {
-                let binding_var = desugarer.env().get(binding_name).unwrap().clone();
-                FieldBinding {
-                    field_name: field_name.clone(),
-                    binding_var,
-                }
-            })
-            .collect();
-        destructure_lets.push(DestructureEntry {
-            synthetic_name: synthetic_name.clone(),
-            fields: field_bindings,
-        });
+    // Resolve block destructure entries now that names are in the environment.
+    let mut block_raw_iter = block_raw.into_iter();
+    let mut list_raw_iter = list_raw.into_iter();
+    for slot in &mut let_order {
+        match slot {
+            DestructureLet::Block(entry) => {
+                let (_, fields) = block_raw_iter.next().unwrap();
+                entry.fields = fields
+                    .iter()
+                    .map(|(field_name, binding_name)| {
+                        let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                        FieldBinding {
+                            field_name: field_name.clone(),
+                            binding_var,
+                        }
+                    })
+                    .collect();
+            }
+            DestructureLet::List(entry) => {
+                let (_, element_names) = list_raw_iter.next().unwrap();
+                entry.elements = element_names
+                    .iter()
+                    .enumerate()
+                    .map(|(index, binding_name)| {
+                        let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                        ListElementBinding { index, binding_var }
+                    })
+                    .collect();
+            }
+        }
     }
 
     // Desugar body with all names in scope
@@ -248,41 +348,74 @@ fn desugar_declaration_body_with_patterns(
         desugarer.env_mut().pop();
     }
 
-    // Wrap body in DestructureBlockLet for each destructuring pattern,
-    // innermost first (last pattern wraps outermost).
-    // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
-    for entry in destructure_lets.iter().rev() {
+    // Wrap body in destructuring lets for each pattern, innermost first
+    // (last pattern wraps outermost), preserving argument order.
+    for slot in let_order.iter().rev() {
         // Look up the synthetic param FreeVar from the lambda_param_vars
         // (the env frame has already been popped)
         let synthetic_fv = lambda_param_vars
             .iter()
             .zip(lambda_param_names.iter())
-            .find(|(_, n)| **n == entry.synthetic_name)
+            .find(|(_, n)| **n == slot.synthetic_name())
             .map(|(fv, _)| fv.clone())
             .unwrap();
 
         let smid = desugarer.new_smid(span);
         let synthetic_var = RcExpr::from(Expr::Var(smid, moniker::Var::Free(synthetic_fv)));
 
-        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
-            .fields
-            .iter()
-            .map(|fb| {
-                let lookup = RcExpr::from(Expr::Lookup(
-                    smid,
-                    synthetic_var.clone(),
-                    fb.field_name.clone(),
-                    None,
-                ));
-                (Binder(fb.binding_var.clone()), Embed(lookup))
-            })
-            .collect();
+        match slot {
+            DestructureLet::Block(entry) => {
+                // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
+                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                    .fields
+                    .iter()
+                    .map(|fb| {
+                        let lookup = RcExpr::from(Expr::Lookup(
+                            smid,
+                            synthetic_var.clone(),
+                            fb.field_name.clone(),
+                            None,
+                        ));
+                        (Binder(fb.binding_var.clone()), Embed(lookup))
+                    })
+                    .collect();
 
-        body = RcExpr::from(Expr::Let(
-            smid,
-            Scope::new(Rec::new(bindings), body),
-            LetType::DestructureBlockLet,
-        ));
+                body = RcExpr::from(Expr::Let(
+                    smid,
+                    Scope::new(Rec::new(bindings), body),
+                    LetType::DestructureBlockLet,
+                ));
+            }
+            DestructureLet::List(entry) => {
+                // Each binding uses HEAD/TAIL chaining:
+                //   a = HEAD(__p0)
+                //   b = HEAD(TAIL(__p0))
+                //   c = HEAD(TAIL(TAIL(__p0)))
+                //
+                // This correctly handles lists built by the STG compiler
+                // where the nil tail is a global ref, not a local ref.
+                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                    .elements
+                    .iter()
+                    .map(|eb| {
+                        // Build TAIL applied `index` times to synthetic_var
+                        let mut list_expr = synthetic_var.clone();
+                        for _ in 0..eb.index {
+                            list_expr = core::app(smid, core::bif(smid, "TAIL"), vec![list_expr]);
+                        }
+                        // Apply HEAD to get the element at this position
+                        let head_call = core::app(smid, core::bif(smid, "HEAD"), vec![list_expr]);
+                        (Binder(eb.binding_var.clone()), Embed(head_call))
+                    })
+                    .collect();
+
+                body = RcExpr::from(Expr::Let(
+                    smid,
+                    Scope::new(Rec::new(bindings), body),
+                    LetType::DestructureListLet,
+                ));
+            }
+        }
     }
 
     Ok((body, lambda_param_names, lambda_param_vars))

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -35,6 +35,259 @@ fn text_range_to_span(range: TextRange) -> Span {
     Span::new(start, end)
 }
 
+/// Return type of `desugar_declaration_body_with_patterns`:
+/// `(body_expr, lambda_param_names, lambda_param_vars)`
+type PatternBodyResult = (RcExpr, Vec<String>, Vec<moniker::FreeVar<String>>);
+
+/// Entry for a single field binding in a destructuring let.
+struct FieldBinding {
+    /// Name of the field in the source block (for Lookup)
+    field_name: String,
+    /// FreeVar for the binding name in the body
+    binding_var: moniker::FreeVar<String>,
+}
+
+/// Entry for a destructuring block let: synthetic param + field bindings.
+struct DestructureEntry {
+    /// Synthetic parameter name (e.g. `__p0`)
+    synthetic_name: String,
+    /// Field bindings to generate
+    fields: Vec<FieldBinding>,
+}
+
+/// A parsed parameter pattern in a function declaration
+enum ParamPattern {
+    /// Simple identifier: `x`
+    Simple(String),
+    /// Block destructuring: `{x y}` or `{x: a  y: b}`.
+    ///
+    /// Each entry is `(field_name, binding_name)`. For shorthand `{x}`,
+    /// field and binding are both `"x"`. For rename `{x: a}`,
+    /// field is `"x"` and binding is `"a"`.
+    Block(Vec<(String, String)>),
+}
+
+/// Parse a block parameter pattern `{x y}` or `{x: a  y: b}` from a
+/// Rowan `Block` AST node in a function parameter position.
+///
+/// Block patterns may contain:
+/// - Shorthand names in block metadata: `{x y}` → `[(x, x), (y, y)]`
+/// - Rename declarations: `{x: a  y: b}` → `[(x, a), (y, b)]`
+/// - Mixed: `{x  y: b}` → `[(x, x), (y, b)]`
+fn parse_block_pattern(block: &rowan_ast::Block) -> Result<Vec<(String, String)>, CoreError> {
+    let mut fields: Vec<(String, String)> = Vec::new();
+
+    // Extract shorthand names from block metadata soup (e.g. `x y` in `{x y}`)
+    if let Some(meta) = block.meta() {
+        if let Some(soup) = meta.soup() {
+            for element in soup.elements() {
+                if let rowan_ast::Element::Name(name) = element {
+                    if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier()
+                    {
+                        let field_name = normal.text().to_string();
+                        // Shorthand: field name = binding name
+                        fields.push((field_name.clone(), field_name));
+                    }
+                }
+            }
+        }
+    }
+
+    // Extract rename fields from declarations (e.g. `x: a  y: b`)
+    for decl in block.declarations() {
+        if let Some(head) = decl.head() {
+            let kind = head.classify_declaration();
+            if let rowan_ast::DeclarationKind::Property(prop) = kind {
+                let field_name = prop.text().to_string();
+                // Check if there's a body (rename) or not
+                let binding_name = if let Some(body) = decl.body() {
+                    if let Some(body_soup) = body.soup() {
+                        // Body should be a single normal identifier (the binding name)
+                        if let Some(rowan_ast::Element::Name(name)) = body_soup.singleton() {
+                            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) =
+                                name.identifier()
+                            {
+                                normal.text().to_string()
+                            } else {
+                                // Not a normal identifier — use field name as fallback
+                                field_name.clone()
+                            }
+                        } else {
+                            // Complex expression in body — use field name as fallback
+                            field_name.clone()
+                        }
+                    } else {
+                        field_name.clone()
+                    }
+                } else {
+                    // No body in declaration — field name = binding name (shorthand)
+                    field_name.clone()
+                };
+                fields.push((field_name, binding_name));
+            }
+        }
+    }
+
+    Ok(fields)
+}
+
+/// Parse a function parameter soup into a `ParamPattern`.
+///
+/// Returns `None` if the soup is not a valid single-element parameter.
+fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
+    match soup.singleton() {
+        Some(rowan_ast::Element::Name(name)) => {
+            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                Some(ParamPattern::Simple(normal.text().to_string()))
+            } else {
+                None
+            }
+        }
+        Some(rowan_ast::Element::Block(block)) => {
+            parse_block_pattern(&block).ok().map(ParamPattern::Block)
+        }
+        _ => None,
+    }
+}
+
+/// Desugar a function body with support for destructuring parameter patterns.
+///
+/// For simple parameter patterns, this behaves like `desugar_declaration_body`.
+/// For block patterns, a synthetic parameter (`__pN`) is introduced as the
+/// lambda binder, and let bindings for each field are added around the body.
+///
+/// Returns `(body_expr, lambda_param_names, lambda_param_vars)`.
+fn desugar_declaration_body_with_patterns(
+    decl: &rowan_ast::Declaration,
+    desugarer: &mut Desugarer,
+    patterns: &[ParamPattern],
+    span: Span,
+) -> Result<PatternBodyResult, CoreError> {
+    // Build the complete list of names to push into the environment,
+    // tracking which ones are lambda binders (synthetic params) and
+    // which are only binding names for let bindings.
+    let mut all_env_names: Vec<String> = Vec::new();
+    let mut lambda_param_names: Vec<String> = Vec::new();
+    // For each pattern, record the synthetic param name (if any) and
+    // the field-to-binding mappings (for DestructureBlockLet).
+    let mut destructure_entries: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    // Will be built from destructure_entries after env push
+    let mut synthetic_counter = 0usize;
+
+    for pattern in patterns {
+        match pattern {
+            ParamPattern::Simple(name) => {
+                all_env_names.push(name.clone());
+                lambda_param_names.push(name.clone());
+            }
+            ParamPattern::Block(fields) => {
+                let synthetic_name = format!("__p{}", synthetic_counter);
+                synthetic_counter += 1;
+                all_env_names.push(synthetic_name.clone());
+                lambda_param_names.push(synthetic_name.clone());
+                for (_, binding_name) in fields {
+                    all_env_names.push(binding_name.clone());
+                }
+                destructure_entries.push((synthetic_name, fields.clone()));
+            }
+        }
+    }
+
+    // Push all names into the environment as a single frame
+    if !all_env_names.is_empty() {
+        desugarer.env_mut().push_keys(all_env_names.iter().cloned());
+    }
+
+    // Collect FreeVars for lambda binders (before desugaring body)
+    let lambda_param_vars: Vec<moniker::FreeVar<String>> = lambda_param_names
+        .iter()
+        .map(|name| desugarer.env().get(name).unwrap().clone())
+        .collect();
+
+    // Collect FreeVars for binding names (needed for let bindings)
+    let mut destructure_lets: Vec<DestructureEntry> = Vec::new();
+    for (synthetic_name, fields) in &destructure_entries {
+        let field_bindings: Vec<FieldBinding> = fields
+            .iter()
+            .map(|(field_name, binding_name)| {
+                let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                FieldBinding {
+                    field_name: field_name.clone(),
+                    binding_var,
+                }
+            })
+            .collect();
+        destructure_lets.push(DestructureEntry {
+            synthetic_name: synthetic_name.clone(),
+            fields: field_bindings,
+        });
+    }
+
+    // Desugar body with all names in scope
+    let mut body = if let Some(body_node) = decl.body() {
+        if let Some(body_soup) = body_node.soup() {
+            body_soup.desugar(desugarer)?
+        } else {
+            return Err(CoreError::InvalidEmbedding(
+                "empty declaration body".to_string(),
+                desugarer.new_smid(span),
+            ));
+        }
+    } else {
+        return Err(CoreError::InvalidEmbedding(
+            "missing declaration body".to_string(),
+            desugarer.new_smid(span),
+        ));
+    };
+
+    // Apply varify to convert Name expressions to Var expressions
+    body = desugarer.varify(body);
+
+    // Pop environment frame
+    if !all_env_names.is_empty() {
+        desugarer.env_mut().pop();
+    }
+
+    // Wrap body in DestructureBlockLet for each destructuring pattern,
+    // innermost first (last pattern wraps outermost).
+    // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
+    for entry in destructure_lets.iter().rev() {
+        // Look up the synthetic param FreeVar from the lambda_param_vars
+        // (the env frame has already been popped)
+        let synthetic_fv = lambda_param_vars
+            .iter()
+            .zip(lambda_param_names.iter())
+            .find(|(_, n)| **n == entry.synthetic_name)
+            .map(|(fv, _)| fv.clone())
+            .unwrap();
+
+        let smid = desugarer.new_smid(span);
+        let synthetic_var = RcExpr::from(Expr::Var(smid, moniker::Var::Free(synthetic_fv)));
+
+        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+            .fields
+            .iter()
+            .map(|fb| {
+                let lookup = RcExpr::from(Expr::Lookup(
+                    smid,
+                    synthetic_var.clone(),
+                    fb.field_name.clone(),
+                    None,
+                ));
+                (Binder(fb.binding_var.clone()), Embed(lookup))
+            })
+            .collect();
+
+        body = RcExpr::from(Expr::Let(
+            smid,
+            Scope::new(Rec::new(bindings), body),
+            LetType::DestructureBlockLet,
+        ));
+    }
+
+    Ok((body, lambda_param_names, lambda_param_vars))
+}
+
 /// Literals desugar into core Primitives
 impl Desugarable for rowan_ast::Literal {
     fn desugar(&self, desugarer: &mut Desugarer) -> Result<RcExpr, CoreError> {
@@ -331,37 +584,57 @@ fn extract_rowan_declaration_components(
                 })
             }
             rowan_ast::DeclarationKind::Function(func, args_tuple) => {
-                // Extract argument names from the apply tuple
-                let arg_names: Vec<String> = args_tuple
+                // Parse each argument into a ParamPattern (simple name or
+                // destructuring pattern). Fall back to simple name extraction
+                // for any arg that doesn't parse as a pattern (shouldn't
+                // happen after Task 2 validation, but be defensive).
+                let patterns: Vec<ParamPattern> = args_tuple
                     .items()
-                    .filter_map(|soup| {
-                        // Each argument should be a single name
-                        if let Some(rowan_ast::Element::Name(name)) = soup.singleton() {
-                            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) =
-                                name.identifier()
-                            {
-                                Some(normal.text().to_string())
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    })
+                    .filter_map(|soup| parse_param_pattern(&soup))
                     .collect();
 
-                let (body, arg_vars) = desugar_declaration_body(decl, desugarer, &arg_names, span)?;
+                // If all patterns are Simple (no destructuring), use the
+                // existing fast path so as not to disturb existing behaviour.
+                let all_simple = patterns
+                    .iter()
+                    .all(|p| matches!(p, ParamPattern::Simple(_)));
 
-                Ok(RowanDeclarationComponents {
-                    span,
-                    metadata,
-                    name: func.text().to_string(),
-                    args: arg_names,
-                    body,
-                    arg_vars,
-                    is_operator: false,
-                    fixity: None,
-                })
+                if all_simple {
+                    let arg_names: Vec<String> = patterns
+                        .into_iter()
+                        .map(|p| match p {
+                            ParamPattern::Simple(n) => n,
+                            _ => unreachable!(),
+                        })
+                        .collect();
+                    let (body, arg_vars) =
+                        desugar_declaration_body(decl, desugarer, &arg_names, span)?;
+                    Ok(RowanDeclarationComponents {
+                        span,
+                        metadata,
+                        name: func.text().to_string(),
+                        args: arg_names,
+                        body,
+                        arg_vars,
+                        is_operator: false,
+                        fixity: None,
+                    })
+                } else {
+                    // At least one destructuring pattern — use pattern-aware
+                    // desugaring which injects synthetic params and let bindings.
+                    let (body, lambda_param_names, lambda_param_vars) =
+                        desugar_declaration_body_with_patterns(decl, desugarer, &patterns, span)?;
+                    Ok(RowanDeclarationComponents {
+                        span,
+                        metadata,
+                        name: func.text().to_string(),
+                        args: lambda_param_names,
+                        body,
+                        arg_vars: lambda_param_vars,
+                        is_operator: false,
+                        fixity: None,
+                    })
+                }
             }
             rowan_ast::DeclarationKind::Prefix(_, op, arg) => {
                 let args = vec![arg.text().to_string()];

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -186,10 +186,17 @@ impl<T: BoundTerm<String> + Clone> IntoIterator for BlockMap<T> {
 
 /// Used to tag lets that have a default block as body, to support
 /// optimisations that don't then need to work with the body.
+///
+/// `DestructureBlockLet` and `DestructureListLet` mark lets generated
+/// by desugaring a destructuring parameter pattern.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LetType {
     DefaultBlockLet,
     OtherLet,
+    /// Let generated from a block destructuring parameter `{x y}`
+    DestructureBlockLet,
+    /// Let generated from a list destructuring parameter `[a, b, c]`
+    DestructureListLet,
 }
 
 impl_bound_term_ignore!(LetType);

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -698,6 +698,16 @@ lazy_static! {
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 131
+            name: "LIST.NTH",
+            ty: function(vec![list(), num(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
+    Intrinsic { // 132
+            name: "LIST.DROP",
+            ty: function(vec![num(), list(), list()]).unwrap(),
+            strict: vec![0, 1],
+    },
     ];
 }
 

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -7,7 +7,10 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::intrinsic::{CallGlobal1, CallGlobal2, Const, IntrinsicMachine, StgIntrinsic},
+        machine::{
+            env::SynClosure,
+            intrinsic::{CallGlobal1, CallGlobal2, Const, IntrinsicMachine, StgIntrinsic},
+        },
         memory::{mutator::MutatorHeapView, syntax::Ref},
     },
 };
@@ -15,13 +18,17 @@ use crate::{
 use super::{
     force::SeqNumList,
     panic::Panic,
-    support::{collect_num_list, machine_return_bool, machine_return_num_list},
+    support::{
+        collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
+    },
     syntax::{
         dsl::{annotated_lambda, app_bif, case, data, force, local, lref, str, value},
         LambdaForm,
     },
     tags::DataConstructor,
 };
+
+use crate::eval::memory::syntax::HeapSyn;
 
 /// A constant for CONS
 pub struct Cons;
@@ -174,3 +181,106 @@ impl StgIntrinsic for SortNumList {
 }
 
 impl CallGlobal1 for SortNumList {}
+
+/// LIST.NTH(list, n) — return the nth element (0-indexed) of a list.
+///
+/// Both arguments are forced (strict: [0, 1]). The list must be a
+/// fully-evaluated cons structure. Panics if the list has fewer than
+/// n+1 elements.
+pub struct ListNth;
+
+impl StgIntrinsic for ListNth {
+    fn name(&self) -> &str {
+        "LIST.NTH"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = {
+            let num = num_arg(machine, view, &args[1])?;
+            num.as_u64().unwrap_or(0) as usize
+        };
+        let mut iter = data_list_arg(machine, view, args[0].clone())?;
+        let mut current: Option<SynClosure> = None;
+        for _ in 0..=n {
+            current = iter.next().transpose()?;
+        }
+        match current {
+            Some(closure) => machine.set_closure(closure),
+            None => Err(ExecutionError::Panic(format!(
+                "LIST.NTH: index {} out of bounds",
+                n
+            ))),
+        }
+    }
+}
+
+impl CallGlobal2 for ListNth {}
+
+/// LIST.DROP(n, list) — drop the first n elements and return the remainder.
+///
+/// Both arguments are forced (strict: [0, 1]). The list must be a
+/// fully-evaluated cons structure. Returns an empty list if n exceeds
+/// the list length.
+pub struct ListDrop;
+
+impl StgIntrinsic for ListDrop {
+    fn name(&self) -> &str {
+        "LIST.DROP"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = {
+            let num = num_arg(machine, view, &args[0])?;
+            num.as_u64().unwrap_or(0) as usize
+        };
+
+        // Navigate through the cons structure, skipping n elements.
+        // We traverse the tail links directly so we can return the
+        // remaining cons cell (rather than reconstructing the list).
+        let mut closure = machine.nav(view).resolve(&args[1])?;
+        for _ in 0..n {
+            let code = view.scoped(closure.code());
+            match &*code {
+                HeapSyn::Cons { tag, args: cons_args } => {
+                    match (*tag).try_into() {
+                        Ok(DataConstructor::ListCons) => {
+                            let tail_ref = cons_args.get(1).ok_or_else(|| {
+                                ExecutionError::Panic("malformed cons cell".to_string())
+                            })?;
+                            closure = closure.navigate_local(&view, tail_ref);
+                        }
+                        Ok(DataConstructor::ListNil) => {
+                            // Ran out of elements — return the nil (empty list)
+                            return machine.set_closure(closure);
+                        }
+                        _ => {
+                            return Err(ExecutionError::Panic(
+                                "LIST.DROP: expected list".to_string(),
+                            ));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ExecutionError::Panic(
+                        "LIST.DROP: expected list".to_string(),
+                    ));
+                }
+            }
+        }
+        machine.set_closure(closure)
+    }
+}
+
+impl CallGlobal2 for ListDrop {}

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -253,7 +253,10 @@ impl StgIntrinsic for ListDrop {
         for _ in 0..n {
             let code = view.scoped(closure.code());
             match &*code {
-                HeapSyn::Cons { tag, args: cons_args } => {
+                HeapSyn::Cons {
+                    tag,
+                    args: cons_args,
+                } => {
                     match (*tag).try_into() {
                         Ok(DataConstructor::ListCons) => {
                             let tail_ref = cons_args.get(1).ok_or_else(|| {

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -174,6 +174,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
+    rt.add(Box::new(list::ListNth));
+    rt.add(Box::new(list::ListDrop));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -708,11 +708,11 @@ impl DeclarationHead {
                     if let Some(args) = args {
                         let mut errors = vec![];
                         for arg in args.items() {
-                            if arg
+                            let valid = arg
                                 .singleton()
-                                .and_then(|e| e.as_normal_identifier())
-                                .is_none()
-                            {
+                                .map(|e| e.is_valid_param_pattern())
+                                .unwrap_or(false);
+                            if !valid {
                                 errors.push(ParseError::InvalidFormalParameter {
                                     head_range: self.syntax().text_range(),
                                     range: arg.syntax().text_range(),
@@ -1138,6 +1138,27 @@ impl Element {
                 _ => None,
             }),
             _ => None,
+        }
+    }
+
+    /// Return true if this element is a valid formal parameter pattern.
+    ///
+    /// A valid parameter is one of:
+    /// - A normal identifier: `x`
+    /// - A block pattern (block destructuring): `{x y}`
+    /// - A list pattern (list destructuring): `[a, b, c]`
+    pub fn is_valid_param_pattern(&self) -> bool {
+        match self {
+            Element::Name(n) => n
+                .identifier()
+                .and_then(|id| match id {
+                    Identifier::NormalIdentifier(_) => Some(()),
+                    _ => None,
+                })
+                .is_some(),
+            Element::Block(_) => true,
+            Element::List(_) => true,
+            _ => false,
         }
     }
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -430,6 +430,11 @@ pub fn test_harness_090() {
 }
 
 #[test]
+pub fn test_harness_091() {
+    run_test(&opts("091_destructure_block.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -435,6 +435,11 @@ pub fn test_harness_091() {
 }
 
 #[test]
+pub fn test_harness_092() {
+    run_test(&opts("092_destructure_list.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

Implements eu-spqy (destructuring & named args) — block and fixed-length list destructuring patterns in function parameter positions.

- **Block destructuring**: `f({x y}): x + y` binds named fields from a block argument using shorthand or rename syntax
- **Fixed-length list destructuring**: `f([a, b, c]): a + b + c` binds positional elements from a list argument using `HEAD`/`TAIL` chains
- **Mixed patterns**: normal, block, and list parameters can be freely combined
- Infrastructure: `DestructureBlockLet` and `DestructureListLet` `LetType` markers added; `LIST.NTH` and `LIST.DROP` intrinsics registered (for future use)

Documentation updated in `doc/reference/syntax.md`, `doc/appendices/cheat-sheet.md`, and `doc/guide/functions-and-combinators.md` with verified working examples.

Harness tests 091 (block) and 092 (list) added.

## Commits

- `c9f0db5` feat: add DestructureBlockLet/DestructureListLet LetType markers and LIST.NTH/LIST.DROP intrinsics
- `1375430` feat: relax function parameter validation for destructuring patterns
- `828a665` feat: block destructuring in function parameters
- `4c853bb` feat: fixed-length list destructuring in function parameters
- `89194d8` docs: add destructuring parameter documentation

## Test plan

- [ ] `cargo test test_harness_091` — block destructuring (shorthand, rename, mixed)
- [ ] `cargo test test_harness_092` — list destructuring (two-element, three-element)
- [ ] `cargo test` — all 127 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — no warnings
- [ ] `cargo fmt --all -- --check` — no formatting issues

## Remaining subtasks (separate PRs)

The following eu-spqy subtasks are left for subsequent PRs:
- `eu-t9tw`: Head/tail list destructuring `[x : xs]`
- `eu-cpvn`: Cons operator `‖`
- `eu-airm`: Juxtaposed call syntax `f{...}` / `f[...]`
- `eu-8bgw`: Destructure fusion pass
- `eu-7u6z`: Error case tests
- `eu-t6sx`: Integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)