### PR TITLE
fix(eu-u26l,eu-4vdk): fix cons pattern mangling, section spacing, juxtaposed sugar in eu fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/src/syntax/export/format.rs
+++ b/src/syntax/export/format.rs
@@ -368,9 +368,11 @@ impl Formatter {
         if elements[idx].as_operator_identifier().is_none() {
             return false;
         }
-        // Prefix operator is either at position 0, or follows another operator
+        // An operator at position 0 is NOT necessarily prefix — it may be the
+        // operator in a section like `(+ 1)`. Returning true here would suppress
+        // the space between `+` and `1`, producing `(+1)` which is wrong.
         if idx == 0 {
-            return true;
+            return false;
         }
         // If the previous element is also an operator, this could be a prefix op
         // (e.g., in "x + -y", the "-" after "+" is a prefix operator)
@@ -500,6 +502,20 @@ impl Formatter {
             return RcDoc::text("[]");
         }
 
+        // Preserve cons patterns: `[x : xs]` or `[a, b : rest]`.
+        // These have different semantics from fixed-length lists and must NOT be
+        // reformatted as `[x, xs]`.
+        if list.is_cons_pattern() && items.len() >= 2 {
+            let (heads, tail_slice) = items.split_at(items.len() - 1);
+            let tail = &tail_slice[0];
+            let head_docs: Vec<_> = heads.iter().map(|s| self.reformat_soup(s)).collect();
+            return RcDoc::text("[")
+                .append(RcDoc::intersperse(head_docs, RcDoc::text(", ")))
+                .append(RcDoc::text(" : "))
+                .append(self.reformat_soup(tail))
+                .append(RcDoc::text("]"));
+        }
+
         // Estimate single-line length
         let single_line_len: usize = items
             .iter()
@@ -538,6 +554,15 @@ impl Formatter {
 
         if items.is_empty() {
             return RcDoc::text("()");
+        }
+
+        // Juxtaposed apply sugar: `f{...}` and `f[...]` must be preserved as such.
+        // The ApplyTuple wraps the block/list content — emit with the appropriate
+        // brackets rather than canonical parentheses.
+        if at.is_block_apply() || at.is_list_apply() {
+            // Preserve the original source text to avoid losing shorthand patterns
+            // like `{x y}` (which have no declarations, only block meta).
+            return RcDoc::text(at.syntax().text().to_string());
         }
 
         let docs: Vec<_> = items.iter().map(|s| self.reformat_soup(s)).collect();
@@ -1227,6 +1252,103 @@ mod tests {
         assert!(
             formatted.contains("\n\n"),
             "Multiple blank lines should preserve separation"
+        );
+    }
+}
+
+#[cfg(test)]
+mod correctness_tests {
+    use super::*;
+
+    fn reformat(source: &str) -> String {
+        let config = FormatterConfig::new(80, 2, true);
+        format_source(source, &config).unwrap()
+    }
+
+    #[test]
+    fn test_cons_pattern_preserved() {
+        let source = "f([h : t]): h\n";
+        let result = reformat(source);
+        assert!(
+            result.contains(" : "),
+            "Cons pattern colon must be preserved: {}",
+            result
+        );
+        assert!(
+            !result.contains("[h, t]"),
+            "Cons pattern must not become a list: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_multi_head_cons_pattern_preserved() {
+        let source = "f([a, b : rest]): a\n";
+        let result = reformat(source);
+        assert!(
+            result.contains(" : "),
+            "Multi-head cons pattern must preserve colon: {}",
+            result
+        );
+        assert!(
+            !result.contains("[a, b, rest]"),
+            "Multi-head cons must not become a plain list: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_section_spacing_preserved() {
+        let source = "f: (+ 1)\n";
+        let result = reformat(source);
+        assert!(
+            result.contains("(+ 1)"),
+            "Section spacing must be preserved: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_juxtaposed_block_call_preserved() {
+        let source = "result: f{x: 1}\n";
+        let result = reformat(source);
+        assert!(
+            !result.contains("f({"),
+            "Juxtaposed block call must not gain parens: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_juxtaposed_list_call_preserved() {
+        let source = "result: f[1, 2]\n";
+        let result = reformat(source);
+        assert!(
+            !result.contains("f(["),
+            "Juxtaposed list call must not gain parens: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_juxtaposed_block_definition_preserved() {
+        let source = "f{x, y}: x + y\n";
+        let result = reformat(source);
+        assert!(
+            !result.contains("f({"),
+            "Juxtaposed block definition must not gain parens: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_juxtaposed_list_definition_preserved() {
+        let source = "f[x, y]: x + y\n";
+        let result = reformat(source);
+        assert!(
+            !result.contains("f(["),
+            "Juxtaposed list definition must not gain parens: {}",
+            result
         );
     }
 }


### PR DESCRIPTION
## Summary

Three formatter fixes for `eu fmt --reformat` mode, addressing bugs found during harness verification (eu-w88v):

- **eu-u26l — Cons pattern preservation**: `[x : xs]` was incorrectly reformatted as `[x, xs]`. These have different semantics (head/tail destructuring vs fixed-length list). Fixed via `list.is_cons_pattern()` check in `reformat_list`. Supports multi-head patterns like `[a, b : rest]`.

- **eu-4vdk — Section spacing**: `(+ 1)` was collapsed to `(+1)` in reformat mode. Root cause: `is_prefix_operator` returned `true` for operators at index 0, suppressing the space. Sections like `(+ 1)` are `ParenExpr` containing `[OperatorIdentifier, Literal]` — the operator is at index 0 but is not prefix. Fix: return `false` for index 0.

- **eu-4vdk — Juxtaposed apply sugar**: `f{x: 1}` and `f[1, 2]` were gaining spurious parentheses (`f({x: 1})`, `f([1, 2])`). Fixed by detecting `is_block_apply()` / `is_list_apply()` in `reformat_apply_tuple` and preserving the original source text. Also fixes shorthand block patterns `f{x, y}:` and `f[x, y]:` in declaration heads.

## Test plan

- [x] 7 new correctness tests covering all fixed cases
- [x] All 594 lib tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied