### PR TITLE
fix: add string concatenation hint when '++' used on strings

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -404,15 +404,24 @@ impl ExecutionError {
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {
                 data_tag_mismatch_notes(*actual, expected)
             }
-            ExecutionError::NoBranchForNative(_, _) => {
-                vec![
+            ExecutionError::NoBranchForNative(_, type_name) => {
+                let mut notes = vec![
                     "list operations such as 'head', 'tail', '++', 'map', 'filter' require \
                      list arguments"
                         .to_string(),
                     "check that the value is a list before applying list operations; \
                      use 'nil?' to test for an empty list"
                         .to_string(),
-                ]
+                ];
+                if type_name == "string" {
+                    notes.push(
+                        "if you are trying to concatenate strings, use string interpolation \
+                         (e.g. 'join-on' or string patterns with variable references) \
+                         rather than '++'"
+                            .to_string(),
+                    );
+                }
+                notes
             }
             ExecutionError::BlackHole(_) => {
                 vec![


### PR DESCRIPTION
## Error message: '++' used on strings — missing actionable hint

### Scenario

A user tries to concatenate strings using `++` (following Haskell conventions or thinking `++` is a general concatenation operator):

```
name: "Alice"
age: 30
result: name ++ " is " ++ age ++ " years old"
```

In eucalypt, `++` is `append` which works on lists. For string concatenation, users should use string interpolation or `join-on`.

### Before

```
error: type mismatch: received a string where a structured value (block or list) was expected
 = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
 = check that the value is a list before applying list operations; use 'nil?' to test for an empty list

exit: 1
```

The hint about "list operations" is accurate but doesn't explain that `++` is not for strings and what to use instead.

### After

```
error: type mismatch: received a string where a structured value (block or list) was expected
 = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
 = check that the value is a list before applying list operations; use 'nil?' to test for an empty list
 = if you are trying to concatenate strings, use string interpolation (e.g. 'join-on' or string patterns with variable references) rather than '++'

exit: 1
```

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change

Modified `NoBranchForNative` note generation in `src/eval/error.rs` to check the type name. When `type_name == "string"`, a third note is added directing users to string interpolation and `join-on` instead of `++`.

The hint is intentionally general (not showing raw curly brace syntax) to avoid YAML parsing issues in the test harness report format.

### Risks

- The `NoBranchForNative(_, "string")` error also occurs in other contexts (e.g. `map` applied to a block whose keys are strings). In those cases, the string concatenation hint may be slightly misleading, but it follows the primary "list operations require list arguments" hint which is accurate, so the hint ordering preserves correct information first.
- Low risk: purely additive.