### PR TITLE
fix: hint for string concatenation when ++ is used on strings

### DIFF
--- a/harness/test/errors/047_str_plus_plus.eu
+++ b/harness/test/errors/047_str_plus_plus.eu
@@ -1,0 +1,3 @@
+# Error test: using ++ to concatenate strings (++ is list append, not string concat)
+greeting: "Hello, " ++ "World!"
+RESULT: greeting

--- a/harness/test/errors/047_str_plus_plus.eu.expect
+++ b/harness/test/errors/047_str_plus_plus.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "to concatenate strings, use string interpolation"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -413,15 +413,25 @@ impl ExecutionError {
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {
                 data_tag_mismatch_notes(*actual, expected)
             }
-            ExecutionError::NoBranchForNative(_, _) => {
-                vec![
+            ExecutionError::NoBranchForNative(_, type_desc) => {
+                let mut notes = vec![
                     "list operations such as 'head', 'tail', '++', 'map', 'filter' require \
                      list arguments"
                         .to_string(),
                     "check that the value is a list before applying list operations; \
                      use 'nil?' to test for an empty list"
                         .to_string(),
-                ]
+                ];
+                // When the value is a string, the user may be trying to concatenate
+                // strings using '++' (which is list append). Suggest alternatives.
+                if type_desc == "string" {
+                    notes.push(
+                        "note: to concatenate strings, use string interpolation \
+                         or 'join-on' on a list of strings; '++' is for list append"
+                            .to_string(),
+                    );
+                }
+                notes
             }
             ExecutionError::BlackHole(_) => {
                 vec![

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -700,3 +700,8 @@ pub fn test_error_045() {
 pub fn test_error_046() {
     run_error_test(&error_opts("046_import_keyword.eu"));
 }
+
+#[test]
+pub fn test_error_047() {
+    run_error_test(&error_opts("047_str_plus_plus.eu"));
+}


### PR DESCRIPTION
## Error message: string concatenation via ++ (list append operator)

### Scenario
A user coming from Python, JavaScript, or similar languages may try to concatenate strings using \`++\`:
\`\`\`eucalypt
greeting: "Hello, " ++ "World!"
\`\`\`
In eucalypt, \`++\` is the list append operator, not a string concatenation operator.

### Before
\`\`\`
error: type mismatch: received a string where a structured value (block or list) was expected
 = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
 = check that the value is a list before applying list operations; use 'nil?' to test for an empty list
\`\`\`

### After
\`\`\`
error: type mismatch: received a string where a structured value (block or list) was expected
 = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
 = check that the value is a list before applying list operations; use 'nil?' to test for an empty list
 = note: to concatenate strings, use string interpolation or 'join-on' on a list of strings; '++' is for list append
\`\`\`

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: good → excellent

### Change
Added a type-specific note in `ExecutionError::NoBranchForNative` handling in `src/eval/error.rs`. When the native type description is "string", an additional note is shown suggesting string interpolation or `join-on` as the correct approach.

A new error test `047_str_plus_plus.eu` exercises this hint.

### Risks
Low. The change is purely additive. The "string" type description also appears for some number-based errors (a pre-existing oddity in the VM), but the hint remains harmless in those cases — users trying to apply list operations to numbers will understand the note does not apply to them.