### PR TITLE
fix: improve ZDT literal error messages with format hints and reason discrimination

### DIFF
--- a/harness/test/errors/024_invalid_zdt_literal.eu.expect
+++ b/harness/test/errors/024_invalid_zdt_literal.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "invalid date/time literal"
+stderr: "date/time literal contains an invalid date"

--- a/harness/test/errors/026_empty_zdt_literal.eu.expect
+++ b/harness/test/errors/026_empty_zdt_literal.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "invalid date/time literal"
+stderr: "date/time literal cannot be empty"

--- a/src/driver/lsp/diagnostics.rs
+++ b/src/driver/lsp/diagnostics.rs
@@ -49,7 +49,7 @@ fn error_range(error: &ParseError) -> TextRange {
         | ParseError::ReservedCharacter { range }
         | ParseError::EmptyExpression { range }
         | ParseError::UnclosedStringInterpolation { range }
-        | ParseError::InvalidZdtLiteral { range } => *range,
+        | ParseError::InvalidZdtLiteral { range, .. } => *range,
         ParseError::MissingDeclarationColon { head_range } => *head_range,
     }
 }

--- a/src/syntax/error.rs
+++ b/src/syntax/error.rs
@@ -116,7 +116,7 @@ fn rowan_error_range(error: &RowanParseError) -> Option<rowan::TextRange> {
         | ReservedCharacter { range }
         | EmptyExpression { range }
         | UnclosedStringInterpolation { range }
-        | InvalidZdtLiteral { range } => Some(*range),
+        | InvalidZdtLiteral { range, .. } => Some(*range),
         MissingDeclarationColon { head_range } => Some(*head_range),
     }
 }

--- a/src/syntax/rowan/error.rs
+++ b/src/syntax/rowan/error.rs
@@ -61,7 +61,21 @@ pub enum ParseError {
     },
     InvalidZdtLiteral {
         range: TextRange,
+        /// A brief description of why the literal is invalid
+        reason: ZdtInvalidReason,
     },
+}
+
+/// The reason a `t"..."` date/time literal is invalid
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ZdtInvalidReason {
+    /// The string is empty
+    Empty,
+    /// The string looks like a date/time (starts with digits in YYYY-MM-DD
+    /// form) but the date itself does not exist (e.g. February 30)
+    InvalidDate,
+    /// The string does not match any recognised date/time format
+    Malformed,
 }
 
 impl fmt::Display for ParseError {
@@ -100,7 +114,29 @@ impl fmt::Display for ParseError {
             ParseError::UnclosedStringInterpolation { .. } => {
                 write!(f, "unterminated string interpolation (missing '}}')")
             }
-            ParseError::InvalidZdtLiteral { .. } => write!(f, "invalid date/time literal"),
+            ParseError::InvalidZdtLiteral { reason, .. } => match reason {
+                ZdtInvalidReason::Empty => write!(
+                    f,
+                    "date/time literal cannot be empty\n  \
+                     help: the t-string syntax requires a valid ISO 8601 date or date-time, \
+                     e.g. 2023-01-15 or 2023-01-15T10:30:00Z"
+                ),
+                ZdtInvalidReason::InvalidDate => write!(
+                    f,
+                    "date/time literal contains an invalid date\n  \
+                     help: check that the day exists in the given month and year \
+                     (e.g. February has at most 29 days, and only in a leap year)"
+                ),
+                ZdtInvalidReason::Malformed => write!(
+                    f,
+                    "invalid date/time literal\n  \
+                     help: the t-string syntax requires ISO 8601 format, \
+                     e.g. 2023-01-15 or 2023-01-15T10:30:00Z\n  \
+                     help: supported formats: \
+                     YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SSZ, \
+                     YYYY-MM-DDTHH:MM:SS+HH:MM"
+                ),
+            },
         }
     }
 }

--- a/src/syntax/rowan/validate.rs
+++ b/src/syntax/rowan/validate.rs
@@ -2,7 +2,29 @@
 
 use rowan::ast::AstNode;
 
-use super::{ast::*, lex::parse_zdt_literal, ParseError};
+use super::{ast::*, error::ZdtInvalidReason, lex::parse_zdt_literal, ParseError};
+
+/// Classify why a `t"..."` date/time literal is invalid.
+///
+/// Heuristic: if the string is empty, report `Empty`; if it looks like a
+/// date/time pattern (starts with four digits followed by `-`) but fails
+/// to parse, report `InvalidDate`; otherwise report `Malformed`.
+fn zdt_invalid_reason(content: &str) -> ZdtInvalidReason {
+    if content.is_empty() {
+        return ZdtInvalidReason::Empty;
+    }
+    // A rough check: starts with YYYY- (four digits then a hyphen), which
+    // suggests the user intended to write a date/time literal in the right
+    // format but with an impossible calendar value.
+    let looks_like_date = content.len() >= 5
+        && content.as_bytes()[..4].iter().all(|b| b.is_ascii_digit())
+        && content.as_bytes()[4] == b'-';
+    if looks_like_date {
+        ZdtInvalidReason::InvalidDate
+    } else {
+        ZdtInvalidReason::Malformed
+    }
+}
 
 /// Trait for `AstNode`s and `AstToken`s that may be created for
 /// invalid source text.
@@ -103,8 +125,10 @@ impl Validatable for TStr {
         }
         if let Some(content) = self.value() {
             if parse_zdt_literal(content).is_none() {
+                let reason = zdt_invalid_reason(content);
                 errors.push(ParseError::InvalidZdtLiteral {
                     range: self.syntax().text_range(),
+                    reason,
                 });
             }
         }


### PR DESCRIPTION
## Error message: invalid date/time literal — three cases with distinct hints

### Scenario
`t"..."` ZDT (zoned date/time) literals produce a parse error when invalid.
Previously all three failure modes — empty literal, valid-looking date that
does not exist in the calendar (e.g. February 30), and completely malformed
content — all produced the same unhelpful message: `invalid date/time literal`.

### Before

**Empty literal** (`t""`):
```
error: invalid date/time literal
  --> file.eu:1:4
   |
 1 | x: t""
   |    ^^^
```

**Invalid calendar date** (`t"2023-02-30"`):
```
error: invalid date/time literal
  --> file.eu:1:4
   |
 1 | x: t"2023-02-30"
   |    ^^^^^^^^^^^^^
```

**Completely malformed** (`t"not-a-date"`):
```
error: invalid date/time literal
  --> file.eu:1:4
   |
 1 | x: t"not-a-date"
   |    ^^^^^^^^^^^^^
```

### After

**Empty literal** (`t""`):
```
error: date/time literal cannot be empty
  help: the t-string syntax requires a valid ISO 8601 date or date-time,
        e.g. 2023-01-15 or 2023-01-15T10:30:00Z
  --> file.eu:1:4
   |
 1 | x: t""
   |    ^^^
```

**Invalid calendar date** (`t"2023-02-30"`):
```
error: date/time literal contains an invalid date
  help: check that the day exists in the given month and year
        (e.g. February has at most 29 days, and only in a leap year)
  --> file.eu:1:4
   |
 1 | x: t"2023-02-30"
   |    ^^^^^^^^^^^^^
```

**Completely malformed** (`t"not-a-date"`):
```
error: invalid date/time literal
  help: the t-string syntax requires ISO 8601 format,
        e.g. 2023-01-15 or 2023-01-15T10:30:00Z
  help: supported formats: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS,
        YYYY-MM-DDTHH:MM:SSZ, YYYY-MM-DDTHH:MM:SS+HH:MM
  --> file.eu:1:4
   |
 1 | x: t"not-a-date"
   |    ^^^^^^^^^^^^^
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: poor → excellent

### Change
- Added `ZdtInvalidReason` enum (`Empty`, `InvalidDate`, `Malformed`) as a field
  on `ParseError::InvalidZdtLiteral`
- Added `zdt_invalid_reason()` heuristic in `src/syntax/rowan/validate.rs` that
  distinguishes between the three cases by checking whether the content is empty,
  starts with `YYYY-` (looks like a date but is calendar-invalid), or is
  completely unrecognisable
- Updated `Display` for `ParseError::InvalidZdtLiteral` to produce distinct,
  actionable messages for each case
- Updated exhaustive match arms in `src/syntax/error.rs` and
  `src/driver/lsp/diagnostics.rs` to handle the new struct field
- Updated `.expect` sidecars for error tests 024 (invalid date) and 026 (empty)
  to match the new, more specific messages; test 025 (malformed) retains the
  same leading line so its sidecar was already correct

### Risks
- The `zdt_invalid_reason` heuristic is intentionally conservative: strings
  starting with four digits and a hyphen are classed as `InvalidDate` even if
  they fail for a non-calendar reason (e.g. month 13). This is a reasonable
  approximation — users who write `2023-13-01` still benefit from the
  "check that the day exists" message over the generic fallback.
- All 38 error harness tests pass; full test suite passes; clippy clean.