### PR TITLE
fix: add hints for even?/odd? predicate errors

### DIFF
--- a/harness/test/errors/065_even_predicate_hint.eu
+++ b/harness/test/errors/065_even_predicate_hint.eu
@@ -1,0 +1,3 @@
+# Mistake: using even? (Python/Haskell style) — does not exist in eucalypt
+xs: [1, 2, 3, 4, 5]
+evens: xs filter(even?)

--- a/harness/test/errors/065_even_predicate_hint.eu.expect
+++ b/harness/test/errors/065_even_predicate_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "modulo"

--- a/harness/test/errors/066_odd_predicate_hint.eu
+++ b/harness/test/errors/066_odd_predicate_hint.eu
@@ -1,0 +1,3 @@
+# Mistake: using odd? (Python/Haskell style) — does not exist in eucalypt
+xs: [1, 2, 3, 4, 5]
+odds: xs filter(odd?)

--- a/harness/test/errors/066_odd_predicate_hint.eu.expect
+++ b/harness/test/errors/066_odd_predicate_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "modulo"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -243,6 +243,26 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    "even?" | "even" | "isEven" | "is_even" => {
+                        notes.push(
+                            "eucalypt has no built-in 'even?' predicate; \
+                             test with the modulo operator: '(_ % 2 = 0)'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "example: 'xs filter(_ % 2 = 0)' to keep even numbers".to_string(),
+                        );
+                    }
+                    "odd?" | "odd" | "isOdd" | "is_odd" => {
+                        notes.push(
+                            "eucalypt has no built-in 'odd?' predicate; \
+                             test with the modulo operator: '(_ % 2 = 1)'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "example: 'xs filter(_ % 2 = 1)' to keep odd numbers".to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -800,3 +800,13 @@ pub fn test_error_063() {
 pub fn test_error_064() {
     run_error_test(&error_opts("064_has_string_not_sym.eu"));
 }
+
+#[test]
+pub fn test_error_065() {
+    run_error_test(&error_opts("065_even_predicate_hint.eu"));
+}
+
+#[test]
+pub fn test_error_066() {
+    run_error_test(&error_opts("066_odd_predicate_hint.eu"));
+}


### PR DESCRIPTION
## Error message: even?/odd? unresolved variable

### Scenario

Users from Haskell, Python, Ruby, or JavaScript often write `even?` or `odd?` as predicate functions for filtering even or odd numbers. These do not exist in eucalypt.

**Perturbed code:**
```eucalypt
xs: [1, 2, 3, 4, 5]
evens: xs filter(even?)
```

### Before

```
error: unresolved variable 'even?'
   ┌─ test.eu:2:18
   │
 2 │ evens: xs filter(even?)
   │                  ^^^^^
   │
   = check that the variable is defined and in scope
```

No hint about how to achieve the same result in eucalypt.

### After

```
error: unresolved variable 'even?'
   ┌─ test.eu:2:18
   │
 2 │ evens: xs filter(even?)
   │                  ^^^^^
   │
   = check that the variable is defined and in scope
   = eucalypt has no built-in 'even?' predicate; test with the modulo operator: '(_ % 2 = 0)'
   = example: 'xs filter(_ % 2 = 0)' to keep even numbers
```

Similarly for `odd?`:
```
   = eucalypt has no built-in 'odd?' predicate; test with the modulo operator: '(_ % 2 = 1)'
   = example: 'xs filter(_ % 2 = 1)' to keep odd numbers
```

### Assessment

- Human diagnosability: poor → excellent.
- LLM diagnosability: poor → excellent.

### Change

Added `"even?" | "even" | "isEven" | "is_even"` and `"odd?" | "odd" | "isOdd" | "is_odd"` arms to the `FreeVar` hint match in `src/eval/stg/compiler.rs`. Each arm pushes two notes: one explaining the modulo pattern, and one showing a concrete example with `filter`.

Test files added:
- `harness/test/errors/059_even_predicate_hint.eu` + `.expect`
- `harness/test/errors/060_odd_predicate_hint.eu` + `.expect`

### Risks

Minimal. The match is purely additive — it only fires for these exact variable names. Existing error messages are unaffected.