### PR TITLE
feat: add hint for def/fn/function keyword errors

### DIFF
--- a/harness/test/errors/071_def_keyword.eu
+++ b/harness/test/errors/071_def_keyword.eu
@@ -1,0 +1,3 @@
+# Mistake: using def keyword (Python/Ruby style) — not valid in eucalypt
+def square(x): x * x
+result: square(5)

--- a/harness/test/errors/071_def_keyword.eu.expect
+++ b/harness/test/errors/071_def_keyword.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "name.args.: body"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -273,6 +273,16 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Function definition keywords from Python, Ruby, Rust, JavaScript, Haskell.
+                    // In eucalypt, functions are declared with a colon: 'square(x): x * x'.
+                    "def" | "fn" | "fun" | "func" | "function" | "defn" | "define" => {
+                        notes.push(
+                            "eucalypt does not use a 'def' or 'fn' keyword for functions; \
+                             define a function with 'name(args): body', \
+                             e.g. 'square(x): x * x'"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -830,3 +830,8 @@ pub fn test_error_069() {
 pub fn test_error_070() {
     run_error_test(&error_opts("070_str_upper_method.eu"));
 }
+
+#[test]
+pub fn test_error_071() {
+    run_error_test(&error_opts("071_def_keyword.eu"));
+}


### PR DESCRIPTION
## Error message: function definition keyword (def/fn/function)

### Scenario
A user writes `def square(x): x * x` — Python/Ruby style function definition syntax not valid in eucalypt. The free variable `def` is unresolved.

### Before
```
error: unresolved variable 'def'
  ┌─ 067_def_keyword.eu:2:1
  │
2 │ def square(x): x * x
  │ ^^^
  │
  = check that the variable is defined and in scope
```
Human diagnosability: poor — the error is technically correct but gives no hint about eucalypt's actual function definition syntax.

### After
```
error: unresolved variable 'def'
  ┌─ 067_def_keyword.eu:2:1
  │
2 │ def square(x): x * x
  │ ^^^
  │
  = check that the variable is defined and in scope
  = eucalypt does not use a 'def' or 'fn' keyword for functions; define a function with 'name(args): body', e.g. 'square(x): x * x'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added a new arm to the free-variable hint match in `src/eval/stg/compiler.rs` covering `def`, `fn`, `fun`, `func`, `function`, `defn`, and `define` — keywords used across Python, Ruby, Rust, JavaScript, Haskell, and Lisp. The hint explains eucalypt's `name(args): body` declaration syntax with a concrete example.

New harness test: `harness/test/errors/067_def_keyword.eu`.

### Risks
Low. The hint is purely additive and only fires when the exact keywords appear as free variables.