### PR TITLE
feat: add hints for where/let/do keywords from other languages

### DIFF
--- a/harness/test/errors/074_where_keyword.eu
+++ b/harness/test/errors/074_where_keyword.eu
@@ -1,0 +1,5 @@
+# Mistake: using Haskell-style 'where' clause — not valid in eucalypt
+result: x + y
+  where
+    x: 1
+    y: 2

--- a/harness/test/errors/074_where_keyword.eu.expect
+++ b/harness/test/errors/074_where_keyword.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "eucalypt has no .where. clause"

--- a/harness/test/errors/075_let_keyword.eu
+++ b/harness/test/errors/075_let_keyword.eu
@@ -1,0 +1,2 @@
+# Mistake: using Haskell/Scheme-style 'let...in' expression — not valid in eucalypt
+result: let x: 1 in x + 2

--- a/harness/test/errors/075_let_keyword.eu.expect
+++ b/harness/test/errors/075_let_keyword.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "eucalypt has no .let. expression"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -340,6 +340,38 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // 'where' clause from Haskell, OCaml, SQL.
+                    // Eucalypt uses inline block bindings instead.
+                    "where" => {
+                        notes.push(
+                            "eucalypt has no 'where' clause; define helper bindings inside \
+                             a block: '{ helper: 1  result: helper + 2 }'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "or bind before use at the top level: \
+                             'helper: 1  result: helper + 2'"
+                                .to_string(),
+                        );
+                    }
+                    // 'let'/'in' from Haskell, Scheme, OCaml, ML.
+                    // Eucalypt uses block declarations instead of let-bindings.
+                    "let" => {
+                        notes.push(
+                            "eucalypt has no 'let' expression; use block bindings instead: \
+                             '{ x: 1  y: x + 2 }' or top-level declarations 'x: 1  y: x + 2'"
+                                .to_string(),
+                        );
+                    }
+                    // 'do' keyword from Haskell, Rust, or Ruby.
+                    // Eucalypt has no do-notation or do-blocks.
+                    "do" => {
+                        notes.push(
+                            "eucalypt has no 'do' keyword; use block declarations \
+                             'x: 1  y: x + 2' or function pipelines 'xs map(_ * 2)'"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -845,3 +845,13 @@ pub fn test_error_072() {
 pub fn test_error_073() {
     run_error_test(&error_opts("073_sprintf_hint.eu"));
 }
+
+#[test]
+pub fn test_error_074() {
+    run_error_test(&error_opts("074_where_keyword.eu"));
+}
+
+#[test]
+pub fn test_error_075() {
+    run_error_test(&error_opts("075_let_keyword.eu"));
+}


### PR DESCRIPTION
## Error message: where/let/do functional programming keywords

### Scenario
Users coming from Haskell, OCaml, Scheme, SQL, or Ruby might write:
- `result: x + y  where  x: 1  y: 2` — Haskell-style `where` clause
- `result: let x: 1 in x + 2` — Haskell/Scheme-style `let...in` expression
- `do { x: 1  result: x + 2 }` — Haskell do-notation or Ruby/Rust `do` blocks

In all cases the keyword becomes an unresolved variable with no helpful context.

### Before
```
error: unresolved variable 'where'
  ┌─ 070_where_keyword.eu:3:3
  │
3 │   where
  │   ^^^^^
  │
  = check that the variable is defined and in scope
```
```
error: unresolved variable 'let'
  ┌─ 071_let_keyword.eu:2:9
  │
2 │ result: let x: 1 in x + 2
  │         ^^^
  │
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable 'where'
  ...
  = check that the variable is defined and in scope
  = eucalypt has no 'where' clause; define helper bindings inside a block: '{ helper: 1  result: helper + 2 }'
  = or bind before use at the top level: 'helper: 1  result: helper + 2'
```
```
error: unresolved variable 'let'
  ...
  = check that the variable is defined and in scope
  = eucalypt has no 'let' expression; use block bindings instead: '{ x: 1  y: x + 2 }' or top-level declarations 'x: 1  y: x + 2'
```

### Assessment
- Human diagnosability: poor → excellent
- LLM diagnosability: poor → excellent

### Change
Added three new arms to the free-variable hint match in `src/eval/stg/compiler.rs`:
- `where` — explains eucalypt uses block declarations instead of where-clauses
- `let` — explains eucalypt uses block bindings instead of let-expressions
- `do` — explains eucalypt uses block declarations instead of do-notation

New harness tests: `harness/test/errors/070_where_keyword.eu` and `harness/test/errors/071_let_keyword.eu`.

### Risks
Low. These keywords are common identifiers but only trigger when they appear as unresolved free variables. The hints are purely additive.