### PR TITLE
feat(aoc25): further list destructuring improvements in day01 and day09

### DIFF
--- a/examples/aoc25/day01.eu
+++ b/examples/aoc25/day01.eu
@@ -15,16 +15,14 @@ Notable eucalypt techniques:
 - `scanl` for running totals
 - sections `(% 100 = 0)` for divisibility predicates
 - `window(2, 1)` for consecutive-pair analysis
+- list destructuring in `to-offset([dir, mag])` and `zeros([a, b])`
 - scoped imports with target metadata
 
 Running time: ~3s (part 1), ~10s (part 2)
 "
 
 ` "Convert Lxx / Rxx instructions to numeric offsets."
-to-offset(m): {
-  magnitude: m second num
-  sign: ((m first) = "L") then(-1, 1)
-}.(sign * magnitude)
+to-offset([dir, mag]): ((dir = "L") then(-1, 1)) * (mag num)
 
 parse-instruction(s): s str.match-with("([LR])([0-9]+)") tail to-offset
 

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -20,6 +20,8 @@ Notable eucalypt techniques:
 - block-scoped modules (`levels`, `search`) for organising complex logic
 - `cross` for Cartesian product of tile x-coords
 - `foldr` with accumulator for gap-level insertion
+- list destructuring in function parameters: `v-spans?(y, [_, y_lo, y_hi])`,
+  `inner-step(... [left, right, best], [lv-y, lv-l, lv-r, tiles])`
 
 Running time: ~3 min (part 1), ~3 min (part 2)
 "
@@ -59,13 +61,13 @@ levels: {
   INF: 999999
 
   ` "Does vertical edge `v` [x, y-lo, y-hi] span y-coordinate `y`?"
-  v-spans?(y, v): (second(v) <= y) ∧ (y < v !! 2)
+  v-spans?(y, [_, y_lo, y_hi]): y_lo <= y ∧ y < y_hi
 
   ` "Does horizontal edge `h` [y, x-lo, x-hi] lie at y-coordinate `y`?"
-  has-y?(y, h): first(h) = y
+  has-y?(y, [hy, _, _]): hy = y
 
   ` "Does point `p` [x, y] lie at y-coordinate `y`?"
-  at-y?(y, p): second(p) = y
+  at-y?(y, [_, py]): py = y
 
   ` "Build edge list from consecutive vertex pairs, wrapping last to first."
   make-edges(pts): zip(pts, pts rotate(1))
@@ -92,9 +94,8 @@ levels: {
   tile-xs-at(y, pts): pts filter(at-y?(y)) map(first)
 
   ` "Build a level [y, left, right, tile-xs] at a given `y`."
-  make-level(y, ves, hes, pts): {
-    cs: xsect(y, ves, hes)
-  }.[y, first(cs), second(cs), tile-xs-at(y, pts)]
+  make-level(y, ves, hes, pts):
+    [y] ++ xsect(y, ves, hes) ++ [tile-xs-at(y, pts)]
 
   ` "Insert gap levels between non-adjacent levels.
   Folds right so each level can peek at the next via the accumulator."
@@ -149,18 +150,14 @@ search: {
   (never widen) as we descend. State is `[left, right, best]`.
   Pruned when the corridor has closed or the remaining area cannot
   beat `best`."
-  inner-step(sy, start-tiles, ymax, state, lv): {
-    left: state !! 0
-    right: state !! 1
-    best: state !! 2
+  inner-step(sy, start-tiles, ymax, [left, right, best], [lv-y, lv-l, lv-r, tiles]): {
     # narrow corridor to this level's bounds
-    new-left: max(left, lv !! 1)
-    new-right: min(right, lv !! 2)
+    new-left: max(left, lv-l)
+    new-right: min(right, lv-r)
     max-possible: (ymax - sy + 1) * (new-right - new-left + 1)
-    tiles: lv !! 3
-    area: tiles nil? then(0, max-rect(sy, start-tiles, lv !! 0, tiles, new-left, new-right))
+    area: tiles nil? then(0, max-rect(sy, start-tiles, lv-y, tiles, new-left, new-right))
     pruned?: (left > right) ∨ (max-possible <= best)
-  }.(pruned? then(state,
+  }.(pruned? then([left, right, best],
     [new-left, new-right, max(best, area)]))
 
   ` "Inner sweep: fold downward from a fixed start level, narrowing


### PR DESCRIPTION
## Summary

Further idiomatic improvements to AoC 2025 examples, building on the
list destructuring and pipeline-style work already merged into 0.4.0.

### day01.eu

- Replace `to-offset(m)` block with direct parameter destructuring:
  `to-offset([dir, mag])`, eliminating intermediate `magnitude` and
  `sign` bindings from the block body.

### day09.eu (`levels` module)

- `v-spans?(y, [_, y_lo, y_hi])` — destructure the vertical-edge triple,
  removing `second(v)` and `v !! 2` index accesses.
- `has-y?(y, [hy, _, _])` — destructure the horizontal-edge triple.
- `at-y?(y, [_, py])` — destructure the point pair.
- `make-level` — eliminate the single-use `cs` binding; build the level
  list with `[y] ++ xsect(...) ++ [tile-xs-at(...)]`.

### day09.eu (`search` module)

- `inner-step` — destructure both the state `[left, right, best]` and
  level `[lv-y, lv-l, lv-r, tiles]` function parameters, removing six
  `!! n` index accesses from the body.

## Test plan

- [x] `eu -t test examples/aoc25/day01.eu` → PASS
- [x] `eu -t test examples/aoc25/day09.eu` → PASS
- [x] `eu -t test2 examples/aoc25/day09.eu` → PASS
- [x] All other days (02–08, 10, 11) unmodified, existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)