### PR TITLE
fix: hint for import/use/require as unresolved variables

### DIFF
--- a/harness/test/errors/046_import_keyword.eu
+++ b/harness/test/errors/046_import_keyword.eu
@@ -1,0 +1,6 @@
+# Error test: using 'import' keyword (Python/JS style) instead of eucalypt import metadata syntax
+# 'import' is not a keyword in eucalypt - this should trigger a helpful hint
+x: import
+
+result: 42
+RESULT: result

--- a/harness/test/errors/046_import_keyword.eu.expect
+++ b/harness/test/errors/046_import_keyword.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "eucalypt does not have an import statement"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -103,6 +103,21 @@ impl CompileError {
                             .to_string(),
                     );
                 }
+                // Hint for import-style idioms from other languages.
+                // In eucalypt, imports use metadata attached to the importing block.
+                if matches!(
+                    name.as_str(),
+                    "import" | "use" | "require" | "include" | "load"
+                ) {
+                    notes.push(
+                        "note: eucalypt does not have an import statement; \
+                         use import metadata to bring a file into scope in a block"
+                            .to_string(),
+                    );
+                    notes.push(
+                        "example: ` { import: path/to/file.eu }  my-block: { ... }".to_string(),
+                    );
+                }
                 diag.with_notes(notes)
             }
             _ => diag,

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -695,3 +695,8 @@ pub fn test_error_044() {
 pub fn test_error_045() {
     run_error_test(&error_opts("045_list_plus_concat.eu"));
 }
+
+#[test]
+pub fn test_error_046() {
+    run_error_test(&error_opts("046_import_keyword.eu"));
+}


### PR DESCRIPTION
## Error message: foreign import idioms (import/use/require)

### Scenario
A user coming from Python, JavaScript, Ruby, or similar languages may write:
\`\`\`eucalypt
import my-lib
\`\`\`
or even just reference `import` as a name. This triggers "unresolved variable 'import'" which is accurate but unhelpful — the user needs to understand eucalypt's import mechanism.

### Before
\`\`\`
error: unresolved variable 'import'
  ┌─ file.eu:3:4
  │
3 │ x: import
  │    ^^^^^^
  │
  = check that the variable is defined and in scope
\`\`\`

### After
\`\`\`
error: unresolved variable 'import'
  ┌─ file.eu:3:4
  │
3 │ x: import
  │    ^^^^^^
  │
  = check that the variable is defined and in scope
  = note: eucalypt does not have an import statement; use import metadata to bring a file into scope in a block
  = example: ` { import: path/to/file.eu }  my-block: { ... }
\`\`\`

The hint is triggered for `import`, `use`, `require`, `include`, and `load` — common import keywords across languages.

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: poor → excellent

### Change
Added an import-keyword detection block in `CompileError::FreeVar::to_diagnostic()` in `src/eval/stg/compiler.rs`. When the free variable name is one of `import`, `use`, `require`, `include`, or `load`, two notes are added: one explaining eucalypt's lack of an import statement, and one showing the correct metadata syntax.

A new error test `046_import_keyword.eu` exercises the hint.

### Risks
Low. This is purely additive — additional notes are shown for a subset of free-variable errors. The note text avoids double quotes to prevent a known issue with the test harness YAML escaping.