### PR TITLE
feat: improve assertion failure messages with expected/actual values (eu-0i4b)

### DIFF
--- a/harness/test/errors/010_assert.eu.expect
+++ b/harness/test/errors/010_assert.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "Assertion failed"
+stderr: "assertion failed: expected false, got true"

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -807,38 +807,47 @@ assertions: {
 }
 
 ` { doc: "`e //= v` - add metadata to check expression `e` evaluates to `v` and return whether valid"
-    export: :suppress 
+    export: :suppress
     associates: :left
     precedence: :meta }
 (e //= v): e with-meta({ assert: (= v)}) assertions.check
 
-` { doc: "`e //=> v` - add metadata to assert expression `e` evaluates to `v` and return `e`."
-    export: :suppress 
+` { doc: "`e //=> v` - assert expression `e` evaluates to `v` and return `e`.
+
+    On failure, reports the expected and actual values:
+    `assertion failed: expected <v>, got <e>`"
+    export: :suppress
     associates: :left
     precedence: :meta }
-(e //=> v): e with-meta({ assert: (= v)}) assertions.checked
+(e //=> v): if(e = v, e, __ASSERT_FAIL(e, v))
 
 ` { doc: "`e //=? f` - add metadata to assert expression `e` satisfies predicate `f` and return `e`."
-    export: :suppress 
+    export: :suppress
     associates: :left
     precedence: :meta }
 (e //=? f): e with-meta({ assert: f}) assertions.checked
 
 ` { doc: "`e //!? f` - add metadata to assert expression `e` does not satisfy predicate `f` and return `e`."
-    export: :suppress 
+    export: :suppress
     associates: :left
     precedence: :meta }
 (e //!? f): e with-meta({ assert: complement(f)}) assertions.checked
 
-` { doc: "`e //! f` - add metadata to assert expression `e` is true and return `e`."
-    export: :suppress 
-    precedence: :meta }
-(e //!): e with-meta({ assert: (= true) }) assertions.checked
+` { doc: "`e //!` - assert expression `e` is true and return `e`.
 
-` { doc: "`e //!! f` - add metadata to assert expression `e` is false and return `e`."
-    export: :suppress 
+    On failure, reports the actual value:
+    `assertion failed: expected true, got <e>`"
+    export: :suppress
     precedence: :meta }
-(e //!!): e with-meta({ assert: (= false) }) assertions.checked
+(e //!): if(e = true, e, __ASSERT_FAIL(e, true))
+
+` { doc: "`e //!!` - assert expression `e` is false and return `e`.
+
+    On failure, reports the actual value:
+    `assertion failed: expected false, got <e>`"
+    export: :suppress
+    precedence: :meta }
+(e //!!): if(e = false, e, __ASSERT_FAIL(e, false))
 
 #
 # List library functions, maps and folds

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -348,6 +348,7 @@ pub fn intrinsic_display_name(name: &str) -> Option<&str> {
         // Control flow
         "IF" => Some("if"),
         "PANIC" => Some("panic"),
+        "ASSERT_FAIL" => Some("assert.fail"),
 
         // Date/time
         "ZDT" => Some("zdt"),

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -708,6 +708,11 @@ lazy_static! {
             ty: function(vec![num(), list(), list()]).unwrap(),
             strict: vec![0, 1],
     },
+    Intrinsic { // 133
+            name: "ASSERT_FAIL",
+            ty: function(vec![unk(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
     ];
 }
 

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -1,0 +1,151 @@
+//! ASSERT_FAIL intrinsic — reports expected vs actual on assertion failure
+//!
+//! Called only when an assertion has already been determined to have
+//! failed. Attempts to display both values as human-readable strings;
+//! falls back to a type label when the value is a structured type
+//! (list, block) that cannot be reduced to a scalar.
+
+use std::convert::TryInto;
+
+use crate::eval::{
+    emit::Emitter,
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        mutator::MutatorHeapView,
+        syntax::{HeapSyn, Native, Ref},
+    },
+};
+
+use super::tags::DataConstructor;
+
+/// Format a value ref as a human-readable string for assertion messages.
+///
+/// Resolves the closure at `r` to WHNF and formats it:
+/// - Boxed scalars (number, string, symbol, zdt) — their literal form
+/// - Booleans and null — their keyword form
+/// - Lists and blocks — a type label such as `[list]` or `{block}`
+/// - Unevaluated / unknown — `<unevaluated>`
+fn format_ref(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> String {
+    // Resolve to a closure, following Atom indirections.
+    // The closure should already be at WHNF since the //=> operator
+    // forced both sides via the equality check.
+    let closure = match machine.nav(view).resolve(r) {
+        Ok(c) => c,
+        Err(_) => return "<unknown>".to_string(),
+    };
+
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::BoolTrue) => "true".to_string(),
+                Ok(DataConstructor::BoolFalse) => "false".to_string(),
+                Ok(DataConstructor::Unit) => "null".to_string(),
+                Ok(DataConstructor::ListNil) => "[]".to_string(),
+                Ok(DataConstructor::ListCons) => "[list]".to_string(),
+                Ok(DataConstructor::Block) => "{block}".to_string(),
+                Ok(DataConstructor::BlockPair) | Ok(DataConstructor::BlockKvList) => {
+                    "{block}".to_string()
+                }
+                Ok(DataConstructor::BoxedNumber) => {
+                    // The inner ref is args[0]: try to get it as a native num
+                    args.get(0)
+                        .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
+                        .unwrap_or_else(|| "<number>".to_string())
+                }
+                Ok(DataConstructor::BoxedString) => args
+                    .get(0)
+                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<string>".to_string()),
+                Ok(DataConstructor::BoxedSymbol) => args
+                    .get(0)
+                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<symbol>".to_string()),
+                Ok(DataConstructor::BoxedZdt) => args
+                    .get(0)
+                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<datetime>".to_string()),
+                Err(_) => "<value>".to_string(),
+            }
+        }
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => format_native(n, view, machine),
+        _ => "<unevaluated>".to_string(),
+    }
+}
+
+/// Format an inner ref (arg of a boxed constructor) as a string.
+///
+/// Handles `Ref::V` directly and resolves `Ref::L` through the given
+/// env frame.
+fn format_inner_ref(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = match r {
+        Ref::V(n) => n.clone(),
+        Ref::L(idx) => {
+            let closure = env.get(&view, *idx)?;
+            let code = view.scoped(closure.code());
+            match &*code {
+                HeapSyn::Atom {
+                    evaluand: Ref::V(n),
+                } => n.clone(),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+    Some(format_native(&native, view, machine))
+}
+
+/// Render a `Native` value as a human-readable string.
+fn format_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicMachine) -> String {
+    match n {
+        Native::Num(num) => num.to_string(),
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            format!("\"{}\"", (*scoped).as_str())
+        }
+        Native::Sym(id) => format!(":{}", machine.symbol_pool().resolve(*id)),
+        Native::Zdt(dt) => dt.to_rfc3339(),
+        Native::Index(_) => "<block-index>".to_string(),
+        Native::Set(_) => "<set>".to_string(),
+    }
+}
+
+/// ASSERT_FAIL(actual, expected)
+///
+/// Always panics. Called by the `//=>`, `//!`, and `//!!` operators
+/// when an assertion has been determined to have failed. Formats the
+/// panic message with expected and actual values where possible.
+pub struct AssertFail;
+
+impl StgIntrinsic for AssertFail {
+    fn name(&self) -> &str {
+        "ASSERT_FAIL"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let actual_str = format_ref(machine, view, &args[0]);
+        let expected_str = format_ref(machine, view, &args[1]);
+        Err(ExecutionError::Panic(format!(
+            "assertion failed: expected {expected_str}, got {actual_str}"
+        )))
+    }
+}
+
+impl CallGlobal2 for AssertFail {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -2,6 +2,7 @@
 //! compiler for core syntax that targets it.
 //!
 pub mod arith;
+pub mod assert;
 pub mod block;
 pub mod boolean;
 pub mod compiler;
@@ -71,6 +72,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(boolean::Not));
     rt.add(Box::new(boolean::If));
     rt.add(Box::new(panic::Panic));
+    rt.add(Box::new(assert::AssertFail));
     rt.add(Box::new(block::Block));
     rt.add(Box::new(block::Kv));
     rt.add(Box::new(block::Dekv));


### PR DESCRIPTION
## Summary

- Adds a new `ASSERT_FAIL` intrinsic (`src/eval/stg/assert.rs`) that formats both expected and actual values into the panic message on assertion failure
- Changes `//=>`, `//!`, and `//!!` operators in the prelude from metadata-based checking to direct `if`/`ASSERT_FAIL` calls
- Updates `harness/test/errors/010_assert.eu.expect` to match the new message format

## Behaviour change

Before:
```
error: panic: Assertion failed
```

After:
```
error: panic: assertion failed: expected 2, got 1
error: panic: assertion failed: expected "world", got "hello"
error: panic: assertion failed: expected true, got false
```

Scalar values (numbers, strings, symbols, datetimes) are formatted as their literal form; booleans and null as keywords; lists and blocks as type labels (`[list]`, `{block}`).

## Implementation notes

The `ASSERT_FAIL` intrinsic is declared with `strict: vec![0, 1]` so the STG wrapper emits `force` calls that evaluate both arguments to WHNF before `execute` is called. This allows `format_ref` to inspect the `HeapSyn::Cons` or `HeapSyn::Atom` node at the head of each closure.

The `//=` and `//=?`, `//!?` operators are unchanged — they use the metadata-based system and return booleans, which is intentional.

## Test plan

- [x] `cargo test --test harness_test` — 131 tests pass
- [x] `cargo test test_error` — 40 error tests pass including updated `010_assert`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Manual verification: `1 //=> 2` gives `assertion failed: expected 2, got 1`
- [x] Manual verification: passing assertions (`1 //=> 1`) still return the value

Closes eu-0i4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)