### PR TITLE
fix: add hint for list '+' mismatch — suggest append or ++

### DIFF
--- a/harness/test/errors/045_list_plus_concat.eu
+++ b/harness/test/errors/045_list_plus_concat.eu
@@ -1,0 +1,4 @@
+# Mistake: using '+' to concatenate lists (Python / JavaScript style)
+a: [1, 2, 3]
+b: [4, 5]
+result: a + b

--- a/harness/test/errors/045_list_plus_concat.eu.expect
+++ b/harness/test/errors/045_list_plus_concat.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "to concatenate two lists, use 'append"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -31,6 +31,10 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
         (String, Number) => vec!["if you need to convert a number to a string, use 'str' or \
              string interpolation"
             .to_string()],
+        (Number, List(_)) => vec![
+            "arithmetic operators like '+' work on numbers, not lists".to_string(),
+            "to concatenate two lists, use 'append(xs, ys)' or the '++' operator".to_string(),
+        ],
         _ => vec![],
     }
 }
@@ -51,6 +55,11 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
             "for lists, use the index operator for indexing (e.g. xs index 0) or \
              pipeline functions like 'head', 'nth'"
                 .to_string(),
+        ]
+    } else if is_list && expects_number {
+        vec![
+            "arithmetic operators like '+' work on numbers, not lists".to_string(),
+            "to concatenate two lists, use 'append(xs, ys)' or the '++' operator".to_string(),
         ]
     } else if is_string && expects_number {
         vec![

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -690,3 +690,8 @@ pub fn test_error_043() {
 pub fn test_error_044() {
     run_error_test(&error_opts("044_double_colon_type_annot.eu"));
 }
+
+#[test]
+pub fn test_error_045() {
+    run_error_test(&error_opts("045_list_plus_concat.eu"));
+}


### PR DESCRIPTION
## Error message: list concatenation — missing actionable hint

### Scenario

A user tries to concatenate two lists using `+`, following Python or JavaScript conventions:

```
a: [1, 2, 3]
b: [4, 5]
result: a + b
```

This is a very common mistake. In Python `a + b` concatenates lists; in JavaScript spread or `concat` is used. Eucalypt uses `append(xs, ys)` or `++`.

### Before

```
error: type mismatch: expected number, found list

exit: 1
```

No hint about how to actually concatenate lists.

### After

```
error: type mismatch: expected number, found list
 = arithmetic operators like '+' work on numbers, not lists
 = to concatenate two lists, use 'append(xs, ys)' or the '++' operator

exit: 1
```

### Assessment

- Human diagnosability: fair → excellent
- LLM diagnosability: fair → excellent

### Change

Added the `(Number, List(_))` arm to `type_mismatch_notes` in `src/eval/error.rs`, and added the `is_list && expects_number` branch to `data_tag_mismatch_notes`. Both branches produce the same two-line hint.

The `NoBranchForDataTag` path is the one actually triggered by `a + b` (the `+` intrinsic uses a case expression over the data tag and finds a list where it expects a boxed number). The `TypeMismatch(Number, List)` arm handles any path that comes via `num_arg()`.

Added harness test `042_list_plus_concat.eu`.

### Risks

Low. Purely additive — only adds notes to existing error variants.