### PR TITLE
fix: add hints for common identifier names from other languages

### DIFF
--- a/harness/test/errors/058_python_true.eu
+++ b/harness/test/errors/058_python_true.eu
@@ -1,0 +1,3 @@
+# Error test: using Python's capitalised 'True' instead of eucalypt's lowercase 'true'
+x: True
+RESULT: x

--- a/harness/test/errors/058_python_true.eu.expect
+++ b/harness/test/errors/058_python_true.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "lowercase.*true"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -189,6 +189,35 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Capitalized boolean literals from Python/Ruby/Haskell.
+                    // Eucalypt uses lowercase 'true' and 'false'.
+                    "True" => {
+                        notes.push("note: eucalypt uses lowercase 'true', not 'True'".to_string())
+                    }
+                    "False" => {
+                        notes.push("note: eucalypt uses lowercase 'false', not 'False'".to_string())
+                    }
+                    // Null/None from Python, Java, JavaScript, Ruby
+                    "None" | "NULL" | "Null" | "undefined" | "Undefined" => notes.push(
+                        "note: eucalypt uses 'null' for the null/nil value, not 'None'/'NULL'"
+                            .to_string(),
+                    ),
+                    // Common Haskell/ML keywords that don't exist in eucalypt
+                    "else" | "then" => {
+                        notes.push(
+                            "note: eucalypt does not use 'if…then…else' syntax; \
+                             use the 'if' function: 'if(condition, then-value, else-value)'"
+                                .to_string(),
+                        );
+                    }
+                    "return" => {
+                        notes.push(
+                            "note: eucalypt has no 'return' statement; \
+                             functions evaluate to their body expression — the last \
+                             binding value is the function result"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -765,3 +765,8 @@ pub fn test_error_056() {
 pub fn test_error_057() {
     run_error_test(&error_opts("057_head_empty_list.eu"));
 }
+
+#[test]
+pub fn test_error_058() {
+    run_error_test(&error_opts("058_python_true.eu"));
+}


### PR DESCRIPTION
## Error message: unresolved variable — Python/Ruby/Java identifiers

### Scenario
Users coming from Python, Ruby, Java, or Haskell try to use identifier names
that don't exist in eucalypt:
- `x: True` (Python/Ruby capitalised boolean)
- `x: False` (Python/Ruby capitalised boolean)
- `x: None` or `x: NULL` (Python/Java null value)
- `result: if x > 3 then "big" else "small"` (Haskell/Ruby `if…then…else`)
- `f(x): return x * 2` (imperative `return` keyword)

### Before
```
error: unresolved variable 'True'
  ┌─ test.eu:1:4
  │
1 │ x: True
  │    ^^^^
  │
  = check that the variable is defined and in scope
```

### After (True example)
```
error: unresolved variable 'True'
  ┌─ test.eu:1:4
  │
1 │ x: True
  │    ^^^^
  │
  = check that the variable is defined and in scope
  = note: eucalypt uses lowercase 'true', not 'True'
```

### After (else example)
```
error: unresolved variable 'else'
  = check that the variable is defined and in scope
  = note: eucalypt does not use 'if…then…else' syntax; use the 'if' function: 'if(condition, then-value, else-value)'
```

### After (return example)
```
error: unresolved variable 'return'
  = check that the variable is defined and in scope
  = note: eucalypt has no 'return' statement; functions evaluate to their body expression — the last binding value is the function result
```

### Assessment
- Human diagnosability: poor → good (clearly states what to use instead)
- LLM diagnosability: fair → excellent (concrete correction with examples)

### Change
Added new `match name.as_str()` arms in `CompileError::FreeVar` handler in
`src/eval/stg/compiler.rs`:
- `"True"` → lowercase hint
- `"False"` → lowercase hint
- `"None"` | `"NULL"` | `"Null"` | `"undefined"` | `"Undefined"` → null hint
- `"else"` | `"then"` → if-function hint
- `"return"` → no-return-statement hint

### Risks
Low — additive notes only. 141 harness tests pass; full suite passes; clippy clean.