### PR TITLE
fix: add hints for Python lambda/for/in keywords

### DIFF
--- a/harness/test/errors/061_lambda_keyword.eu
+++ b/harness/test/errors/061_lambda_keyword.eu
@@ -1,0 +1,5 @@
+# Error test: using Python's 'lambda' keyword which does not exist in eucalypt
+# Eucalypt uses anaphora or named function definitions instead.
+double: lambda x: x * 2
+result: double(5)
+RESULT: result

--- a/harness/test/errors/061_lambda_keyword.eu.expect
+++ b/harness/test/errors/061_lambda_keyword.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "anaphora.*anonymous"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -205,7 +205,7 @@ impl CompileError {
                     // Common Haskell/ML keywords that don't exist in eucalypt
                     "else" | "then" => {
                         notes.push(
-                            "note: eucalypt does not use 'if…then…else' syntax; \
+                            "note: eucalypt does not use 'if\u{2026}then\u{2026}else' syntax; \
                              use the 'if' function: 'if(condition, then-value, else-value)'"
                                 .to_string(),
                         );
@@ -213,8 +213,33 @@ impl CompileError {
                     "return" => {
                         notes.push(
                             "note: eucalypt has no 'return' statement; \
-                             functions evaluate to their body expression — the last \
+                             functions evaluate to their body expression \u{2014} the last \
                              binding value is the function result"
+                                .to_string(),
+                        );
+                    }
+                    // Python 'lambda' keyword — eucalypt uses anaphora or named functions
+                    "lambda" => {
+                        notes.push(
+                            "eucalypt has no 'lambda' keyword; use anaphora for anonymous \
+                             functions: '(_ * 2)' is a doubling function, or define a named \
+                             function with 'double(x): x * 2'"
+                                .to_string(),
+                        );
+                    }
+                    // Python/Haskell 'for'/'in' keywords (list comprehension / for-loop)
+                    "for" => {
+                        notes.push(
+                            "eucalypt has no for-loop or list comprehension; use 'map' to \
+                             transform lists, e.g. 'xs map(_ * 2)' doubles each element, \
+                             or 'xs filter(_ > 0)' to select elements"
+                                .to_string(),
+                        );
+                    }
+                    "in" => {
+                        notes.push(
+                            "eucalypt has no 'in' keyword for list comprehensions; \
+                             use 'map' and 'filter' instead: 'xs filter(_ > 0) map(_ * 2)'"
                                 .to_string(),
                         );
                     }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -780,3 +780,8 @@ pub fn test_error_059() {
 pub fn test_error_060() {
     run_error_test(&error_opts("060_return_keyword.eu"));
 }
+
+#[test]
+pub fn test_error_061() {
+    run_error_test(&error_opts("061_lambda_keyword.eu"));
+}


### PR DESCRIPTION
## Error message: unresolved variable — Python lambda/list comprehension syntax

### Scenario
Users coming from Python or Haskell frequently try to write:
- `double: lambda x: x * 2` (Python lambda expression)
- `result: [x * 2 for x in xs]` (Python list comprehension)

These produce plain "unresolved variable" errors with no guidance.

### Before

**lambda:**
```
error: unresolved variable 'lambda'
  ┌─ test.eu:1:9
  │
1 │ double: lambda x: x * 2
  │         ^^^^^^
  │
  = check that the variable is defined and in scope
```

**for (in list comprehension):**
```
error: unresolved variable 'in'
  ┌─ test.eu:1:22
  │
1 │ result: [x * 2 for x in [1, 2, 3]]
  │                      ^^
  │
  = check that the variable is defined and in scope
```

### After

**lambda:**
```
error: unresolved variable 'lambda'
  = check that the variable is defined and in scope
  = eucalypt has no 'lambda' keyword; use anaphora for anonymous functions: '(_ * 2)' is a doubling function, or define a named function with 'double(x): x * 2'
```

**in:**
```
error: unresolved variable 'in'
  = check that the variable is defined and in scope
  = eucalypt has no 'in' keyword for list comprehensions; use 'map' and 'filter' instead: 'xs filter(_ > 0) map(_ * 2)'
```

**for:**
```
error: unresolved variable 'for'
  = check that the variable is defined and in scope
  = eucalypt has no for-loop or list comprehension; use 'map' to transform lists, e.g. 'xs map(_ * 2)' doubles each element, or 'xs filter(_ > 0)' to select elements
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added `"lambda"`, `"for"`, and `"in"` arms to the `match name.as_str()` block
in `CompileError::FreeVar` handler in `src/eval/stg/compiler.rs`.

### Risks
Low — additive notes only. 144 harness tests pass; full suite passes; clippy clean.