### PR TITLE
feat(eu-loj2): allow paren-free bracket pair declarations

### DIFF
--- a/doc/appendices/cheat-sheet.md
+++ b/doc/appendices/cheat-sheet.md
@@ -87,7 +87,7 @@ x: 42 # inline comment
 | Binary operator | `(l op r): expr` | Infix operator |
 | Prefix operator | `(op x): expr` | Unary prefix |
 | Postfix operator | `(x op): expr` | Unary postfix |
-| Idiot bracket | `(⟦ x ⟧): expr` | Unicode bracket pair functor |
+| Idiot bracket | `⟦ x ⟧: expr` | Unicode bracket pair functor |
 
 ## Idiot Brackets
 
@@ -95,7 +95,7 @@ Idiot brackets allow applicative functor lifting using Unicode bracket pairs.
 
 ```eu,notest
 # Declare a bracket pair function
-(⟦ x ⟧): my-functor(x)
+⟦ x ⟧: my-functor(x)
 
 # Use the bracket pair in expressions
 result: ⟦ some-expression ⟧  # calls my-functor(some-expression)
@@ -111,7 +111,7 @@ spec.  A bracket block (declarations directly inside brackets) followed by `.exp
 desugars as a bind chain (like `do`-notation).
 
 ```eu,notest
-(⟦{}⟧): { bind: my-bind  return: my-return }
+⟦{}⟧: { :monad bind: my-bind  return: my-return }
 
 # ⟦ a: ma  b: mb ⟧.return_expr
 # desugars to: my-bind(ma, (a): my-bind(mb, (b): my-return(return_expr)))

--- a/doc/reference/syntax.md
+++ b/doc/reference/syntax.md
@@ -204,14 +204,20 @@ in the symbol or punctuation classes are fine for operators.
 In addition to named operators, you can define **idiot brackets** —
 Unicode bracket pairs that define applicative functor lifting.  A
 bracket pair declaration uses a Unicode bracket pair wrapping a single
-parameter:
+parameter directly (paren-free style):
 
 ```eu
 # Ceiling brackets lift into a "double" functor
-(⌈ x ⌉): x * 2
+⌈ x ⌉: x * 2
 
 # Floor brackets lift into an "increment" functor
-(⌊ x ⌋): x + 1
+⌊ x ⌋: x + 1
+```
+
+The older paren-wrapped style is still supported for backwards compatibility:
+
+```eu
+(⌈ x ⌉): x * 2    # paren style — still valid
 ```
 
 Once declared, the bracket pair can be used as an expression:
@@ -221,9 +227,9 @@ doubled: ⌈ 3 + 4 ⌉    # => 14
 bumped:  ⌊ 5 ⌋         # => 6
 ```
 
-The declaration `(⟦ x ⟧): body` defines a function named `⟦⟧` (open
+The declaration `⌈ x ⌉: body` defines a function named `⌈⌉` (open
 then close bracket) that takes one argument `x` and returns `body`.
-Using `⟦ expr ⟧` in an expression calls that function with `expr`.
+Using `⌈ expr ⌉` in an expression calls that function with `expr`.
 
 The following Unicode bracket pairs are built-in and can be used for
 idiot brackets without any registration:
@@ -249,10 +255,16 @@ idiot brackets without any registration:
 
 A bracket pair gains a **monad spec** when declared with an empty
 block `{}` as its parameter and a body supplying `bind` and `return`
-function names:
+function names (paren-free style):
 
 ```eu
-(⟦{}⟧): { bind: my-bind  return: my-return }
+⟦{}⟧: { bind: my-bind  return: my-return }
+```
+
+The paren-wrapped style is also supported:
+
+```eu
+(⟦{}⟧): { bind: my-bind  return: my-return }    # still valid
 ```
 
 A bracket expression whose inner content contains top-level colons is
@@ -281,7 +293,7 @@ may be any single element: a name (`.r`), a parenthesised expression
 id-bind(ma, f): f(ma)
 id-return(a): a
 
-(⟦{}⟧): { bind: id-bind  return: id-return }
+⟦{}⟧: { bind: id-bind  return: id-return }
 
 result: ⟦ x: 10  r: x + 5 ⟧.r     # => 15
 ```
@@ -292,7 +304,7 @@ result: ⟦ x: 10  r: x + 5 ⟧.r     # => 15
 maybe-bind(ma, f): if(ma = [], [], f(ma head))
 maybe-return(a): [a]
 
-(⌈{}⌉): { bind: maybe-bind  return: maybe-return }
+⌈{}⌉: { bind: maybe-bind  return: maybe-return }
 
 just:    ⌈ x: [1]  y: [2] ⌉.(x + y)   # => [3]
 nothing: ⌈ x: []   y: [2] ⌉.(x + y)   # => []

--- a/harness/test/097_idiom_brackets.eu
+++ b/harness/test/097_idiom_brackets.eu
@@ -1,8 +1,13 @@
 ##
-## 095: Idiot bracket declarations and usage
+## 097: Idiot bracket declarations and usage
 ##
 ## Idiot brackets allow applicative functor application to be expressed
-## using Unicode bracket pairs.  A bracket pair is declared with:
+## using Unicode bracket pairs.  A bracket pair is declared with either
+## paren-free style (preferred):
+##
+##   ⟦ x ⟧: some-function(x)
+##
+## or the older paren style (still supported):
 ##
 ##   (⟦ x ⟧): some-function(x)
 ##
@@ -13,17 +18,17 @@
 ## which desugars to a call to the named bracket pair function.
 ##
 
-# Simple identity bracket pair using white square brackets ⟦⟧
-(⟦ x ⟧): x
+# Simple identity bracket pair using white square brackets ⟦⟧ (paren-free)
+⟦ x ⟧: x
 
-# Doubling bracket pair using ceiling brackets ⌈⌉
-(⌈ x ⌉): x * 2
+# Doubling bracket pair using ceiling brackets ⌈⌉ (paren-free)
+⌈ x ⌉: x * 2
 
-# List-wrapping bracket pair using angle brackets ⟨⟩
+# List-wrapping bracket pair using angle brackets ⟨⟩ (paren style — still valid)
 (⟨ x ⟩): [x]
 
-# Increment bracket pair using floor brackets ⌊⌋
-(⌊ x ⌋): x + 1
+# Increment bracket pair using floor brackets ⌊⌋ (paren-free)
+⌊ x ⌋: x + 1
 
 tests: {
 

--- a/src/syntax/export/format.rs
+++ b/src/syntax/export/format.rs
@@ -292,13 +292,21 @@ impl Formatter {
                     .append(RcDoc::text(y.syntax().text().to_string()))
                     .append(RcDoc::text(")"))
             }
-            rowan_ast::DeclarationKind::BracketPair(paren, _, _) => {
-                // Format: (⟦ x ⟧) — preserve from the paren expression
-                RcDoc::text(paren.syntax().text().to_string())
+            rowan_ast::DeclarationKind::BracketPair(paren, bracket, _) => {
+                // Format: preserve source text (with or without surrounding parens)
+                if let Some(p) = paren {
+                    RcDoc::text(p.syntax().text().to_string())
+                } else {
+                    RcDoc::text(bracket.syntax().text().to_string())
+                }
             }
-            rowan_ast::DeclarationKind::BracketBlockDef(paren, _) => {
-                // Format: (⟦{}⟧) — preserve from the paren expression
-                RcDoc::text(paren.syntax().text().to_string())
+            rowan_ast::DeclarationKind::BracketBlockDef(paren, bracket) => {
+                // Format: preserve source text (with or without surrounding parens)
+                if let Some(p) = paren {
+                    RcDoc::text(p.syntax().text().to_string())
+                } else {
+                    RcDoc::text(bracket.syntax().text().to_string())
+                }
             }
             rowan_ast::DeclarationKind::MalformedHead(_) => {
                 // Preserve original for malformed heads

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -659,13 +659,18 @@ pub enum DeclarationKind {
         OperatorIdentifier,
         NormalIdentifier,
     ),
-    /// Idiot bracket pair definition (e.g. (⟦ x ⟧): ...) - Embedding: `[:a-decl-bracket paren bracket param]`
+    /// Idiot bracket pair definition — e.g. `⟦ x ⟧: body` or `(⟦ x ⟧): body`
     ///
+    /// The optional `ParenExpr` is `Some` when parens were written and `None` when the
+    /// bracket appears directly in the head (paren-free style).
     /// The `BracketExpr` contains the bracket pair characters and the single formal parameter.
-    BracketPair(ParenExpr, BracketExpr, NormalIdentifier),
-    /// Monadic bracket block definition (e.g. (⟦{}⟧): ...) — an empty block `{}` as the parameter
-    /// signals that this bracket pair expects block content (declarations) for monadic use.
-    BracketBlockDef(ParenExpr, BracketExpr),
+    BracketPair(Option<ParenExpr>, BracketExpr, NormalIdentifier),
+    /// Monadic bracket block definition — e.g. `⟦{}⟧: body` or `(⟦{}⟧): body`
+    ///
+    /// The optional `ParenExpr` is `Some` when parens were written and `None` for paren-free style.
+    /// An empty block `{}` as the parameter signals that this bracket pair expects block content
+    /// (declarations) for monadic use.
+    BracketBlockDef(Option<ParenExpr>, BracketExpr),
     /// Invalid declaration head - Embedding: `[:a-decl-malformed errors...]`
     MalformedHead(Vec<ParseError>),
 }
@@ -675,6 +680,37 @@ pub enum DeclarationKind {
 // AST embedding syntax:
 // - `[:a-decl-head elements...]` - Declaration head containing name and parameter patterns
 ast_node!(DeclarationHead, DECL_HEAD);
+
+/// Classify a `BracketExpr` that appears directly at the declaration head level
+/// (paren-free style, e.g. `⟦ x ⟧: body` or `⟦{}⟧: body`).
+fn classify_bracket_direct(bracket: BracketExpr, head_range: TextRange) -> DeclarationKind {
+    let inner_elements: Vec<_> = bracket
+        .soup()
+        .map(|s| s.elements().collect())
+        .unwrap_or_default();
+    if inner_elements.len() == 1 {
+        if let Some(param) = inner_elements[0].as_normal_identifier() {
+            DeclarationKind::BracketPair(None, bracket, param)
+        } else if let Element::Block(_) = &inner_elements[0] {
+            // Block-mode bracket pair definition: ⟦{}⟧: ...
+            DeclarationKind::BracketBlockDef(None, bracket)
+        } else {
+            DeclarationKind::MalformedHead(vec![ParseError::InvalidFormalParameter {
+                head_range,
+                range: inner_elements[0].syntax().text_range(),
+            }])
+        }
+    } else if inner_elements.is_empty() {
+        DeclarationKind::MalformedHead(vec![ParseError::MalformedDeclarationHead {
+            range: head_range,
+        }])
+    } else {
+        // Multiple elements inside the bracket — invalid for a declaration head
+        DeclarationKind::MalformedHead(vec![ParseError::MalformedDeclarationHead {
+            range: head_range,
+        }])
+    }
+}
 
 // Classify a paren expression into a DeclarationKind
 fn classify_operator(pe: ParenExpr) -> DeclarationKind {
@@ -699,11 +735,11 @@ fn classify_operator(pe: ParenExpr) -> DeclarationKind {
                     .unwrap_or_default();
                 if inner_elements.len() == 1 {
                     if let Some(param) = inner_elements[0].as_normal_identifier() {
-                        DeclarationKind::BracketPair(pe, bracket.clone(), param)
+                        DeclarationKind::BracketPair(Some(pe), bracket.clone(), param)
                     } else if let Element::Block(_) = &inner_elements[0] {
                         // Block-mode bracket pair definition: (⟦{}⟧): ...
                         // The `{}` parameter signals block content (declarations) mode.
-                        DeclarationKind::BracketBlockDef(pe, bracket.clone())
+                        DeclarationKind::BracketBlockDef(Some(pe), bracket.clone())
                     } else {
                         DeclarationKind::MalformedHead(vec![ParseError::InvalidFormalParameter {
                             head_range: pe.syntax().text_range(),
@@ -815,6 +851,9 @@ impl DeclarationHead {
                     }
                 } else if let Some(pe) = ParenExpr::cast(items[0].clone()) {
                     classify_operator(pe)
+                } else if let Some(bracket) = BracketExpr::cast(items[0].clone()) {
+                    // Paren-free bracket pair declaration: ⟦ x ⟧: body
+                    classify_bracket_direct(bracket, self.syntax().text_range())
                 } else {
                     malformed()
                 }

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -1198,7 +1198,9 @@ impl BlockEventSink {
                 ParseEvent::StartNode(_) if depth > 1 => {
                     depth -= 1;
                 }
-                ParseEvent::StartNode(PAREN_EXPR) | ParseEvent::StartNode(NAME) => {
+                ParseEvent::StartNode(PAREN_EXPR)
+                | ParseEvent::StartNode(NAME)
+                | ParseEvent::StartNode(BRACKET_EXPR) => {
                     break;
                 }
                 ParseEvent::StartNode(ARG_TUPLE) => {


### PR DESCRIPTION
## Summary

- Bracket pair declarations no longer require surrounding parentheses — the design-doc style `⟦ x ⟧: body` now works
- The paren-wrapped style `(⟦ x ⟧): body` is still accepted (backwards-compatible)
- Applies to both idiom bracket pairs and monadic bracket block definitions

## Root cause

Two separate issues prevented paren-free declarations:
1. `split_off_head` in `parse.rs` only recognised `PAREN_EXPR` and `NAME` as valid head-start nodes; `BRACKET_EXPR` fell through to the "invalid — refuse split" branch, so the declaration head was always empty
2. `classify_declaration` in `ast.rs` only dispatched to `classify_operator` for `ParenExpr` items — there was no path for a bare `BracketExpr` at the head level

## Changes

- `src/syntax/rowan/ast.rs`:
  - `DeclarationKind::BracketPair` and `BracketBlockDef` now carry `Option<ParenExpr>` (the paren wrapper, or `None` for paren-free)
  - New `classify_bracket_direct` function handles bare `BracketExpr` head items
  - `classify_declaration` dispatches to `classify_bracket_direct` when the head item is a `BracketExpr`
- `src/syntax/rowan/parse.rs`: `split_off_head` adds `BRACKET_EXPR` to valid head-start nodes
- `src/syntax/export/format.rs`: formatting uses `BracketExpr` text when no `ParenExpr` is present
- `harness/test/097_idiom_brackets.eu`: updated to use paren-free declarations
- `doc/reference/syntax.md`: updated to show paren-free as the primary style

## Test plan

- [x] `cargo test test_harness_097` passes (paren-free and paren-wrapped mix)
- [x] `cargo test test_harness_096` passes (monadic blocks still work)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Manual test of `⟦ x ⟧: x * 2` and `⟦{}⟧: { bind: ... return: ... }` paren-free declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)