### PR TITLE
fix(tree-sitter): address eu-non1 code review findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ editors/vscode/node_modules/
 editors/vscode/out/
 editors/vscode/*.vsix
 
+# Byte-compiled Emacs Lisp
+*.elc
+
 # Local settings
 *.local.json
 

--- a/editors/tree-sitter-eucalypt/grammar.js
+++ b/editors/tree-sitter-eucalypt/grammar.js
@@ -8,12 +8,24 @@
  * rendering structured data formats (YAML, JSON, TOML).
  */
 
-// Helper to define operator characters
-// Includes: standard punctuation operators, unicode math/arrows, and special chars used in prelude
-// Notable: ? (for //=?, //!?), $ (for <$>), ∸ (unary minus)
-const OPER_CHARS = /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘→←⊕⊗⊙⊡⊞⊟⟨⟩⟪⟫⟦⟧⌈⌉⌊⌋¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/;
+// Helper to define operator characters.
+// Includes: standard punctuation operators, Unicode math/arrows, and
+// special characters used in the prelude.
+// Notable inclusions: ? (for //=?, //!?), $ (for <$>), ∸ (unary minus),
+// ‖ (U+2016 DOUBLE VERTICAL LINE — the cons operator).
+// Note: bracket characters (⟦⟧⟨⟩⟪⟫⌈⌉⌊⌋) are intentionally excluded here;
+// they are handled by the bracket_expr rule instead.
+const OPER_CHARS = /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘‖→←⊕⊗⊙⊡⊞⊟¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/;
 
-// Unicode idiom bracket open characters (must match brackets.rs BUILTIN_BRACKET_PAIRS)
+// Unicode idiom bracket open characters (must match brackets.rs BUILTIN_BRACKET_PAIRS).
+//
+// NOTE ON BRACKET DETECTION LIMITATIONS:
+// The Rust parser uses dynamic Unicode Ps/Pe category detection, meaning any
+// Unicode bracket pair (Open/Close punctuation categories) works automatically.
+// This tree-sitter grammar hardcodes specific pairs instead.  To add a new
+// bracket pair, add the open character to BRACKET_OPEN_RE and the corresponding
+// close character to BRACKET_CLOSE_RE, then regenerate parser.c with
+// `tree-sitter generate`.
 const BRACKET_OPEN_RE = /[⟦⟨⟪⌈⌊⦃⦇⦉«【〔〖〘〚]/;
 const BRACKET_CLOSE_RE = /[⟧⟩⟫⌉⌋⦄⦈⦊»】〕〗〙〛]/;
 
@@ -183,6 +195,8 @@ module.exports = grammar({
       $.list,
       $.paren_expr,
       $.application,
+      $.block_application,
+      $.list_application,
       $.bracket_expr,
     ),
 
@@ -205,11 +219,52 @@ module.exports = grammar({
       ')',
     )),
 
+    // Juxtaposed block call: f{x: 1, y: 2} — sugar for f({x: 1, y: 2}).
+    // The Rust parser handles this via OPEN_BRACE_APPLY token ('{' immediately
+    // following a name/expression, with no whitespace).
+    block_application: $ => prec(2, seq(
+      choice($.name, $.paren_expr),
+      $.block_argument,
+    )),
+
+    block_argument: $ => prec(2, seq(
+      token.immediate('{'),
+      repeat(seq(
+        $.declaration,
+        optional(','),
+      )),
+      '}',
+    )),
+
+    // Juxtaposed list call: f[1, 2] — sugar for f([1, 2]).
+    // The Rust parser handles this via OPEN_SQUARE_APPLY token ('[' immediately
+    // following a name/expression, with no whitespace).
+    list_application: $ => prec(2, seq(
+      choice($.name, $.paren_expr),
+      $.list_argument,
+    )),
+
+    list_argument: $ => prec(2, seq(
+      token.immediate('['),
+      optional(seq(
+        $.soup,
+        repeat(seq(',', $.soup)),
+        optional(','),
+      )),
+      ']',
+    )),
+
     // Idiom bracket expression: ⟦ expr ⟧, «expr», ⌈ expr ⌉, etc.
     // The bracket pair determines which bracket-pair function is applied.
+    //
+    // Monadic blocks use bracket syntax and may contain declarations rather
+    // than plain expressions, so we allow either soup or declarations inside.
     bracket_expr: $ => seq(
       BRACKET_OPEN_RE,
-      optional($.soup),
+      optional(choice(
+        $.soup,
+        repeat1(seq($.declaration, optional(','))),
+      )),
       BRACKET_CLOSE_RE,
     ),
 
@@ -336,9 +391,11 @@ module.exports = grammar({
       "'",
     ),
 
-    // Operators: sequences of operator characters
-    // Must match OPER_CHARS above - includes ?, $, ∸ for prelude operators
-    operator: $ => token(prec(-1, /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘→←⊕⊗⊙⊡⊞⊟⟨⟩⟪⟫⟦⟧⌈⌉⌊⌋¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪¡££€⨈∅∏]+/)),
+    // Operators: sequences of operator characters.
+    // Bracket characters (⟦⟧⟨⟩⟪⟫⌈⌉⌊⌋) are deliberately excluded here;
+    // they are matched by the bracket_expr rule via BRACKET_OPEN_RE/BRACKET_CLOSE_RE.
+    // ‖ (U+2016 DOUBLE VERTICAL LINE) is included as the cons operator.
+    operator: $ => token(prec(-1, /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘‖→←⊕⊗⊙⊡⊞⊟¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/)),
 
     // Anaphora: _ or _0, _1, etc., or • or •0, •1, etc.
     anaphor: $ => choice(

--- a/editors/tree-sitter-eucalypt/src/scanner.c
+++ b/editors/tree-sitter-eucalypt/src/scanner.c
@@ -42,6 +42,7 @@ static bool is_operator_char(int32_t c) {
     if (c >= 0x2200 && c <= 0x22FF) return true;  // Mathematical operators
     if (c >= 0x27F0 && c <= 0x27FF) return true;  // Supplemental arrows
     if (c == 0x2227 || c == 0x2228 || c == 0x2218) return true;  // ∧ ∨ ∘
+    if (c == 0x2016) return true;  // ‖ DOUBLE VERTICAL LINE (cons operator)
     return false;
 }
 

--- a/editors/tree-sitter-eucalypt/test/corpus/declarations.txt
+++ b/editors/tree-sitter-eucalypt/test/corpus/declarations.txt
@@ -320,3 +320,298 @@ result: ⟦ x ⟧
         (soup
           (name
             (identifier)))))))
+
+================================================================================
+Anaphor underscore
+================================================================================
+
+f: _ + 1
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (anaphor)
+      (operator)
+      (literal
+        (number)))))
+
+================================================================================
+Anaphor numbered
+================================================================================
+
+f: _0 + _1
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (anaphor)
+      (operator)
+      (anaphor))))
+
+================================================================================
+Bullet anaphor
+================================================================================
+
+f: • + 1
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (anaphor)
+      (operator)
+      (literal
+        (number)))))
+
+================================================================================
+Unicode operators — arithmetic
+================================================================================
+
+x: a ÷ b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode operators — comparison
+================================================================================
+
+check: a ≠ b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode operators — ordering
+================================================================================
+
+check: a ≤ b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode operators — logical
+================================================================================
+
+check: a ∧ b
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode operators — negation
+================================================================================
+
+check: ¬ a
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode operators — composition
+================================================================================
+
+h: f ∘ g
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Unicode cons operator
+================================================================================
+
+xs: h ‖ t
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (name
+        (identifier))
+      (operator)
+      (name
+        (identifier)))))
+
+================================================================================
+Nested block
+================================================================================
+
+config: { x: 1 y: { a: 2 } }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (block
+        (declaration
+          (declaration_head
+            (identifier))
+          (soup
+            (literal
+              (number))))
+        (declaration
+          (declaration_head
+            (identifier))
+          (soup
+            (block
+              (declaration
+                (declaration_head
+                  (identifier))
+                (soup
+                  (literal
+                    (number)))))))))))
+
+================================================================================
+Nested list
+================================================================================
+
+matrix: [[1, 2], [3, 4]]
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (list
+        (soup
+          (list
+            (soup
+              (literal
+                (number)))
+            (soup
+              (literal
+                (number)))))
+        (soup
+          (list
+            (soup
+              (literal
+                (number)))
+            (soup
+              (literal
+                (number)))))))))
+
+================================================================================
+Juxtaposed block call
+================================================================================
+
+result: f{x: 1}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (block_application
+        (name
+          (identifier))
+        (block_argument
+          (declaration
+            (declaration_head
+              (identifier))
+            (soup
+              (literal
+                (number)))))))))
+
+================================================================================
+Juxtaposed list call
+================================================================================
+
+result: f[1, 2]
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (declaration
+    (declaration_head
+      (identifier))
+    (soup
+      (list_application
+        (name
+          (identifier))
+        (list_argument
+          (soup
+            (literal
+              (number)))
+          (soup
+            (literal
+              (number))))))))


### PR DESCRIPTION
## Summary

Fixes all findings from the eu-non1 code review of the tree-sitter grammar for Eucalypt.

- **eu-b944 (CRITICAL)** Add `‖` (U+2016 DOUBLE VERTICAL LINE, cons operator) to `OPER_CHARS` constant and `operator` token regex in `grammar.js`, and to `is_operator_char()` in `src/scanner.c`
- **eu-h3xa (IMPORTANT)** Add `block_application` and `list_application` grammar rules for juxtaposed call syntax `f{...}` and `f[...]`, matching the Rust parser's `OPEN_BRACE_APPLY`/`OPEN_SQUARE_APPLY` tokens; add corresponding `block_argument` and `list_argument` helper rules using `token.immediate` to require no whitespace
- **eu-cwv0 (IMPORTANT)** Add comment explaining that the Rust parser uses dynamic Unicode Ps/Pe category detection for bracket pairs, while the tree-sitter grammar hardcodes them and requires manual addition plus `tree-sitter generate` regeneration
- **eu-qnq8 (IMPORTANT)** Update `bracket_expr` to accept either `soup` or a sequence of `declaration`s inside brackets, supporting monadic block content
- **eu-8rfs (IMPORTANT)** Remove bracket characters (`⟦⟧⟨⟩⟪⟫⌈⌉⌊⌋`) from the `operator` token regex — they are handled exclusively by `bracket_expr` via `BRACKET_OPEN_RE`/`BRACKET_CLOSE_RE`
- **eu-a0y5** Add `*.elc` to `.gitignore` to prevent accidental commits of byte-compiled Emacs Lisp
- **eu-45sl** Expand test corpus with cases for: anaphora (`_`, `_0`, `•`), Unicode operators (`÷`, `≠`, `≤`, `∧`, `¬`, `∘`, `‖`), nested block and list structures, juxtaposed block call (`f{x: 1}`), and juxtaposed list call (`f[1, 2]`)

## Note on parser.c regeneration

`tree-sitter generate` was not available in the build environment. The generated `src/parser.c` has **not** been updated. This must be done locally or via CI before merging:

```
cd editors/tree-sitter-eucalypt
npm install
npx tree-sitter generate
npx tree-sitter test
```

## Test plan

- [ ] Run `tree-sitter generate` in `editors/tree-sitter-eucalypt/` to regenerate `parser.c`
- [ ] Run `tree-sitter test` — all corpus tests should pass including the new ones
- [ ] Verify `‖` is parsed as an operator (not an error) in a simple test case
- [ ] Verify `f{x: 1}` and `f[1, 2]` parse as `block_application` / `list_application`
- [ ] Verify `⟦ x: 1 ⟧` (monadic block content) parses without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)