### PR TITLE
feat(eu-qg0j): add stream_next single-advance function

### DIFF
--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -86,3 +86,17 @@ pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
         }
     })
 }
+
+/// Advance a stream producer by a single step.
+///
+/// Returns `Some(value)` if the producer yielded an element, or
+/// `None` if the stream is exhausted or the handle is invalid.
+pub fn stream_next(handle: u32) -> Option<Rc<StgSyn>> {
+    STREAM_TABLE.with(|table| {
+        let table = table.borrow();
+        match table.get(handle) {
+            Some(producer) => producer.borrow_mut().next(),
+            None => None,
+        }
+    })
+}


### PR DESCRIPTION
## Summary

- Adds `stream_next(handle: u32) -> Option<Rc<StgSyn>>` to `src/eval/stg/stream.rs`
- Advances the stream producer by exactly one step, returning `Some(value)` or `None` if exhausted/invalid
- Retains `stream_drain` unchanged for existing callers
- Required by `eu-uihm` (lazy cons cell rewrite of `StreamNext` intrinsic)

## Test plan

- [ ] `cargo build` — passes
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Function will be exercised by the lazy cons intrinsic tests in `eu-uihm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)