### PR TITLE
fix: hints for type predicate names from other functional languages

### DIFF
--- a/harness/test/errors/072_number_type_pred.eu
+++ b/harness/test/errors/072_number_type_pred.eu
@@ -1,0 +1,4 @@
+# Error test: using 'number?' type predicate which does not exist in eucalypt
+x: 42
+result: x number?
+RESULT: result

--- a/harness/test/errors/072_number_type_pred.eu.expect
+++ b/harness/test/errors/072_number_type_pred.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "no.*number.*type predicate"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -243,6 +243,46 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Type predicates from Haskell/Clojure/Racket/Ruby.
+                    // Eucalypt has 'block?' and 'list?' but not type predicates for
+                    // primitives.  Users must use pattern matching or error handling.
+                    "number?" | "num?" | "isNum" | "is_num" | "isNumber" | "is_number"
+                    | "isnumber" | "numeric?" => {
+                        notes.push(
+                            "eucalypt has no 'number?' type predicate; \
+                             the 'block?' and 'list?' predicates test structured types, \
+                             but primitive types (number, string, symbol) have no predicates"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "if you need type-safe dispatch, restructure your data so the type \
+                             is explicit, e.g. use a tagged block '{kind: \"num\", value: 42}'"
+                                .to_string(),
+                        );
+                    }
+                    "string?" | "str?" | "isStr" | "is_str" | "isString" | "is_string"
+                    | "isstring" => {
+                        notes.push(
+                            "eucalypt has no 'string?' type predicate; \
+                             the 'block?' and 'list?' predicates test structured types, \
+                             but primitive types (number, string, symbol) have no predicates"
+                                .to_string(),
+                        );
+                    }
+                    "symbol?" | "sym?" | "isSym" | "is_sym" | "isSymbol" | "is_symbol" => {
+                        notes.push(
+                            "eucalypt has no 'symbol?' type predicate; \
+                             to test if a block has a given symbol key, use 'has(:key)'"
+                                .to_string(),
+                        );
+                    }
+                    "bool?" | "boolean?" | "isBool" | "is_bool" | "isBoolean" => {
+                        notes.push(
+                            "eucalypt has no 'bool?' type predicate; \
+                             use 'if(v, true-branch, false-branch)' — 'if' coerces its condition"
+                                .to_string(),
+                        );
+                    }
                     "even?" | "even" | "isEven" | "is_even" => {
                         notes.push(
                             "eucalypt has no built-in 'even?' predicate; \

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -835,3 +835,8 @@ pub fn test_error_070() {
 pub fn test_error_071() {
     run_error_test(&error_opts("071_def_keyword.eu"));
 }
+
+#[test]
+pub fn test_error_072() {
+    run_error_test(&error_opts("072_number_type_pred.eu"));
+}


### PR DESCRIPTION
## Error message: unresolved variable for type predicates

### Scenario
A user from Haskell, Clojure, Racket, or Ruby tries to use common type-testing predicates:

```eucalypt
x: 42
result: x number?
RESULT: result
```

or

```eucalypt
x: "hello"
result: x string?
RESULT: result
```

### Before
```
error: unresolved variable 'number?'
  = check that the variable is defined and in scope
```
No guidance about what eucalypt provides for type testing.

### After
```
error: unresolved variable 'number?'
  = check that the variable is defined and in scope
  = eucalypt has no 'number?' type predicate; the 'block?' and 'list?' predicates test structured types, but primitive types (number, string, symbol) have no predicates
  = if you need type-safe dispatch, restructure your data so the type is explicit, e.g. use a tagged block '{kind: "num", value: 42}'
```

### Assessment
- Human diagnosability: poor → good (explains what exists, what doesn't, and offers a design approach)
- LLM diagnosability: poor → excellent (clear explanation of the limitation and alternative)

### Change
Added match arms for common type predicate names in the `CompileError::FreeVar` handler in `src/eval/stg/compiler.rs`:
- `number?`/`num?`/`isNum`/`isNumber` → explains no primitive type predicates, suggests tagged blocks
- `string?`/`str?`/`isStr`/`isString` → same explanation
- `symbol?`/`sym?`/`isSymbol` → notes `has(:key)` for symbol-based dispatch
- `bool?`/`boolean?`/`isBool` → explains `if` coerces its condition

### Risks
Low — these names are extremely unlikely to be used as eucalypt variable names in practice, and only fire when the name is genuinely unresolved.