### PR TITLE
feat(eu-uihm,eu-qg0j): lazy cons cells for stream memoisation

### DIFF
--- a/harness/test/079_streams.eu
+++ b/harness/test/079_streams.eu
@@ -12,15 +12,25 @@ csv-a-first: (csv head).a //= "1"
 txt-count: txt count //= 3
 txt-first: txt head //= "line 1, some text"
 
-# Memoisation verification: accessing the same stream position multiple
-# times must return the same value without re-advancing the producer.
-# Without memoisation, the second head access would return Bob's data.
-memo-head-name: (jl head).name //= "Alice"
-memo-head-age: (jl head).age //= 30
-memo-same-head: ((jl head).name = (jl head).name) //= true
+# Memoisation verification: the stream head thunk must be evaluated only
+# once. aux_import.jsonl has Alice first (age 30), then Bob (age 25).
+# Without memoisation, the second access to `jl head` would re-advance
+# the producer and return Bob's record instead of Alice's.
+#
+# `jl-head` is bound once; both field accesses share the same thunk.
+# If age returned 25 (Bob), memoisation is broken.
+jl-head: jl head
+memo-head-name: jl-head.name //= "Alice"
+memo-head-age: jl-head.age //= 30
+
+# Cross-binding sharing: `jl head` evaluated twice must still return Alice.
+# Without memoisation the second call advances the producer to Bob.
+memo-head-name-again: (jl head).name //= "Alice"
+memo-head-age-again: (jl head).age //= 30
 
 # Traversal consistency: count and map must agree on length.
 memo-count-after-map: ((jl map(_.name) count) = (jl count)) //= true
 
 RESULT: [jsonl-count, jsonl-names, jsonl-ages, csv-count, csv-a-first, txt-count, txt-first,
-         memo-head-name, memo-head-age, memo-same-head, memo-count-after-map] all-true? then(:PASS, :FAIL)
+         memo-head-name, memo-head-age, memo-head-name-again, memo-head-age-again,
+         memo-count-after-map] all-true? then(:PASS, :FAIL)

--- a/harness/test/079_streams.eu
+++ b/harness/test/079_streams.eu
@@ -12,4 +12,15 @@ csv-a-first: (csv head).a //= "1"
 txt-count: txt count //= 3
 txt-first: txt head //= "line 1, some text"
 
-RESULT: [jsonl-count, jsonl-names, jsonl-ages, csv-count, csv-a-first, txt-count, txt-first] all-true? then(:PASS, :FAIL)
+# Memoisation verification: accessing the same stream position multiple
+# times must return the same value without re-advancing the producer.
+# Without memoisation, the second head access would return Bob's data.
+memo-head-name: (jl head).name //= "Alice"
+memo-head-age: (jl head).age //= 30
+memo-same-head: ((jl head).name = (jl head).name) //= true
+
+# Traversal consistency: count and map must agree on length.
+memo-count-after-map: ((jl map(_.name) count) = (jl count)) //= true
+
+RESULT: [jsonl-count, jsonl-names, jsonl-ages, csv-count, csv-a-first, txt-count, txt-first,
+         memo-head-name, memo-head-age, memo-same-head, memo-count-after-map] all-true? then(:PASS, :FAIL)

--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -86,3 +86,17 @@ pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
         }
     })
 }
+
+/// Advance a stream producer by a single step.
+///
+/// Returns `Some(value)` if the producer yielded an element, or
+/// `None` if the stream is exhausted or the handle is invalid.
+pub fn stream_next(handle: u32) -> Option<Rc<StgSyn>> {
+    STREAM_TABLE.with(|table| {
+        let table = table.borrow();
+        match table.get(handle) {
+            Some(producer) => producer.borrow_mut().next(),
+            None => None,
+        }
+    })
+}

--- a/src/eval/stg/stream_intrinsic.rs
+++ b/src/eval/stg/stream_intrinsic.rs
@@ -1,8 +1,8 @@
 //! __STREAM_NEXT intrinsic implementation
 //!
-//! Eagerly drains a stream producer and builds a complete list,
-//! avoiding thunk-update issues with lazy cons cells in the STG
-//! machine.
+//! Produces a lazy cons cell for each stream element, allowing the
+//! STG machine's Update mechanism to memoise the result of each
+//! tail thunk.
 
 use crate::eval::{
     emit::Emitter,
@@ -19,15 +19,19 @@ use crate::eval::{
     },
 };
 
-use super::{stream::stream_drain, support::num_arg, tags::DataConstructor};
+use super::{stream::stream_next, support::num_arg, tags::DataConstructor};
 
 /// STREAM_NEXT(handle)
 ///
-/// Eagerly drains all remaining values from the stream producer
-/// identified by the numeric handle, then builds and returns the
-/// complete list. This avoids the STG thunk-update issue where
-/// lazy tail thunks in `Let` bindings are not memoised across
-/// multiple traversals of the same cons cell.
+/// Advances the stream producer by one element. If the stream is
+/// exhausted, returns Nil. Otherwise, builds a lazy cons cell whose
+/// head is the current value and whose tail is an updatable thunk
+/// that calls STREAM_NEXT(handle) again when forced.
+///
+/// The `update=true` flag on the tail thunk ensures the STG
+/// machine's Update continuation memoises the result, so repeated
+/// traversals of the same cons cell share work and the producer is
+/// advanced at most once per list position.
 pub struct StreamNext;
 
 impl StgIntrinsic for StreamNext {
@@ -54,44 +58,45 @@ impl StgIntrinsic for StreamNext {
             ExecutionError::Panic("stream handle must be a positive integer".to_string())
         })? as u32;
 
-        // Eagerly drain all values from the stream producer
-        let values = stream_drain(handle);
+        // Advance the stream by one element
+        let value_stg = match stream_next(handle) {
+            Some(v) => v,
+            None => {
+                // Stream exhausted — return Nil
+                let nil = view.nil()?;
+                return machine.set_closure(SynClosure::new(nil.as_ptr(), machine.root_env()));
+            }
+        };
 
-        if values.is_empty() {
-            let nil = view.nil()?;
-            return machine.set_closure(SynClosure::new(nil.as_ptr(), machine.root_env()));
-        }
-
-        // Build a complete list in reverse: start with Nil, then
-        // prepend each element as a Cons cell.
+        // Build a lazy cons cell:
         //
-        // Layout: LetRec([nil, v_n, cons_n, ..., v_0, cons_0], Atom(L(last)))
-        let mut bindings: Vec<LambdaForm> = Vec::with_capacity(1 + values.len() * 2);
+        //   Let([value, tail_thunk],
+        //       Cons(ListCons, [L(0), L(1)]))
+        //
+        // - Binding 0 (value): the current element, as a non-updatable value
+        // - Binding 1 (tail_thunk): an updatable thunk (arity=0, update=true)
+        //   whose body calls STREAM_NEXT(handle) again — memoised by the STG
+        //   Update continuation so the producer advances at most once per position
+        let value_ptr = load(&view, machine.symbol_pool_mut(), value_stg)?;
 
-        // Binding 0: Nil
-        let nil_ptr = view.nil()?.as_ptr();
-        bindings.push(LambdaForm::value(nil_ptr));
+        let handle_ref = Ref::num(handle as u64);
+        let bif_index = self.index() as u8;
+        let tail_body = view.app_bif(bif_index, Array::from_slice(&view, &[handle_ref]))?;
 
-        // Build cons cells from last to first
-        for value_stg in values.into_iter().rev() {
-            let value_ptr = load(&view, machine.symbol_pool_mut(), value_stg)?;
-            bindings.push(LambdaForm::value(value_ptr));
-            let val_idx = bindings.len() - 1;
-            let prev_idx = val_idx - 1; // previous cons cell (or nil)
+        let bindings = Array::from_slice(
+            &view,
+            &[
+                LambdaForm::value(value_ptr),
+                LambdaForm::thunk(tail_body.as_ptr()),
+            ],
+        );
 
-            let cons_node = view
-                .data(
-                    DataConstructor::ListCons.tag(),
-                    Array::from_slice(&view, &[Ref::L(val_idx), Ref::L(prev_idx)]),
-                )?
-                .as_ptr();
-            bindings.push(LambdaForm::value(cons_node));
-        }
+        let cons_body = view.data(
+            DataConstructor::ListCons.tag(),
+            Array::from_slice(&view, &[Ref::L(0), Ref::L(1)]),
+        )?;
 
-        // The last binding is the outermost cons cell
-        let list_idx = bindings.len() - 1;
-        let body = view.atom(Ref::L(list_idx))?;
-        let result = view.letrec(Array::from_slice(&view, &bindings), body)?;
+        let result = view.let_(bindings, cons_body)?;
 
         machine.set_closure(SynClosure::new(result.as_ptr(), machine.root_env()))
     }


### PR DESCRIPTION
## Summary

Adds stream infrastructure and memoisation tests for lazy stream imports.

**stream.rs** — adds `stream_next(handle) -> Option<Rc<StgSyn>>` (eu-qg0j), a single-step advance function used by the lazy cons intrinsic. `stream_drain` is retained for existing callers.

**stream_intrinsic.rs** — rewrites `StreamNext.execute()` (eu-uihm) to produce one lazy cons cell per call:
- Binding 0: the current element (non-updatable value)
- Binding 1: an updatable thunk (arity=0, update=true) whose body calls `STREAM_NEXT(handle)` again

The tail thunk is memoised by the STG Update continuation, so each stream position is advanced at most once even under repeated traversal.

**vm.rs** — removes the `suppress_next_update` flag. The flag was suppressing Update continuations for stream tail thunks accessed through the TAIL intrinsic (whose branch body is `local(1)` = `Atom(Ref::L(1))`, triggering the flag condition). Tail-position calls in the compiler use `single_use=true` (non-updatable), so the flag was redundant for its original purpose but harmful for stream memoisation. Removal is safe: all 184 harness and 587 lib tests pass.

**079_streams.eu** — extends the stream harness test with explicit memoisation assertions:
- `jl-head` is bound once; both `jl-head.name //= "Alice"` and `jl-head.age //= 30` share the same thunk — if the thunk were not memoised the age would return 25 (Bob's age)
- `(jl head).name //= "Alice"` and `(jl head).age //= 30` evaluated independently confirm the producer does not advance again on the second access
- Traversal consistency: `map` and `count` must agree on length

**Rebased on origin/0.4.0** as requested.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --test harness_test` — all 184 pass
- [x] `cargo test --lib` — all 587 pass
- [x] `test_harness_047`, `test_error_078`, `test_harness_079` all pass in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)