### PR TITLE
chore(emacs): add declare-function stubs for optional dependencies

### DIFF
--- a/editors/emacs/eucalypt-mode.el
+++ b/editors/emacs/eucalypt-mode.el
@@ -38,6 +38,14 @@
 (require 'quail)
 (require 'transient)
 
+;; Optional dependencies — declare to suppress byte-compile warnings.
+;; These are loaded conditionally at runtime via `with-eval-after-load'
+;; or `commandp' guards.
+(defvar eglot-server-programs)
+(declare-function rainbow-delimiters-mode "rainbow-delimiters" ())
+(declare-function yaml-mode "yaml-mode" ())
+(declare-function json-mode "json-mode" ())
+
 ;;; Group
 
 (defgroup eucalypt nil


### PR DESCRIPTION
## Summary

- Adds `defvar` and `declare-function` declarations for optional runtime dependencies (`eglot`, `rainbow-delimiters`, `yaml-mode`, `json-mode`) in `eucalypt-mode.el`
- These packages are correctly guarded at runtime (via `with-eval-after-load` or `commandp`), but without declarations the byte-compiler emits free-variable and undefined-function warnings

## Verification (eu-0x8c)

Checks performed as part of final verification:

- No stale `eucalypt-ts` references remain in `eucalypt-mode.el`
- `require` ordering is correct (treesit, prog-mode, cl-lib, quail, transient — all at top of file)
- No unused helpers present
- `highlights.scm` prelude keyword list is already comprehensive and up to date
- `emacs -Q --batch -f batch-byte-compile editors/emacs/eucalypt-mode.el` now produces **zero warnings**

Closes eu-0x8c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)