### PR TITLE
feat: add monadic block expressions (eu-1x9a)

### DIFF
--- a/doc/appendices/cheat-sheet.md
+++ b/doc/appendices/cheat-sheet.md
@@ -104,6 +104,23 @@ result: ⟦ some-expression ⟧  # calls my-functor(some-expression)
 Built-in bracket pairs: `⟦⟧`, `⟨⟩`, `⟪⟫`, `⌈⌉`, `⌊⌋`, `⦃⦄`, `⦇⦈`, `⦉⦊`, `«»`,
 `【】`, `〔〕`, `〖〗`, `〘〙`, `〚〛`.
 
+## Monadic Blocks
+
+When a bracket pair declaration carries `bind` and `return` metadata, using that
+bracket pair with a block inner desugars as a bind chain (like `do`-notation).
+
+```eu,notest
+` { bind: my-bind return: my-return }
+(⟦ x ⟧): x
+
+# ⟦ { a: ma, b: mb, r: expr } ⟧
+# desugars to: my-bind(ma, (a): my-bind(mb, (b): my-return(expr)))
+result: ⟦ { a: ma, b: mb, r: a + b } ⟧
+```
+
+The last declaration is the return step; all earlier declarations are bind steps
+whose names are in scope for subsequent declarations.
+
 ## Metadata Annotations
 
 ```eu,notest

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -203,6 +203,59 @@ idiom brackets without any registration:
 | `〘` | `〙`  | CJK white tortoise shell brackets |
 | `〚` | `〛`  | CJK white square brackets |
 
+### Monadic blocks
+
+When a bracket pair declaration is annotated with `bind` and `return`
+metadata naming monad functions, the bracket pair gains a **monad
+spec**.  A bracket expression whose inner content is a block then
+desugars as a bind chain (analogous to Haskell's `do`-notation):
+
+```eu
+` { bind: my-bind return: my-return }
+(⟦ x ⟧): x
+
+result: ⟦ { a: ma, b: mb, r: expr } ⟧
+```
+
+The block inner desugars to:
+
+```
+my-bind(ma, (a): my-bind(mb, (b): my-return(expr)))
+```
+
+The **last declaration** in the block is treated as the return value:
+its value is wrapped in `return`.  All earlier declarations are bind
+steps whose bound names are in scope for later declarations and the
+final expression.
+
+**Example — identity monad:**
+
+```eu
+id-bind(ma, f): f(ma)
+id-return(a): a
+
+` { bind: id-bind return: id-return }
+(⟦ x ⟧): x
+
+result: ⟦ { x: 10, r: x + 5 } ⟧     # => 15
+```
+
+**Example — maybe monad (optional lists):**
+
+```eu
+maybe-bind(ma, f): if(ma = [], [], f(ma head))
+maybe-return(a): [a]
+
+` { bind: maybe-bind return: maybe-return }
+(⌈ x ⌉): x
+
+just:    ⌈ { x: [1], y: [2], r: x + y } ⌉   # => [3]
+nothing: ⌈ { x: [],  y: [2], r: x + y } ⌉   # => []
+```
+
+If the bracket pair has no monad spec but a block is used as the
+inner, eucalypt raises an error at compile time.
+
 To control the precedence and associativity of user defined operators,
 you need metadata annotations.
 

--- a/harness/test/096_monadic_blocks.eu
+++ b/harness/test/096_monadic_blocks.eu
@@ -1,0 +1,74 @@
+##
+## 096: Monadic block expressions
+##
+## When a bracket pair declaration includes `bind` and `return` metadata,
+## it gains a monad spec.  A bracket expression whose inner is a block
+## then desugars as a bind chain:
+##
+##   ⟦ { a: ma, b: mb, r: expr } ⟧
+##   →  bind(ma, (a): bind(mb, (b): return(expr)))
+##
+
+# ---------------------------------------------------------------------------
+# Identity monad: bind(ma, f) = f(ma), return(a) = a
+# Under the identity monad the block expressions are equivalent to let-bindings.
+id-bind(ma, f): f(ma)
+id-return(a): a
+
+` { bind: id-bind return: id-return }
+(⟦ x ⟧): x
+
+# ---------------------------------------------------------------------------
+# Maybe monad implemented as optional lists: Just(a) = [a], Nothing = []
+# bind([a], f) = f(a)   bind([], f) = []
+# return(a) = [a]
+maybe-bind(ma, f): if(ma = [], [], f(ma head))
+maybe-return(a): [a]
+
+` { bind: maybe-bind return: maybe-return }
+(⌈ x ⌉): x
+
+# ---------------------------------------------------------------------------
+tests: {
+
+  ` "Identity monad — single declaration"
+  id-single: {
+    ` "return wraps a literal"
+    a: ⟦ { r: 42 } ⟧ //= 42
+    ` "return wraps an expression"
+    b: ⟦ { r: 1 + 2 } ⟧ //= 3
+  }
+
+  ` "Identity monad — two declarations"
+  id-two: {
+    ` "bind a value then return computed expression"
+    a: ⟦ { x: 10, r: x + 5 } ⟧ //= 15
+    ` "bind a string and reference it"
+    b: ⟦ { s: "hello", r: s } ⟧ //= "hello"
+  }
+
+  ` "Identity monad — three declarations"
+  id-three: {
+    ` "bind two values and combine them"
+    a: ⟦ { a: 1, b: 2, r: a + b } ⟧ //= 3
+    ` "bind two values and use only first"
+    b: ⟦ { a: 7, b: 3, r: a } ⟧ //= 7
+  }
+
+  ` "Maybe monad — value present"
+  maybe-just: {
+    ` "bind through two Just values"
+    a: ⌈ { x: [1], y: [2], r: x + y } ⌉ //= [3]
+  }
+
+  ` "Maybe monad — short-circuits on Nothing"
+  maybe-nothing: {
+    ` "bind with first argument Nothing"
+    a: ⌈ { x: [], y: [2], r: x + y } ⌉ //= []
+    ` "bind with second argument Nothing"
+    b: ⌈ { x: [1], y: [], r: x + y } ⌉ //= []
+  }
+
+}
+
+RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -14,6 +14,19 @@ use codespan::Span;
 use moniker::FreeVar;
 use std::collections::{HashMap, HashSet};
 
+/// A monad specification registered for a bracket pair.
+///
+/// When a bracket pair declaration includes `bind` and `return` metadata keys,
+/// it is recorded here so that monadic block desugaring (`⟦ { a: ma, b: mb } ⟧`)
+/// can emit bind chains using the nominated functions.
+#[derive(Debug, Clone)]
+pub struct MonadSpec {
+    /// Name of the monadic bind function (e.g. `"list-bind"`)
+    pub bind_name: String,
+    /// Name of the monadic return function (e.g. `"list-return"`)
+    pub return_name: String,
+}
+
 /// State kept during desugaring pass
 pub struct Desugarer<'smap> {
     /// While in the scope of anaphoric string pattern, collect all the
@@ -33,6 +46,11 @@ pub struct Desugarer<'smap> {
     env: DefaultingEnvironment<String, FreeVar<String>>,
     /// Current usize
     file: Vec<usize>,
+    /// Registry mapping bracket pair names (e.g. `"⟦⟧"`) to their monad spec.
+    ///
+    /// Populated when a bracket pair declaration with `bind` and `return` metadata
+    /// is desugared.  Consulted when desugaring `⟦ { ... } ⟧` block expressions.
+    monad_registry: HashMap<String, MonadSpec>,
 }
 
 impl<'smap> Desugarer<'smap> {
@@ -51,7 +69,21 @@ impl<'smap> Desugarer<'smap> {
             source_map,
             env: DefaultingEnvironment::new(|k| FreeVar::fresh_named(k)),
             file: vec![],
+            monad_registry: HashMap::new(),
         }
+    }
+
+    /// Register a monad spec for a bracket pair.
+    ///
+    /// Called when a bracket pair declaration with `bind` and `return` metadata
+    /// is processed so that subsequent monadic block usages can look up the spec.
+    pub fn register_monad_spec(&mut self, pair_name: String, spec: MonadSpec) {
+        self.monad_registry.insert(pair_name, spec);
+    }
+
+    /// Look up the monad spec for a bracket pair, if one has been registered.
+    pub fn monad_spec(&self, pair_name: &str) -> Option<&MonadSpec> {
+        self.monad_registry.get(pair_name)
     }
 
     /// Desugar content at locator (and imports) to create a new

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -627,6 +627,111 @@ impl Desugarable for rowan_ast::Literal {
     }
 }
 
+/// Desugar a monadic block using a registered monad spec.
+///
+/// Given `⟦ { a: ma, b: mb, r: expr } ⟧` and a monad spec `{ bind, return }`,
+/// produces:
+/// ```text
+/// bind(ma, (a): bind(mb, (b): return(expr)))
+/// ```
+///
+/// All declarations except the last are desugared as monadic bind steps,
+/// with the declaration name becoming a lambda parameter.  The last
+/// declaration's value is wrapped in `return`; its name is not bound.
+fn desugar_monadic_block(
+    smid: Smid,
+    block: &rowan_ast::Block,
+    spec: &super::desugarer::MonadSpec,
+    desugarer: &mut Desugarer,
+) -> Result<RcExpr, CoreError> {
+    // Collect all declarations in order
+    let decls: Vec<rowan_ast::Declaration> = block.declarations().collect();
+
+    if decls.is_empty() {
+        return Err(CoreError::EmptyMonadicBlock(smid));
+    }
+
+    // We need to push all bind-names into the environment before desugaring
+    // any bodies, so that later bodies can reference earlier names.
+    // The bind names are all declaration names except the last.
+    let bind_names: Vec<String> = decls[..decls.len() - 1]
+        .iter()
+        .map(extract_declaration_name)
+        .collect::<Result<Vec<_>, CoreError>>()?;
+
+    // Push bind names into environment so bodies can reference earlier bindings
+    if !bind_names.is_empty() {
+        desugarer.env_mut().push_keys(bind_names.iter().cloned());
+    }
+
+    // Collect bind FreeVars while names are in scope
+    let bind_vars: Vec<moniker::FreeVar<String>> = bind_names
+        .iter()
+        .map(|name| desugarer.env().get(name).unwrap().clone())
+        .collect();
+
+    // Desugar all declaration bodies (in order) with bind names in scope
+    let mut name_value_pairs: Vec<(String, RcExpr)> = Vec::with_capacity(decls.len());
+    for (i, decl) in decls.iter().enumerate() {
+        let decl_name = if i < bind_names.len() {
+            bind_names[i].clone()
+        } else {
+            extract_declaration_name(decl)?
+        };
+        let span = text_range_to_span(decl.syntax().text_range());
+        let value = if let Some(body) = decl.body() {
+            if let Some(soup) = body.soup() {
+                let expr = soup.desugar(desugarer)?;
+                desugarer.varify(expr)
+            } else {
+                if !bind_names.is_empty() {
+                    desugarer.env_mut().pop();
+                }
+                return Err(CoreError::InvalidEmbedding(
+                    "empty monadic block declaration body".to_string(),
+                    desugarer.new_smid(span),
+                ));
+            }
+        } else {
+            if !bind_names.is_empty() {
+                desugarer.env_mut().pop();
+            }
+            return Err(CoreError::InvalidEmbedding(
+                "missing monadic block declaration body".to_string(),
+                desugarer.new_smid(span),
+            ));
+        };
+        name_value_pairs.push((decl_name, value));
+    }
+
+    // Pop bind names from environment
+    if !bind_names.is_empty() {
+        desugarer.env_mut().pop();
+    }
+
+    // Build the bind chain right-to-left:
+    //   Last declaration: return(last_value)
+    //   Each prior declaration: bind(value, (name): rest)
+    let (_, last_value) = name_value_pairs.pop().unwrap();
+
+    // Build the return function call
+    let return_fn = desugarer.varify(RcExpr::from(Expr::Name(smid, spec.return_name.clone())));
+    let mut result = RcExpr::from(Expr::App(smid, return_fn, vec![last_value]));
+
+    // Build bind chain from right-to-left using the remaining pairs
+    for ((_, value), bind_var) in name_value_pairs
+        .into_iter()
+        .zip(bind_vars.into_iter())
+        .rev()
+    {
+        let lambda = core::lam(smid, vec![bind_var], result);
+        let bind_fn = desugarer.varify(RcExpr::from(Expr::Name(smid, spec.bind_name.clone())));
+        result = RcExpr::from(Expr::App(smid, bind_fn, vec![value, lambda]));
+    }
+
+    Ok(result)
+}
+
 /// Element (equivalent to Expression) desugaring
 impl Desugarable for Element {
     fn desugar(&self, desugarer: &mut Desugarer) -> Result<RcExpr, CoreError> {
@@ -703,10 +808,6 @@ impl Desugarable for Element {
                 )
             }
             Element::BracketExpr(bracket) => {
-                // A bracket expression ⟦ x ⟧ desugars to applying the bracket pair function
-                // (named e.g. "⟦⟧") to the inner soup expression.
-                //
-                // This is equivalent to: ⟦⟧(x)  where ⟦⟧ is looked up in scope.
                 let span = text_range_to_span(bracket.syntax().text_range());
                 let smid = desugarer.new_smid(span);
 
@@ -717,26 +818,49 @@ impl Desugarable for Element {
                     )
                 })?;
 
-                // Desugar the inner soup
-                let inner = if let Some(soup) = bracket.soup() {
-                    soup.desugar(desugarer)?
-                } else {
-                    return Err(CoreError::InvalidEmbedding(
-                        "empty bracket expression".to_string(),
-                        smid,
-                    ));
-                };
+                // Detect monadic block mode: inner soup is a single Block element.
+                //
+                // ⟦ { a: ma, b: mb, r: expr } ⟧
+                // desugars (when ⟦⟧ has a monad spec) to:
+                //   bind(ma, (a): bind(mb, (b): return(expr)))
+                let inner_block: Option<rowan_ast::Block> =
+                    bracket.soup().and_then(|s| s.singleton()).and_then(|e| {
+                        if let Element::Block(b) = e {
+                            Some(b)
+                        } else {
+                            None
+                        }
+                    });
 
-                // Build: name(⟦⟧) applied to inner
-                // Desugars the bracket expression ⟦ x ⟧ as a call to the
-                // bracket pair function by name, with the inner expression as
-                // the sole argument.  Both the function name and the argument
-                // must be varified so that Name nodes are resolved to Var
-                // references before the STG compiler sees them.
-                let bracket_fn_name = RcExpr::from(Expr::Name(smid, pair_name));
-                let bracket_fn = desugarer.varify(bracket_fn_name);
-                let arg = desugarer.varify(inner);
-                Ok(RcExpr::from(Expr::App(smid, bracket_fn, vec![arg])))
+                if let Some(block) = inner_block {
+                    // Monadic block mode — look up the monad spec
+                    let spec = desugarer
+                        .monad_spec(&pair_name)
+                        .cloned()
+                        .ok_or_else(|| CoreError::NoMonadSpec(pair_name.clone(), smid))?;
+
+                    desugar_monadic_block(smid, &block, &spec, desugarer)
+                } else {
+                    // Simple expression mode: ⟦ x ⟧ → ⟦⟧(x)
+                    //
+                    // Desugar the inner soup and apply the bracket pair function.
+                    // Both the function name and the argument must be varified so
+                    // that Name nodes are resolved to Var references before the
+                    // STG compiler sees them.
+                    let inner = if let Some(soup) = bracket.soup() {
+                        soup.desugar(desugarer)?
+                    } else {
+                        return Err(CoreError::InvalidEmbedding(
+                            "empty bracket expression".to_string(),
+                            smid,
+                        ));
+                    };
+
+                    let bracket_fn_name = RcExpr::from(Expr::Name(smid, pair_name));
+                    let bracket_fn = desugarer.varify(bracket_fn_name);
+                    let arg = desugarer.varify(inner);
+                    Ok(RcExpr::from(Expr::App(smid, bracket_fn, vec![arg])))
+                }
             }
             Element::ApplyTuple(tuple) => {
                 let span = text_range_to_span(tuple.syntax().text_range());
@@ -1467,6 +1591,17 @@ fn rowan_declaration_to_binding(
                     .expect("failure translating import"),
             );
         }
+    }
+
+    // Register monad spec if this is a bracket pair declaration with bind/return metadata
+    if let (Some(bind_name), Some(return_name)) = (metadata.bind, metadata.monad_return) {
+        desugarer.register_monad_spec(
+            components.name.clone(),
+            super::desugarer::MonadSpec {
+                bind_name,
+                return_name,
+            },
+        );
     }
 
     // Note: argument names were already resolved during body desugaring

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -45,6 +45,10 @@ pub enum CoreError {
     TargetNotFound(String),
     #[error("target {0} could not be referenced")]
     BadTarget(String),
+    #[error("monadic block used without a monad spec — bracket pair '{0}' has no 'bind'/'return' metadata")]
+    NoMonadSpec(String, Smid),
+    #[error("monadic block must contain at least one declaration")]
+    EmptyMonadicBlock(Smid),
 }
 
 impl HasSmid for CoreError {
@@ -58,6 +62,8 @@ impl HasSmid for CoreError {
             MixedAnaphora(s) => s,
             UnresolvedVariable(s, _) => s,
             RedeclaredVariable(s, _) => s,
+            NoMonadSpec(_, s) => s,
+            EmptyMonadicBlock(s) => s,
             _ => Smid::default(),
         }
     }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -4,11 +4,30 @@ use crate::common::sourcemap::*;
 use crate::core::error::*;
 use crate::core::expr::*;
 use crate::syntax::input::*;
+use moniker;
 
 /// Read typed metadata out of core expressions, mutating to persist
 /// any evaluations or transformations made along the way.
 pub trait ReadMetadata<M> {
     fn read_metadata(&mut self) -> Result<M, CoreError>;
+}
+
+/// Extract a function name from a metadata value.
+///
+/// Accepts:
+/// - String literal `"name"` → `"name"`
+/// - Symbol literal `:name` → `"name"`
+/// - Var expression (desugared identifier) → the pretty name
+fn extract_function_name(expr: &RcExpr) -> Option<String> {
+    // Try string or symbol literal first
+    if let Some(s) = (expr as &dyn Extract<String>).extract() {
+        return Some(s);
+    }
+    // Then try Var (desugared identifier reference)
+    if let Expr::Var(_, moniker::Var::Free(fv)) = &*expr.inner {
+        return fv.pretty_name.clone();
+    }
+    None
 }
 
 /// Support a few shortcuts for metadata
@@ -53,6 +72,8 @@ pub fn strip_desugar_phase_metadata(expr: &RcExpr) -> RcExpr {
                             | "import"
                             | "embedding"
                             | "parse-embed"
+                            | "bind"
+                            | "return"
                     )
                 })
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -90,6 +111,10 @@ pub struct DesugarPhaseDeclarationMetadata {
     pub doc: Option<String>,
     /// Embedding - describes how / what is embedded (e.g. core quote-embed)
     pub embedding: Option<String>,
+    /// Monad bind function name (for bracket pair monad specs)
+    pub bind: Option<String>,
+    /// Monad return function name (for bracket pair monad specs)
+    pub monad_return: Option<String>,
 }
 
 impl ReadMetadata<DesugarPhaseDeclarationMetadata> for RcExpr {
@@ -108,6 +133,8 @@ impl ReadMetadata<DesugarPhaseDeclarationMetadata> for RcExpr {
                 imports: imap.get("import").and_then(|e| e.extract()),
                 doc: imap.get("doc").and_then(|e| e.extract()),
                 embedding: imap.get("embedding").and_then(|e| e.extract()),
+                bind: imap.get("bind").and_then(extract_function_name),
+                monad_return: imap.get("return").and_then(extract_function_name),
             }),
             Expr::Let(_, _, _) => {
                 self.inner = self.clone().instantiate_lets().inner;

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -455,6 +455,11 @@ pub fn test_harness_095() {
 }
 
 #[test]
+pub fn test_harness_096() {
+    run_test(&opts("096_monadic_blocks.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds monadic block expressions — `do`-notation-style sequencing using Unicode bracket pairs
- When a bracket pair declaration carries `bind` and `return` metadata, using that bracket with a block inner desugars as a bind chain
- `⟦ { a: ma, b: mb, r: expr } ⟧` → `bind(ma, (a): bind(mb, (b): return(expr)))`
- Works with any user-defined monad; the monad spec is registered from bracket pair declaration metadata during desugaring

## Changes

- **`src/core/metadata.rs`**: `extract_function_name` helper for identifier references in metadata; `bind`/`monad_return` fields on `DesugarPhaseDeclarationMetadata`; strip `bind`/`return` keys during metadata cleanup
- **`src/core/desugar/desugarer.rs`**: `MonadSpec` struct and `monad_registry: HashMap<String, MonadSpec>` on `Desugarer`
- **`src/core/error.rs`**: `NoMonadSpec` and `EmptyMonadicBlock` error variants
- **`src/core/desugar/rowan_ast.rs`**: `desugar_monadic_block` function; `BracketExpr` dispatches to monadic mode when inner is a block; monad spec registered from bracket pair declaration metadata
- **`harness/test/096_monadic_blocks.eu`**: harness test covering identity monad and maybe monad (Just/Nothing short-circuit)
- **`tests/harness_test.rs`**: `test_harness_096` registered
- **`doc/reference/syntax.md`**: Monadic blocks section documenting the feature
- **`doc/appendices/cheat-sheet.md`**: Monadic blocks quick-reference entry

## Test plan

- [x] `cargo test` — all 147 tests pass (131 existing + 1 new harness + 15 error tests previously on `0.4.0`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes
- [x] Identity monad: single/two/three-declaration blocks produce correct values
- [x] Maybe monad: Just values thread through; Nothing short-circuits

🤖 Generated with [Claude Code](https://claude.com/claude-code)