### PR TITLE
feat: destructure fusion pass — elide block/list construction on direct pattern match

### DIFF
--- a/doc/appendices/cheat-sheet.md
+++ b/doc/appendices/cheat-sheet.md
@@ -170,6 +170,7 @@ From highest to lowest binding:
 | 85 | exp | right | `^`, `∘`, `;` | Power, composition |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |
+| 55 | -- | right | `‖` | List cons (prepend element) |
 | 50 | cmp | left | `<`, `>`, `<=`, `>=` | Comparison |
 | 45 | append | right | `++`, `<<` | List append, deep merge |
 | 42 | map | left | `<$>` | Functor map |

--- a/doc/appendices/cheat-sheet.md
+++ b/doc/appendices/cheat-sheet.md
@@ -80,6 +80,9 @@ x: 42 # inline comment
 |------|--------|-------|
 | Property | `name: expr` | Defines a named value |
 | Function | `f(x, y): expr` | Named function with parameters |
+| Block pattern | `f({x y}): expr` | Destructures block argument fields |
+| Block rename | `f({x: a  y: b}): expr` | Destructures with renamed bindings |
+| List pattern | `f([a, b, c]): expr` | Destructures fixed-length list |
 | Binary operator | `(l op r): expr` | Infix operator |
 | Prefix operator | `(op x): expr` | Unary prefix |
 | Postfix operator | `(x op): expr` | Unary postfix |

--- a/doc/guide/functions-and-combinators.md
+++ b/doc/guide/functions-and-combinators.md
@@ -3,6 +3,7 @@
 In this chapter you will learn:
 
 - How to define and call functions
+- How destructuring parameters work
 - How currying and partial application work
 - The standard combinators: `identity`, `const`, `compose`, `flip`
 - How to build functions from other functions without lambdas
@@ -37,6 +38,106 @@ Pipelines](expressions-and-pipelines.md)):
 ```eu
 a: 5 square
 b: 4 add(3)
+```
+
+## Destructuring Parameters
+
+Function parameters can be **destructuring patterns** that extract
+structure from an argument inline, binding its components as named
+variables in the function body.
+
+### Block destructuring
+
+A block pattern binds named fields from a block argument. Shorthand
+form binds the field name directly:
+
+```eu
+sum-of-point({x y}): x + y
+
+p: { x: 3 y: 4 }
+result: sum-of-point(p)
+```
+
+```yaml
+result: 7
+```
+
+A rename form binds a field under a different local name, using a
+colon between the field name and the binding name:
+
+```eu
+scaled({x: a  y: b}, scale): a * scale + b * scale
+
+result: scaled({x: 2  y: 3}, 10)
+```
+
+```yaml
+result: 50
+```
+
+Shorthand and rename can be mixed freely:
+
+```eu
+describe({x  y: height}): "x={x} h={height}"
+
+result: describe({x: 1  y: 5})
+```
+
+```yaml
+result: x=1 h=5
+```
+
+### Fixed-length list destructuring
+
+A list pattern binds positional elements from a list argument:
+
+```eu
+add-pair([a, b]): a + b
+
+result: add-pair([10, 20])
+```
+
+```yaml
+result: 30
+```
+
+Multiple elements at any position are supported:
+
+```eu
+third([a, b, c]): c
+
+result: third([1, 2, 3])
+```
+
+```yaml
+result: 3
+```
+
+### Mixing patterns
+
+Normal parameters and destructuring patterns can be combined in any
+order:
+
+```eu
+weighted-sum(w, [a, b, c]): w * a + w * b + w * c
+
+result: weighted-sum(2, [1, 3, 5])
+```
+
+```yaml
+result: 18
+```
+
+Multiple destructuring parameters are also allowed:
+
+```eu
+combine({x}, [a, b]): x + a + b
+
+result: combine({x: 10}, [3, 7])
+```
+
+```yaml
+result: 20
 ```
 
 ## Functions are Values

--- a/doc/guide/functions-and-combinators.md
+++ b/doc/guide/functions-and-combinators.md
@@ -113,6 +113,100 @@ result: third([1, 2, 3])
 result: 3
 ```
 
+### Head/tail list destructuring
+
+A head/tail pattern separates a list into its first element and the
+remaining list. A colon inside square brackets separates the fixed
+elements (heads) from the tail binding:
+
+```eu
+first-of([x : xs]): x
+rest-of([x : xs]): xs
+
+a: first-of([1, 2, 3])
+b: rest-of([1, 2, 3])
+```
+
+```yaml
+a: 1
+b: [2, 3]
+```
+
+Multiple heads are separated by commas before the colon:
+
+```eu
+sum-first-two([a, b : rest]): a + b
+
+result: sum-first-two([10, 20, 30])
+```
+
+```yaml
+result: 30
+```
+
+### Juxtaposed call syntax
+
+When a function takes a block or list argument, you may call it by
+placing the block or list immediately after the function name with no
+space:
+
+```eu
+sum-xy({x y}): x + y
+
+a: sum-xy{x: 3 y: 4}    # same as sum-xy({x: 3 y: 4})
+```
+
+```yaml
+a: 7
+```
+
+Similarly for list arguments:
+
+```eu
+add-pair([a, b]): a + b
+
+b: add-pair[10, 20]      # same as add-pair([10, 20])
+```
+
+```yaml
+b: 30
+```
+
+Combined with block destructuring, juxtaposed calls give named
+arguments as an emergent pattern — no extra language concept needed:
+
+```eu
+greet({name greeting}): "{greeting}, {name}!"
+
+result: greet{name: "Alice" greeting: "Hello"}
+```
+
+```yaml
+result: Hello, Alice!
+```
+
+### The cons operator `‖`
+
+The `‖` operator (U+2016, DOUBLE VERTICAL LINE) prepends a single
+element to a list. It is right-associative, so chains build lists
+left-to-right without parentheses:
+
+```eu
+a: 1 ‖ [2, 3]          # [1, 2, 3]
+b: 1 ‖ 2 ‖ [3]         # [1, 2, 3]
+c: 1 ‖ []              # [1]
+```
+
+```yaml
+a: [1, 2, 3]
+b: [1, 2, 3]
+c: [1]
+```
+
+The precedence of `‖` (55) is between comparison (50) and arithmetic
+(75), so it binds more tightly than comparisons but less tightly than
+addition or multiplication.
+
 ### Mixing patterns
 
 Normal parameters and destructuring patterns can be combined in any

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -122,12 +122,44 @@ mixed({x  y: b}): x + b
 # Fixed-length list destructuring
 f-sum([a, b, c]): a + b + c
 f-first([a, b]): a
+
+# Head/tail list destructuring — colon separates fixed heads from tail
+get-head([x : xs]): x
+get-tail([x : xs]): xs
+drop-two([a, b : rest]): rest
+```
+
+Juxtaposed call syntax passes a block or list literal as a single
+argument without parentheses. No space between the function name and
+the opening bracket:
+
+```eu
+# f{...} is sugar for f({...})
+sum-xy{x: 10 y: 20}
+
+# f[...] is sugar for f([...])
+add-pair[1, 2]
+```
+
+Combined with block destructuring, this gives named arguments:
+
+```eu
+greet({name greeting}): "{greeting}, {name}!"
+greet{name: "Alice" greeting: "Hello"}    # => "Hello, Alice!"
 ```
 
 Destructuring patterns can be mixed with normal parameters:
 
 ```eu
 f(n, [a, b]): n * (a + b)
+```
+
+The `‖` operator (U+2016, DOUBLE VERTICAL LINE) prepends an element to
+a list. It is right-associative:
+
+```eu
+1 ‖ [2, 3]        # => [1, 2, 3]
+1 ‖ 2 ‖ [3]       # => [1, 2, 3]
 ```
 
 See [Functions and Combinators](../guide/functions-and-combinators.md)

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -104,6 +104,35 @@ f(x, y): x + y
 two: f(1, 1)
 ```
 
+Function parameters can be **destructuring patterns** as well as
+simple names. A block pattern extracts named fields from a block
+argument; a list pattern extracts positional elements from a list
+argument:
+
+```eu
+# Block destructuring — shorthand binds field name as variable name
+sum-xy({x y}): x + y
+
+# Block destructuring — rename binds field under a new variable name
+product-ab({x: a  y: b}): a * b
+
+# Mixed shorthand and rename
+mixed({x  y: b}): x + b
+
+# Fixed-length list destructuring
+f-sum([a, b, c]): a + b + c
+f-first([a, b]): a
+```
+
+Destructuring patterns can be mixed with normal parameters:
+
+```eu
+f(n, [a, b]): n * (a + b)
+```
+
+See [Functions and Combinators](../guide/functions-and-combinators.md)
+for more detail on destructuring.
+
 ...and using some brackets and suitable names, you can define
 operators too, either binary:
 

--- a/harness/test/091_destructure_block.eu
+++ b/harness/test/091_destructure_block.eu
@@ -1,0 +1,37 @@
+##
+## 091: Block destructuring in function parameters
+##
+
+f-basic({x y}): x + y
+f-rename({x: a  y: b}): a * b
+f-mixed({x  y: b}): x + b
+
+tests: {
+
+  ` "Basic block destructuring"
+  basic: {
+    ` "sum of fields x and y"
+    a: f-basic({x: 1 y: 2}) //= 3
+    ` "sum with larger values"
+    b: f-basic({x: 10 y: 20}) //= 30
+  }
+
+  ` "Block destructuring with renaming"
+  rename: {
+    ` "product via renamed fields"
+    a: f-rename({x: 3 y: 4}) //= 12
+    ` "product with different values"
+    b: f-rename({x: 5 y: 6}) //= 30
+  }
+
+  ` "Mixed shorthand and rename"
+  mixed: {
+    ` "sum of shorthand x and renamed y"
+    a: f-mixed({x: 10 y: 20}) //= 30
+    ` "sum with different values"
+    b: f-mixed({x: 7 y: 3}) //= 10
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/092_destructure_list.eu
+++ b/harness/test/092_destructure_list.eu
@@ -1,0 +1,29 @@
+##
+## 092: List destructuring in function parameters
+##
+
+f-sum([a, b, c]): a + b + c
+f-first([a, b]): a
+f-second([a, b]): b
+
+tests: {
+
+  ` "Fixed-length list destructuring"
+  fixed: {
+    ` "sum of three elements"
+    a: f-sum([10, 20, 30]) //= 60
+    ` "sum of different values"
+    b: f-sum([1, 2, 3]) //= 6
+  }
+
+  ` "Two-element list"
+  pair: {
+    ` "first element"
+    a: f-first([1, 2]) //= 1
+    ` "second element"
+    b: f-second([1, 2]) //= 2
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/092_destructure_list.eu
+++ b/harness/test/092_destructure_list.eu
@@ -6,6 +6,11 @@ f-sum([a, b, c]): a + b + c
 f-first([a, b]): a
 f-second([a, b]): b
 
+f-head([x : xs]): x
+f-tail([x : xs]): xs
+f-multi-head([a, b : rest]): a + b
+f-rest([a, b : rest]): rest
+
 tests: {
 
   ` "Fixed-length list destructuring"
@@ -22,6 +27,22 @@ tests: {
     a: f-first([1, 2]) //= 1
     ` "second element"
     b: f-second([1, 2]) //= 2
+  }
+
+  ` "Head/tail with colon"
+  head-tail: {
+    ` "extract head"
+    a: f-head([1, 2, 3]) //= 1
+    ` "extract tail"
+    b: (f-tail([1, 2, 3]) = [2, 3]) //= true
+  }
+
+  ` "Multiple heads plus tail"
+  multi-head: {
+    ` "sum of first two elements"
+    a: f-multi-head([10, 20, 30, 40]) //= 30
+    ` "rest after first two"
+    b: (f-rest([10, 20, 30, 40]) = [30, 40]) //= true
   }
 
 }

--- a/harness/test/093_cons_operator.eu
+++ b/harness/test/093_cons_operator.eu
@@ -1,0 +1,33 @@
+##
+## 093: Cons operator ‖ for list construction
+##
+
+tests: {
+
+  ` "Cons single element onto list"
+  single: {
+    ` "prepend 1 to [2, 3]"
+    a: (1 ‖ [2, 3]) //= [1, 2, 3]
+    ` "prepend :a to [:b :c]"
+    b: (:a ‖ [:b, :c]) //= [:a, :b, :c]
+  }
+
+  ` "Cons chain right-associative"
+  chain: {
+    ` "1 ‖ 2 ‖ [3] should be [1, 2, 3]"
+    a: (1 ‖ 2 ‖ [3]) //= [1, 2, 3]
+    ` "chaining three elements"
+    b: (10 ‖ 20 ‖ 30 ‖ []) //= [10, 20, 30]
+  }
+
+  ` "Cons onto empty list"
+  empty: {
+    ` "single element from empty"
+    a: (1 ‖ []) //= [1]
+    ` "two elements from empty"
+    b: (1 ‖ 2 ‖ []) //= [1, 2]
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/094_juxtaposed_call.eu
+++ b/harness/test/094_juxtaposed_call.eu
@@ -1,0 +1,44 @@
+##
+## 094: Juxtaposed call syntax f{...} and f[...]
+##
+
+f-block({x y}): x + y
+f-list([a, b]): a + b
+greet({name greeting}): "{greeting}, {name}!"
+f-rename({x: px  y: py}): px * px + py * py
+
+tests: {
+
+  ` "Juxtaposed block call"
+  block-call: {
+    ` "basic block apply"
+    a: f-block{x: 1 y: 2} //= 3
+    ` "block apply with larger values"
+    b: f-block{x: 10 y: 20} //= 30
+  }
+
+  ` "Juxtaposed list call"
+  list-call: {
+    ` "basic list apply"
+    a: f-list[10, 20] //= 30
+    ` "list apply with different values"
+    b: f-list[1, 2] //= 3
+  }
+
+  ` "Named argument style"
+  named-args: {
+    ` "greet with named arguments"
+    a: greet{name: "World" greeting: "Hello"} //= "Hello, World!"
+    ` "greet with different arguments"
+    b: greet{name: "Alice" greeting: "Hi"} //= "Hi, Alice!"
+  }
+
+  ` "Named args with renaming"
+  renamed: {
+    ` "point distance squared"
+    a: f-rename{x: 3 y: 4} //= 25
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/095_destructuring_integration.eu
+++ b/harness/test/095_destructuring_integration.eu
@@ -1,0 +1,68 @@
+##
+## 095: Comprehensive integration tests for destructuring and named args
+##
+
+sum-xy({x y}): x + y
+sum-xy-renamed({x: px  y: py}): px + py
+add-pair([a, b]): a + b
+get-head([x : xs]): x
+get-rest([x : xs]): xs
+sum-multi([a, b : rest]): a + b + (rest head)
+prepend-zero([x : xs]): 0 ‖ xs
+plain-add(a, b): a + b
+
+data-blocks: [{x: 1 y: 2}, {x: 3 y: 4}]
+data-pairs: [[1, 2], [3, 4], [5, 6]]
+data-lists: [[1, 2, 3], [4, 5, 6]]
+
+tests: {
+
+  ` "Destructuring in pipeline"
+  pipeline: {
+    ` "map block destructuring over list"
+    a: (data-blocks map(sum-xy)) //= [3, 7]
+    ` "map renamed block destructuring over list"
+    b: (data-blocks map(sum-xy-renamed)) //= [3, 7]
+  }
+
+  ` "Positional and destructured functions coexist"
+  coexist: {
+    ` "plain positional function"
+    a: plain-add(1, 2) //= 3
+    ` "block destructuring function"
+    b: sum-xy({x: 1 y: 2}) //= 3
+    ` "juxtaposed block call"
+    c: sum-xy{x: 10 y: 20} //= 30
+  }
+
+  ` "List destructuring in pipeline"
+  list-pipeline: {
+    ` "map list destructuring over list of pairs"
+    a: (data-pairs map(add-pair)) //= [3, 7, 11]
+  }
+
+  ` "Head/tail in pipeline"
+  head-tail-pipeline: {
+    ` "extract heads from each list"
+    a: (data-lists map(get-head)) //= [1, 4]
+    ` "extract rests from each list"
+    b: (data-lists map(get-rest)) //= [[2, 3], [5, 6]]
+  }
+
+  ` "Cons operator in context"
+  cons-context: {
+    ` "build list using cons"
+    a: (1 ‖ 2 ‖ [3]) //= [1, 2, 3]
+    ` "prepend zero to tail of destructured list"
+    b: (prepend-zero([1, 2, 3])) //= [0, 2, 3]
+  }
+
+  ` "Mixed fixed and head/tail"
+  mixed-patterns: {
+    ` "sum first two and include third via rest"
+    a: sum-multi([10, 20, 30, 40]) //= 60
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/harness/test/errors/042_destructure_missing_field.eu
+++ b/harness/test/errors/042_destructure_missing_field.eu
@@ -1,0 +1,3 @@
+# Error test: missing field in block destructuring
+f({x y}): x + y
+RESULT: f({x: 1})

--- a/harness/test/errors/042_destructure_missing_field.eu.expect
+++ b/harness/test/errors/042_destructure_missing_field.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "key 'y' not found"

--- a/harness/test/errors/043_destructure_short_list.eu
+++ b/harness/test/errors/043_destructure_short_list.eu
@@ -1,0 +1,3 @@
+# Error test: list too short for fixed-length destructuring
+f([a, b, c]): a + b + c
+RESULT: f([1, 2])

--- a/harness/test/errors/043_destructure_short_list.eu.expect
+++ b/harness/test/errors/043_destructure_short_list.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch"

--- a/harness/test/errors/044_destructure_empty_cons.eu
+++ b/harness/test/errors/044_destructure_empty_cons.eu
@@ -1,0 +1,3 @@
+# Error test: head/tail pattern applied to empty list
+f([x : xs]): x
+RESULT: f([])

--- a/harness/test/errors/044_destructure_empty_cons.eu.expect
+++ b/harness/test/errors/044_destructure_empty_cons.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch"

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -119,6 +119,11 @@ when(p?, f, x): if(x p?, x f, x)
 ` "`cons(h, t)` - construct new list by prepending item `h` to list `t`."
 cons: __CONS
 
+` { doc: "`x ‖ xs` - prepend element `x` to list `xs`. Right-associative cons operator."
+    associates: :right
+    precedence: 55 }
+(x ‖ xs): __CONS(x, xs)
+
 ` "`head(xs)` - return the head item of list `xs`, panic if empty."
 head: __HEAD
 

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -55,6 +55,22 @@ struct DestructureEntry {
     fields: Vec<FieldBinding>,
 }
 
+/// Entry for a single list element binding.
+struct ListElementBinding {
+    /// Zero-based index of the element
+    index: usize,
+    /// FreeVar for the binding name in the body
+    binding_var: moniker::FreeVar<String>,
+}
+
+/// Entry for a destructuring list let: synthetic param + element bindings.
+struct ListDestructureEntry {
+    /// Synthetic parameter name (e.g. `__p0`)
+    synthetic_name: String,
+    /// Element bindings at each position
+    elements: Vec<ListElementBinding>,
+}
+
 /// A parsed parameter pattern in a function declaration
 enum ParamPattern {
     /// Simple identifier: `x`
@@ -65,6 +81,10 @@ enum ParamPattern {
     /// field and binding are both `"x"`. For rename `{x: a}`,
     /// field is `"x"` and binding is `"a"`.
     Block(Vec<(String, String)>),
+    /// Fixed-length list destructuring: `[a, b, c]`.
+    ///
+    /// Contains the binding names for each positional element.
+    List(Vec<String>),
 }
 
 /// Parse a block parameter pattern `{x y}` or `{x: a  y: b}` from a
@@ -131,6 +151,31 @@ fn parse_block_pattern(block: &rowan_ast::Block) -> Result<Vec<(String, String)>
     Ok(fields)
 }
 
+/// Parse a fixed-length list parameter pattern `[a, b, c]` from a
+/// Rowan `List` AST node in a function parameter position.
+///
+/// Each item in the list should be a single normal identifier.
+/// Returns a list of binding names in positional order.
+fn parse_list_pattern(list: &rowan_ast::List) -> Option<Vec<String>> {
+    let mut elements: Vec<String> = Vec::new();
+    for item in list.items() {
+        if let Some(rowan_ast::Element::Name(name)) = item.singleton() {
+            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                elements.push(normal.text().to_string());
+            } else {
+                return None; // Not a normal identifier — invalid pattern
+            }
+        } else {
+            return None; // Not a single name — invalid pattern
+        }
+    }
+    if elements.is_empty() {
+        None // Empty list pattern not valid
+    } else {
+        Some(elements)
+    }
+}
+
 /// Parse a function parameter soup into a `ParamPattern`.
 ///
 /// Returns `None` if the soup is not a valid single-element parameter.
@@ -146,7 +191,25 @@ fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
         Some(rowan_ast::Element::Block(block)) => {
             parse_block_pattern(&block).ok().map(ParamPattern::Block)
         }
+        Some(rowan_ast::Element::List(list)) => parse_list_pattern(&list).map(ParamPattern::List),
         _ => None,
+    }
+}
+
+/// Ordered record of a destructuring let to emit after the body is desugared.
+enum DestructureLet {
+    /// Block destructuring: lookup each field by name.
+    Block(DestructureEntry),
+    /// List destructuring: index each element with LIST.NTH.
+    List(ListDestructureEntry),
+}
+
+impl DestructureLet {
+    fn synthetic_name(&self) -> &str {
+        match self {
+            DestructureLet::Block(e) => &e.synthetic_name,
+            DestructureLet::List(e) => &e.synthetic_name,
+        }
     }
 }
 
@@ -155,6 +218,8 @@ fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
 /// For simple parameter patterns, this behaves like `desugar_declaration_body`.
 /// For block patterns, a synthetic parameter (`__pN`) is introduced as the
 /// lambda binder, and let bindings for each field are added around the body.
+/// For list patterns, the same synthetic-parameter approach is used, with
+/// `LIST.NTH` calls for each positional element.
 ///
 /// Returns `(body_expr, lambda_param_names, lambda_param_vars)`.
 fn desugar_declaration_body_with_patterns(
@@ -168,10 +233,12 @@ fn desugar_declaration_body_with_patterns(
     // which are only binding names for let bindings.
     let mut all_env_names: Vec<String> = Vec::new();
     let mut lambda_param_names: Vec<String> = Vec::new();
-    // For each pattern, record the synthetic param name (if any) and
-    // the field-to-binding mappings (for DestructureBlockLet).
-    let mut destructure_entries: Vec<(String, Vec<(String, String)>)> = Vec::new();
-    // Will be built from destructure_entries after env push
+    // Raw data for block patterns: (synthetic_name, [(field_name, binding_name)])
+    let mut block_raw: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    // Raw data for list patterns: (synthetic_name, [binding_name])
+    let mut list_raw: Vec<(String, Vec<String>)> = Vec::new();
+    // Ordered sequence of lets to emit — preserves argument order for correct nesting.
+    let mut let_order: Vec<DestructureLet> = Vec::new();
     let mut synthetic_counter = 0usize;
 
     for pattern in patterns {
@@ -188,7 +255,27 @@ fn desugar_declaration_body_with_patterns(
                 for (_, binding_name) in fields {
                     all_env_names.push(binding_name.clone());
                 }
-                destructure_entries.push((synthetic_name, fields.clone()));
+                block_raw.push((synthetic_name.clone(), fields.clone()));
+                // Placeholder — resolved after env push
+                let_order.push(DestructureLet::Block(DestructureEntry {
+                    synthetic_name,
+                    fields: Vec::new(),
+                }));
+            }
+            ParamPattern::List(element_names) => {
+                let synthetic_name = format!("__p{}", synthetic_counter);
+                synthetic_counter += 1;
+                all_env_names.push(synthetic_name.clone());
+                lambda_param_names.push(synthetic_name.clone());
+                for binding_name in element_names {
+                    all_env_names.push(binding_name.clone());
+                }
+                list_raw.push((synthetic_name.clone(), element_names.clone()));
+                // Placeholder — resolved after env push
+                let_order.push(DestructureLet::List(ListDestructureEntry {
+                    synthetic_name,
+                    elements: Vec::new(),
+                }));
             }
         }
     }
@@ -204,23 +291,36 @@ fn desugar_declaration_body_with_patterns(
         .map(|name| desugarer.env().get(name).unwrap().clone())
         .collect();
 
-    // Collect FreeVars for binding names (needed for let bindings)
-    let mut destructure_lets: Vec<DestructureEntry> = Vec::new();
-    for (synthetic_name, fields) in &destructure_entries {
-        let field_bindings: Vec<FieldBinding> = fields
-            .iter()
-            .map(|(field_name, binding_name)| {
-                let binding_var = desugarer.env().get(binding_name).unwrap().clone();
-                FieldBinding {
-                    field_name: field_name.clone(),
-                    binding_var,
-                }
-            })
-            .collect();
-        destructure_lets.push(DestructureEntry {
-            synthetic_name: synthetic_name.clone(),
-            fields: field_bindings,
-        });
+    // Resolve block destructure entries now that names are in the environment.
+    let mut block_raw_iter = block_raw.into_iter();
+    let mut list_raw_iter = list_raw.into_iter();
+    for slot in &mut let_order {
+        match slot {
+            DestructureLet::Block(entry) => {
+                let (_, fields) = block_raw_iter.next().unwrap();
+                entry.fields = fields
+                    .iter()
+                    .map(|(field_name, binding_name)| {
+                        let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                        FieldBinding {
+                            field_name: field_name.clone(),
+                            binding_var,
+                        }
+                    })
+                    .collect();
+            }
+            DestructureLet::List(entry) => {
+                let (_, element_names) = list_raw_iter.next().unwrap();
+                entry.elements = element_names
+                    .iter()
+                    .enumerate()
+                    .map(|(index, binding_name)| {
+                        let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                        ListElementBinding { index, binding_var }
+                    })
+                    .collect();
+            }
+        }
     }
 
     // Desugar body with all names in scope
@@ -248,41 +348,74 @@ fn desugar_declaration_body_with_patterns(
         desugarer.env_mut().pop();
     }
 
-    // Wrap body in DestructureBlockLet for each destructuring pattern,
-    // innermost first (last pattern wraps outermost).
-    // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
-    for entry in destructure_lets.iter().rev() {
+    // Wrap body in destructuring lets for each pattern, innermost first
+    // (last pattern wraps outermost), preserving argument order.
+    for slot in let_order.iter().rev() {
         // Look up the synthetic param FreeVar from the lambda_param_vars
         // (the env frame has already been popped)
         let synthetic_fv = lambda_param_vars
             .iter()
             .zip(lambda_param_names.iter())
-            .find(|(_, n)| **n == entry.synthetic_name)
+            .find(|(_, n)| **n == slot.synthetic_name())
             .map(|(fv, _)| fv.clone())
             .unwrap();
 
         let smid = desugarer.new_smid(span);
         let synthetic_var = RcExpr::from(Expr::Var(smid, moniker::Var::Free(synthetic_fv)));
 
-        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
-            .fields
-            .iter()
-            .map(|fb| {
-                let lookup = RcExpr::from(Expr::Lookup(
-                    smid,
-                    synthetic_var.clone(),
-                    fb.field_name.clone(),
-                    None,
-                ));
-                (Binder(fb.binding_var.clone()), Embed(lookup))
-            })
-            .collect();
+        match slot {
+            DestructureLet::Block(entry) => {
+                // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
+                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                    .fields
+                    .iter()
+                    .map(|fb| {
+                        let lookup = RcExpr::from(Expr::Lookup(
+                            smid,
+                            synthetic_var.clone(),
+                            fb.field_name.clone(),
+                            None,
+                        ));
+                        (Binder(fb.binding_var.clone()), Embed(lookup))
+                    })
+                    .collect();
 
-        body = RcExpr::from(Expr::Let(
-            smid,
-            Scope::new(Rec::new(bindings), body),
-            LetType::DestructureBlockLet,
-        ));
+                body = RcExpr::from(Expr::Let(
+                    smid,
+                    Scope::new(Rec::new(bindings), body),
+                    LetType::DestructureBlockLet,
+                ));
+            }
+            DestructureLet::List(entry) => {
+                // Each binding uses HEAD/TAIL chaining:
+                //   a = HEAD(__p0)
+                //   b = HEAD(TAIL(__p0))
+                //   c = HEAD(TAIL(TAIL(__p0)))
+                //
+                // This correctly handles lists built by the STG compiler
+                // where the nil tail is a global ref, not a local ref.
+                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                    .elements
+                    .iter()
+                    .map(|eb| {
+                        // Build TAIL applied `index` times to synthetic_var
+                        let mut list_expr = synthetic_var.clone();
+                        for _ in 0..eb.index {
+                            list_expr = core::app(smid, core::bif(smid, "TAIL"), vec![list_expr]);
+                        }
+                        // Apply HEAD to get the element at this position
+                        let head_call = core::app(smid, core::bif(smid, "HEAD"), vec![list_expr]);
+                        (Binder(eb.binding_var.clone()), Embed(head_call))
+                    })
+                    .collect();
+
+                body = RcExpr::from(Expr::Let(
+                    smid,
+                    Scope::new(Rec::new(bindings), body),
+                    LetType::DestructureListLet,
+                ));
+            }
+        }
     }
 
     Ok((body, lambda_param_names, lambda_param_vars))

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -63,12 +63,22 @@ struct ListElementBinding {
     binding_var: moniker::FreeVar<String>,
 }
 
+/// Entry for the tail binding in a head/tail list pattern.
+struct ListTailBinding {
+    /// Number of head elements to skip (i.e., the drop count)
+    drop_count: usize,
+    /// FreeVar for the tail binding name in the body
+    binding_var: moniker::FreeVar<String>,
+}
+
 /// Entry for a destructuring list let: synthetic param + element bindings.
 struct ListDestructureEntry {
     /// Synthetic parameter name (e.g. `__p0`)
     synthetic_name: String,
     /// Element bindings at each position
     elements: Vec<ListElementBinding>,
+    /// Optional tail binding for head/tail patterns (`[x : xs]`)
+    tail: Option<ListTailBinding>,
 }
 
 /// A parsed parameter pattern in a function declaration
@@ -84,7 +94,8 @@ enum ParamPattern {
     /// Fixed-length list destructuring: `[a, b, c]`.
     ///
     /// Contains the binding names for each positional element.
-    List(Vec<String>),
+    /// The optional tail is `None` for fixed-length patterns.
+    List(Vec<String>, Option<String>),
 }
 
 /// Parse a block parameter pattern `{x y}` or `{x: a  y: b}` from a
@@ -151,28 +162,70 @@ fn parse_block_pattern(block: &rowan_ast::Block) -> Result<Vec<(String, String)>
     Ok(fields)
 }
 
-/// Parse a fixed-length list parameter pattern `[a, b, c]` from a
-/// Rowan `List` AST node in a function parameter position.
+/// Parse a list parameter pattern from a Rowan `List` AST node in a
+/// function parameter position.
 ///
-/// Each item in the list should be a single normal identifier.
-/// Returns a list of binding names in positional order.
-fn parse_list_pattern(list: &rowan_ast::List) -> Option<Vec<String>> {
-    let mut elements: Vec<String> = Vec::new();
-    for item in list.items() {
-        if let Some(rowan_ast::Element::Name(name)) = item.singleton() {
-            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
-                elements.push(normal.text().to_string());
+/// Handles both fixed-length patterns `[a, b, c]` and head/tail
+/// patterns `[x : xs]` and `[a, b : rest]`.
+///
+/// Returns `(head_elements, tail)` where `tail` is `None` for
+/// fixed-length patterns and `Some(tail_name)` for head/tail patterns.
+fn parse_list_pattern(list: &rowan_ast::List) -> Option<(Vec<String>, Option<String>)> {
+    let has_colon = list.has_colon();
+    let all_items: Vec<_> = list.items().collect();
+
+    if has_colon {
+        // Head/tail pattern: items before the colon are heads,
+        // the last item after the colon is the tail.
+        // The List node's items() returns all Soup children in order:
+        // for [a, b : rest], items are: a, b, rest (colon is a token, not a child node).
+        // We collect all items; the last is the tail, the rest are heads.
+        if all_items.len() < 2 {
+            return None; // Need at least one head and one tail
+        }
+        let mut heads = Vec::new();
+        for item in &all_items[..all_items.len() - 1] {
+            if let Some(rowan_ast::Element::Name(name)) = item.singleton() {
+                if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                    heads.push(normal.text().to_string());
+                } else {
+                    return None;
+                }
             } else {
-                return None; // Not a normal identifier — invalid pattern
+                return None;
+            }
+        }
+        // Last item is the tail binding
+        let tail_item = all_items.last().unwrap();
+        if let Some(rowan_ast::Element::Name(name)) = tail_item.singleton() {
+            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                let tail = normal.text().to_string();
+                Some((heads, Some(tail)))
+            } else {
+                None
             }
         } else {
-            return None; // Not a single name — invalid pattern
+            None
         }
-    }
-    if elements.is_empty() {
-        None // Empty list pattern not valid
     } else {
-        Some(elements)
+        // Fixed-length pattern: all items are positional bindings
+        let mut elements = Vec::new();
+        for item in &all_items {
+            if let Some(rowan_ast::Element::Name(name)) = item.singleton() {
+                if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                    elements.push(normal.text().to_string());
+                } else {
+                    return None; // Not a normal identifier — invalid pattern
+                }
+            } else {
+                return None; // Not a single name — invalid pattern
+            }
+        }
+        if elements.is_empty() {
+            None // Empty list pattern not valid
+        } else {
+            Some((elements, None))
+        }
     }
 }
 
@@ -191,7 +244,9 @@ fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
         Some(rowan_ast::Element::Block(block)) => {
             parse_block_pattern(&block).ok().map(ParamPattern::Block)
         }
-        Some(rowan_ast::Element::List(list)) => parse_list_pattern(&list).map(ParamPattern::List),
+        Some(rowan_ast::Element::List(list)) => {
+            parse_list_pattern(&list).map(|(heads, tail)| ParamPattern::List(heads, tail))
+        }
         _ => None,
     }
 }
@@ -235,8 +290,8 @@ fn desugar_declaration_body_with_patterns(
     let mut lambda_param_names: Vec<String> = Vec::new();
     // Raw data for block patterns: (synthetic_name, [(field_name, binding_name)])
     let mut block_raw: Vec<(String, Vec<(String, String)>)> = Vec::new();
-    // Raw data for list patterns: (synthetic_name, [binding_name])
-    let mut list_raw: Vec<(String, Vec<String>)> = Vec::new();
+    // Raw data for list patterns: (synthetic_name, [head_names], tail_name?)
+    let mut list_raw: Vec<(String, Vec<String>, Option<String>)> = Vec::new();
     // Ordered sequence of lets to emit — preserves argument order for correct nesting.
     let mut let_order: Vec<DestructureLet> = Vec::new();
     let mut synthetic_counter = 0usize;
@@ -262,7 +317,7 @@ fn desugar_declaration_body_with_patterns(
                     fields: Vec::new(),
                 }));
             }
-            ParamPattern::List(element_names) => {
+            ParamPattern::List(element_names, tail_name) => {
                 let synthetic_name = format!("__p{}", synthetic_counter);
                 synthetic_counter += 1;
                 all_env_names.push(synthetic_name.clone());
@@ -270,11 +325,19 @@ fn desugar_declaration_body_with_patterns(
                 for binding_name in element_names {
                     all_env_names.push(binding_name.clone());
                 }
-                list_raw.push((synthetic_name.clone(), element_names.clone()));
+                if let Some(tail) = tail_name {
+                    all_env_names.push(tail.clone());
+                }
+                list_raw.push((
+                    synthetic_name.clone(),
+                    element_names.clone(),
+                    tail_name.clone(),
+                ));
                 // Placeholder — resolved after env push
                 let_order.push(DestructureLet::List(ListDestructureEntry {
                     synthetic_name,
                     elements: Vec::new(),
+                    tail: None,
                 }));
             }
         }
@@ -310,7 +373,8 @@ fn desugar_declaration_body_with_patterns(
                     .collect();
             }
             DestructureLet::List(entry) => {
-                let (_, element_names) = list_raw_iter.next().unwrap();
+                let (_, element_names, tail_name) = list_raw_iter.next().unwrap();
+                let drop_count = element_names.len();
                 entry.elements = element_names
                     .iter()
                     .enumerate()
@@ -319,6 +383,13 @@ fn desugar_declaration_body_with_patterns(
                         ListElementBinding { index, binding_var }
                     })
                     .collect();
+                entry.tail = tail_name.as_ref().map(|tail_name| {
+                    let binding_var = desugarer.env().get(tail_name).unwrap().clone();
+                    ListTailBinding {
+                        drop_count,
+                        binding_var,
+                    }
+                });
             }
         }
     }
@@ -392,9 +463,13 @@ fn desugar_declaration_body_with_patterns(
                 //   b = HEAD(TAIL(__p0))
                 //   c = HEAD(TAIL(TAIL(__p0)))
                 //
+                // For head/tail patterns, the tail binding uses TAIL applied
+                // `drop_count` times:
+                //   xs = TAIL(TAIL(__p0))   (for [a, b : xs])
+                //
                 // This correctly handles lists built by the STG compiler
                 // where the nil tail is a global ref, not a local ref.
-                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                let mut bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
                     .elements
                     .iter()
                     .map(|eb| {
@@ -408,6 +483,15 @@ fn desugar_declaration_body_with_patterns(
                         (Binder(eb.binding_var.clone()), Embed(head_call))
                     })
                     .collect();
+
+                // Add the tail binding if present
+                if let Some(tb) = &entry.tail {
+                    let mut tail_expr = synthetic_var.clone();
+                    for _ in 0..tb.drop_count {
+                        tail_expr = core::app(smid, core::bif(smid, "TAIL"), vec![tail_expr]);
+                    }
+                    bindings.push((Binder(tb.binding_var.clone()), Embed(tail_expr)));
+                }
 
                 body = RcExpr::from(Expr::Let(
                     smid,

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -35,6 +35,259 @@ fn text_range_to_span(range: TextRange) -> Span {
     Span::new(start, end)
 }
 
+/// Return type of `desugar_declaration_body_with_patterns`:
+/// `(body_expr, lambda_param_names, lambda_param_vars)`
+type PatternBodyResult = (RcExpr, Vec<String>, Vec<moniker::FreeVar<String>>);
+
+/// Entry for a single field binding in a destructuring let.
+struct FieldBinding {
+    /// Name of the field in the source block (for Lookup)
+    field_name: String,
+    /// FreeVar for the binding name in the body
+    binding_var: moniker::FreeVar<String>,
+}
+
+/// Entry for a destructuring block let: synthetic param + field bindings.
+struct DestructureEntry {
+    /// Synthetic parameter name (e.g. `__p0`)
+    synthetic_name: String,
+    /// Field bindings to generate
+    fields: Vec<FieldBinding>,
+}
+
+/// A parsed parameter pattern in a function declaration
+enum ParamPattern {
+    /// Simple identifier: `x`
+    Simple(String),
+    /// Block destructuring: `{x y}` or `{x: a  y: b}`.
+    ///
+    /// Each entry is `(field_name, binding_name)`. For shorthand `{x}`,
+    /// field and binding are both `"x"`. For rename `{x: a}`,
+    /// field is `"x"` and binding is `"a"`.
+    Block(Vec<(String, String)>),
+}
+
+/// Parse a block parameter pattern `{x y}` or `{x: a  y: b}` from a
+/// Rowan `Block` AST node in a function parameter position.
+///
+/// Block patterns may contain:
+/// - Shorthand names in block metadata: `{x y}` → `[(x, x), (y, y)]`
+/// - Rename declarations: `{x: a  y: b}` → `[(x, a), (y, b)]`
+/// - Mixed: `{x  y: b}` → `[(x, x), (y, b)]`
+fn parse_block_pattern(block: &rowan_ast::Block) -> Result<Vec<(String, String)>, CoreError> {
+    let mut fields: Vec<(String, String)> = Vec::new();
+
+    // Extract shorthand names from block metadata soup (e.g. `x y` in `{x y}`)
+    if let Some(meta) = block.meta() {
+        if let Some(soup) = meta.soup() {
+            for element in soup.elements() {
+                if let rowan_ast::Element::Name(name) = element {
+                    if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier()
+                    {
+                        let field_name = normal.text().to_string();
+                        // Shorthand: field name = binding name
+                        fields.push((field_name.clone(), field_name));
+                    }
+                }
+            }
+        }
+    }
+
+    // Extract rename fields from declarations (e.g. `x: a  y: b`)
+    for decl in block.declarations() {
+        if let Some(head) = decl.head() {
+            let kind = head.classify_declaration();
+            if let rowan_ast::DeclarationKind::Property(prop) = kind {
+                let field_name = prop.text().to_string();
+                // Check if there's a body (rename) or not
+                let binding_name = if let Some(body) = decl.body() {
+                    if let Some(body_soup) = body.soup() {
+                        // Body should be a single normal identifier (the binding name)
+                        if let Some(rowan_ast::Element::Name(name)) = body_soup.singleton() {
+                            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) =
+                                name.identifier()
+                            {
+                                normal.text().to_string()
+                            } else {
+                                // Not a normal identifier — use field name as fallback
+                                field_name.clone()
+                            }
+                        } else {
+                            // Complex expression in body — use field name as fallback
+                            field_name.clone()
+                        }
+                    } else {
+                        field_name.clone()
+                    }
+                } else {
+                    // No body in declaration — field name = binding name (shorthand)
+                    field_name.clone()
+                };
+                fields.push((field_name, binding_name));
+            }
+        }
+    }
+
+    Ok(fields)
+}
+
+/// Parse a function parameter soup into a `ParamPattern`.
+///
+/// Returns `None` if the soup is not a valid single-element parameter.
+fn parse_param_pattern(soup: &rowan_ast::Soup) -> Option<ParamPattern> {
+    match soup.singleton() {
+        Some(rowan_ast::Element::Name(name)) => {
+            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) = name.identifier() {
+                Some(ParamPattern::Simple(normal.text().to_string()))
+            } else {
+                None
+            }
+        }
+        Some(rowan_ast::Element::Block(block)) => {
+            parse_block_pattern(&block).ok().map(ParamPattern::Block)
+        }
+        _ => None,
+    }
+}
+
+/// Desugar a function body with support for destructuring parameter patterns.
+///
+/// For simple parameter patterns, this behaves like `desugar_declaration_body`.
+/// For block patterns, a synthetic parameter (`__pN`) is introduced as the
+/// lambda binder, and let bindings for each field are added around the body.
+///
+/// Returns `(body_expr, lambda_param_names, lambda_param_vars)`.
+fn desugar_declaration_body_with_patterns(
+    decl: &rowan_ast::Declaration,
+    desugarer: &mut Desugarer,
+    patterns: &[ParamPattern],
+    span: Span,
+) -> Result<PatternBodyResult, CoreError> {
+    // Build the complete list of names to push into the environment,
+    // tracking which ones are lambda binders (synthetic params) and
+    // which are only binding names for let bindings.
+    let mut all_env_names: Vec<String> = Vec::new();
+    let mut lambda_param_names: Vec<String> = Vec::new();
+    // For each pattern, record the synthetic param name (if any) and
+    // the field-to-binding mappings (for DestructureBlockLet).
+    let mut destructure_entries: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    // Will be built from destructure_entries after env push
+    let mut synthetic_counter = 0usize;
+
+    for pattern in patterns {
+        match pattern {
+            ParamPattern::Simple(name) => {
+                all_env_names.push(name.clone());
+                lambda_param_names.push(name.clone());
+            }
+            ParamPattern::Block(fields) => {
+                let synthetic_name = format!("__p{}", synthetic_counter);
+                synthetic_counter += 1;
+                all_env_names.push(synthetic_name.clone());
+                lambda_param_names.push(synthetic_name.clone());
+                for (_, binding_name) in fields {
+                    all_env_names.push(binding_name.clone());
+                }
+                destructure_entries.push((synthetic_name, fields.clone()));
+            }
+        }
+    }
+
+    // Push all names into the environment as a single frame
+    if !all_env_names.is_empty() {
+        desugarer.env_mut().push_keys(all_env_names.iter().cloned());
+    }
+
+    // Collect FreeVars for lambda binders (before desugaring body)
+    let lambda_param_vars: Vec<moniker::FreeVar<String>> = lambda_param_names
+        .iter()
+        .map(|name| desugarer.env().get(name).unwrap().clone())
+        .collect();
+
+    // Collect FreeVars for binding names (needed for let bindings)
+    let mut destructure_lets: Vec<DestructureEntry> = Vec::new();
+    for (synthetic_name, fields) in &destructure_entries {
+        let field_bindings: Vec<FieldBinding> = fields
+            .iter()
+            .map(|(field_name, binding_name)| {
+                let binding_var = desugarer.env().get(binding_name).unwrap().clone();
+                FieldBinding {
+                    field_name: field_name.clone(),
+                    binding_var,
+                }
+            })
+            .collect();
+        destructure_lets.push(DestructureEntry {
+            synthetic_name: synthetic_name.clone(),
+            fields: field_bindings,
+        });
+    }
+
+    // Desugar body with all names in scope
+    let mut body = if let Some(body_node) = decl.body() {
+        if let Some(body_soup) = body_node.soup() {
+            body_soup.desugar(desugarer)?
+        } else {
+            return Err(CoreError::InvalidEmbedding(
+                "empty declaration body".to_string(),
+                desugarer.new_smid(span),
+            ));
+        }
+    } else {
+        return Err(CoreError::InvalidEmbedding(
+            "missing declaration body".to_string(),
+            desugarer.new_smid(span),
+        ));
+    };
+
+    // Apply varify to convert Name expressions to Var expressions
+    body = desugarer.varify(body);
+
+    // Pop environment frame
+    if !all_env_names.is_empty() {
+        desugarer.env_mut().pop();
+    }
+
+    // Wrap body in DestructureBlockLet for each destructuring pattern,
+    // innermost first (last pattern wraps outermost).
+    // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
+    for entry in destructure_lets.iter().rev() {
+        // Look up the synthetic param FreeVar from the lambda_param_vars
+        // (the env frame has already been popped)
+        let synthetic_fv = lambda_param_vars
+            .iter()
+            .zip(lambda_param_names.iter())
+            .find(|(_, n)| **n == entry.synthetic_name)
+            .map(|(fv, _)| fv.clone())
+            .unwrap();
+
+        let smid = desugarer.new_smid(span);
+        let synthetic_var = RcExpr::from(Expr::Var(smid, moniker::Var::Free(synthetic_fv)));
+
+        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+            .fields
+            .iter()
+            .map(|fb| {
+                let lookup = RcExpr::from(Expr::Lookup(
+                    smid,
+                    synthetic_var.clone(),
+                    fb.field_name.clone(),
+                    None,
+                ));
+                (Binder(fb.binding_var.clone()), Embed(lookup))
+            })
+            .collect();
+
+        body = RcExpr::from(Expr::Let(
+            smid,
+            Scope::new(Rec::new(bindings), body),
+            LetType::DestructureBlockLet,
+        ));
+    }
+
+    Ok((body, lambda_param_names, lambda_param_vars))
+}
+
 /// Literals desugar into core Primitives
 impl Desugarable for rowan_ast::Literal {
     fn desugar(&self, desugarer: &mut Desugarer) -> Result<RcExpr, CoreError> {
@@ -331,37 +584,57 @@ fn extract_rowan_declaration_components(
                 })
             }
             rowan_ast::DeclarationKind::Function(func, args_tuple) => {
-                // Extract argument names from the apply tuple
-                let arg_names: Vec<String> = args_tuple
+                // Parse each argument into a ParamPattern (simple name or
+                // destructuring pattern). Fall back to simple name extraction
+                // for any arg that doesn't parse as a pattern (shouldn't
+                // happen after Task 2 validation, but be defensive).
+                let patterns: Vec<ParamPattern> = args_tuple
                     .items()
-                    .filter_map(|soup| {
-                        // Each argument should be a single name
-                        if let Some(rowan_ast::Element::Name(name)) = soup.singleton() {
-                            if let Some(rowan_ast::Identifier::NormalIdentifier(normal)) =
-                                name.identifier()
-                            {
-                                Some(normal.text().to_string())
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    })
+                    .filter_map(|soup| parse_param_pattern(&soup))
                     .collect();
 
-                let (body, arg_vars) = desugar_declaration_body(decl, desugarer, &arg_names, span)?;
+                // If all patterns are Simple (no destructuring), use the
+                // existing fast path so as not to disturb existing behaviour.
+                let all_simple = patterns
+                    .iter()
+                    .all(|p| matches!(p, ParamPattern::Simple(_)));
 
-                Ok(RowanDeclarationComponents {
-                    span,
-                    metadata,
-                    name: func.text().to_string(),
-                    args: arg_names,
-                    body,
-                    arg_vars,
-                    is_operator: false,
-                    fixity: None,
-                })
+                if all_simple {
+                    let arg_names: Vec<String> = patterns
+                        .into_iter()
+                        .map(|p| match p {
+                            ParamPattern::Simple(n) => n,
+                            _ => unreachable!(),
+                        })
+                        .collect();
+                    let (body, arg_vars) =
+                        desugar_declaration_body(decl, desugarer, &arg_names, span)?;
+                    Ok(RowanDeclarationComponents {
+                        span,
+                        metadata,
+                        name: func.text().to_string(),
+                        args: arg_names,
+                        body,
+                        arg_vars,
+                        is_operator: false,
+                        fixity: None,
+                    })
+                } else {
+                    // At least one destructuring pattern — use pattern-aware
+                    // desugaring which injects synthetic params and let bindings.
+                    let (body, lambda_param_names, lambda_param_vars) =
+                        desugar_declaration_body_with_patterns(decl, desugarer, &patterns, span)?;
+                    Ok(RowanDeclarationComponents {
+                        span,
+                        metadata,
+                        name: func.text().to_string(),
+                        args: lambda_param_names,
+                        body,
+                        arg_vars: lambda_param_vars,
+                        is_operator: false,
+                        fixity: None,
+                    })
+                }
             }
             rowan_ast::DeclarationKind::Prefix(_, op, arg) => {
                 let args = vec![arg.text().to_string()];

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -186,10 +186,17 @@ impl<T: BoundTerm<String> + Clone> IntoIterator for BlockMap<T> {
 
 /// Used to tag lets that have a default block as body, to support
 /// optimisations that don't then need to work with the body.
+///
+/// `DestructureBlockLet` and `DestructureListLet` mark lets generated
+/// by desugaring a destructuring parameter pattern.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LetType {
     DefaultBlockLet,
     OtherLet,
+    /// Let generated from a block destructuring parameter `{x y}`
+    DestructureBlockLet,
+    /// Let generated from a list destructuring parameter `[a, b, c]`
+    DestructureListLet,
 }
 
 impl_bound_term_ignore!(LetType);

--- a/src/core/transform/destructure_fusion.rs
+++ b/src/core/transform/destructure_fusion.rs
@@ -1,0 +1,557 @@
+//! Destructure fusion pass: elide block/list construction on direct pattern match.
+//!
+//! When a function with a destructuring parameter is called with a literal
+//! block or list, this pass fuses the construction and deconstruction into
+//! direct bindings, avoiding the intermediate allocation.
+//!
+//! For block destructuring:
+//!
+//! ```text
+//! App(Lam([__p0], Let(DestructureBlockLet, [x = Lookup(__p0, "x"), y = Lookup(__p0, "y")], body)),
+//!     [Block({x: e_x, y: e_y})])
+//! ```
+//!
+//! becomes:
+//!
+//! ```text
+//! Let(OtherLet, [x = e_x, y = e_y], body)
+//! ```
+//!
+//! For fixed-length list destructuring:
+//!
+//! ```text
+//! App(Lam([__p0], Let(DestructureListLet, [a = HEAD(__p0), b = HEAD(TAIL(__p0))], body)),
+//!     [List([e_a, e_b])])
+//! ```
+//!
+//! becomes:
+//!
+//! ```text
+//! Let(OtherLet, [a = e_a, b = e_b], body)
+//! ```
+//!
+//! Head/tail patterns (where the tail binding is `xs = TAIL^n(__p0)`) are NOT
+//! fused because fusing the tail would require constructing a sub-list.
+//!
+//! This pass runs before the inline pass. It is conservative: it only fuses
+//! when the argument is a literal block or list (not a variable or computed
+//! value), and only when ALL bindings in the destructure let can be directly
+//! resolved from the literal.
+
+use crate::common::sourcemap::Smid;
+use crate::core::error::CoreError;
+use crate::core::expr::*;
+use moniker::*;
+
+/// Type alias for the let scope used in destructuring lets.
+type LetScope = Scope<Rec<Vec<(Binder<String>, Embed<RcExpr>)>>, RcExpr>;
+
+/// Run the destructure fusion pass over an expression.
+///
+/// Recursively walks the expression tree, fusing any directly applicable
+/// pattern.
+pub fn destructure_fusion(expr: &RcExpr) -> Result<RcExpr, CoreError> {
+    match &*expr.inner {
+        Expr::App(s, f, args) => {
+            // Recurse into the function first (in case it contains fuseable apps)
+            let f_reduced = destructure_fusion(f)?;
+            let args_reduced = args
+                .iter()
+                .map(destructure_fusion)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            // Attempt to fuse
+            let fused = try_fuse_app(*s, &f_reduced, &args_reduced)?;
+            match fused {
+                Some(result) => {
+                    // Recurse into the fused result (may expose more fusions)
+                    destructure_fusion(&result)
+                }
+                None => Ok(RcExpr::from(Expr::App(*s, f_reduced, args_reduced))),
+            }
+        }
+        _ => expr.try_walk_safe(&mut |e| destructure_fusion(e)),
+    }
+}
+
+/// Attempt to fuse `App(f, args)` where `f` is a lambda with destructuring lets.
+///
+/// Returns `Some(fused)` if fusion was possible, `None` if not applicable.
+fn try_fuse_app(s: Smid, f: &RcExpr, args: &[RcExpr]) -> Result<Option<RcExpr>, CoreError> {
+    // Only handle single-param lambdas with a single arg for simplicity
+    // (the common case for destructuring patterns)
+    if args.len() != 1 {
+        return Ok(None);
+    }
+
+    let arg = &args[0];
+
+    // The function must be a non-inline lambda
+    let lam_scope = match &*f.inner {
+        Expr::Lam(_, false, scope) => scope,
+        _ => return Ok(None),
+    };
+
+    // Unbind the lambda — this replaces the lambda param (now bound) with a fresh FreeVar
+    let (binders, body) = lam_scope.clone().unbind();
+
+    // Only handle exactly one param (the synthetic destructure param)
+    if binders.len() != 1 {
+        return Ok(None);
+    }
+
+    // The body (possibly wrapped in metadata) must be a DestructureBlockLet or
+    // DestructureListLet at the top level.
+    let (let_s, let_scope, let_type) = match top_destructure_let(&body) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    // Extract the FreeVar for the synthetic param (after unbind, it's a fresh FreeVar)
+    let p0_fv = match &binders[0] {
+        Binder(fv) => fv.clone(),
+    };
+
+    let _ = s;
+
+    match (let_type, &*arg.inner) {
+        (LetType::DestructureBlockLet, Expr::Block(_, block_map)) => {
+            // Try to fuse block destructuring with a block literal
+            try_fuse_block(let_s, &p0_fv, let_scope, block_map)
+        }
+        (LetType::DestructureListLet, Expr::List(_, list_items)) => {
+            // Try to fuse list destructuring with a list literal
+            try_fuse_list(let_s, &p0_fv, let_scope, list_items)
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Find the top-level destructure let in an expression, looking through
+/// metadata wrappers.
+fn top_destructure_let(expr: &RcExpr) -> Option<(Smid, LetScope, LetType)> {
+    match &*expr.inner {
+        Expr::Let(s, scope, lt @ LetType::DestructureBlockLet)
+        | Expr::Let(s, scope, lt @ LetType::DestructureListLet) => Some((*s, scope.clone(), *lt)),
+        Expr::Meta(_, inner, _) => top_destructure_let(inner),
+        _ => None,
+    }
+}
+
+/// Fuse block destructuring: replace `Lookup(__p0, field)` bindings with
+/// the corresponding block field values.
+///
+/// Only fuses if ALL bindings can be resolved directly. Returns `None`
+/// if any binding cannot be fused (e.g., field not present in literal).
+fn try_fuse_block(
+    let_s: Smid,
+    p0_fv: &FreeVar<String>,
+    let_scope: LetScope,
+    block_map: &BlockMap<RcExpr>,
+) -> Result<Option<RcExpr>, CoreError> {
+    let (binders, let_body) = let_scope.unbind();
+    let open_binders = binders.unrec();
+
+    // For each binding, check if it is `binding_var = Lookup(Var::Free(p0_fv), "field")`
+    // and if so, replace it with `binding_var = block_map[field]`.
+    let mut fused_bindings: Vec<(Binder<String>, Embed<RcExpr>)> = Vec::new();
+
+    for (binder, Embed(value)) in &open_binders {
+        match try_match_block_lookup(p0_fv, value, block_map) {
+            Some(field_val) => {
+                fused_bindings.push((binder.clone(), Embed(field_val)));
+            }
+            None => {
+                // Some binding could not be fused — do not fuse partially
+                return Ok(None);
+            }
+        }
+    }
+
+    // Check that __p0 is not referenced in the let body (outside the now-fused bindings).
+    // For a pure block destructure, __p0 should only appear in the Lookup calls.
+    if is_free_var_in(p0_fv, &let_body) {
+        // __p0 still needed in body — cannot eliminate without substitution
+        return Ok(None);
+    }
+
+    // Reconstruct as an OtherLet — the synthetic param is no longer needed
+    let result = RcExpr::from(Expr::Let(
+        let_s,
+        Scope::new(Rec::new(fused_bindings), let_body),
+        LetType::OtherLet,
+    ));
+
+    Ok(Some(result))
+}
+
+/// Match `Lookup(Var::Free(p0_fv), field_name, None)` and return the value
+/// from `block_map` for that field, if present.
+fn try_match_block_lookup(
+    p0_fv: &FreeVar<String>,
+    value: &RcExpr,
+    block_map: &BlockMap<RcExpr>,
+) -> Option<RcExpr> {
+    match &*value.inner {
+        Expr::Lookup(_, obj, field, None) => {
+            if is_exactly_free_var(obj, p0_fv) {
+                block_map.get(field).cloned()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Fuse list destructuring: replace `HEAD(TAIL^n(__p0))` bindings with
+/// the corresponding list element values.
+///
+/// Only fuses fixed-length element bindings (HEAD/TAIL chains). Tail
+/// bindings (`xs = TAIL^n(__p0)`) are NOT fused because constructing a
+/// sub-list at compile time would be more expensive than runtime access.
+fn try_fuse_list(
+    let_s: Smid,
+    p0_fv: &FreeVar<String>,
+    let_scope: LetScope,
+    list_items: &[RcExpr],
+) -> Result<Option<RcExpr>, CoreError> {
+    let (binders, let_body) = let_scope.unbind();
+    let open_binders = binders.unrec();
+
+    let mut fused_bindings: Vec<(Binder<String>, Embed<RcExpr>)> = Vec::new();
+
+    for (binder, Embed(value)) in &open_binders {
+        match try_match_list_access(p0_fv, value, list_items) {
+            Some(elem_val) => {
+                fused_bindings.push((binder.clone(), Embed(elem_val)));
+            }
+            None => {
+                // Cannot fuse this binding — do not fuse partially
+                return Ok(None);
+            }
+        }
+    }
+
+    // Check __p0 is not referenced in let_body outside the fused bindings
+    if is_free_var_in(p0_fv, &let_body) {
+        return Ok(None);
+    }
+
+    let result = RcExpr::from(Expr::Let(
+        let_s,
+        Scope::new(Rec::new(fused_bindings), let_body),
+        LetType::OtherLet,
+    ));
+
+    Ok(Some(result))
+}
+
+/// Match a list element access: `HEAD(TAIL^n(__p0))` for index `n`.
+///
+/// The pattern is: the value is `HEAD(tail_chain)` where `tail_chain` is
+/// zero or more `TAIL(...)` applications wrapping `Var::Free(p0_fv)`.
+///
+/// Returns the corresponding list item if the pattern matches and the index
+/// is within bounds.
+fn try_match_list_access(
+    p0_fv: &FreeVar<String>,
+    value: &RcExpr,
+    list_items: &[RcExpr],
+) -> Option<RcExpr> {
+    // The outer expression must be HEAD(...)
+    match &*value.inner {
+        Expr::App(_, head_f, head_args) if head_args.len() == 1 => {
+            if let Expr::Intrinsic(_, name) = &*head_f.inner {
+                if name != "HEAD" {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+
+            // Count TAIL applications inside HEAD's argument
+            let (inner, tail_count) = peel_tail_apps(&head_args[0]);
+
+            // The innermost expression must be Var::Free(p0_fv)
+            if is_exactly_free_var(inner, p0_fv) {
+                // This is HEAD(TAIL^tail_count(__p0)) — element at index tail_count
+                list_items.get(tail_count).cloned()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Peel off TAIL applications: `TAIL(TAIL(TAIL(e)))` → `(e, 3)`.
+fn peel_tail_apps(expr: &RcExpr) -> (&RcExpr, usize) {
+    match &*expr.inner {
+        Expr::App(_, f, args) if args.len() == 1 => {
+            if let Expr::Intrinsic(_, name) = &*f.inner {
+                if name == "TAIL" {
+                    let (inner, count) = peel_tail_apps(&args[0]);
+                    return (inner, count + 1);
+                }
+            }
+            (expr, 0)
+        }
+        _ => (expr, 0),
+    }
+}
+
+/// Check if `expr` is exactly `Var::Free(fv)` by unique identity.
+fn is_exactly_free_var(expr: &RcExpr, fv: &FreeVar<String>) -> bool {
+    match &*expr.inner {
+        Expr::Var(_, Var::Free(expr_fv)) => expr_fv == fv,
+        _ => false,
+    }
+}
+
+/// Check if a free variable appears anywhere in `expr`.
+fn is_free_var_in(fv: &FreeVar<String>, expr: &RcExpr) -> bool {
+    let mut found = false;
+    expr.visit_vars(&mut |var| {
+        if let Var::Free(expr_fv) = var {
+            if expr_fv == fv {
+                found = true;
+            }
+        }
+    });
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::expr::acore::*;
+    use crate::core::verify::binding;
+
+    fn lookup_free(fv: FreeVar<String>, field: &str) -> RcExpr {
+        RcExpr::from(Expr::Lookup(
+            Smid::default(),
+            var(fv),
+            field.to_string(),
+            None,
+        ))
+    }
+
+    fn destruct_block_let(
+        p0_fv: FreeVar<String>,
+        fields: &[(&str, &str)], // (field_name, binding_name)
+        body: RcExpr,
+    ) -> RcExpr {
+        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = fields
+            .iter()
+            .map(|(field, binding)| {
+                let binding_fv = free(binding);
+                (Binder(binding_fv), Embed(lookup_free(p0_fv.clone(), field)))
+            })
+            .collect();
+        RcExpr::from(Expr::Let(
+            Smid::default(),
+            Scope::new(Rec::new(bindings), body),
+            LetType::DestructureBlockLet,
+        ))
+    }
+
+    fn head_of(fv: FreeVar<String>) -> RcExpr {
+        app(bif("HEAD"), vec![var(fv)])
+    }
+
+    fn tail_of(fv: FreeVar<String>) -> RcExpr {
+        app(bif("TAIL"), vec![var(fv)])
+    }
+
+    fn head_tail_of(fv: FreeVar<String>, tail_count: usize) -> RcExpr {
+        let mut expr = var(fv);
+        for _ in 0..tail_count {
+            expr = app(bif("TAIL"), vec![expr]);
+        }
+        app(bif("HEAD"), vec![expr])
+    }
+
+    fn destruct_list_let(
+        p0_fv: FreeVar<String>,
+        elems: &[&str], // binding names for each position
+        body: RcExpr,
+    ) -> RcExpr {
+        let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = elems
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                let binding_fv = free(name);
+                (Binder(binding_fv), Embed(head_tail_of(p0_fv.clone(), i)))
+            })
+            .collect();
+        RcExpr::from(Expr::Let(
+            Smid::default(),
+            Scope::new(Rec::new(bindings), body),
+            LetType::DestructureListLet,
+        ))
+    }
+
+    #[test]
+    fn test_no_fusion_without_block_arg() {
+        // App(Lam([p0], Let(DestructureBlockLet, ...)), [non-block]) — should not fuse
+        let p0 = free("__p0");
+        let x = free("x");
+
+        let lam_body = destruct_block_let(p0.clone(), &[("x", "x")], var(x));
+        let input = app(lam(vec![p0], lam_body), vec![num(42)]);
+
+        let result = destructure_fusion(&input).unwrap();
+        // Should not fuse — 42 is not a Block
+        assert!(matches!(&*result.inner, Expr::App(_, _, _)));
+    }
+
+    #[test]
+    fn test_block_fusion_basic() {
+        // sum-xy({x y}): x + y  applied to  {x: 3, y: 4}
+        // → Let([x = 3, y = 4], x + y)
+        let p0 = free("__p0");
+        let x = free("x");
+        let y = free("y");
+
+        let body = app(bif("+"), vec![var(x.clone()), var(y.clone())]);
+        let lam_body = destruct_block_let(p0.clone(), &[("x", "x"), ("y", "y")], body);
+        let f = lam(vec![p0], lam_body);
+
+        let block_arg = block(vec![("x".to_string(), num(3)), ("y".to_string(), num(4))]);
+
+        let input = app(f, vec![block_arg]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Result should be a Let (not an App)
+        assert!(
+            matches!(&*result.inner, Expr::Let(_, _, LetType::OtherLet)),
+            "Expected Let(OtherLet), got: {:?}",
+            &*result.inner
+        );
+
+        // Binding check
+        binding::verify(&result).expect("binding check failed after block fusion");
+    }
+
+    #[test]
+    fn test_block_fusion_field_missing() {
+        // Block literal is missing a field that the destructure expects — no fusion
+        let p0 = free("__p0");
+        let x = free("x");
+        let z = free("z");
+
+        // Destructures x and z, but block only has x
+        let body = app(bif("+"), vec![var(x.clone()), var(z.clone())]);
+        let lam_body = destruct_block_let(p0.clone(), &[("x", "x"), ("z", "z")], body);
+        let f = lam(vec![p0], lam_body);
+
+        let block_arg = block(vec![("x".to_string(), num(3))]); // no "z" field
+
+        let input = app(f, vec![block_arg]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Should not fuse (z field missing)
+        assert!(matches!(&*result.inner, Expr::App(_, _, _)));
+    }
+
+    #[test]
+    fn test_list_fusion_basic() {
+        // add-pair([a, b]): a + b  applied to  [10, 20]
+        // → Let([a = 10, b = 20], a + b)
+        let p0 = free("__p0");
+        let a = free("a");
+        let b = free("b");
+
+        let body = app(bif("+"), vec![var(a.clone()), var(b.clone())]);
+        let lam_body = destruct_list_let(p0.clone(), &["a", "b"], body);
+        let f = lam(vec![p0], lam_body);
+
+        let list_arg = list(vec![num(10), num(20)]);
+
+        let input = app(f, vec![list_arg]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Result should be a Let (not an App)
+        assert!(
+            matches!(&*result.inner, Expr::Let(_, _, LetType::OtherLet)),
+            "Expected Let(OtherLet), got: {:?}",
+            &*result.inner
+        );
+
+        // Binding check
+        binding::verify(&result).expect("binding check failed after list fusion");
+    }
+
+    #[test]
+    fn test_list_fusion_out_of_bounds() {
+        // List literal has fewer elements than destructure expects — no fusion
+        let p0 = free("__p0");
+        let a = free("a");
+        let b = free("b");
+
+        let body = app(bif("+"), vec![var(a.clone()), var(b.clone())]);
+        // Destructures [a, b, c] but literal only has [10, 20]
+        let lam_body = destruct_list_let(p0.clone(), &["a", "b", "c"], body);
+        let f = lam(vec![p0], lam_body);
+
+        let list_arg = list(vec![num(10), num(20)]);
+
+        let input = app(f, vec![list_arg]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Should not fuse (c out of bounds)
+        assert!(matches!(&*result.inner, Expr::App(_, _, _)));
+    }
+
+    #[test]
+    fn test_no_fusion_for_variable_arg() {
+        // App(Lam([p0], DestructureBlockLet), [Var(x)]) — arg is a variable, not literal
+        let p0 = free("__p0");
+        let x = free("x");
+        let y = free("y");
+
+        let body = var(y.clone());
+        let lam_body = destruct_block_let(p0.clone(), &[("y", "y")], body);
+        let f = lam(vec![p0], lam_body);
+
+        // Arg is a variable, not a block literal
+        let input = app(f, vec![var(x)]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Should not fuse
+        assert!(matches!(&*result.inner, Expr::App(_, _, _)));
+    }
+
+    #[test]
+    fn test_head_tail_not_fused() {
+        // Head/tail pattern [a : xs] — tail binding cannot be fused (no sub-list construction)
+        // Destructure: a = HEAD(__p0), xs = TAIL(__p0)
+        // The TAIL binding does not match the HEAD(TAIL^n) pattern, so fusion fails
+        let p0 = free("__p0");
+        let a = free("a");
+        let xs = free("xs");
+
+        let body = var(a.clone());
+
+        // Bindings: a = HEAD(__p0), xs = TAIL(__p0)
+        let bindings = vec![
+            (Binder(a.clone()), Embed(head_of(p0.clone()))),
+            (Binder(xs.clone()), Embed(tail_of(p0.clone()))),
+        ];
+        let lam_body = RcExpr::from(Expr::Let(
+            Smid::default(),
+            Scope::new(Rec::new(bindings), body),
+            LetType::DestructureListLet,
+        ));
+
+        let f = lam(vec![p0], lam_body);
+        let list_arg = list(vec![num(1), num(2), num(3)]);
+
+        let input = app(f, vec![list_arg]);
+        let result = destructure_fusion(&input).unwrap();
+
+        // Should not fuse (xs = TAIL(__p0) is not a HEAD pattern)
+        assert!(matches!(&*result.inner, Expr::App(_, _, _)));
+    }
+}

--- a/src/core/transform/mod.rs
+++ b/src/core/transform/mod.rs
@@ -1,2 +1,3 @@
+pub mod destructure_fusion;
 pub mod dynamise;
 pub mod succ;

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -149,6 +149,15 @@ pub fn prepare(
         return Ok(Command::Exit);
     }
 
+    // Fuse destructuring patterns with literal block/list arguments
+    {
+        let t = Instant::now();
+
+        loader.fuse_destructuring()?;
+
+        stats.record("fuse-destructuring", t.elapsed());
+    }
+
     // Prune unused bindings to reduce inline overhead
     if !opt.no_dce() {
         let t = Instant::now();

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -8,6 +8,7 @@ use crate::core::inline::reduce;
 use crate::core::inline::tag;
 use crate::core::simplify::compress;
 use crate::core::simplify::prune;
+use crate::core::transform::destructure_fusion;
 use crate::core::unit::TranslationUnit;
 use crate::core::verify::content;
 use crate::driver::error::EucalyptError;
@@ -405,6 +406,13 @@ impl SourceLoader {
     /// application tree and to handle expression anaphora
     pub fn cook(&mut self) -> Result<(), EucalyptError> {
         self.core.expr = cook::cook(self.core.expr.clone())?;
+        Ok(())
+    }
+
+    /// Run the destructure fusion pass to elide block/list construction when
+    /// a destructuring function is called with a literal argument.
+    pub fn fuse_destructuring(&mut self) -> Result<(), EucalyptError> {
+        self.core.expr = destructure_fusion::destructure_fusion(&self.core.expr)?;
         Ok(())
     }
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -698,6 +698,16 @@ lazy_static! {
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 131
+            name: "LIST.NTH",
+            ty: function(vec![list(), num(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
+    Intrinsic { // 132
+            name: "LIST.DROP",
+            ty: function(vec![num(), list(), list()]).unwrap(),
+            strict: vec![0, 1],
+    },
     ];
 }
 

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -7,7 +7,10 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::intrinsic::{CallGlobal1, CallGlobal2, Const, IntrinsicMachine, StgIntrinsic},
+        machine::{
+            env::SynClosure,
+            intrinsic::{CallGlobal1, CallGlobal2, Const, IntrinsicMachine, StgIntrinsic},
+        },
         memory::{mutator::MutatorHeapView, syntax::Ref},
     },
 };
@@ -15,13 +18,17 @@ use crate::{
 use super::{
     force::SeqNumList,
     panic::Panic,
-    support::{collect_num_list, machine_return_bool, machine_return_num_list},
+    support::{
+        collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
+    },
     syntax::{
         dsl::{annotated_lambda, app_bif, case, data, force, local, lref, str, value},
         LambdaForm,
     },
     tags::DataConstructor,
 };
+
+use crate::eval::memory::syntax::HeapSyn;
 
 /// A constant for CONS
 pub struct Cons;
@@ -174,3 +181,106 @@ impl StgIntrinsic for SortNumList {
 }
 
 impl CallGlobal1 for SortNumList {}
+
+/// LIST.NTH(list, n) — return the nth element (0-indexed) of a list.
+///
+/// Both arguments are forced (strict: [0, 1]). The list must be a
+/// fully-evaluated cons structure. Panics if the list has fewer than
+/// n+1 elements.
+pub struct ListNth;
+
+impl StgIntrinsic for ListNth {
+    fn name(&self) -> &str {
+        "LIST.NTH"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = {
+            let num = num_arg(machine, view, &args[1])?;
+            num.as_u64().unwrap_or(0) as usize
+        };
+        let mut iter = data_list_arg(machine, view, args[0].clone())?;
+        let mut current: Option<SynClosure> = None;
+        for _ in 0..=n {
+            current = iter.next().transpose()?;
+        }
+        match current {
+            Some(closure) => machine.set_closure(closure),
+            None => Err(ExecutionError::Panic(format!(
+                "LIST.NTH: index {} out of bounds",
+                n
+            ))),
+        }
+    }
+}
+
+impl CallGlobal2 for ListNth {}
+
+/// LIST.DROP(n, list) — drop the first n elements and return the remainder.
+///
+/// Both arguments are forced (strict: [0, 1]). The list must be a
+/// fully-evaluated cons structure. Returns an empty list if n exceeds
+/// the list length.
+pub struct ListDrop;
+
+impl StgIntrinsic for ListDrop {
+    fn name(&self) -> &str {
+        "LIST.DROP"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = {
+            let num = num_arg(machine, view, &args[0])?;
+            num.as_u64().unwrap_or(0) as usize
+        };
+
+        // Navigate through the cons structure, skipping n elements.
+        // We traverse the tail links directly so we can return the
+        // remaining cons cell (rather than reconstructing the list).
+        let mut closure = machine.nav(view).resolve(&args[1])?;
+        for _ in 0..n {
+            let code = view.scoped(closure.code());
+            match &*code {
+                HeapSyn::Cons { tag, args: cons_args } => {
+                    match (*tag).try_into() {
+                        Ok(DataConstructor::ListCons) => {
+                            let tail_ref = cons_args.get(1).ok_or_else(|| {
+                                ExecutionError::Panic("malformed cons cell".to_string())
+                            })?;
+                            closure = closure.navigate_local(&view, tail_ref);
+                        }
+                        Ok(DataConstructor::ListNil) => {
+                            // Ran out of elements — return the nil (empty list)
+                            return machine.set_closure(closure);
+                        }
+                        _ => {
+                            return Err(ExecutionError::Panic(
+                                "LIST.DROP: expected list".to_string(),
+                            ));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ExecutionError::Panic(
+                        "LIST.DROP: expected list".to_string(),
+                    ));
+                }
+            }
+        }
+        machine.set_closure(closure)
+    }
+}
+
+impl CallGlobal2 for ListDrop {}

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -253,7 +253,10 @@ impl StgIntrinsic for ListDrop {
         for _ in 0..n {
             let code = view.scoped(closure.code());
             match &*code {
-                HeapSyn::Cons { tag, args: cons_args } => {
+                HeapSyn::Cons {
+                    tag,
+                    args: cons_args,
+                } => {
                     match (*tag).try_into() {
                         Ok(DataConstructor::ListCons) => {
                             let tail_ref = cons_args.get(1).ok_or_else(|| {

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -174,6 +174,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
+    rt.add(Box::new(list::ListNth));
+    rt.add(Box::new(list::ListDrop));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -708,11 +708,11 @@ impl DeclarationHead {
                     if let Some(args) = args {
                         let mut errors = vec![];
                         for arg in args.items() {
-                            if arg
+                            let valid = arg
                                 .singleton()
-                                .and_then(|e| e.as_normal_identifier())
-                                .is_none()
-                            {
+                                .map(|e| e.is_valid_param_pattern())
+                                .unwrap_or(false);
+                            if !valid {
                                 errors.push(ParseError::InvalidFormalParameter {
                                     head_range: self.syntax().text_range(),
                                     range: arg.syntax().text_range(),
@@ -1138,6 +1138,27 @@ impl Element {
                 _ => None,
             }),
             _ => None,
+        }
+    }
+
+    /// Return true if this element is a valid formal parameter pattern.
+    ///
+    /// A valid parameter is one of:
+    /// - A normal identifier: `x`
+    /// - A block pattern (block destructuring): `{x y}`
+    /// - A list pattern (list destructuring): `[a, b, c]`
+    pub fn is_valid_param_pattern(&self) -> bool {
+        match self {
+            Element::Name(n) => n
+                .identifier()
+                .and_then(|id| match id {
+                    Identifier::NormalIdentifier(_) => Some(()),
+                    _ => None,
+                })
+                .is_some(),
+            Element::Block(_) => true,
+            Element::List(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -784,7 +784,13 @@ impl Block {
     }
 
     pub fn open_brace(&self) -> Option<SyntaxToken> {
-        support::syntax_token(self.syntax(), SyntaxKind::OPEN_BRACE)
+        // Accept both OPEN_BRACE and OPEN_BRACE_APPLY (juxtaposed call sugar)
+        self.0
+            .children_with_tokens()
+            .filter_map(|it| it.into_token())
+            .find(|t| {
+                t.kind() == SyntaxKind::OPEN_BRACE || t.kind() == SyntaxKind::OPEN_BRACE_APPLY
+            })
     }
 
     pub fn close_brace(&self) -> Option<SyntaxToken> {
@@ -802,6 +808,16 @@ impl List {
     pub fn items(&self) -> AstChildren<Soup> {
         support::children::<Soup>(&self.0)
     }
+
+    /// Returns true if this list contains a `:` head/tail separator.
+    ///
+    /// Used to detect `[x : xs]` and `[a, b : rest]` patterns in
+    /// function parameter positions.
+    pub fn has_colon(&self) -> bool {
+        self.0
+            .children_with_tokens()
+            .any(|it| it.as_token().is_some_and(|t| t.kind() == SyntaxKind::COLON))
+    }
 }
 
 // Function application arguments tuple
@@ -817,6 +833,20 @@ impl ApplyTuple {
 
     pub fn open_paren(&self) -> Option<SyntaxToken> {
         support::syntax_token(self.syntax(), SyntaxKind::OPEN_PAREN_APPLY)
+    }
+
+    /// Returns true if this tuple was created from juxtaposed `f{...}` syntax.
+    pub fn is_block_apply(&self) -> bool {
+        self.0
+            .first_token()
+            .is_some_and(|t| t.kind() == SyntaxKind::OPEN_BRACE_APPLY)
+    }
+
+    /// Returns true if this tuple was created from juxtaposed `f[...]` syntax.
+    pub fn is_list_apply(&self) -> bool {
+        self.0
+            .first_token()
+            .is_some_and(|t| t.kind() == SyntaxKind::OPEN_SQUARE_APPLY)
     }
 
     pub fn close_paren(&self) -> Option<SyntaxToken> {

--- a/src/syntax/rowan/kind.rs
+++ b/src/syntax/rowan/kind.rs
@@ -5,10 +5,12 @@
 #[repr(u16)]
 pub enum SyntaxKind {
     OPEN_BRACE,              // '{'
+    OPEN_BRACE_APPLY,        // '{' in application context (f{...})
     CLOSE_BRACE,             // '}
     BACKTICK,                // '`'`
     COLON,                   // ':'
     OPEN_SQUARE,             // '['
+    OPEN_SQUARE_APPLY,       // '[' in application context (f[...])
     CLOSE_SQUARE,            // ']'
     COMMA,                   // ','
     WHITESPACE,              // any unicode whitespace
@@ -116,6 +118,7 @@ impl SyntaxKind {
     pub fn is_callable_terminal(&self) -> bool {
         *self == CLOSE_PAREN
             || *self == CLOSE_BRACE
+            || *self == CLOSE_SQUARE
             || *self == UNQUOTED_IDENTIFIER
             || *self == STRING_PATTERN_END
             || *self == C_STRING_PATTERN_END

--- a/src/syntax/rowan/lex.rs
+++ b/src/syntax/rowan/lex.rs
@@ -520,6 +520,32 @@ where
         }
     }
 
+    /// Read `{` as either an open brace or the start of a juxtaposed block call.
+    ///
+    /// `f{x: 1}` (no space between `f` and `{`) is sugar for `f({x: 1})`.
+    fn brace(&mut self, i: ByteIndex) -> (SyntaxKind, Span) {
+        let brace_offset = ByteOffset::from_char_len('{');
+        match self.last_token {
+            Some(ref tok) if tok.is_callable_terminal() && !self.whitespace_since_last_token => {
+                (OPEN_BRACE_APPLY, Span::new(i, i + brace_offset))
+            }
+            _ => (OPEN_BRACE, Span::new(i, i + brace_offset)),
+        }
+    }
+
+    /// Read `[` as either an open square bracket or the start of a juxtaposed list call.
+    ///
+    /// `f[1, 2]` (no space between `f` and `[`) is sugar for `f([1, 2])`.
+    fn square(&mut self, i: ByteIndex) -> (SyntaxKind, Span) {
+        let square_offset = ByteOffset::from_char_len('[');
+        match self.last_token {
+            Some(ref tok) if tok.is_callable_terminal() && !self.whitespace_since_last_token => {
+                (OPEN_SQUARE_APPLY, Span::new(i, i + square_offset))
+            }
+            _ => (OPEN_SQUARE, Span::new(i, i + square_offset)),
+        }
+    }
+
     /// check whether next character matches supplied predicate
     fn lookahead<P>(&mut self, predicate: P) -> bool
     where
@@ -581,9 +607,9 @@ where
         }
 
         let ret = match self.bump() {
-            Some((i, '{')) => Some((OPEN_BRACE, Span::new(i, i + ONE_BYTE))),
+            Some((i, '{')) => Some(self.brace(i)),
             Some((i, '}')) => Some((CLOSE_BRACE, Span::new(i, i + ONE_BYTE))),
-            Some((i, '[')) => Some((OPEN_SQUARE, Span::new(i, i + ONE_BYTE))),
+            Some((i, '[')) => Some(self.square(i)),
             Some((i, ']')) => Some((CLOSE_SQUARE, Span::new(i, i + ONE_BYTE))),
             Some((i, '(')) => Some(self.paren(i)),
             Some((i, ')')) => Some((CLOSE_PAREN, Span::new(i, i + ONE_BYTE))),

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -233,6 +233,16 @@ impl<'text> Parser<'text> {
                 self.parse_block_expression();
                 true
             }
+            Some((OPEN_BRACE_APPLY, _)) => {
+                // f{x: 1} — juxtaposed block call: sugar for f({x: 1})
+                self.parse_block_apply_tuple();
+                true
+            }
+            Some((OPEN_SQUARE_APPLY, _)) => {
+                // f[1, 2] — juxtaposed list call: sugar for f([1, 2])
+                self.parse_list_apply_tuple();
+                true
+            }
             Some((RESERVED_OPEN, _)) => {
                 self.parse_reserved_paren_expression();
                 true
@@ -250,10 +260,17 @@ impl<'text> Parser<'text> {
                 self.sink().token(k);
                 self.add_trivia();
                 while self.try_parse_soup() {
-                    if !self.try_accept(COMMA) {
+                    if self.try_accept(COMMA) {
+                        self.add_trivia();
+                    } else if self.try_accept(COLON) {
+                        // Head/tail separator in list pattern: [heads... : tail]
+                        // Emit the colon token and parse exactly one more soup.
+                        self.add_trivia();
+                        self.try_parse_soup();
+                        break;
+                    } else {
                         break;
                     }
-                    self.add_trivia();
                 }
                 self.add_trivia();
                 self.expect(CLOSE_SQUARE);
@@ -350,6 +367,53 @@ impl<'text> Parser<'text> {
         // if instead unterminated, there will be a missing close paren
 
         self.sink().finish_node();
+    }
+
+    /// Parse a juxtaposed block call `f{x: 1}` as an `ARG_TUPLE` containing a single block.
+    ///
+    /// This desugars `f{x: 1}` to the same AST as `f({x: 1})`.
+    fn parse_block_apply_tuple(&mut self) {
+        self.sink().start_node(ARG_TUPLE);
+        self.sink().start_node(SOUP);
+        self.sink().start_node(BLOCK);
+        // Consume the OPEN_BRACE_APPLY token as-is.
+        self.expect(OPEN_BRACE_APPLY);
+        self.add_trivia();
+        self.parse_block_content();
+        self.add_trivia();
+        self.expect(CLOSE_BRACE);
+        self.sink().finish_node(); // BLOCK
+        self.sink().finish_node(); // SOUP
+        self.sink().finish_node(); // ARG_TUPLE
+    }
+
+    /// Parse a juxtaposed list call `f[1, 2]` as an `ARG_TUPLE` containing a single list.
+    ///
+    /// This desugars `f[1, 2]` to the same AST as `f([1, 2])`.
+    fn parse_list_apply_tuple(&mut self) {
+        self.sink().start_node(ARG_TUPLE);
+        self.sink().start_node(SOUP);
+        self.sink().start_node(LIST);
+        // Consume the OPEN_SQUARE_APPLY token as-is.
+        self.expect(OPEN_SQUARE_APPLY);
+        self.add_trivia();
+        while self.try_parse_soup() {
+            if self.try_accept(COMMA) {
+                self.add_trivia();
+            } else if self.try_accept(COLON) {
+                // Head/tail separator inside a list apply argument
+                self.add_trivia();
+                self.try_parse_soup();
+                break;
+            } else {
+                break;
+            }
+        }
+        self.add_trivia();
+        self.expect(CLOSE_SQUARE);
+        self.sink().finish_node(); // LIST
+        self.sink().finish_node(); // SOUP
+        self.sink().finish_node(); // ARG_TUPLE
     }
 
     /// Parse a block expression (next token is '{')

--- a/src/syntax/rowan/validate.rs
+++ b/src/syntax/rowan/validate.rs
@@ -319,7 +319,10 @@ impl Validatable for ApplyTuple {
         for item in self.items() {
             item.validate(errors);
         }
-        if self.close_paren().is_none() {
+        // Block/list apply tuples (`f{...}` and `f[...]`) have no close paren —
+        // their closing delimiter is `}` or `]` respectively.
+        let is_juxtaposed = self.is_block_apply() || self.is_list_apply();
+        if !is_juxtaposed && self.close_paren().is_none() {
             errors.push(ParseError::InvalidParenExpr {
                 open_paren_range: self.open_paren().map(|op| op.text_range()),
                 range: self.syntax().text_range(),

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -430,6 +430,11 @@ pub fn test_harness_090() {
 }
 
 #[test]
+pub fn test_harness_091() {
+    run_test(&opts("091_destructure_block.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -435,6 +435,11 @@ pub fn test_harness_091() {
 }
 
 #[test]
+pub fn test_harness_092() {
+    run_test(&opts("092_destructure_list.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -440,6 +440,21 @@ pub fn test_harness_092() {
 }
 
 #[test]
+pub fn test_harness_093() {
+    run_test(&opts("093_cons_operator.eu"));
+}
+
+#[test]
+pub fn test_harness_094() {
+    run_test(&opts("094_juxtaposed_call.eu"));
+}
+
+#[test]
+pub fn test_harness_095() {
+    run_test(&opts("095_destructuring_integration.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }
@@ -674,4 +689,19 @@ pub fn test_error_040() {
 #[test]
 pub fn test_error_041() {
     run_error_test(&error_opts("041_modulo_by_zero.eu"));
+}
+
+#[test]
+pub fn test_error_042() {
+    run_error_test(&error_opts("042_destructure_missing_field.eu"));
+}
+
+#[test]
+pub fn test_error_043() {
+    run_error_test(&error_opts("043_destructure_short_list.eu"));
+}
+
+#[test]
+pub fn test_error_044() {
+    run_error_test(&error_opts("044_destructure_empty_cons.eu"));
 }


### PR DESCRIPTION
## Summary

- **eu-8bgw**: Implements a core-to-core optimisation pass that detects when a destructuring function is called with a literal block or list argument, and fuses the construction/deconstruction into direct let bindings.
- Runs after `cook` and before the first dead-code elimination pass in the compilation pipeline.
- Conservative: only fuses when ALL bindings in the destructure let can be resolved directly from the literal. Partial fusion is not attempted.

## How it works

**Block destructuring fusion:**
```
App(Lam([__p0], Let(DestructureBlockLet, [x = Lookup(__p0, "x"), y = Lookup(__p0, "y")], body)),
    [Block({x: e_x, y: e_y})])
→ Let(OtherLet, [x = e_x, y = e_y], body)
```

**Fixed-length list destructuring fusion:**
```
App(Lam([__p0], Let(DestructureListLet, [a = HEAD(__p0), b = HEAD(TAIL(__p0))], body)),
    [List([e_a, e_b])])
→ Let(OtherLet, [a = e_a, b = e_b], body)
```

**Not fused:** Head/tail patterns (`[a : xs]`), because the tail binding `xs = TAIL^n(__p0)` would require constructing a sub-list at compile time. Also not fused: variable/computed arguments (only literal Block/List), or patterns where a field is missing from the literal.

## Implementation notes

Uses moniker's `unbind()` to open the lambda scope and get fresh free variables for the synthetic params. After unbind, the embedded let binding values contain free variable references that can be pattern-matched to identify Lookup/HEAD-TAIL chains and resolve them against the literal.

Free variable identity is compared by `unique_id` (not pretty name) for correctness.

## Test plan

- [x] 7 unit tests covering block fusion, list fusion, and all non-fusion cases
- [x] All 133 existing harness tests pass (including destructuring tests 092-095)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

## Part of eu-spqy (destructuring epic)

This is the final subtask required to close eu-spqy. Depends on PR #311 (head/tail destructuring, cons operator, juxtaposed call syntax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)