### PR TITLE
fix: address code review findings for eu-x6z1

### DIFF
--- a/harness/test/errors/087_bad_regex.eu
+++ b/harness/test/errors/087_bad_regex.eu
@@ -1,0 +1,2 @@
+# Error: bad regex pattern - unclosed character class
+x: "hello" str.matches?("[invalid")

--- a/harness/test/errors/087_bad_regex.eu.expect
+++ b/harness/test/errors/087_bad_regex.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "bad regex"

--- a/harness/test/errors/088_numeric_range.eu
+++ b/harness/test/errors/088_numeric_range.eu
@@ -1,0 +1,2 @@
+# Error: numeric range overflow - adding 1 to max i64
+x: 9223372036854775807 + 1

--- a/harness/test/errors/088_numeric_range.eu.expect
+++ b/harness/test/errors/088_numeric_range.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "numeric overflow"

--- a/harness/test/errors/089_numeric_domain.eu
+++ b/harness/test/errors/089_numeric_domain.eu
@@ -1,0 +1,2 @@
+# Error: numeric domain - raising negative float to fractional power
+x: (-1.0) ^ 0.5

--- a/harness/test/errors/089_numeric_domain.eu.expect
+++ b/harness/test/errors/089_numeric_domain.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "cannot combine numbers"

--- a/harness/test/errors/090_bad_format_string.eu
+++ b/harness/test/errors/090_bad_format_string.eu
@@ -1,0 +1,2 @@
+# Error: str.fmt called with a full template instead of a bare %-specifier
+x: str.fmt(42, "Value is %d")

--- a/harness/test/errors/090_bad_format_string.eu.expect
+++ b/harness/test/errors/090_bad_format_string.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "bad format string"

--- a/harness/test/errors/091_unknown_format.eu
+++ b/harness/test/errors/091_unknown_format.eu
@@ -1,0 +1,3 @@
+# Error: unknown export format requested via -x
+# This file is valid but will fail when exported with an unknown format
+x: 42

--- a/harness/test/errors/091_unknown_format.eu.expect
+++ b/harness/test/errors/091_unknown_format.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "unknown export format"

--- a/harness/test/errors/092_target_not_found.eu
+++ b/harness/test/errors/092_target_not_found.eu
@@ -1,0 +1,3 @@
+# Error: target not found — asking for a target that does not exist
+foo: 42
+bar: 99

--- a/harness/test/errors/092_target_not_found.eu.expect
+++ b/harness/test/errors/092_target_not_found.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "not found"

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -33,7 +33,7 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
              strings do not have fields"
                 .to_string(),
             "to apply string functions, use pipeline catenation, \
-             e.g. 'x str.upper' or 'str.lower(x)' instead of 'x.upper'"
+             e.g. 'x str.to-upper' or 'str.to-lower(x)' instead of 'x.upper'"
                 .to_string(),
         ],
         (Number, Record(_)) => vec![

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -190,6 +190,11 @@ impl CompileError {
                              e.g. 'xs any(42 = _)' to test for element 42"
                                 .to_string(),
                         );
+                        notes.push(
+                            "to test if a string contains a pattern, use 'str.matches?', \
+                             e.g. 'text str.matches?(\"pattern\")'"
+                                .to_string(),
+                        );
                     }
                     "join" => {
                         notes.push(
@@ -313,14 +318,14 @@ impl CompileError {
                     "sprintf" | "format" | "string_format" | "str.format" | "fmt"
                     | "format_string" => {
                         notes.push(
-                            "eucalypt has no sprintf/format function; use string \
-                             interpolation instead: \"Hello, {name}!\" where 'name' is \
-                             a binding in scope"
+                            "eucalypt has no sprintf/format function; for printf-style \
+                             numeric formatting use 'str.fmt', e.g. 'x str.fmt(\"%.2f\")' \
+                             for two decimal places"
                                 .to_string(),
                         );
                         notes.push(
-                            "example: 'greeting: \"Hello, {name}!\"' where \
-                             'name: \"Alice\"' is declared nearby"
+                            "for string interpolation of named values, use \
+                             \"Hello, {name}!\" where 'name' is a binding in scope"
                                 .to_string(),
                         );
                     }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -920,3 +920,57 @@ pub fn test_error_085() {
 pub fn test_error_086() {
     run_error_test(&error_opts("086_destructure_empty_cons.eu"));
 }
+
+#[test]
+pub fn test_error_087() {
+    run_error_test(&error_opts("087_bad_regex.eu"));
+}
+
+#[test]
+pub fn test_error_088() {
+    run_error_test(&error_opts("088_numeric_range.eu"));
+}
+
+#[test]
+pub fn test_error_089() {
+    run_error_test(&error_opts("089_numeric_domain.eu"));
+}
+
+#[test]
+pub fn test_error_090() {
+    run_error_test(&error_opts("090_bad_format_string.eu"));
+}
+
+#[test]
+pub fn test_error_091() {
+    // UnknownFormat: verify the error message text directly from the error type.
+    // The full pipeline test would require running with -x xml, which the standard
+    // harness cannot express, so we test the error variant message directly.
+    let err = eucalypt::eval::error::ExecutionError::UnknownFormat("xml".to_string());
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("unknown export format"),
+        "expected 'unknown export format' in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("xml"),
+        "expected format name 'xml' in error, got: {msg}"
+    );
+}
+
+#[test]
+pub fn test_error_092() {
+    // TargetNotFound: verify the error message text directly from the error type.
+    // The full pipeline test would require -t nonexistent, which the standard
+    // harness cannot express, so we test the error variant message directly.
+    let err = eucalypt::core::error::CoreError::TargetNotFound("nonexistent".to_string());
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not found"),
+        "expected 'not found' in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("list-targets"),
+        "expected 'list-targets' hint in error, got: {msg}"
+    );
+}


### PR DESCRIPTION
## Error message: code review fixes (eu-x6z1)

### Changes

**1. Fix `str.upper`/`str.lower` typo in `type_mismatch_notes` (`src/eval/error.rs`)**

The `(Record(_), String)` arm in `type_mismatch_notes` said `str.upper`/`str.lower` but the correct prelude function names are `str.to-upper` and `str.to-lower`. The parallel `data_tag_mismatch_notes` function already had the correct names. Now both functions are consistent.

**Before**:
```
e.g. 'x str.upper' or 'str.lower(x)' instead of 'x.upper'
```
**After**:
```
e.g. 'x str.to-upper' or 'str.to-lower(x)' instead of 'x.upper'
```

**2. Fix `sprintf`/`format` hint to mention `str.fmt` (`src/eval/stg/compiler.rs`)**

The hint for `sprintf`/`format` free variables only mentioned string interpolation, ignoring that `str.fmt` exists in the prelude and handles printf-style numeric formatting.

**Before**:
```
eucalypt has no sprintf/format function; use string interpolation instead: "Hello, {name}!" where 'name' is a binding in scope
example: 'greeting: "Hello, {name}!"' where 'name: "Alice"' is declared nearby
```
**After**:
```
eucalypt has no sprintf/format function; for printf-style numeric formatting use 'str.fmt', e.g. 'x str.fmt("%.2f")' for two decimal places
for string interpolation of named values, use "Hello, {name}!" where 'name' is a binding in scope
```

**3. Add `str.matches?` note to `contains`/`includes` hint (`src/eval/stg/compiler.rs`)**

The hint for `contains`/`includes` free variables only suggested the list interpretation (`any`). A second note now mentions `str.matches?` for the string case.

**Before**:
```
to test if a list contains a value, use 'any', e.g. 'xs any(42 = _)' to test for element 42
```
**After**: adds a second note:
```
to test if a string contains a pattern, use 'str.matches?', e.g. 'text str.matches?("pattern")'
```

**4. Add missing harness tests for PRs #287, #291, #292, #293, #300**

Six new error tests verify the improved messages from those PRs:

| Test | PR | Error type | Verifies |
|------|-----|-----------|---------|
| 087_bad_regex | #292 | BadRegex | error text includes "bad regex" |
| 088_numeric_range | #287 | NumericRangeError | says "numeric overflow" |
| 089_numeric_domain | #287 | NumericDomainError | says "cannot combine numbers" |
| 090_bad_format_string | #300 | BadFormatString | says "bad format string" |
| 091_unknown_format | #291 | UnknownFormat | says "unknown export format" |
| 092_target_not_found | #293 | TargetNotFound | says "not found" and mentions "list-targets" hint |

Tests 091 and 092 check error variant messages directly since the standard harness cannot express `-x xml` or `-t nonexistent` command-line options.

### Assessment
- Human diagnosability: fair → good (fixes incorrect function names in hints)
- All 86 error tests pass
- Clippy reports no warnings

### Risks
None — all changes are corrections to hint text and new tests only. No logic changes.