### PR TITLE
fix: convert parser panic on unclosed string interpolation to error

### DIFF
--- a/harness/test/errors/048_unclosed_interpolation.eu
+++ b/harness/test/errors/048_unclosed_interpolation.eu
@@ -1,0 +1,5 @@
+# Error test: unterminated string interpolation (no closing brace)
+# A string interpolation '{name more stuff' with no closing '}' used to
+# cause a parser assertion panic; it should produce a clear error message.
+greeting: "Hello {name more stuff"
+RESULT: greeting

--- a/harness/test/errors/048_unclosed_interpolation.eu.expect
+++ b/harness/test/errors/048_unclosed_interpolation.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "unterminated string interpolation"

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -100,6 +100,15 @@ impl<'text> Parser<'text> {
         TextRange::new(start, ch)
     }
 
+    /// Calculate the start offset of the token at the given index.
+    fn token_start_at(&self, idx: usize) -> TextSize {
+        let mut ch: TextSize = 0.into();
+        for (_, s) in &self.tokens[0..idx] {
+            ch += TextSize::of(*s);
+        }
+        ch
+    }
+
     /// Operate on the event sink at the top of the stack
     fn sink(&mut self) -> &mut dyn EventSink {
         self.sink_stack.last_mut().unwrap().as_mut()
@@ -588,7 +597,8 @@ impl<'text> Parser<'text> {
                     self.sink().finish_node();
                 }
                 OPEN_BRACE => {
-                    // Start of interpolation
+                    // Start of interpolation — record the token index before consuming
+                    let open_brace_idx = self.next_token;
                     self.sink().start_node(STRING_INTERPOLATION);
                     self.sink().token(OPEN_BRACE);
                     self.next(); // consume {
@@ -600,6 +610,44 @@ impl<'text> Parser<'text> {
                     if let Some((CLOSE_BRACE, _)) = self.peek() {
                         self.sink().token(CLOSE_BRACE);
                         self.next();
+                    } else {
+                        // No closing brace immediately — consume any stray
+                        // interpolation tokens that the content parser did not
+                        // consume.  We stop if we encounter a closing brace (which
+                        // means the format spec or dotted path was merely malformed,
+                        // not truly unclosed) or the end of the enclosing string.
+                        let mut found_close = false;
+                        while let Some((k, _)) = self.peek() {
+                            if k == CLOSE_BRACE {
+                                // A closing brace is present; consume it and stop.
+                                // This handles malformed-but-closed interpolations
+                                // such as `{x:.2f}` where the parser cannot parse
+                                // the full format spec.
+                                self.sink().token(CLOSE_BRACE);
+                                self.next();
+                                found_close = true;
+                                break;
+                            }
+                            if k == STRING_LITERAL_CONTENT
+                                || k == STRING_PATTERN_END
+                                || k == C_STRING_PATTERN_END
+                                || k == RAW_STRING_PATTERN_END
+                                || k == end_kind
+                            {
+                                // Stop before the end of the string — these
+                                // will be consumed by the outer loop.
+                                break;
+                            }
+                            self.sink().token(k);
+                            self.next();
+                        }
+                        if !found_close {
+                            let open_start = self.token_start_at(open_brace_idx);
+                            let open_len = TextSize::of(self.tokens[open_brace_idx].1);
+                            self.errors.push(ParseError::UnclosedStringInterpolation {
+                                range: TextRange::at(open_start, open_len),
+                            });
+                        }
                     }
 
                     self.sink().finish_node(); // end STRING_INTERPOLATION

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -705,3 +705,8 @@ pub fn test_error_046() {
 pub fn test_error_047() {
     run_error_test(&error_opts("047_str_plus_plus.eu"));
 }
+
+#[test]
+pub fn test_error_048() {
+    run_error_test(&error_opts("048_unclosed_interpolation.eu"));
+}


### PR DESCRIPTION
## Error message: Parser panic / unclosed string interpolation

### Scenario
A string literal with an unterminated interpolation expression — `"Hello {name more stuff"` (no closing `}`) — caused a hard parser assertion panic (exit code 101) instead of producing a useful error message.

### Before
```
thread 'main' panicked at src/syntax/rowan/parse.rs:122:9:
assertion `left == right` failed
  left: [..., OPEN_BRACE, STRING_INTERPOLATION_TARGET, STRING_PATTERN_END, ...]
 right: [..., OPEN_BRACE, STRING_INTERPOLATION_TARGET, STRING_INTERPOLATION_TARGET, STRING_INTERPOLATION_TARGET, STRING_PATTERN_END, ...]
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
exit: 101
```

### After
```
error: unterminated string interpolation (missing '}')
  ┌─ test.eu:1:18
  │
1 │ greeting: "Hello {name more stuff"
  │                  ^

exit: 1
```

### Assessment
- Human diagnosability: poor (panic, no message) → excellent (clear error with source location)
- LLM diagnosability: poor (panic with token dump) → excellent (named error at source position)

### Change

`src/syntax/rowan/parse.rs`: in `parse_string_pattern()`, when an interpolation's content is parsed and no `CLOSE_BRACE` immediately follows, the parser now:

1. Enters a token-draining loop that consumes any stray tokens (e.g. extra `STRING_INTERPOLATION_TARGET` words, `OPERATOR_IDENTIFIER` dots, `STRING_FORMAT_SPEC` text) so that the token-count assertion in `build()` does not panic.
2. Stops the loop if a `CLOSE_BRACE` is found — this handles the "malformed-but-closed" case (e.g. `{x:.2f}` where a dot in a format spec produces an unexpected `OPERATOR_IDENTIFIER` token). In that case the close brace is consumed and no error is reported.
3. If no `CLOSE_BRACE` was found, emits `ParseError::UnclosedStringInterpolation` (the variant existed but was never generated) with the source range pointing at the opening `{`.

A `token_start_at(idx)` helper was also added to `Parser` to compute the open-brace offset after consuming subsequent tokens.

### Risks
- The `UnclosedStringInterpolation` variant already existed in `error.rs` with a well-formed `Display` message; no display changes were needed.
- The fix is localised to the token-consumption else-branch in `parse_string_pattern()`; valid closed interpolations are unaffected.
- The draining loop is guarded by stops at all string-end token kinds (`STRING_PATTERN_END`, etc.) so it cannot escape the string context.
- All 126 tests pass; `test_error_048` validates the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)