### PR TITLE
fix: replace hard-coded bracket table with Unicode Ps/Pe category detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "toml",
+ "unicode-bidi-mirroring",
  "unicode-general-category",
  "url",
  "uuid 1.20.0",
@@ -1901,6 +1902,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
 
 [[package]]
 name = "unicode-general-category"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ codespan-reporting = "0.11.1"
 serde_json = "1.0.85"
 yaml-rust = { git = "https://github.com/curvelogic/yaml-rust", rev = "e3a9b432c43fcf9a19f1836657091caf7ae3b15f" }
 unicode-general-category = "1"
+unicode-bidi-mirroring = "0.4.0"
 itertools = "0.10.5"
 thiserror = "1.0.37"
 url = "2.3.1"

--- a/src/syntax/rowan/brackets.rs
+++ b/src/syntax/rowan/brackets.rs
@@ -1,18 +1,62 @@
-//! Bracket pair lookup table for idiom brackets.
+//! Unicode bracket pair detection for idiom brackets.
 //!
-//! Idiom brackets allow applicative functor application to be expressed
-//! using Unicode bracket pairs, e.g. `⟦ x ⟧` or `⌈ x ⌉`.
+//! Idiom brackets allow user-defined bracket pair expressions, e.g. `«x»` or `⟦x⟧`.
 //!
-//! A bracket pair is declared in a block using the syntax:
+//! Bracket pair recognition uses Unicode general categories:
+//! - **Opening**: any character in Unicode category Ps (OpenPunctuation) or Pi (InitialPunctuation)
+//! - **Closing**: any character in Unicode category Pe (ClosePunctuation) or Pf (FinalPunctuation)
 //!
-//! ```eucalypt
-//! (⟦ x ⟧): f(x)
-//! ```
+//! Matching of open→close uses Unicode Bidi Mirroring Glyph property.
 //!
-//! which defines a function named `⟦⟧` taking one argument and applying `f`.
-//!
-//! The bracket pair lookup table maps each supported Unicode open bracket
-//! character to its corresponding close bracket character.
+//! The ASCII bracket characters `(`, `)`, `[`, `]`, `{`, `}` are excluded as
+//! they are reserved by the eucalypt language.
+
+use unicode_bidi_mirroring::get_mirrored;
+use unicode_general_category::{get_general_category, GeneralCategory};
+
+/// Return true if `c` is a Unicode bracket open character eligible for use as
+/// an idiom bracket.
+///
+/// This includes any character in Unicode categories Ps (OpenPunctuation) or
+/// Pi (InitialPunctuation), excluding the ASCII brackets reserved by the
+/// eucalypt language: `(`, `[`, `{`.
+pub fn is_bracket_open(c: char) -> bool {
+    if c.is_ascii() {
+        return false; // ASCII open brackets are language-reserved
+    }
+    matches!(
+        get_general_category(c),
+        GeneralCategory::OpenPunctuation | GeneralCategory::InitialPunctuation
+    )
+}
+
+/// Return true if `c` is a Unicode bracket close character eligible for use as
+/// an idiom bracket.
+///
+/// This includes any character in Unicode categories Pe (ClosePunctuation) or
+/// Pf (FinalPunctuation), excluding the ASCII brackets reserved by the
+/// eucalypt language: `)`, `]`, `}`.
+pub fn is_bracket_close(c: char) -> bool {
+    if c.is_ascii() {
+        return false; // ASCII close brackets are language-reserved
+    }
+    matches!(
+        get_general_category(c),
+        GeneralCategory::ClosePunctuation | GeneralCategory::FinalPunctuation
+    )
+}
+
+/// Return the matching closing bracket for an opening bracket character, using
+/// the Unicode Bidi Mirroring Glyph property.
+///
+/// Returns `None` if `open` is not a recognised bracket open character or has
+/// no mirroring glyph.
+pub fn close_for_open(open: char) -> Option<char> {
+    if !is_bracket_open(open) {
+        return None;
+    }
+    get_mirrored(open)
+}
 
 /// A Unicode bracket pair consisting of open and close characters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,98 +80,12 @@ impl BracketPair {
     }
 }
 
-/// All built-in Unicode bracket pairs recognised as idiom brackets.
-///
-/// Pairs are drawn from common mathematical and typographical Unicode
-/// bracket characters.  Additional pairs can be registered at runtime
-/// via bracket pair declarations.
-pub const BUILTIN_BRACKET_PAIRS: &[BracketPair] = &[
-    // Mathematical angle brackets
-    BracketPair {
-        open: '⟦',
-        close: '⟧',
-    }, // MATHEMATICAL LEFT WHITE SQUARE BRACKET / RIGHT
-    BracketPair {
-        open: '⟨',
-        close: '⟩',
-    }, // MATHEMATICAL LEFT ANGLE BRACKET / RIGHT
-    BracketPair {
-        open: '⟪',
-        close: '⟫',
-    }, // MATHEMATICAL LEFT DOUBLE ANGLE BRACKET / RIGHT
-    BracketPair {
-        open: '⌈',
-        close: '⌉',
-    }, // LEFT CEILING / RIGHT CEILING
-    BracketPair {
-        open: '⌊',
-        close: '⌋',
-    }, // LEFT FLOOR / RIGHT FLOOR
-    BracketPair {
-        open: '⦃',
-        close: '⦄',
-    }, // MATHEMATICAL LEFT WHITE CURLY BRACKET / RIGHT
-    BracketPair {
-        open: '⦇',
-        close: '⦈',
-    }, // MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET / RIGHT
-    BracketPair {
-        open: '⦉',
-        close: '⦊',
-    }, // MATHEMATICAL LEFT FLATTENED PARENTHESIS / RIGHT
-    // French quotation marks (guillemets)
-    BracketPair {
-        open: '«',
-        close: '»',
-    }, // LEFT-POINTING DOUBLE ANGLE QUOTATION MARK / RIGHT
-    // CJK brackets
-    BracketPair {
-        open: '【',
-        close: '】',
-    }, // LEFT BLACK LENTICULAR BRACKET / RIGHT
-    BracketPair {
-        open: '〔',
-        close: '〕',
-    }, // LEFT TORTOISE SHELL BRACKET / RIGHT
-    BracketPair {
-        open: '〖',
-        close: '〗',
-    }, // LEFT WHITE LENTICULAR BRACKET / RIGHT
-    BracketPair {
-        open: '〘',
-        close: '〙',
-    }, // LEFT WHITE TORTOISE SHELL BRACKET / RIGHT
-    BracketPair {
-        open: '〚',
-        close: '〛',
-    }, // LEFT WHITE SQUARE BRACKET / RIGHT
-];
-
-/// Look up the close bracket for a given open bracket character, if it is a
-/// known idiom bracket pair.
-pub fn close_for_open(open: char) -> Option<char> {
-    BUILTIN_BRACKET_PAIRS
-        .iter()
-        .find(|p| p.open == open)
-        .map(|p| p.close)
-}
-
 /// Return the `BracketPair` for an open bracket character, if recognised.
+///
+/// Uses Unicode category and Bidi Mirroring property to determine the pair.
 pub fn pair_for_open(open: char) -> Option<BracketPair> {
-    BUILTIN_BRACKET_PAIRS
-        .iter()
-        .copied()
-        .find(|p| p.open == open)
-}
-
-/// Return true if `c` is a recognised idiom bracket open character.
-pub fn is_bracket_open(c: char) -> bool {
-    BUILTIN_BRACKET_PAIRS.iter().any(|p| p.open == c)
-}
-
-/// Return true if `c` is a recognised idiom bracket close character.
-pub fn is_bracket_close(c: char) -> bool {
-    BUILTIN_BRACKET_PAIRS.iter().any(|p| p.close == c)
+    let close = close_for_open(open)?;
+    Some(BracketPair { open, close })
 }
 
 #[cfg(test)]
@@ -135,32 +93,110 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_close_for_open() {
+    fn test_close_for_open_known_pairs() {
+        // Pairs that were previously in the hard-coded table
         assert_eq!(close_for_open('⟦'), Some('⟧'));
         assert_eq!(close_for_open('⟨'), Some('⟩'));
+        assert_eq!(close_for_open('⟪'), Some('⟫'));
+        assert_eq!(close_for_open('⌈'), Some('⌉'));
+        assert_eq!(close_for_open('⌊'), Some('⌋'));
+        assert_eq!(close_for_open('⦃'), Some('⦄'));
+        assert_eq!(close_for_open('⦇'), Some('⦈'));
+        assert_eq!(close_for_open('⦉'), Some('⦊'));
         assert_eq!(close_for_open('«'), Some('»'));
-        assert_eq!(close_for_open('('), None); // ASCII paren, not a bracket pair
+        assert_eq!(close_for_open('【'), Some('】'));
+        assert_eq!(close_for_open('〔'), Some('〕'));
+        assert_eq!(close_for_open('〖'), Some('〗'));
+        assert_eq!(close_for_open('〘'), Some('〙'));
+        assert_eq!(close_for_open('〚'), Some('〛'));
+    }
+
+    #[test]
+    fn test_ascii_brackets_excluded() {
+        // ASCII brackets are language-reserved and must not be bracket pairs
+        assert_eq!(close_for_open('('), None);
+        assert_eq!(close_for_open('['), None);
+        assert_eq!(close_for_open('{'), None);
+        assert!(!is_bracket_open('('));
+        assert!(!is_bracket_open('['));
+        assert!(!is_bracket_open('{'));
+        assert!(!is_bracket_close(')'));
+        assert!(!is_bracket_close(']'));
+        assert!(!is_bracket_close('}'));
+    }
+
+    #[test]
+    fn test_non_bracket_chars_excluded() {
         assert_eq!(close_for_open('a'), None);
+        assert_eq!(close_for_open('1'), None);
+        assert!(!is_bracket_open('a'));
+        assert!(!is_bracket_close('b'));
+    }
+
+    #[test]
+    fn test_is_bracket_open_known() {
+        assert!(is_bracket_open('⟦'));
+        assert!(is_bracket_open('«'));
+        assert!(is_bracket_open('⟨'));
+        assert!(is_bracket_open('⌈'));
+        assert!(is_bracket_open('⌊'));
+    }
+
+    #[test]
+    fn test_is_bracket_close_known() {
+        assert!(is_bracket_close('⟧'));
+        assert!(is_bracket_close('»'));
+        assert!(is_bracket_close('⟩'));
+        assert!(is_bracket_close('⌉'));
+        assert!(is_bracket_close('⌋'));
     }
 
     #[test]
     fn test_pair_name() {
         let pair = pair_for_open('⟦').unwrap();
         assert_eq!(pair.name(), "⟦⟧");
+
+        let pair2 = pair_for_open('«').unwrap();
+        assert_eq!(pair2.name(), "«»");
+    }
+
+    // Test with a bracket pair NOT in the old hard-coded table to prove
+    // dynamic detection works.
+    #[test]
+    fn test_dynamic_detection_new_pair() {
+        // U+2768 MEDIUM LEFT CURLY BRACKET ORNAMENT /
+        // U+2769 MEDIUM RIGHT CURLY BRACKET ORNAMENT
+        // These were NOT in the previous hard-coded table.
+        let open = '\u{2768}'; // ❨
+        let close = '\u{2769}'; // ❩
+        assert!(
+            is_bracket_open(open),
+            "❨ should be detected as bracket open"
+        );
+        assert!(
+            is_bracket_close(close),
+            "❩ should be detected as bracket close"
+        );
+        assert_eq!(close_for_open(open), Some(close), "❨ should mirror to ❩");
+        let pair = pair_for_open(open).unwrap();
+        assert_eq!(pair.name(), "❨❩");
     }
 
     #[test]
-    fn test_is_bracket_open() {
-        assert!(is_bracket_open('⟦'));
-        assert!(is_bracket_open('«'));
-        assert!(!is_bracket_open('('));
-        assert!(!is_bracket_open(')'));
-    }
-
-    #[test]
-    fn test_is_bracket_close() {
-        assert!(is_bracket_close('⟧'));
-        assert!(is_bracket_close('»'));
-        assert!(!is_bracket_close(')'));
+    fn test_dynamic_detection_ornament_angle_bracket() {
+        // U+276C MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+        // U+276D MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+        // Also not in the old hard-coded table.
+        let open = '\u{276c}'; // ❬
+        let close = '\u{276d}'; // ❭
+        assert!(
+            is_bracket_open(open),
+            "❬ should be detected as bracket open"
+        );
+        assert!(
+            is_bracket_close(close),
+            "❭ should be detected as bracket close"
+        );
+        assert_eq!(close_for_open(open), Some(close));
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the static 14-pair bracket lookup table in `brackets.rs` with dynamic detection using Unicode general categories Ps/Pi (open) and Pe/Pf (close)
- Adds `unicode-bidi-mirroring = "0.4.0"` dependency to provide open→close mapping via the Unicode Bidi Mirroring Glyph property
- All 14 previously hard-coded bracket pairs continue to work
- Adds tests proving dynamic detection of pairs NOT in the old table (❨❩ U+2768/2769, ❬❭ U+276C/276D)
- ASCII brackets `()[]{}` remain excluded (language-reserved)
- Public API unchanged: `is_bracket_open`, `is_bracket_close`, `close_for_open`, `pair_for_open`, `BracketPair`

## Test plan

- [x] `cargo test --lib` — all 581 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Dynamic detection test: `test_dynamic_detection_new_pair` (❨❩)
- [x] Dynamic detection test: `test_dynamic_detection_ornament_angle_bracket` (❬❭)
- [x] All 14 original pairs verified in `test_close_for_open_known_pairs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)