### PR TITLE
fix(eu-dap7): fix single_use_args for Var→Global intrinsic calls (IF tail recursion)

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -903,7 +903,18 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // Find a reference for the function
         let f_index: Box<dyn ProtoReference> = match &*self.f.inner {
-            Expr::Var(s, v) => Box::new(ProtoVar::new(extract_bound_var(s, v)?.clone())),
+            Expr::Var(s, v) => {
+                let bound_var = extract_bound_var(s, v)?.clone();
+                // If this var resolves to a global intrinsic, look up its
+                // argument metadata. This covers calls like `if(c, t, e)`
+                // where `if` is a prelude binding backed by the IF intrinsic.
+                if let Ok(Ref::G(n)) = context.lookup(&bound_var) {
+                    let info = intrinsics::intrinsic(n);
+                    strict_args = info.strict_args();
+                    single_use_args = info.single_use_args();
+                }
+                Box::new(ProtoVar::new(bound_var))
+            }
             Expr::Intrinsic(_, bif) => {
                 intrinsic_index = intrinsics::index(bif);
                 let n =


### PR DESCRIPTION
## Summary

Fixes the dead `single_use_args` compiler path from 5e7b5ea. The original code only looked up single_use_args when the call target was `Expr::Intrinsic`. User-written `if(c, t, e)` uses `Expr::Var("if")`, which resolves to `Ref::G(10)` — the IF global wrapper. The IF intrinsic's metadata (args 1 and 2 are single-use) was never consulted.

**Fix**: In `ProtoAppGroup::take_syntax`, when `Expr::Var` resolves to `Ref::G(n)` via `context.lookup`, look up `intrinsics::intrinsic(n)` and apply its `strict_args` and `single_use_args` to argument compilation.

Now IF's branch args (positions 1 and 2) compile as `LambdaForm::value` (update=false) rather than `LambdaForm::thunk` (update=true), so no Update continuation is pushed when they are entered. This prevents O(N) Update accumulation in tail-recursive conditionals.

## Why no restore of suppress_next_update needed

The original `suppress_next_update` flag (removed in 3d8dd0a) fired for **all** case branches entering a local ref, which broke stream tail thunk memoisation. This compiler-level fix is precise: it only affects arguments that the intrinsic metadata explicitly marks as single-use. Stream thunks are not IF branch args and are unaffected.

## Benchmark

`countdown(n): if(n = 0, 0, countdown(n - 1))` with N=100,000:

| Metric | 0.4.0 HEAD (5e7b5ea broken) | This PR |
|--------|----------------------------|---------|
| Allocs | 33.5M | 700k |
| Improvement | — | ~48x |

## Test plan

- [x] `cargo test --test harness_test` — all 187 tests pass (including test 100, the tail recursion harness)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Benchmark: 700k allocs for N=100k countdown
- [x] Stream tests (harness 095-097) pass — memoisation unaffected