### PR TITLE
feat(aoc25): use destructuring in AoC 2025 examples

### DIFF
--- a/examples/aoc25/day01.eu
+++ b/examples/aoc25/day01.eu
@@ -32,9 +32,7 @@ solve(data): data map(parse-instruction) scanl(+, 50) filter(% 100 = 0) count
 
 ` "Count zero crossings between consecutive positions. Shift by 1 when
 moving left so that starting on a multiple of 100 is not counted."
-zeros(pair): {
-  a: pair first
-  b: pair second
+zeros([a, b]): {
   s: (b < a) then(1, 0)
 }.(abs((b - s) / 100 - (a - s) / 100))
 

--- a/examples/aoc25/day02.eu
+++ b/examples/aoc25/day02.eu
@@ -77,7 +77,7 @@ subtract invalid-for(d=6, p=1)."
 include-exclude: {
 
   ` "Flip the sign and multiply divisor by prime p."
-  extend-one(p, term): [negate(first(term)), second(term) * p]
+  extend-one(p, [sign, divisor]): [negate(sign), divisor * p]
 
   ` "Each prime doubles the terms: keep existing, add flipped copies."
   extend(terms, p): terms ++ (terms map(extend-one(p)))
@@ -86,7 +86,7 @@ include-exclude: {
   terms(primes): foldl(extend, [[-1, 1]], primes) tail
 
   ` "Evaluate one term: sign * (sum of IDs with pattern length d/divisor)."
-  apply(a, b, d, term): first(term) * invalid-for(a, b, d, d / second(term))
+  apply(a, b, d, [sign, divisor]): sign * invalid-for(a, b, d, d / divisor)
 }
 
 ` "Sum of invalid d-digit IDs in [a,b].  Generate IE terms from the

--- a/examples/aoc25/day04.eu
+++ b/examples/aoc25/day04.eu
@@ -57,8 +57,7 @@ parse(data): data map(to-bits)
 solve(grid): survivals(grid) map(sum) sum
 
 ` "One removal step: returns [new-grid, count-removed]."
-remove-step(state): {
-  grid: state first
+remove-step([grid, _]): {
   removed: survivals(grid)
   n: removed map(sum) sum
   new-grid: zip-with(zip-with(-), grid, removed)

--- a/examples/aoc25/day05.eu
+++ b/examples/aoc25/day05.eu
@@ -20,7 +20,7 @@ Running time: ~3s (part 1), < 1s (part 2)
 
 parse-range(s): str.split(s, "-") map(num)
 
-contains-id?(id, r): id >= first(r) ∧ id <= second(r)
+contains-id?(id, [lo, hi]): id >= lo ∧ id <= hi
 
 is-fresh?(ranges, id): ranges any(contains-id?(id))
 
@@ -31,21 +31,22 @@ solve(ranges, ids): ids filter(is-fresh?(ranges)) count
 ` "Merge a new range into [merged-so-far, current-range].  If the new
 range overlaps or is adjacent, extend current; otherwise emit current
 and start fresh."
-merge-step(state, r): {
-  merged: first(state)
-  cur: second(state)
-  cur-hi: second(cur)
-}.(if(first(r) <= cur-hi + 1,
-     [merged, [first(cur), max(cur-hi, second(r))]],
-     [merged ++ [cur], r]))
+merge-step([merged, cur], [r-lo, r-hi]): {
+  cur-lo: cur first
+  cur-hi: cur second
+}.(if(r-lo <= cur-hi + 1,
+     [merged, [cur-lo, max(cur-hi, r-hi)]],
+     [merged ++ [cur], [r-lo, r-hi]]))
 
 ` "Sort ranges by start, then fold to merge overlapping intervals."
 merge-ranges(ranges): {
   sorted: ranges sort-by-num(first)
   result: sorted tail foldl(merge-step, [[], sorted head])
-}.(first(result) ++ [second(result)])
+  completed: result first
+  last: result second
+}.(completed ++ [last])
 
-range-size(r): second(r) - first(r) + 1
+range-size([lo, hi]): hi - lo + 1
 
 solve2(ranges): merge-ranges(ranges) map(range-size) sum
 

--- a/examples/aoc25/day06.eu
+++ b/examples/aoc25/day06.eu
@@ -57,11 +57,7 @@ parse-col(col): {
 }.(digits nil? then([], [col last, digits map(num) digits-to-num]))
 
 ` "Process one column in the right-to-left fold.  State is [total, nums]."
-col-step(state, entry): {
-  total: first(state)
-  nums: second(state)
-  op: first(entry)
-  n: second(entry)
+col-step([total, nums], [op, n]): {
 }.(if(op?(op),
      [total + apply-op(op, nums ++ [n]), []],
      [total, nums ++ [n]]))

--- a/examples/aoc25/day07.eu
+++ b/examples/aoc25/day07.eu
@@ -47,9 +47,7 @@ parse(data): {
 
 ` "Process one row: update beam positions and accumulate split count.
 State is [beam-vector, total-splits]."
-row-step(state, row): {
-  beam: first(state)
-  total: second(state)
+row-step([beam, total], row): {
   sp: to-splitters(row)
   ` "Hits: beam positions that coincide with splitters."
   h: zip-with(*, beam, sp)

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -71,20 +71,14 @@ levels: {
   make-edges(pts): zip(pts, pts rotate(1))
 
   ` "Is edge vertical / horizontal?"
-  vertical?(e): first(first(e)) = first(second(e))
-  horizontal?(e): second(first(e)) = second(second(e))
+  vertical?([p, q]): first(p) = first(q)
+  horizontal?([p, q]): second(p) = second(q)
 
   ` "Extract vertical edges as [x, y-lo, y-hi]."
-  vert-edge(e): {
-    p: first(e)
-    q: second(e)
-  }.([first(p), min(second(p), second(q)), max(second(p), second(q))])
+  vert-edge([p, q]): [first(p), min(second(p), second(q)), max(second(p), second(q))]
 
   ` "Extract horizontal edges as [y, x-lo, x-hi]."
-  horiz-edge(e): {
-    p: first(e)
-    q: second(e)
-  }.([second(p), min(first(p), first(q)), max(first(p), first(q))])
+  horiz-edge([p, q]): [second(p), min(first(p), first(q)), max(first(p), first(q))]
 
   ` "Cross-section at `y`: [left, right] assuming single interval."
   xsect(y, ves, hes): {

--- a/examples/aoc25/day11.eu
+++ b/examples/aoc25/day11.eu
@@ -53,10 +53,8 @@ State threaded as [order_list, visited_set] using set for O(log n) membership.
 Parameters ordered so partial application dfs-topo(g) matches foldl(acc, elem).
 NB: graph.topo-sort works on numeric adjacency lists; converting to/from
 string-keyed blocks is slower than processing directly."
-dfs-topo(g, state, node): {
-  order: state first
-  visited: state second
-}.(set.contains?(node, visited) then(state, {
+dfs-topo(g, [order, visited], node): {
+}.(set.contains?(node, visited) then([order, visited], {
     new-vis: visited set.add(node)
     after: foldl(dfs-topo(g), [order, new-vis], dests-of(g, node))
   }.[cons(node, after first), after second]))

--- a/examples/aoc25/day12.eu
+++ b/examples/aoc25/day12.eu
@@ -33,7 +33,10 @@ parse-shapes(section):
 ` "Parse a region spec like '12x5: 1 0 1 0 2 2' into [w, h, [shape-counts]]."
 parse-region(line): {
   ns: str.matches(line, "\d+") map(num)
-}.[ns first, ns second, ns drop(2)]
+  w: ns first
+  h: ns second
+  counts: ns drop(2)
+}.[w, h, counts]
 
 ` "Part 1: count regions where all assigned pieces could fit.
 Cell check: total cells needed ≤ grid area. This eliminates regions that are so
@@ -54,12 +57,12 @@ solve-all(data): {
   sizes: shapes map(count)
 
   # cell check
-  needed(r): zip-with(*, r !! 2, sizes) sum
-  total(r): (r !! 0) * (r !! 1)
+  needed([w, h, counts]): zip-with(*, counts, sizes) sum
+  total([w, h, _]): w * h
   area-ok?(r): needed(r) <= total(r)
 
   # box check
-  min-dim(r): min(r !! 0, r !! 1)
+  min-dim([w, h, _]): min(w, h)
   box-ok?(r): min-dim(r) >= 3
 
   fits?(r): area-ok?(r) ∧ box-ok?(r)


### PR DESCRIPTION
## Summary

Replace manual `first`/`second`/`!! n` pair unpacking with list destructuring patterns across 9 of the 12 AoC 2025 example files, demonstrating 0.4.0 destructuring syntax in realistic code.

### Changes per day

- **day01**: `zeros([a, b])` — pair from `window(2,1)`
- **day02**: `extend-one(p, [sign, divisor])` and `apply(a, b, d, [sign, divisor])` — IE term pairs
- **day04**: `remove-step([grid, _])` — ignore count from iterate state
- **day05**: `contains-id?(id, [lo, hi])`, `merge-step([merged, cur], [r-lo, r-hi])`, `range-size([lo, hi])` — range pairs throughout
- **day06**: `col-step([total, nums], [op, n])` — both accumulator state and column entry destructured
- **day07**: `row-step([beam, total], row)` — beam simulation state pair
- **day09**: `vertical?([p, q])`, `horizontal?([p, q])`, `vert-edge([p, q])`, `horiz-edge([p, q])` — edge pairs in polygon level building
- **day11**: `dfs-topo(g, [order, visited], node)` — DFS state pair
- **day12**: `needed([w, h, counts])`, `total([w, h, _])`, `min-dim([w, h, _])` — region spec triple

### Notes

- Only single-level destructuring is used (nested destructuring is not yet supported)
- Block property bindings (e.g. `[a, b]: expr`) are not valid — destructuring only works in function parameter position
- Days 03, 08, 10 had no natural destructuring opportunities

## Test plan

- [x] All test targets pass: days 01–11 (day 12 has no test example data)
- [x] `day12 -t part-1` produces expected answer (541)

🤖 Generated with [Claude Code](https://claude.com/claude-code)