### PR TITLE
feat: add hints for camelCase list function names from Haskell/Scala/JavaScript

### DIFF
--- a/harness/test/errors/079_camelcase_take_while.eu
+++ b/harness/test/errors/079_camelcase_take_while.eu
@@ -1,0 +1,3 @@
+# Mistake: using camelCase Haskell-style takeWhile instead of eucalypt's take-while
+xs: [1, 2, 3, 4, 5]
+result: takeWhile((_ < 4), xs)

--- a/harness/test/errors/079_camelcase_take_while.eu.expect
+++ b/harness/test/errors/079_camelcase_take_while.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "kebab-case"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -445,6 +445,54 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // CamelCase names for list functions that have kebab-case equivalents.
+                    // Haskell, Scala, and JavaScript all use camelCase for these.
+                    "takeWhile" | "take_while" => {
+                        notes.push(
+                            "eucalypt uses kebab-case: 'take-while', e.g. \
+                             'xs take-while(_ < 4)'"
+                                .to_string(),
+                        );
+                    }
+                    "dropWhile" | "drop_while" => {
+                        notes.push(
+                            "eucalypt uses kebab-case: 'drop-while', e.g. \
+                             'xs drop-while(_ < 4)'"
+                                .to_string(),
+                        );
+                    }
+                    "zipWith" | "zip_with" => {
+                        notes.push(
+                            "eucalypt uses kebab-case: 'zip-with', e.g. \
+                             'zip-with(+, xs, ys)' or 'xs zip-with(+, ys)'"
+                                .to_string(),
+                        );
+                    }
+                    "groupBy" | "group_by" => {
+                        notes.push(
+                            "eucalypt uses kebab-case: 'group-by', e.g. \
+                             'xs group-by(_ % 2)' to group by remainder"
+                                .to_string(),
+                        );
+                    }
+                    "sortBy" | "sort_by" => {
+                        notes.push(
+                            "eucalypt uses kebab-case: 'sort-by' (for general ordering) or \
+                             'sort-by-num' (for numeric keys), e.g. \
+                             'xs sort-by-num(.score)'"
+                                .to_string(),
+                        );
+                    }
+                    // Common names for prefix sum / running total / cumulative sum.
+                    // In eucalypt, use 'scanl' with the '+' operator.
+                    "running-total" | "running_total" | "prefix-sum" | "prefix_sum" | "cumsum"
+                    | "cumulative-sum" | "cumulative_sum" | "scan" => {
+                        notes.push(
+                            "to compute a running total, use 'scanl', e.g. \
+                             'xs scanl(+, 0)' produces prefix sums"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -870,3 +870,8 @@ pub fn test_error_077() {
 pub fn test_error_078() {
     run_error_test(&error_opts("078_anon_anaphor_scope.eu"));
 }
+
+#[test]
+pub fn test_error_079() {
+    run_error_test(&error_opts("079_camelcase_take_while.eu"));
+}


### PR DESCRIPTION
## Error message: camelCase function name variants

### Scenario
Users coming from Haskell, Scala, or JavaScript write camelCase function names that have kebab-case equivalents in eucalypt, e.g. `takeWhile` instead of `take-while`.

### Before
```
error: unresolved variable 'takeWhile'
  ┌─ test.eu:3:9
  │
3 │ result: takeWhile((_ < 4), xs)
  │         ^^^^^^^^^
  │
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable 'takeWhile'
  ...
  = check that the variable is defined and in scope
  = eucalypt uses kebab-case: 'take-while', e.g. 'xs take-while(_ < 4)'
```

### Assessment
- Human diagnosability: poor → excellent
- LLM diagnosability: fair → excellent

### Change
Added new arms to the free-variable hint match in `src/eval/stg/compiler.rs` covering:
- `takeWhile`/`take_while` → `take-while`
- `dropWhile`/`drop_while` → `drop-while`
- `zipWith`/`zip_with` → `zip-with`
- `groupBy`/`group_by` → `group-by`
- `sortBy`/`sort_by` → `sort-by`/`sort-by-num`
- `running-total`, `prefix-sum`, `cumsum`, `scan` variants → `scanl(+, 0)`

New harness test: `harness/test/errors/074_camelcase_take_while.eu`.

### Risks
Low. These are purely additive hints for specific identifier names that cannot be used in valid eucalypt code. No existing tests are affected.