### PR TITLE
fix: hints for Python/Ruby-style string method names in str namespace lookup failures

### DIFF
--- a/harness/test/errors/061_str_upper_method.eu
+++ b/harness/test/errors/061_str_upper_method.eu
@@ -1,0 +1,3 @@
+# Error test: using Python-style 'str.upper' instead of eucalypt's 'str.to-upper'
+x: "hello" str.upper
+RESULT: x

--- a/harness/test/errors/061_str_upper_method.eu.expect
+++ b/harness/test/errors/061_str_upper_method.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "str\.to-upper"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -204,6 +204,69 @@ fn format_lookup_failure(key: &str, suggestions: &[String]) -> String {
     msg
 }
 
+/// Generate contextual notes for lookup failure errors.
+///
+/// Recognises common Python/Ruby string method names used as block keys and
+/// suggests the correct eucalypt equivalents in the `str` namespace.
+fn lookup_failure_notes(key: &str, suggestions: &[String]) -> Vec<String> {
+    // Only produce extra notes when there are no edit-distance suggestions,
+    // i.e. the key is genuinely unknown and not a near-miss of an existing key.
+    if !suggestions.is_empty() {
+        return vec![];
+    }
+    match key {
+        "upper" | "toUpper" | "toUpperCase" | "toupper" => vec![
+            "to convert a string to upper case, use 'str.to-upper', \
+             e.g. 'text str.to-upper'"
+                .to_string(),
+        ],
+        "lower" | "toLower" | "toLowerCase" | "tolower" => vec![
+            "to convert a string to lower case, use 'str.to-lower', \
+             e.g. 'text str.to-lower'"
+                .to_string(),
+        ],
+        "replace" | "sub" | "gsub" => vec![
+            "eucalypt has no 'replace' function; \
+             use 'str.matches-of(re, s)' to find matches, or construct a replacement \
+             by splitting and re-joining: 's str.split-on(re) join-on(replacement)'"
+                .to_string(),
+        ],
+        "strip" | "trim" | "rstrip" | "lstrip" => vec![
+            "eucalypt has no 'trim'/'strip' function; \
+             to remove surrounding whitespace use a regex: \
+             'text str.extract(\"^\\\\s*(.*?)\\\\s*$\")'"
+                .to_string(),
+        ],
+        "startswith" | "starts_with" | "startsWith" | "hasPrefix" => vec![
+            "to test if a string starts with a prefix, use 'str.matches?(re, s)' \
+             with an anchored regex, e.g. 'text str.matches?(\"^prefix\")'"
+                .to_string(),
+        ],
+        "endswith" | "ends_with" | "endsWith" | "hasSuffix" => vec![
+            "to test if a string ends with a suffix, use 'str.matches?(re, s)' \
+             with an anchored regex, e.g. 'text str.matches?(\"suffix$\")'"
+                .to_string(),
+        ],
+        "find" | "index" | "indexOf" | "indexof" => vec![
+            "eucalypt has no string 'find'/'index' function; \
+             to extract a substring use 'str.extract(re, s)' with a capture group, \
+             e.g. 'text str.extract(\"(pattern)\")'"
+                .to_string(),
+        ],
+        "encode" | "decode" => vec![
+            "to encode a string as base64 use 'str.base64-encode', \
+             to decode use 'str.base64-decode'"
+                .to_string(),
+        ],
+        "format" | "sprintf" | "printf" => vec![
+            "to format a value as a string, use 'str.fmt', \
+             e.g. 'str.fmt(x, \"%.2f\")' for two decimal places"
+                .to_string(),
+        ],
+        _ => vec![],
+    }
+}
+
 /// Format a "not a value" error message when a non-value expression is found
 /// where a primitive value was expected.
 fn format_not_value(context: &str) -> String {
@@ -552,6 +615,9 @@ impl ExecutionError {
                 ]
             }
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
+            ExecutionError::LookupFailure(_, key, suggestions) => {
+                lookup_failure_notes(key, suggestions)
+            }
             _ => vec![],
         };
         if notes.is_empty() {

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -780,3 +780,8 @@ pub fn test_error_059() {
 pub fn test_error_060() {
     run_error_test(&error_opts("060_return_keyword.eu"));
 }
+
+#[test]
+pub fn test_error_061() {
+    run_error_test(&error_opts("061_str_upper_method.eu"));
+}


### PR DESCRIPTION
## Error message: lookup failure for Python/Ruby-style string method names

### Scenario
A user familiar with Python or Ruby tries to use string methods directly on the `str` namespace:
```eucalypt
x: "hello" str.upper
RESULT: x
```
or
```eucalypt
x: "hello world" str.replace("world","earth")
RESULT: x
```

### Before
```
error: key 'upper' not found in block
```
```
error: key 'replace' not found in block
```
No hint about what the correct function name is or where to find it.

### After
```
error: key 'upper' not found in block
 = to convert a string to upper case, use 'str.to-upper', e.g. 'text str.to-upper'
```
```
error: key 'replace' not found in block
 = eucalypt has no 'replace' function; use 'str.matches-of(re, s)' to find matches, or construct a replacement by splitting and re-joining: 's str.split-on(re) join-on(replacement)'
```

### Assessment
- Human diagnosability: poor → good (user now knows the correct eucalypt name)
- LLM diagnosability: fair → excellent (exact function names provided)

### Change
Added a `lookup_failure_notes()` function in `src/eval/error.rs` that is called from `to_diagnostic()` for `ExecutionError::LookupFailure`. The function matches common Python/Ruby string method names:
- `upper`/`toUpper`/`toUpperCase` → `str.to-upper`
- `lower`/`toLower`/`toLowerCase` → `str.to-lower`
- `replace`/`sub`/`gsub` → `str.split-on`/`join-on` pattern
- `strip`/`trim`/`rstrip`/`lstrip` → `str.extract` with regex
- `startswith`/`startsWith` → `str.matches?` with anchored regex
- `endswith`/`endsWith` → `str.matches?` with anchored regex
- `find`/`indexOf` → `str.extract` with capture group
- `encode`/`decode` → `str.base64-encode`/`str.base64-decode`
- `format`/`sprintf` → `str.fmt`

Notes are only shown when the edit-distance suggestion system has no close matches (i.e. the key is genuinely semantically different, not just a typo of an existing key).

### Risks
- The note matcher is limited to the `str` namespace errors but fires for any block key lookup failure with that name. This is unlikely to be a problem in practice since these method names would rarely appear as user-defined block keys.
- Adding new method aliases here requires manual updates to this function.