### PR TITLE
refactor(aoc25): improve idiomatic style in AoC 2025 examples

### DIFF
--- a/examples/aoc25/day02.eu
+++ b/examples/aoc25/day02.eu
@@ -21,7 +21,7 @@ Notable eucalypt techniques:
 Running time: < 1s (both parts)
 "
 
-parse-range(s): str.split(s, "-") map(num)
+parse-range(s): s str.split-on("-") map(num)
 
 ` "Sum of invalid IDs in [a,b] that are a p-digit pattern repeated
 d/p times.  We find the range of n values whose IDs land in [a,b]
@@ -100,13 +100,13 @@ invalid-for-d(a, b, d):
 invalid-sum2(a, b): range(1, 12) map(invalid-for-d(a, b)) sum
 
 solve(data):
-  str.split(data first, ",")
+  data first str.split-on(",")
     map(parse-range)
     map(uncurry(invalid-sum))
     sum
 
 solve2(data):
-  str.split(data first, ",")
+  data first str.split-on(",")
     map(parse-range)
     map(uncurry(invalid-sum2))
     sum

--- a/examples/aoc25/day03.eu
+++ b/examples/aoc25/day03.eu
@@ -13,7 +13,7 @@ skip to its first occurrence, take it, and recurse.
 Notable eucalypt techniques:
 - `;` forward compose for point-free pipelines: `batteries ; pick(2) ; digits-to-num`
 - `drop-while` for scanning to the best digit
-- `foldl` with block accumulator for digit-to-number conversion
+- `foldl` with expression anaphora `_0 * 10 + _1` for digit-to-number conversion
 
 Running time: ~1s (both parts)
 "
@@ -26,13 +26,13 @@ enough to leave k-1 picks remaining, skip forward to its first
 occurrence, take it, and recurse on the suffix."
 pick(k, ds): {
 
-  best: take(count(ds) - k + 1, ds) max-of
-  at-best: drop-while(!= best, ds)
+  best: ds take((ds count) - k + 1) max-of
+  at-best: ds drop-while(!= best)
 
 }.((k = 0) then([], cons(best, pick(k - 1, at-best tail))))
 
 ` "Convert a list of digits to a number: [9,8,7] -> 987."
-digits-to-num(ds): ds foldl({ acc: • d: • }.(acc * 10 + d), 0)
+digits-to-num(ds): ds foldl(_0 * 10 + _1, 0)
 
 solve(data, n): data map(batteries ; pick(n) ; digits-to-num) sum
 

--- a/examples/aoc25/day05.eu
+++ b/examples/aoc25/day05.eu
@@ -18,7 +18,7 @@ Notable eucalypt techniques:
 Running time: ~3s (part 1), < 1s (part 2)
 "
 
-parse-range(s): str.split(s, "-") map(num)
+parse-range(s): s str.split-on("-") map(num)
 
 contains-id?(id, [lo, hi]): id >= lo ∧ id <= hi
 

--- a/examples/aoc25/day06.eu
+++ b/examples/aoc25/day06.eu
@@ -23,7 +23,7 @@ Running time: ~1s (both parts)
 "
 
 ` "Extract all numbers from a line, splitting on whitespace."
-line-nums(line): str.split(line, " +") filter(!= "") map(num)
+line-nums(line): line str.split-on(" +") filter(!= "") map(num)
 
 ` "Extract operators from the operator line."
 ops(line): line str.letters filter(!= " ")
@@ -42,7 +42,7 @@ solve(data): {
 chars(line): line str.letters
 
 ` "Pad a row to length n with spaces."
-pad-to(n, row): row ++ (repeat(" ") take(n - count(row)))
+pad-to(n, row): row ++ (repeat(" ") take(n - (row count)))
 
 ` "Convert a list of digit values to a number: [3,6,9] -> 369."
 digits-to-num(ds): ds foldl(_0 * 10 + _1, 0)
@@ -57,10 +57,10 @@ parse-col(col): {
 }.(digits nil? then([], [col last, digits map(num) digits-to-num]))
 
 ` "Process one column in the right-to-left fold.  State is [total, nums]."
-col-step([total, nums], [op, n]): {
-}.(if(op?(op),
+col-step([total, nums], [op, n]):
+  if(op?(op),
      [total + apply-op(op, nums ++ [n]), []],
-     [total, nums ++ [n]]))
+     [total, nums ++ [n]])
 
 solve2(data): {
   lines: data filter(!= "")

--- a/examples/aoc25/day07.eu
+++ b/examples/aoc25/day07.eu
@@ -55,7 +55,7 @@ row-step([beam, total], row): {
   p: zip-with(-, beam, h)
   emitted: zip-with(max, shift-left(h), shift-right(h))
   new-beam: zip-with(max, p, emitted)
-}.([ new-beam, total + sum(h) ])
+}.([ new-beam, total + (h sum) ])
 
 ` "Count total splits as the beam propagates down the grid."
 solve(rows, b0): rows foldl(row-step, [b0, 0]) second

--- a/examples/aoc25/day08.eu
+++ b/examples/aoc25/day08.eu
@@ -25,7 +25,7 @@ Running time: ~17s (part 1), ~5 min (part 2)
 "
 
 ` "Parse a comma-separated line into a list of numbers."
-parse-point(line): str.split(line, ",") map(num)
+parse-point(line): line str.split-on(",") map(num)
 
 ` "Squared Euclidean distance between two 3D points."
 dist2(a, b): zip-with(-, a, b) map(^ 2) sum

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -24,7 +24,7 @@ Notable eucalypt techniques:
 Running time: ~3 min (part 1), ~3 min (part 2)
 "
 
-parse-coord(line): str.split(line, ",") map(num)
+parse-coord(line): line str.split-on(",") map(num)
 
 area(a, b): zip-with(-, a, b) map(abs ; (+ 1)) product
 

--- a/examples/aoc25/day10.eu
+++ b/examples/aoc25/day10.eu
@@ -58,9 +58,7 @@ has-solution?(k, target, buttons): {
 
 ` "Minimum presses for one machine (Part 1).
 Find the smallest subset size k with a valid solution."
-solve-machine(m): {
-  target: first(m)
-  buttons: second(m)
+solve-machine([target, buttons]): {
   nb: buttons count
   solved?(k): has-solution?(k, target, buttons)
 }.(ℕ take(nb + 1) filter(solved?) min-of-or(nb + 1))
@@ -81,7 +79,7 @@ part-1: solve(input)
 
 ` "Parse machine for Part 2: [joltage-targets, button-bit-vectors]."
 parse-machine2(line): {
-  joltage: str.split(line, " ") last str.matches-of("[0-9]+") map(num)
+  joltage: line str.split-on(" ") last str.matches-of("[0-9]+") map(num)
   n: joltage count
   parse-btn(s): str.matches(s, "[0-9]+") map(num) bit-vec(n)
   buttons: str.matches(line, "[(][0-9,]+[)]") map(parse-btn)
@@ -208,11 +206,9 @@ For nfree = 0: unique solution, just back-substitute.
 For nfree > 0: cost = base-cost + sum(slope_j * f_j).
   The search iterates outer free variables with cost-based pruning,
   and exhaustively searches the last free variable over [lo, hi]."
-solve-machine2(m): {
-  target: first(m)
-  buttons: second(m)
-  nc: count(target)
-  nb: count(buttons)
+solve-machine2([target, buttons]): {
+  nc: target count
+  nb: buttons count
   INF: 999999
 
   # Build augmented matrix [A|b]: rows = counters, cols = buttons + target.
@@ -221,9 +217,9 @@ solve-machine2(m): {
 
   # Use basic gaussian elimination to find pivots and free indices
   result: gauss.forward(nb, mat)
-  reduced: first(result)
-  pivots: second(result)
-  rank: count(pivots)
+  reduced: result first
+  pivots: result second
+  rank: pivots count
   nfree: nb - rank
 
   col-free?(c): pivots filter(= c) nil?
@@ -268,7 +264,7 @@ solve-machine2(m): {
 
   # Integer gaussian elimination for exact back-substitution
   result-int: gauss-int.forward(nb, mat)
-  iref: first(result-int)
+  iref: result-int first
 
   ` "Total button presses for a given free-variable assignment, or INF if infeasible.
   Uses exact integer back-substitution from row rank-1 up to row 0 in the

--- a/examples/aoc25/day11.eu
+++ b/examples/aoc25/day11.eu
@@ -28,9 +28,9 @@ Running time: ~2s (part 1), ~3 min (part 2)
 
 ` "Parse 'name: d1 d2 ...' into [name, [d1, d2, ...]]."
 parse-line(line): {
-  parts: str.split(line, ": ")
+  parts: line str.split-on(": ")
   name: parts first
-  dests: str.split(parts second, " ")
+  dests: parts second str.split-on(" ")
 }.[name, dests]
 
 ` "Parse input into a block mapping sym(name) to [dest_strs] for O(log n) lookup."


### PR DESCRIPTION
Further style improvements to AoC 2025 examples (days 02-11), building on PR 366 which added list destructuring.

Pipeline style: Replace str.split(s, re) with pipeline-friendly s str.split-on(re) across days 02, 05, 06, 08, 09, 10, 11. Replace first/second/count function-call forms with pipeline forms result first, result second, pivots count in day 10.

Expression anaphora (day 03): Replace block-anaphora in digits-to-num with cleaner _0 * 10 + _1.

List destructuring: solve-machine and solve-machine2 in day 10 now use [target, buttons] parameter destructuring.

Minor cleanups: inline the if directly without empty block wrapper in col-step (day 06); pipeline form for h sum in day 07.

All tests pass.