### PR TITLE
fix: convert parser panic on '::' to proper parse error

### DIFF
--- a/harness/test/errors/044_double_colon_type_annot.eu
+++ b/harness/test/errors/044_double_colon_type_annot.eu
@@ -1,0 +1,3 @@
+# Mistake: using '::' for a type annotation (Haskell/Rust style)
+x :: Int
+x: 42

--- a/harness/test/errors/044_double_colon_type_annot.eu.expect
+++ b/harness/test/errors/044_double_colon_type_annot.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "'::' is not valid syntax in eucalypt"

--- a/src/driver/lsp/diagnostics.rs
+++ b/src/driver/lsp/diagnostics.rs
@@ -49,7 +49,8 @@ fn error_range(error: &ParseError) -> TextRange {
         | ParseError::ReservedCharacter { range }
         | ParseError::EmptyExpression { range }
         | ParseError::UnclosedStringInterpolation { range }
-        | ParseError::InvalidZdtLiteral { range, .. } => *range,
+        | ParseError::InvalidZdtLiteral { range, .. }
+        | ParseError::InvalidDoubleColon { range } => *range,
         ParseError::MissingDeclarationColon { head_range } => *head_range,
     }
 }
@@ -79,6 +80,9 @@ fn error_message(error: &ParseError) -> String {
             "unclosed string interpolation (missing closing brace)".to_string()
         }
         ParseError::InvalidZdtLiteral { .. } => "invalid ZDT literal".to_string(),
+        ParseError::InvalidDoubleColon { .. } => {
+            "'::' is not valid syntax; use ':' for declarations".to_string()
+        }
     }
 }
 

--- a/src/syntax/error.rs
+++ b/src/syntax/error.rs
@@ -116,7 +116,8 @@ fn rowan_error_range(error: &RowanParseError) -> Option<rowan::TextRange> {
         | ReservedCharacter { range }
         | EmptyExpression { range }
         | UnclosedStringInterpolation { range }
-        | InvalidZdtLiteral { range, .. } => Some(*range),
+        | InvalidZdtLiteral { range, .. }
+        | InvalidDoubleColon { range } => Some(*range),
         MissingDeclarationColon { head_range } => Some(*head_range),
     }
 }

--- a/src/syntax/rowan/error.rs
+++ b/src/syntax/rowan/error.rs
@@ -64,6 +64,9 @@ pub enum ParseError {
         /// A brief description of why the literal is invalid
         reason: ZdtInvalidReason,
     },
+    InvalidDoubleColon {
+        range: TextRange,
+    },
 }
 
 /// The reason a `t"..."` date/time literal is invalid
@@ -137,6 +140,13 @@ impl fmt::Display for ParseError {
                      YYYY-MM-DDTHH:MM:SS+HH:MM"
                 ),
             },
+            ParseError::InvalidDoubleColon { .. } => write!(
+                f,
+                "'::' is not valid syntax in eucalypt\n  \
+                 help: use ':' for declarations (e.g. `name: value`)\n  \
+                 help: '::' is used in Haskell/Rust for type annotations, \
+                 but eucalypt does not have type annotations"
+            ),
         }
     }
 }

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -83,6 +83,23 @@ impl<'text> Parser<'text> {
         TextRange::at(ch, TextSize::of(self.tokens[self.next_token].1))
     }
 
+    /// Calculate a text range covering the last consumed token and the next token.
+    /// Used for reporting errors that span two adjacent tokens (e.g. `::` is two COLON tokens).
+    fn prev_and_next_range(&self) -> TextRange {
+        let mut ch: TextSize = 0.into();
+        let start_token = self.next_token.saturating_sub(1);
+        for (_, s) in &self.tokens[0..start_token] {
+            ch += TextSize::of(*s);
+        }
+        let start = ch;
+        // span from prev token start to end of next token
+        ch += TextSize::of(self.tokens[start_token].1);
+        if self.next_token < self.tokens.len() {
+            ch += TextSize::of(self.tokens[self.next_token].1);
+        }
+        TextRange::new(start, ch)
+    }
+
     /// Operate on the event sink at the top of the stack
     fn sink(&mut self) -> &mut dyn EventSink {
         self.sink_stack.last_mut().unwrap().as_mut()
@@ -410,9 +427,27 @@ impl<'text> Parser<'text> {
     /// Parse a temporary protoblock element
     fn parse_protoblock_element(&mut self) -> bool {
         match self.next() {
-            Some((k, _))
-                if k == BACKTICK || k == COMMA || k == COLON || k == WHITESPACE || k == COMMENT =>
-            {
+            Some((COLON, _)) => {
+                // Check for '::' — this is not valid eucalypt syntax and, if both
+                // COLON tokens reach the BlockEventSink unguarded, causes a panic in
+                // token accounting. Catch it here: wrap both tokens in an ERROR node so
+                // the BlockEventSink treats them as ordinary buffered content rather
+                // than declaration separators.
+                if let Some((COLON, _)) = self.peek() {
+                    let range = self.prev_and_next_range();
+                    self.next(); // consume second COLON
+                    self.errors.push(ParseError::InvalidDoubleColon { range });
+                    self.sink().start_node(ERROR_STOWAWAYS);
+                    self.sink().token(COLON);
+                    self.sink().token(COLON);
+                    self.sink().finish_node();
+                } else {
+                    self.sink().token(COLON);
+                }
+                self.add_trivia();
+                true
+            }
+            Some((k, _)) if k == BACKTICK || k == COMMA || k == WHITESPACE || k == COMMENT => {
                 self.sink().token(k);
                 self.add_trivia();
                 true

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -685,3 +685,8 @@ pub fn test_error_042() {
 pub fn test_error_043() {
     run_error_test(&error_opts("043_assignment_syntax.eu"));
 }
+
+#[test]
+pub fn test_error_044() {
+    run_error_test(&error_opts("044_double_colon_type_annot.eu"));
+}


### PR DESCRIPTION
## Error message: parser panic on double-colon ('::') syntax

### Scenario

A user writes Haskell or Rust-style type annotation syntax using `::`:

```
x :: Int
x: 42
```

This is a common mistake for users coming from statically typed FP languages (Haskell, Elm) or Rust, where `::` introduces a type annotation.

### Before

```
thread 'main' panicked at src/syntax/rowan/parse.rs:122:9:
assertion `left == right` failed
  left: [COLON, COLON, WHITESPACE, UNQUOTED_IDENTIFIER, WHITESPACE, UNQUOTED_IDENTIFIER, COLON, WHITESPACE, NUMBER, WHITESPACE]
 right: [UNQUOTED_IDENTIFIER, WHITESPACE, COLON, COLON, WHITESPACE, UNQUOTED_IDENTIFIER, WHITESPACE, UNQUOTED_IDENTIFIER, COLON, WHITESPACE, NUMBER, WHITESPACE]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
exit: 101
```

A hard panic with an internal assertion message — the user sees no information about what they did wrong.

### After

```
error: '::' is not valid syntax in eucalypt
  help: use ':' for declarations (e.g. `name: value`)
  help: '::' is used in Haskell/Rust for type annotations, but eucalypt does not have type annotations
 --> test.eu:1:3
  |
1 | x :: Int
  |   ^^
  |   |
  |   unexpected content after expression

exit: 1
```

A clear error with location, explanation, and guidance.

### Assessment

- Human diagnosability: poor → excellent
- LLM diagnosability: poor → excellent

### Change

**Root cause**: The `BlockEventSink` processes COLON tokens as declaration separators. Two consecutive COLON tokens (`::`) caused it to commit an incomplete declaration and start a new one with an empty head, corrupting the token event stream. This triggered an invariant assertion `assert_eq!` in `Parser::build()` which panicked.

**Fix**:
1. Added a `InvalidDoubleColon` variant to `ParseError` with an actionable message explaining that `::` is not valid and pointing to `:` for declarations.
2. Modified `parse_protoblock_element` to detect two consecutive COLON tokens. When found, both are wrapped in an `ERROR_STOWAWAYS` node, preventing the `BlockEventSink` from treating them as declaration separators. Token accounting is preserved.
3. Added a `prev_and_next_range()` helper to compute a span covering both colons so the underline shows `^^` rather than a single `^`.
4. Updated exhaustive match arms in `src/driver/lsp/diagnostics.rs` and `src/syntax/error.rs` for the new variant.
5. Added harness test `042_double_colon_type_annot.eu`.

**Files changed**:
- `src/syntax/rowan/parse.rs` — detection and wrapping of `::`, new helper
- `src/syntax/rowan/error.rs` — new `InvalidDoubleColon` variant
- `src/driver/lsp/diagnostics.rs` — exhaustive match update
- `src/syntax/error.rs` — exhaustive match update
- `tests/harness_test.rs` — test registration
- `harness/test/errors/042_double_colon_type_annot.eu{,.expect}` — test case

### Risks

- The `ERROR_STOWAWAYS` wrapping means that text after `::` (e.g. `Int`) may be parsed with reduced context and produce secondary errors. These are harmless since the primary error is clear.
- The `prev_and_next_range()` helper is only used for this case; it could be made more general in future.