### PR TITLE
fix: add hints for common function names from other languages

### DIFF
--- a/harness/test/errors/056_fold_hint.eu
+++ b/harness/test/errors/056_fold_hint.eu
@@ -1,0 +1,5 @@
+# Error test: using 'fold' (from Python/Haskell/JS) which does not exist in eucalypt
+# Eucalypt uses 'foldl' and 'foldr' instead
+nums: [1, 2, 3, 4]
+result: nums fold((+), 0)
+RESULT: result

--- a/harness/test/errors/056_fold_hint.eu.expect
+++ b/harness/test/errors/056_fold_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "foldl.*foldr"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -121,27 +121,74 @@ impl CompileError {
                 // Suggest eucalypt equivalents for functions common in other languages
                 // that have different names or do not exist in eucalypt.
                 match name.as_str() {
-                    "flatten" | "flat" => notes.push(
-                        "to flatten a list of lists, use 'concat', e.g. 'xs concat'".to_string(),
-                    ),
-                    "length" | "len" | "size" => notes.push(
-                        "to count the elements of a list, use 'count', e.g. 'xs count'".to_string(),
-                    ),
-                    "contains" | "includes" => notes.push(
-                        "to test if a list contains a value, use 'any', \
-                         e.g. xs any(42 = _) to test for element 42"
-                            .to_string(),
-                    ),
-                    "join" => notes.push(
-                        "to join strings with a separator, use 'join-on', \
-                         e.g. xs join-on(sep) where sep is the separator string"
-                            .to_string(),
-                    ),
-                    "index" | "get" | "at" => notes.push(
-                        "to index into a list, use 'nth', e.g. 'xs nth(0)' for \
-                         the first element, or the '!!' operator: xs !! 0"
-                            .to_string(),
-                    ),
+                    "fold" | "reduce" | "foldLeft" | "foldRight" => {
+                        notes.push(
+                            "to fold a list, use 'foldl' (left fold) or 'foldr' (right fold), \
+                             e.g. 'foldl(+, 0, xs)' to sum a list"
+                                .to_string(),
+                        );
+                    }
+                    "sort" | "sorted" => {
+                        notes.push(
+                            "to sort a list of numbers, use 'sort-nums', e.g. 'xs sort-nums'; \
+                             for custom ordering use 'sort-by-num(f, xs)' or 'sort-by(f, xs)'"
+                                .to_string(),
+                        );
+                    }
+                    "slice" => {
+                        notes.push(
+                            "to take the first n elements of a list use 'take', e.g. 'xs take(n)'; \
+                             to drop the first n elements use 'drop', e.g. 'xs drop(n)'"
+                                .to_string(),
+                        );
+                    }
+                    "split" | "splitOn" | "split_on" => {
+                        notes.push(
+                            "to split a string, use 'str.split-on', e.g. \
+                             'text str.split-on(\" \")' (the separator is a regex pattern)"
+                                .to_string(),
+                        );
+                    }
+                    "flatten" | "flat" => {
+                        notes.push(
+                            "to flatten a list of lists, use 'concat', e.g. 'xs concat'"
+                                .to_string(),
+                        );
+                    }
+                    "length" | "len" | "size" => {
+                        notes.push(
+                            "to count the elements of a list, use 'count', e.g. 'xs count'"
+                                .to_string(),
+                        );
+                    }
+                    "contains" | "includes" => {
+                        notes.push(
+                            "to test if a list contains a value, use 'any', \
+                             e.g. 'xs any(42 = _)' to test for element 42"
+                                .to_string(),
+                        );
+                    }
+                    "join" => {
+                        notes.push(
+                            "to join strings with a separator, use 'join-on', \
+                             e.g. 'xs join-on(sep)' where sep is the separator string"
+                                .to_string(),
+                        );
+                    }
+                    "index" | "get" | "at" => {
+                        notes.push(
+                            "to index into a list, use 'nth', e.g. 'xs nth(0)' for \
+                             the first element, or the '!!' operator: 'xs !! 0'"
+                                .to_string(),
+                        );
+                    }
+                    "print" | "println" | "puts" | "console" => {
+                        notes.push(
+                            "eucalypt has no print function; outputs are produced by rendering \
+                             the result value — set the RESULT target to what you want to output"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -750,3 +750,8 @@ pub fn test_error_054() {
 pub fn test_error_055() {
     run_error_test(&error_opts("055_list_not_callable.eu"));
 }
+
+#[test]
+pub fn test_error_056() {
+    run_error_test(&error_opts("056_fold_hint.eu"));
+}


### PR DESCRIPTION
## Error message: unresolved variable — common function names from other languages

### Scenario
When a user writes a function name from Python, Haskell, JavaScript, or Ruby that doesn't exist in eucalypt, the error says only "check that the variable is defined and in scope" with no guidance on what to use instead.

Perturbations tested:
- `nums fold((+), 0)` — Python/Haskell `fold`/`reduce`
- `nums sort` — Python/JavaScript `sort`/`sorted`
- `nums slice(1, 3)` — Python `list[1:3]`
- `text split(" ")` — Python/JavaScript `split`/`splitOn`
- `print(x)` — Python/JavaScript print function
- Also: `flatten`/`flat`, `length`/`len`/`size`, `contains`/`includes`, `join`, `index`/`get`/`at`

### Before
```
error: unresolved variable 'fold'
  ┌─ test.eu:2:14
  │
2 │ result: nums fold((+), 0)
  │              ^^^^
  │
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable 'fold'
  ┌─ test.eu:2:14
  │
2 │ result: nums fold((+), 0)
  │              ^^^^
  │
  = check that the variable is defined and in scope
  = to fold a list, use 'foldl' (left fold) or 'foldr' (right fold), e.g. 'foldl(+, 0, xs)' to sum a list
```

Other examples:
- `sort` → "to sort a list of numbers, use 'sort-nums', e.g. 'xs sort-nums'; for custom ordering use 'sort-by-num(f, xs)' or 'sort-by(f, xs)'"
- `slice` → "to take the first n elements of a list use 'take'...; to drop the first n elements use 'drop'..."
- `split`/`splitOn` → "to split a string, use 'str.split-on'..."
- `print`/`println` → "eucalypt has no print function; outputs are produced by rendering the result value — set the RESULT target..."

### Assessment
- Human diagnosability: poor → good (knows exactly what function to use instead)
- LLM diagnosability: fair → excellent (concrete replacement with usage example)

### Change
Added a `match name.as_str()` block in `CompileError::FreeVar` handler in `src/eval/stg/compiler.rs` covering 14 common function name aliases from other languages.

### Risks
Low — these are additive notes only; existing error messages are unchanged. The `match` arms only fire for exact name matches on specific unresolved variables.