### PR TITLE
fix: allow commas in block destructuring patterns (eu-fjzd)

### DIFF
--- a/harness/test/091_destructure_block.eu
+++ b/harness/test/091_destructure_block.eu
@@ -5,6 +5,8 @@
 f-basic({x y}): x + y
 f-rename({x: a  y: b}): a * b
 f-mixed({x  y: b}): x + b
+f-comma({x, y}): x + y
+f-comma-rename({x: a, y: b}): a * b
 
 tests: {
 
@@ -30,6 +32,22 @@ tests: {
     a: f-mixed({x: 10 y: 20}) //= 30
     ` "sum with different values"
     b: f-mixed({x: 7 y: 3}) //= 10
+  }
+
+  ` "Comma-separated shorthand (commas optional as in block literals)"
+  comma: {
+    ` "sum via comma-separated pattern"
+    a: f-comma({x: 1, y: 2}) //= 3
+    ` "sum with larger values"
+    b: f-comma({x: 10, y: 20}) //= 30
+  }
+
+  ` "Comma-separated rename pattern"
+  comma-rename: {
+    ` "product via comma-separated rename pattern"
+    a: f-comma-rename({x: 3, y: 4}) //= 12
+    ` "product with different values"
+    b: f-comma-rename({x: 5, y: 6}) //= 30
   }
 
 }

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -977,16 +977,11 @@ impl EventSink for BlockEventSink {
                             }
                         }
                         None => {
-                            // error case '{ x , ... }'
-                            let mut head = vec![];
-                            swap(&mut head, &mut self.buffer);
-                            self.declaration = Some(PendingDeclaration {
-                                meta: None,
-                                head,
-                                colon: vec![],
-                                body: vec![],
-                            });
-                            self.commit_declaration();
+                            // Bare names separated by commas, e.g. `{x, y}` in a
+                            // block pattern. Commas are optional separators just as
+                            // in block literals, so leave the buffer as-is and let
+                            // complete() accumulate everything into block metadata,
+                            // producing the same result as `{x y}`.
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Block patterns like `f({x, y}): x + y` previously failed with "unresolved variable 'y'"
- Root cause: in `BlockEventSink`, a comma with no pending declaration triggered `commit_declaration()` for the first bare name, putting it in committed output; subsequent names then became `ERROR_STOWAWAYS`
- Fix: in the `COMMA`/`None` case, leave the buffer unchanged; everything accumulates and is committed together as block metadata by `complete()`, producing the same `BLOCK_META/SOUP` as `{x y}`
- Matches design doc §1: "Commas are optional (as in block literals)"

## Test plan

- [x] Added `f-comma({x, y})` and `f-comma-rename({x: a, y: b})` test functions and cases to `harness/test/091_destructure_block.eu`
- [x] `cargo test test_harness_091` passes
- [x] Full `cargo test` passes (182 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied