### PR TITLE
feat(tree-sitter): update grammar for 0.4.0 destructuring and idiom brackets

### DIFF
--- a/editors/emacs/eucalypt-mode.el
+++ b/editors/emacs/eucalypt-mode.el
@@ -162,7 +162,9 @@ Set via file-local variables, e.g.:
    :feature 'bracket
    '(["(" ")" "[" "]" "{" "}"] @font-lock-bracket-face
      [":" ","] @font-lock-delimiter-face
-     ["`"] @font-lock-preprocessor-face)
+     ["`"] @font-lock-preprocessor-face
+     ;; Idiom bracket expressions: ⟦ expr ⟧, «expr», etc.
+     (bracket_expr) @eucalypt-unicode-bracket-face)
 
    :language 'eucalypt
    :feature 'interpolation
@@ -187,8 +189,16 @@ Set via file-local variables, e.g.:
 
    :language 'eucalypt
    :feature 'parameter
-   '((parameter_list (identifier) @font-lock-variable-name-face)
-     (operator_declaration (identifier) @font-lock-variable-name-face))
+   '(;; Simple parameters
+     (parameter_list (identifier) @font-lock-variable-name-face)
+     (operator_declaration (identifier) @font-lock-variable-name-face)
+     ;; Block destructuring pattern: {x y} or {x: a  y: b}
+     (block_pattern
+      (declaration (declaration_head (identifier) @font-lock-variable-name-face)))
+     ;; Fixed-length list destructuring pattern: [a, b, c]
+     (list_pattern (identifier) @font-lock-variable-name-face)
+     ;; Cons pattern: [h : t]
+     (cons_pattern (identifier) @font-lock-variable-name-face))
 
    :language 'eucalypt
    :feature 'function-call
@@ -232,8 +242,12 @@ Set via file-local variables, e.g.:
      ((parent-is "source_file") column-0 0)
      ;; Inside blocks, indent declarations
      ((parent-is "block") parent-bol eucalypt-indent-offset)
+     ;; Inside block destructuring patterns
+     ((parent-is "block_pattern") parent-bol eucalypt-indent-offset)
      ;; Inside lists, indent elements
      ((parent-is "list") parent-bol eucalypt-indent-offset)
+     ;; Inside idiom bracket expressions
+     ((parent-is "bracket_expr") parent-bol eucalypt-indent-offset)
      ;; Inside parentheses, indent contents
      ((parent-is "paren_expr") parent-bol eucalypt-indent-offset)
      ((parent-is "argument_list") parent-bol eucalypt-indent-offset)

--- a/editors/tree-sitter-eucalypt/grammar.js
+++ b/editors/tree-sitter-eucalypt/grammar.js
@@ -13,6 +13,10 @@
 // Notable: ? (for //=?, //!?), $ (for <$>), ∸ (unary minus)
 const OPER_CHARS = /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘→←⊕⊗⊙⊡⊞⊟⟨⟩⟪⟫⟦⟧⌈⌉⌊⌋¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/;
 
+// Unicode idiom bracket open characters (must match brackets.rs BUILTIN_BRACKET_PAIRS)
+const BRACKET_OPEN_RE = /[⟦⟨⟪⌈⌊⦃⦇⦉«【〔〖〘〚]/;
+const BRACKET_CLOSE_RE = /[⟧⟩⟫⌉⌋⦄⦈⦊»】〕〗〙〛]/;
+
 module.exports = grammar({
   name: 'eucalypt',
 
@@ -81,7 +85,7 @@ module.exports = grammar({
       // Simple property: name (identifier or quoted)
       $.identifier,
       $.quoted_identifier,
-      // Function: name(params)
+      // Function: name(params) — params may include destructuring patterns
       seq(choice($.identifier, $.quoted_identifier), $.parameter_list),
       // Operator declarations in parentheses
       $.operator_declaration,
@@ -91,6 +95,8 @@ module.exports = grammar({
     operator_declaration: $ => seq(
       '(',
       choice(
+        // Idiom bracket operator: (⟦ x ⟧) — declares a bracket-pair function
+        seq(BRACKET_OPEN_RE, $.identifier, BRACKET_CLOSE_RE),
         // Binary operator: (l op r)
         seq($.identifier, $.operator, $.identifier),
         // Unary prefix operator: (op x)
@@ -103,14 +109,60 @@ module.exports = grammar({
       ')',
     ),
 
+    // A parameter in a function declaration may be:
+    //   - a simple identifier: f(x, y)
+    //   - a block destructuring pattern: f({x y}) or f({x: a  y: b})
+    //   - a fixed-length list destructuring pattern: f([a, b])
+    //   - a head/tail cons pattern: f([h : t])
+    _param: $ => choice(
+      $.identifier,
+      $.block_pattern,
+      $.list_pattern,
+      $.cons_pattern,
+    ),
+
     parameter_list: $ => seq(
       '(',
       optional(seq(
-        $.identifier,
-        repeat(seq(',', $.identifier)),
+        $._param,
+        repeat(seq(',', $._param)),
         optional(','),
       )),
       ')',
+    ),
+
+    // Block destructuring pattern in parameter position: {x y} or {x: a  y: b}
+    // A block_pattern has the same surface syntax as a block but only appears
+    // as a function parameter.  Fields may be shorthand (`x` binds field x) or
+    // renamed (`x: a` binds field x as local variable a).
+    block_pattern: $ => seq(
+      '{',
+      repeat(seq(
+        $.declaration,
+        optional(','),
+      )),
+      '}',
+    ),
+
+    // Fixed-length list destructuring pattern: [a, b, c]
+    list_pattern: $ => seq(
+      '[',
+      seq(
+        $.identifier,
+        repeat(seq(',', $.identifier)),
+        optional(','),
+      ),
+      ']',
+    ),
+
+    // Head/tail cons destructuring pattern: [h : t]
+    // Uses ':' as the separator (not ',') to distinguish from list_pattern.
+    cons_pattern: $ => seq(
+      '[',
+      $.identifier,
+      ':',
+      $.identifier,
+      ']',
     ),
 
     // === Expressions (soup) ===
@@ -131,6 +183,7 @@ module.exports = grammar({
       $.list,
       $.paren_expr,
       $.application,
+      $.bracket_expr,
     ),
 
     // Parenthesized expression
@@ -151,6 +204,14 @@ module.exports = grammar({
       )),
       ')',
     )),
+
+    // Idiom bracket expression: ⟦ expr ⟧, «expr», ⌈ expr ⌉, etc.
+    // The bracket pair determines which bracket-pair function is applied.
+    bracket_expr: $ => seq(
+      BRACKET_OPEN_RE,
+      optional($.soup),
+      BRACKET_CLOSE_RE,
+    ),
 
     // === Literals ===
 

--- a/editors/tree-sitter-eucalypt/queries/highlights.scm
+++ b/editors/tree-sitter-eucalypt/queries/highlights.scm
@@ -76,9 +76,26 @@
   (operator) @function
   (identifier) @parameter)
 
-; Function parameters
+; Function parameters — simple identifiers
 (parameter_list
   (identifier) @parameter)
+
+; Destructuring parameters — block pattern field names
+(block_pattern
+  (declaration
+    (declaration_head
+      (identifier) @parameter)))
+
+; Destructuring parameters — list pattern element names
+(list_pattern
+  (identifier) @parameter)
+
+; Destructuring parameters — cons pattern head and tail names
+(cons_pattern
+  (identifier) @parameter)
+
+; Idiom bracket expressions — highlight the bracket delimiters distinctively
+(bracket_expr) @punctuation.special
 
 ; Function application
 (application

--- a/editors/tree-sitter-eucalypt/test/corpus/declarations.txt
+++ b/editors/tree-sitter-eucalypt/test/corpus/declarations.txt
@@ -235,3 +235,88 @@ greeting: c"Hello {name}!\n"
               (identifier)))
           (c_string_content)
           (c_escape_sequence))))))
+
+================================================================================
+Block destructuring parameter
+================================================================================
+
+f({x y}): x + y
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier)
+      (parameter_list
+        (block_pattern
+          (declaration
+            (declaration_head
+              (identifier))))))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+List destructuring parameter
+================================================================================
+
+f([a, b]): a + b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier)
+      (parameter_list
+        (list_pattern
+          (identifier)
+          (identifier))))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Cons destructuring parameter
+================================================================================
+
+f([h : t]): h
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier)
+      (parameter_list
+        (cons_pattern
+          (identifier)
+          (identifier))))
+    (soup
+      (name
+        (identifier)))))
+
+================================================================================
+Idiom bracket expression
+================================================================================
+
+result: ⟦ x ⟧
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (bracket_expr
+        (soup
+          (name
+            (identifier)))))))


### PR DESCRIPTION
## Summary

Updates the tree-sitter grammar, highlight queries, and Emacs mode to track new syntax added in 0.4.0 by Quill.

### Destructuring parameters

Block, list, and cons destructuring patterns are now valid in `parameter_list`:

```eucalypt
# Block destructuring
sum({x y}): x + y
renamed({x: a  y: b}): a + b

# Fixed-length list destructuring
f([a, b, c]): a + b + c

# Head/tail cons destructuring
head([h : t]): h
tail([h : t]): t
```

Changes:
- `grammar.js`: new `_param`, `block_pattern`, `list_pattern`, `cons_pattern` rules; `parameter_list` now uses `_param` instead of bare `identifier`
- `highlights.scm`: parameter names inside all three pattern kinds highlighted as `@parameter`
- `eucalypt-mode.el`: `parameter` font-lock feature extended to cover destructuring nodes

### Idiom bracket expressions

Unicode bracket pairs (`⟦…⟧`, `«…»`, `⌈…⌉`, etc.) used as idiom brackets:

```eucalypt
# Declare a bracket-pair function
(⟦ x ⟧): maybe-apply(x)

# Use it in expressions
result: ⟦ some-value ⟧
```

Changes:
- `grammar.js`: new `bracket_expr` rule in `_element`; idiom bracket operator declarations in `operator_declaration`
- `highlights.scm`: `bracket_expr` highlighted as `@punctuation.special`
- `eucalypt-mode.el`: `bracket_expr` gets `eucalypt-unicode-bracket-face` in the `bracket` feature; indent rule added

### Other

- Carries forward `declare-function` stubs for optional deps (pending merge of #327)
- Four new corpus tests in `test/corpus/declarations.txt`
- Byte-compiles cleanly: zero warnings

## Notes

The `‖` cons operator mentioned in the task brief does not appear to be implemented in 0.4.0 — `cons` is a prelude function, not a new infix operator. No grammar change needed for it.

The `f{...}` / `f[...]` juxtaposed call syntax is not implemented as a distinct surface form in 0.4.0; the parser uses `OPEN_PAREN_APPLY` (no-whitespace `(`) for juxtaposed calls, which was already in the grammar as `argument_list` with `token.immediate('(')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)