### PR TITLE
feat: add hint for sprintf/format unresolved variable errors

### DIFF
--- a/harness/test/errors/073_sprintf_hint.eu
+++ b/harness/test/errors/073_sprintf_hint.eu
@@ -1,0 +1,3 @@
+# Mistake: using sprintf for string formatting — not available in eucalypt
+name: "Alice"
+greeting: sprintf("Hello, %s!", name)

--- a/harness/test/errors/073_sprintf_hint.eu.expect
+++ b/harness/test/errors/073_sprintf_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "sprintf.format function"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -323,6 +323,23 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // String formatting functions from C, Python, Ruby, JavaScript.
+                    // Eucalypt uses string interpolation with {name} placeholders.
+                    // Note: 'printf' is matched by the print/println arm above.
+                    "sprintf" | "format" | "string_format" | "str.format" | "fmt"
+                    | "format_string" => {
+                        notes.push(
+                            "eucalypt has no sprintf/format function; use string \
+                             interpolation instead: \"Hello, {name}!\" where 'name' is \
+                             a binding in scope"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "example: 'greeting: \"Hello, {name}!\"' where \
+                             'name: \"Alice\"' is declared nearby"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -840,3 +840,8 @@ pub fn test_error_071() {
 pub fn test_error_072() {
     run_error_test(&error_opts("072_number_type_pred.eu"));
 }
+
+#[test]
+pub fn test_error_073() {
+    run_error_test(&error_opts("073_sprintf_hint.eu"));
+}


### PR DESCRIPTION
## Error message: sprintf/format string formatting functions

### Scenario
A user writes `greeting: sprintf("Hello, %s!", name)` — using a C/Python/Ruby-style string formatting function that does not exist in eucalypt.

### Before
```
error: unresolved variable 'sprintf'
  ┌─ 070_sprintf_hint.eu:3:11
  │
3 │ greeting: sprintf("Hello, %s!", name)
  │           ^^^^^^^
  │
  = check that the variable is defined and in scope
```
Human diagnosability: poor — the error gives no clue that eucalypt uses string interpolation, not format functions.

### After
```
error: unresolved variable 'sprintf'
  ┌─ 070_sprintf_hint.eu:3:11
  │
3 │ greeting: sprintf("Hello, %s!", name)
  │           ^^^^^^^
  │
  = check that the variable is defined and in scope
  = eucalypt has no sprintf/format function; use string interpolation instead: "Hello, {name}!" where 'name' is a binding in scope
  = example: 'greeting: "Hello, {name}!"' where 'name: "Alice"' is declared nearby
```

### Assessment
- Human diagnosability: poor → excellent
- LLM diagnosability: fair → excellent

### Change
Added a new arm to the free-variable hint match in `src/eval/stg/compiler.rs` covering `sprintf`, `format`, `fmt`, `string_format`, `str.format`, and `format_string`. The hint explains eucalypt's string interpolation mechanism with a concrete example.

New harness test: `harness/test/errors/070_sprintf_hint.eu`.

Note: `printf` was intentionally excluded as it is already matched by the existing `print`/`println`/`printf` arm that explains eucalypt has no print function.

### Risks
Low. The hint is purely additive and only fires when the exact names appear as free variables. The `format` name is short and common but as a free variable it is genuinely an error in eucalypt.