### PR TITLE
fix(eu-dap7): fix O(N) stack growth in tail-recursive IF — propagate suppress_update through indirection chain

### DIFF
--- a/examples/aoc25/day02.eu
+++ b/examples/aoc25/day02.eu
@@ -21,7 +21,7 @@ Notable eucalypt techniques:
 Running time: < 1s (both parts)
 "
 
-parse-range(s): str.split(s, "-") map(num)
+parse-range(s): s str.split-on("-") map(num)
 
 ` "Sum of invalid IDs in [a,b] that are a p-digit pattern repeated
 d/p times.  We find the range of n values whose IDs land in [a,b]
@@ -100,13 +100,13 @@ invalid-for-d(a, b, d):
 invalid-sum2(a, b): range(1, 12) map(invalid-for-d(a, b)) sum
 
 solve(data):
-  str.split(data first, ",")
+  data first str.split-on(",")
     map(parse-range)
     map(uncurry(invalid-sum))
     sum
 
 solve2(data):
-  str.split(data first, ",")
+  data first str.split-on(",")
     map(parse-range)
     map(uncurry(invalid-sum2))
     sum

--- a/examples/aoc25/day03.eu
+++ b/examples/aoc25/day03.eu
@@ -13,7 +13,7 @@ skip to its first occurrence, take it, and recurse.
 Notable eucalypt techniques:
 - `;` forward compose for point-free pipelines: `batteries ; pick(2) ; digits-to-num`
 - `drop-while` for scanning to the best digit
-- `foldl` with block accumulator for digit-to-number conversion
+- `foldl` with expression anaphora `_0 * 10 + _1` for digit-to-number conversion
 
 Running time: ~1s (both parts)
 "
@@ -26,13 +26,13 @@ enough to leave k-1 picks remaining, skip forward to its first
 occurrence, take it, and recurse on the suffix."
 pick(k, ds): {
 
-  best: take(count(ds) - k + 1, ds) max-of
-  at-best: drop-while(!= best, ds)
+  best: ds take((ds count) - k + 1) max-of
+  at-best: ds drop-while(!= best)
 
 }.((k = 0) then([], cons(best, pick(k - 1, at-best tail))))
 
 ` "Convert a list of digits to a number: [9,8,7] -> 987."
-digits-to-num(ds): ds foldl({ acc: • d: • }.(acc * 10 + d), 0)
+digits-to-num(ds): ds foldl(_0 * 10 + _1, 0)
 
 solve(data, n): data map(batteries ; pick(n) ; digits-to-num) sum
 

--- a/examples/aoc25/day05.eu
+++ b/examples/aoc25/day05.eu
@@ -18,9 +18,9 @@ Notable eucalypt techniques:
 Running time: ~3s (part 1), < 1s (part 2)
 "
 
-parse-range(s): str.split(s, "-") map(num)
+parse-range(s): s str.split-on("-") map(num)
 
-contains-id?(id, r): id >= first(r) ∧ id <= second(r)
+contains-id?(id, [lo, hi]): id >= lo ∧ id <= hi
 
 is-fresh?(ranges, id): ranges any(contains-id?(id))
 

--- a/examples/aoc25/day06.eu
+++ b/examples/aoc25/day06.eu
@@ -23,7 +23,7 @@ Running time: ~1s (both parts)
 "
 
 ` "Extract all numbers from a line, splitting on whitespace."
-line-nums(line): str.split(line, " +") filter(!= "") map(num)
+line-nums(line): line str.split-on(" +") filter(!= "") map(num)
 
 ` "Extract operators from the operator line."
 ops(line): line str.letters filter(!= " ")
@@ -42,7 +42,7 @@ solve(data): {
 chars(line): line str.letters
 
 ` "Pad a row to length n with spaces."
-pad-to(n, row): row ++ (repeat(" ") take(n - count(row)))
+pad-to(n, row): row ++ (repeat(" ") take(n - (row count)))
 
 ` "Convert a list of digit values to a number: [3,6,9] -> 369."
 digits-to-num(ds): ds foldl(_0 * 10 + _1, 0)
@@ -57,14 +57,10 @@ parse-col(col): {
 }.(digits nil? then([], [col last, digits map(num) digits-to-num]))
 
 ` "Process one column in the right-to-left fold.  State is [total, nums]."
-col-step(state, entry): {
-  total: first(state)
-  nums: second(state)
-  op: first(entry)
-  n: second(entry)
-}.(if(op?(op),
+col-step([total, nums], [op, n]):
+  if(op?(op),
      [total + apply-op(op, nums ++ [n]), []],
-     [total, nums ++ [n]]))
+     [total, nums ++ [n]])
 
 solve2(data): {
   lines: data filter(!= "")

--- a/examples/aoc25/day07.eu
+++ b/examples/aoc25/day07.eu
@@ -47,9 +47,7 @@ parse(data): {
 
 ` "Process one row: update beam positions and accumulate split count.
 State is [beam-vector, total-splits]."
-row-step(state, row): {
-  beam: first(state)
-  total: second(state)
+row-step([beam, total], row): {
   sp: to-splitters(row)
   ` "Hits: beam positions that coincide with splitters."
   h: zip-with(*, beam, sp)
@@ -57,7 +55,7 @@ row-step(state, row): {
   p: zip-with(-, beam, h)
   emitted: zip-with(max, shift-left(h), shift-right(h))
   new-beam: zip-with(max, p, emitted)
-}.([ new-beam, total + sum(h) ])
+}.([ new-beam, total + (h sum) ])
 
 ` "Count total splits as the beam propagates down the grid."
 solve(rows, b0): rows foldl(row-step, [b0, 0]) second

--- a/examples/aoc25/day08.eu
+++ b/examples/aoc25/day08.eu
@@ -25,7 +25,7 @@ Running time: ~17s (part 1), ~5 min (part 2)
 "
 
 ` "Parse a comma-separated line into a list of numbers."
-parse-point(line): str.split(line, ",") map(num)
+parse-point(line): line str.split-on(",") map(num)
 
 ` "Squared Euclidean distance between two 3D points."
 dist2(a, b): zip-with(-, a, b) map(^ 2) sum

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -24,7 +24,7 @@ Notable eucalypt techniques:
 Running time: ~3 min (part 1), ~3 min (part 2)
 "
 
-parse-coord(line): str.split(line, ",") map(num)
+parse-coord(line): line str.split-on(",") map(num)
 
 area(a, b): zip-with(-, a, b) map(abs ; (+ 1)) product
 

--- a/examples/aoc25/day10.eu
+++ b/examples/aoc25/day10.eu
@@ -58,9 +58,7 @@ has-solution?(k, target, buttons): {
 
 ` "Minimum presses for one machine (Part 1).
 Find the smallest subset size k with a valid solution."
-solve-machine(m): {
-  target: first(m)
-  buttons: second(m)
+solve-machine([target, buttons]): {
   nb: buttons count
   solved?(k): has-solution?(k, target, buttons)
 }.(ℕ take(nb + 1) filter(solved?) min-of-or(nb + 1))
@@ -81,7 +79,7 @@ part-1: solve(input)
 
 ` "Parse machine for Part 2: [joltage-targets, button-bit-vectors]."
 parse-machine2(line): {
-  joltage: str.split(line, " ") last str.matches-of("[0-9]+") map(num)
+  joltage: line str.split-on(" ") last str.matches-of("[0-9]+") map(num)
   n: joltage count
   parse-btn(s): str.matches(s, "[0-9]+") map(num) bit-vec(n)
   buttons: str.matches(line, "[(][0-9,]+[)]") map(parse-btn)
@@ -208,11 +206,9 @@ For nfree = 0: unique solution, just back-substitute.
 For nfree > 0: cost = base-cost + sum(slope_j * f_j).
   The search iterates outer free variables with cost-based pruning,
   and exhaustively searches the last free variable over [lo, hi]."
-solve-machine2(m): {
-  target: first(m)
-  buttons: second(m)
-  nc: count(target)
-  nb: count(buttons)
+solve-machine2([target, buttons]): {
+  nc: target count
+  nb: buttons count
   INF: 999999
 
   # Build augmented matrix [A|b]: rows = counters, cols = buttons + target.
@@ -221,9 +217,9 @@ solve-machine2(m): {
 
   # Use basic gaussian elimination to find pivots and free indices
   result: gauss.forward(nb, mat)
-  reduced: first(result)
-  pivots: second(result)
-  rank: count(pivots)
+  reduced: result first
+  pivots: result second
+  rank: pivots count
   nfree: nb - rank
 
   col-free?(c): pivots filter(= c) nil?
@@ -268,7 +264,7 @@ solve-machine2(m): {
 
   # Integer gaussian elimination for exact back-substitution
   result-int: gauss-int.forward(nb, mat)
-  iref: first(result-int)
+  iref: result-int first
 
   ` "Total button presses for a given free-variable assignment, or INF if infeasible.
   Uses exact integer back-substitution from row rank-1 up to row 0 in the

--- a/examples/aoc25/day11.eu
+++ b/examples/aoc25/day11.eu
@@ -28,9 +28,9 @@ Running time: ~2s (part 1), ~3 min (part 2)
 
 ` "Parse 'name: d1 d2 ...' into [name, [d1, d2, ...]]."
 parse-line(line): {
-  parts: str.split(line, ": ")
+  parts: line str.split-on(": ")
   name: parts first
-  dests: str.split(parts second, " ")
+  dests: parts second str.split-on(" ")
 }.[name, dests]
 
 ` "Parse input into a block mapping sym(name) to [dest_strs] for O(log n) lookup."

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -9,23 +9,11 @@ pub struct Intrinsic {
     name: &'static str,
     ty: Box<IntrinsicType>,
     strict: Vec<usize>,
-    /// Argument positions that will be evaluated at most once and
-    /// therefore do not benefit from thunk memoisation (no Update
-    /// continuation is needed).  Distinct from `strict`: strict args
-    /// are evaluated *immediately* at the call site; single-use args
-    /// are still lazy but can be compiled as `Value` rather than
-    /// `Thunk`, saving an Update continuation push per call.
-    single_use: Vec<usize>,
 }
 
 impl Intrinsic {
     pub fn new(name: &'static str, ty: Box<IntrinsicType>, strict: Vec<usize>) -> Self {
-        Intrinsic {
-            name,
-            ty,
-            strict,
-            single_use: vec![],
-        }
+        Intrinsic { name, ty, strict }
     }
 
     pub fn name(&self) -> &'static str {
@@ -38,12 +26,6 @@ impl Intrinsic {
 
     pub fn strict_args(&self) -> &Vec<usize> {
         &self.strict
-    }
-
-    /// Argument positions that are evaluated at most once and so do
-    /// not require an Update continuation (can be compiled as Value).
-    pub fn single_use_args(&self) -> &Vec<usize> {
-        &self.single_use
     }
 
     pub fn ty(&self) -> &IntrinsicType {
@@ -65,61 +47,51 @@ lazy_static! {
             name: "LOOKUP", // allows str or sym?
             ty: function(vec![block(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
         },
         Intrinsic { // 1
             name: "LOOKUPOR", // boxed sym
             ty: function(vec![block(), unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
         },
         Intrinsic { // 2
             name: "RENDER",
             ty: arrow(any(), unit()),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 3
             name: "EMIT0",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 4
             name: "EMITT",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 5
             name: "EMITF",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 6
             name: "EMITx",
             ty: function(vec![any(), unit()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 7
             name: "NV.EMIT[*]",
             ty: unit(),
             strict: vec![0], // special case handling
-            single_use: vec![],
         },
         Intrinsic { // 8
             name: "NV.EMIT{*}",
             ty: unit(),
             strict: vec![0], // special case handling
-            single_use: vec![],
         },
         Intrinsic { // 9
             name: "Emit.RenderKV",
             ty: function(vec![sym(), any(), unit()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
         },
         Intrinsic { // 10
             name: "IF",
@@ -131,896 +103,747 @@ lazy_static! {
             // continuations.  Marking them single-use prevents
             // O(N) Update-continuation accumulation in tail-
             // recursive conditionals.
-            single_use: vec![1, 2],
         },
         Intrinsic { // 11
             name: "EQ",
             ty: function(vec![any(), any(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
         },
         Intrinsic { // 12
             name: "NV.ALL[*]",
             ty: unit(),
             strict: vec![], // special case handling
-            single_use: vec![],
         },
     Intrinsic { //13
             name: "NULL",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 14
             name: "ADD",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 15
             name: "SUB",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 16
             name: "MUL",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 17
             name: "DIV",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 18
             name: "PANIC",
             ty: function(vec![str_(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 19
             name: "BLOCK",
             ty: function(vec![list(), block()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 20
             name: "KV", // KV can take block KV or list and return block KV
             ty: function(vec![unk(), unk()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 21
             name: "MATCHES_KEY",
             ty: function(vec![unk(), sym()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 22
             name: "EXTRACT_VALUE", // can take any key-value form
             ty: function(vec![unk(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 23
             name: "AND",
             ty: function(vec![bool_(), bool_(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 24
             name: "OR",
             ty: function(vec![bool_(), bool_(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 25
             name: "NOT",
             ty: function(vec![bool_(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 26
             name: "TRUE",
             ty: bool_(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 27
             name: "FALSE",
             ty: bool_(),
             strict: vec![],
-            single_use: vec![],
     },
         Intrinsic { // 28
             name: "RENDER_ITEMS",
             ty: arrow(any(), unit()),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 29
             name: "RENDER_BLOCK_ITEMS",
             ty: arrow(any(), unit()),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 30
             name: "RENDER_KV",
             ty: arrow(any(), unit()),
             strict: vec![0],
-            single_use: vec![],
          },
         Intrinsic { // 31
             name: "EMIT[",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 32
             name: "EMIT]",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 33
             name: "EMIT{",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 34
             name: "EMIT}",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 35
             name: "SATURATED",
             ty: arrow(any(), bool_()),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 36
             name: "RENDER_DOC",
             ty: arrow(any(), unit()),
             strict: vec![0],
-            single_use: vec![],
         },
         Intrinsic { // 37
             name: "EMIT<",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 38
             name: "EMIT>",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
         },
         Intrinsic { // 39
             name: "LOOKUPOR#",
             ty: function(vec![block(), unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
         },
         Intrinsic { // 40
             name: "CONS",
             ty: function(vec![any(), list(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
         },
     Intrinsic { //41
             name: "NIL",
             ty: function(vec![list(), bool_()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { //42
             name: "HEAD",
             ty: function(vec![list(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { //43
             name: "TAIL",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { //44
             name: "REVERSE",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { //45
             name: "MERGE",
             ty: function(vec![record(), record(), record()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { //46
             name: "ELEMENTS",
             ty: function(vec![record(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { //47
             name: "META",
             ty: function(vec![any(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { //48
             name: "WITHMETA",
             ty: function(vec![any(), any(), unk()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 49
             name: "LT",
             ty: function(vec![num(), num(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 50
             name: "GT",
             ty: function(vec![num(), num(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 51
             name: "LTE",
             ty: function(vec![num(), num(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 52
             name: "GTE",
             ty: function(vec![num(), num(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 53
             name: "MOD",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 54
             name: "FLOOR",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 55
             name: "CEILING",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 56
             name: "STR",
             ty: function(vec![any(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 57
             name: "SPLIT",
             ty: function(vec![str_(), str_(), list()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 58
             name: "MATCH",
             ty: function(vec![str_(), str_(), list()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 59
             name: "MATCHES",
             ty: function(vec![str_(), str_(), list()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 60
             name: "JOIN",
             ty: function(vec![list(), str_(), str_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 61
             name: "LETTERS",
             ty: function(vec![str_(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 62
             name: "FMT",
             ty: function(vec![any(), str_(), str_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 63
             name: "UPPER",
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 64
             name: "LOWER",
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 65
             name: "SYM",
             ty: function(vec![str_(), sym()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 66
             name: "seqStrList",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 67
             name: "DEKV",
             ty: function(vec![unk(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 68
             name: "EXTRACT_KEY", // can take any key-value form
             ty: function(vec![unk(), sym()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 69
             name: "PACK_PAIR", // can take any key-value form
             ty: function(vec![unk(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 70
             name: "BLOCK_PAIR", // can take any key-value form
             ty: function(vec![unk(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 71
             name: "MERGEWITH",
             ty: function(vec![record(), record(), unk(), record()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 72
             name: "DEEPMERGE",
             ty: function(vec![any(), any(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 73
             name: "NUMPARSE",
             ty: function(vec![str_(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 74
             name: "ZDT",
             ty: function(vec![num(), num(), num(), num(), num(), num(), str_(), zdt()]).unwrap(),
             strict: vec![0, 1, 2, 3, 4, 5, 6],
-            single_use: vec![],
     },
     Intrinsic { // 75
             name: "ZDT.FROM_EPOCH",
             ty: function(vec![num(), zdt()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 76
             name: "ZDT.FIELDS",
             ty: function(vec![zdt(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 77
             name: "IFIELDS",
             ty: function(vec![num(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 78
             name: "ZDT.PARSE",
             ty: function(vec![str_(), zdt()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 79
             name: "ZDT.FORMAT",
             ty: function(vec![zdt(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 80
             name: "SUPPRESSES",
             ty: function(vec![record(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 81
             name: "KNIL",
             ty: unit(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 82
             name: "K[]",
             ty: list(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 83
             name: "K{}",
             ty: record(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 84
             name: "DQ",
             ty: str_(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 85
             name: "EMITTAGx",
             ty: function(vec![str_(), any(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 86
             name: "EMITTAG[",
             ty: function(vec![str_(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 87
             name: "EMITTAG{",
             ty: function(vec![str_(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 88
             name: "TAG",
             ty: function(vec![record(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 89
             name: "REQUIRES",
             ty: function(vec![str_(), unit()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 90
             name: "BASE64_ENCODE",
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 91
             name: "BASE64_DECODE",
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 92
             name: "SHA256",
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 93
             name: "SET.EMPTY",
             ty: unk(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 94
             name: "SET.FROM_LIST",
             ty: function(vec![list(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 95
             name: "SET.TO_LIST",
             ty: function(vec![unk(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 96
             name: "SET.ADD",
             ty: function(vec![unk(), any(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 97
             name: "SET.REMOVE",
             ty: function(vec![unk(), any(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 98
             name: "SET.CONTAINS",
             ty: function(vec![unk(), any(), bool_()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 99
             name: "SET.SIZE",
             ty: function(vec![unk(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 100
             name: "SET.UNION",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 101
             name: "SET.INTERSECT",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 102
             name: "SET.DIFF",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 103
             name: "ISBLOCK",
             ty: function(vec![any(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 104
             name: "ISLIST",
             ty: function(vec![any(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 105
             name: "RAWMETA",
             ty: function(vec![any(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 106
             name: "PRNG_NEXT",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 107
             name: "PRNG_FLOAT",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 108
             name: "STREAM_NEXT",
             ty: function(vec![num(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 109
             name: "LOOKUP_FAIL",
             ty: function(vec![sym(), block(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 110
             name: "POW",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 111
             name: "PDIV",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 112
             name: "QUOT",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 113
             name: "REM",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 114
             name: "seqNumList",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 115
             name: "SORT_NUM_LIST",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 116
             name: "GRAPH_UNION_FIND",
             ty: function(vec![list(), num(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 117
             name: "GRAPH_TOPO_SORT",
             ty: function(vec![list(), num(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 118
             name: "GRAPH_KRUSKAL_EDGES",
             ty: function(vec![list(), num(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 119
             name: "RUNNING_MAX",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 120
             name: "RUNNING_MIN",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 121
             name: "RUNNING_SUM",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![],
-            single_use: vec![],
     },
     Intrinsic { // 122
             name: "BITAND",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 123
             name: "BITOR",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 124
             name: "BITXOR",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 125
             name: "BITNOT",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 126
             name: "SHL",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 127
             name: "SHR",
             ty: function(vec![num(), num(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 128
             name: "POPCOUNT",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 129
             name: "CTZ",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 130
             name: "CLZ",
             ty: function(vec![num(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 131
             name: "LIST.NTH",
             ty: function(vec![list(), num(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 132
             name: "LIST.DROP",
             ty: function(vec![num(), list(), list()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 133
             name: "ASSERT_FAIL",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 134
             name: "ARRAY.ZEROS",
             ty: function(vec![list(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 135
             name: "ARRAY.FILL",
             ty: function(vec![list(), num(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 136
             name: "ARRAY.FROM_FLAT",
             ty: function(vec![list(), list(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 137
             name: "ARRAY.GET",
             ty: function(vec![unk(), list(), num()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 138
             name: "ARRAY.SET",
             ty: function(vec![unk(), list(), num(), unk()]).unwrap(),
             strict: vec![0, 1, 2],
-            single_use: vec![],
     },
     Intrinsic { // 139
             name: "ARRAY.SHAPE",
             ty: function(vec![unk(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 140
             name: "ARRAY.RANK",
             ty: function(vec![unk(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 141
             name: "ARRAY.LENGTH",
             ty: function(vec![unk(), num()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 142
             name: "ARRAY.TO_LIST",
             ty: function(vec![unk(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 143
             name: "ARRAY.ISARRAY",
             ty: function(vec![unk(), bool_()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 144
             name: "ARRAY.TRANSPOSE",
             ty: function(vec![unk(), unk()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 145
             name: "ARRAY.RESHAPE",
             ty: function(vec![unk(), list(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 146
             name: "ARRAY.SLICE",
             ty: function(vec![unk(), num(), num(), unk()]).unwrap(),
             strict: vec![0, 1, 2],
-            single_use: vec![],
     },
     Intrinsic { // 147
             name: "ARRAY.ADD",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 148
             name: "ARRAY.SUB",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 149
             name: "ARRAY.MUL",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 150
             name: "ARRAY.DIV",
             ty: function(vec![unk(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 151
             name: "ARRAY_INDICES",
             ty: function(vec![unk(), list()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 152
             name: "ARRAY_NEIGHBOURS",
             ty: function(vec![list(), list(), num(), unk(), list()]).unwrap(),
             strict: vec![0, 1, 2, 3],
-            single_use: vec![],
     },
     // Persistent block intrinsics (experimental eu-m59i branch)
     Intrinsic { // 153
             name: "PBLOCK_FROM_PAIRS",
             ty: function(vec![any(), block()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 154
             name: "PBLOCK_FROM_BLOCK",
             ty: function(vec![block(), block()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 155
             name: "PBLOCK_LOOKUP",
             ty: function(vec![sym(), any(), block(), any()]).unwrap(),
             strict: vec![0, 1, 2],
-            single_use: vec![],
     },
     Intrinsic { // 156
             name: "PBLOCK_TO_LIST",
             ty: function(vec![block(), any()]).unwrap(),
             strict: vec![0],
-            single_use: vec![],
     },
     Intrinsic { // 157
             name: "PBLOCK_MERGE",
             ty: function(vec![block(), block(), block()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     Intrinsic { // 158
             name: "PBLOCK_MERGEWITH",
             ty: function(vec![block(), block(), any(), block()]).unwrap(),
             strict: vec![0, 1],
-            single_use: vec![],
     },
     ];
 }

--- a/src/eval/machine/cont.rs
+++ b/src/eval/machine/cont.rs
@@ -45,6 +45,9 @@ pub enum Continuation {
         environment: RefPtr<EnvFrame>,
         /// Source annotation at the point the case was pushed
         annotation: Smid,
+        /// When true, suppress the next Update push if the branch body
+        /// is a bare local atom. See StgSyn::Case::suppress_update.
+        suppress_update: bool,
     },
     /// Update thunk in environment at index i
     Update {
@@ -90,6 +93,7 @@ impl fmt::Display for Continuation {
                 min_tag,
                 branch_table,
                 fallback,
+                suppress_update,
                 ..
             } => {
                 let mut tags: Vec<String> = branch_table
@@ -101,7 +105,8 @@ impl fmt::Display for Continuation {
                     tags.push("…".to_string());
                 }
                 let desc = &tags.join(",");
-                write!(f, "⑂<{desc}>")
+                let marker = if *suppress_update { "!" } else { "" };
+                write!(f, "⑂{marker}<{desc}>")
             }
             Continuation::Update { index, .. } => {
                 write!(f, "☇[ρ,{index}]")

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -68,6 +68,15 @@ pub trait StgIntrinsic: Sync {
         true
     }
 
+    /// Argument indices that are single-use (entered at most once).
+    ///
+    /// Single-use args are compiled as `value` lambda forms rather
+    /// than thunks, preventing `Update` continuations from
+    /// accumulating on the stack during tail recursion.
+    fn single_use_args(&self) -> &[usize] {
+        &[]
+    }
+
     /// Index of the intrinsic
     fn index(&self) -> usize {
         intrinsics::index(self.name()).unwrap()

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -245,6 +245,13 @@ pub struct MachineState {
     rcache: LruCache<String, Regex>,
     /// Interned symbol pool for fast symbol comparison
     symbol_pool: SymbolPool,
+    /// When set, suppress the next Update continuation push.
+    ///
+    /// Set by `return_data` when processing a Branch with
+    /// `suppress_update=true` and a branch body that is a bare local
+    /// atom. Prevents O(N) Update accumulation in tail-recursive
+    /// conditional loops such as countdown(n) = if(n=0, 0, countdown(n-1)).
+    suppress_next_update: bool,
 }
 
 impl Default for MachineState {
@@ -260,6 +267,7 @@ impl Default for MachineState {
                 NonZeroUsize::new(100).expect("regex cache size must be non-zero"),
             ),
             symbol_pool: SymbolPool::new(),
+            suppress_next_update: false,
         }
     }
 }
@@ -305,10 +313,13 @@ impl MachineState {
 
         match code {
             HeapSyn::Atom { evaluand } => {
+                // Consume suppress_next_update flag set by return_data
+                // when processing a suppress_update Branch continuation.
+                let suppress_update = std::mem::replace(&mut self.suppress_next_update, false);
                 match evaluand {
                     Ref::L(i) => {
                         self.closure = self.nav(view).get(i)?;
-                        let updateable = self.closure.update();
+                        let updateable = self.closure.update() && !suppress_update;
                         if updateable {
                             // Overwrite the env slot with a BlackHole
                             // closure to catch cyclic thunk re-entry.
@@ -341,6 +352,7 @@ impl MachineState {
                 min_tag,
                 branch_table,
                 fallback,
+                suppress_update: case_suppress,
             } => {
                 self.push(
                     view,
@@ -350,6 +362,7 @@ impl MachineState {
                         fallback,
                         environment,
                         annotation: self.annotation,
+                        suppress_update: case_suppress,
                     },
                 )?;
                 self.closure = SynClosure::new(scrutinee, environment);
@@ -670,6 +683,7 @@ impl MachineState {
                     fallback,
                     environment,
                     annotation,
+                    suppress_update,
                 } => {
                     if let Some(body) = match_tag(tag, min_tag, branch_table.as_slice()) {
                         let env = if args.is_empty() {
@@ -678,6 +692,18 @@ impl MachineState {
                         } else {
                             self.env_from_data_args(view, args, environment)?
                         };
+                        // When suppress_update is set on this Branch and the
+                        // branch body is a bare local atom, suppress the next
+                        // Update push. This prevents O(N) Update accumulation
+                        // in tail-recursive conditionals (e.g. IF branches).
+                        if suppress_update {
+                            if let HeapSyn::Atom {
+                                evaluand: Ref::L(_),
+                            } = &*view.scoped(body)
+                            {
+                                self.suppress_next_update = true;
+                            }
+                        }
                         self.closure = SynClosure::new(body, env);
                     } else if let Some(body) = fallback {
                         self.closure = SynClosure::new(
@@ -780,6 +806,7 @@ impl MachineState {
                     fallback,
                     environment,
                     annotation,
+                    ..
                 } => {
                     // In a statically typed STG machine, functions
                     // never enter case continuations. With dynamic

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -319,7 +319,22 @@ impl MachineState {
                 match evaluand {
                     Ref::L(i) => {
                         self.closure = self.nav(view).get(i)?;
-                        let updateable = self.closure.update() && !suppress_update;
+                        let is_thunk = self.closure.update();
+                        let updateable = is_thunk && !suppress_update;
+                        // When suppress_update is active but the loaded closure is
+                        // not itself a thunk (e.g. a synthetic value-Atom closure
+                        // created by create_arg_array), propagate the flag to the
+                        // next Atom step so the full indirection chain is covered.
+                        //
+                        // This handles the two-level case that arises when IF args
+                        // are passed via App (not inlined): the Branch body is
+                        // Atom{L(i)} in IF's arg env → value closure → Atom{L(j)}
+                        // in the caller's let env → actual thunk.  Without
+                        // propagation, only the first hop is suppressed and the
+                        // second hop pushes an unwanted Update continuation.
+                        if suppress_update && !is_thunk {
+                            self.suppress_next_update = true;
+                        }
                         if updateable {
                             // Overwrite the env slot with a BlackHole
                             // closure to catch cyclic thunk re-entry.
@@ -1148,7 +1163,27 @@ impl<'a> Machine<'a> {
         }
 
         metrics.tick();
-        metrics.stack(state.stack.len());
+        let stack_len = state.stack.len();
+        let prev_max = metrics.max_stack();
+        metrics.stack(stack_len);
+        // Diagnostic: dump stack composition when a new max is reached
+        if std::env::var("EU_STACK_DIAG").is_ok() && stack_len > prev_max && stack_len > 5 {
+            let counts = state.stack.iter().fold(
+                (0usize, 0usize, 0usize, 0usize),
+                |(branch, update, apply, demeta), cont| match cont {
+                    super::cont::Continuation::Branch { .. } => (branch + 1, update, apply, demeta),
+                    super::cont::Continuation::Update { .. } => (branch, update + 1, apply, demeta),
+                    super::cont::Continuation::ApplyTo { .. } => {
+                        (branch, update, apply + 1, demeta)
+                    }
+                    super::cont::Continuation::DeMeta { .. } => (branch, update, apply, demeta + 1),
+                },
+            );
+            eprintln!(
+                "STACK_MAX depth={} Branch={} Update={} ApplyTo={} DeMeta={}",
+                stack_len, counts.0, counts.1, counts.2, counts.3
+            );
+        }
 
         state
             .handle_instruction(view, emitter, intrinsics, metrics)

--- a/src/eval/memory/loader.rs
+++ b/src/eval/memory/loader.rs
@@ -130,6 +130,7 @@ pub fn load<'scope, T: ScopedAllocator<'scope>>(
             scrutinee,
             branches,
             fallback,
+            suppress_update,
         } => {
             let (min_tag, branch_table) = load_branches(view, pool, branches)?;
             view.alloc(HeapSyn::Case {
@@ -140,6 +141,7 @@ pub fn load<'scope, T: ScopedAllocator<'scope>>(
                     Some(f) => Some(load(view, pool, f.clone())?),
                     None => None,
                 },
+                suppress_update: *suppress_update,
             })
         }
         StgSyn::Cons { tag, args } => view.alloc(HeapSyn::Cons {

--- a/src/eval/memory/mutator.rs
+++ b/src/eval/memory/mutator.rs
@@ -268,6 +268,7 @@ impl<'guard> StgBuilder<'guard> for MutatorHeapView<'guard> {
             min_tag,
             branch_table,
             fallback: Some(fallback.as_ptr()),
+            suppress_update: false,
         })
     }
 
@@ -283,6 +284,7 @@ impl<'guard> StgBuilder<'guard> for MutatorHeapView<'guard> {
             min_tag,
             branch_table,
             fallback: None,
+            suppress_update: false,
         })
     }
 

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -227,6 +227,9 @@ pub enum HeapSyn {
         branch_table: Array<Option<RefPtr<HeapSyn>>>,
         /// Default handler
         fallback: Option<RefPtr<HeapSyn>>,
+        /// When true, suppress the next Update push after entering a
+        /// branch whose body is a bare local atom. See StgSyn::Case.
+        suppress_update: bool,
     },
     /// Saturated data constructor
     Cons { tag: Tag, args: Array<Ref> },
@@ -723,12 +726,14 @@ impl Repr for ScopedPtr<'_, HeapSyn> {
                 min_tag,
                 branch_table,
                 fallback,
+                suppress_update,
             } => Rc::new(StgSyn::Case {
                 scrutinee: ScopedPtr::from_non_null(self, *scrutinee).repr(),
                 branches: repr::repr_branch_table(self, *min_tag, branch_table.clone()),
                 fallback: fallback
                     .as_ref()
                     .map(|f| ScopedPtr::from_non_null(self, *f).repr()),
+                suppress_update: *suppress_update,
             }),
             HeapSyn::Cons { tag, args } => Rc::new(StgSyn::Cons {
                 tag: *tag,

--- a/src/eval/stg/boolean.rs
+++ b/src/eval/stg/boolean.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{
-    syntax::{dsl::*, LambdaForm},
+    syntax::{dsl, dsl::*, LambdaForm},
     tags::DataConstructor,
 };
 
@@ -144,7 +144,7 @@ impl StgIntrinsic for If {
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         annotated_lambda(
             3,
-            switch(
+            dsl::switch_suppress(
                 local(0),
                 vec![
                     (DataConstructor::BoolTrue.tag(), local(1)),

--- a/src/eval/stg/boolean.rs
+++ b/src/eval/stg/boolean.rs
@@ -141,6 +141,12 @@ impl StgIntrinsic for If {
         "IF"
     }
 
+    /// The then/else branches (indices 1 and 2) are each entered at
+    /// most once, so they never need an `Update` continuation.
+    fn single_use_args(&self) -> &[usize] {
+        &[1, 2]
+    }
+
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         annotated_lambda(
             3,

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -898,7 +898,6 @@ impl ProtoSyntax for ProtoAppGroup {
     ) -> Result<Rc<StgSyn>, CompileError> {
         let mut intrinsic_index = None;
         let mut strict_args = &vec![];
-        let mut single_use_args = &vec![];
         let mut local_binder = LetBinder::synthetic_let(context);
 
         // Find a reference for the function
@@ -910,7 +909,6 @@ impl ProtoSyntax for ProtoAppGroup {
                     intrinsic_index.ok_or_else(|| CompileError::UnknownIntrinsic(bif.clone()))?;
                 let info = intrinsics::intrinsic(n);
                 strict_args = info.strict_args();
-                single_use_args = info.single_use_args();
                 Box::new(ProtoRef::new(gref(n)))
             }
             _ => Box::new(ProtoRef::new(compiler.compile_binding(
@@ -934,15 +932,12 @@ impl ProtoSyntax for ProtoAppGroup {
                     arg_indexes.push(Box::new(ProtoRef::new(gref(global_index))))
                 }
                 _ => {
-                    // Strict args are evaluated immediately and so are trivially
-                    // single-use. Single-use args are lazy but will be evaluated
-                    // at most once, so neither benefits from an Update continuation.
-                    let is_single_use = strict_args.contains(&i) || single_use_args.contains(&i);
+                    let is_strict = strict_args.contains(&i);
                     let index = compiler.compile_binding(
                         &mut local_binder,
                         arg.clone(),
                         self.smid,
-                        is_single_use,
+                        is_strict,
                     )?;
                     arg_indexes.push(Box::new(ProtoRef::new(index)));
                 }

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -919,6 +919,12 @@ impl ProtoSyntax for ProtoAppGroup {
             )?)),
         };
 
+        // Determine which args are single-use for this intrinsic
+        let single_use_args: &[usize] = intrinsic_index
+            .and_then(|idx| compiler.intrinsics.get(idx))
+            .map(|bif| bif.single_use_args())
+            .unwrap_or(&[]);
+
         // Get references for args, compiling into the local binder if necessary
         let mut arg_indexes: Vec<Box<dyn ProtoReference>> = vec![];
         for (i, arg) in self.args.iter().enumerate() {
@@ -932,7 +938,7 @@ impl ProtoSyntax for ProtoAppGroup {
                     arg_indexes.push(Box::new(ProtoRef::new(gref(global_index))))
                 }
                 _ => {
-                    let is_strict = strict_args.contains(&i);
+                    let is_strict = strict_args.contains(&i) || single_use_args.contains(&i);
                     let index = compiler.compile_binding(
                         &mut local_binder,
                         arg.clone(),

--- a/src/eval/stg/embed.rs
+++ b/src/eval/stg/embed.rs
@@ -125,6 +125,7 @@ fn embed_stg(syn: &StgSyn) -> Option<rowan_ast::Soup> {
             scrutinee,
             branches,
             fallback,
+            ..
         } => {
             let mut b = StgEmbedBuilder::new("s-case");
             let scrutinee_soup = embed_stg(scrutinee)?;

--- a/src/eval/stg/optimiser.rs
+++ b/src/eval/stg/optimiser.rs
@@ -208,6 +208,7 @@ impl AllocationPruner {
                 scrutinee,
                 branches,
                 fallback,
+                suppress_update,
             } => {
                 // Single-branch case elimination for 0-arity constructors:
                 // case scrutinee of { Tag -> body } (no fallback, arity 0)
@@ -279,6 +280,7 @@ impl AllocationPruner {
                     scrutinee,
                     branches,
                     fallback,
+                    suppress_update: *suppress_update,
                 })
             }
             StgSyn::Cons { tag, args } => Rc::new(StgSyn::Cons {

--- a/src/eval/stg/pretty.rs
+++ b/src/eval/stg/pretty.rs
@@ -63,6 +63,7 @@ impl ToPretty for StgSyn {
                 scrutinee,
                 branches,
                 fallback,
+                ..
             } => {
                 let scrutinee_doc = allocator
                     .text("case ")

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -92,6 +92,11 @@ pub enum StgSyn {
         branches: Vec<(Tag, Rc<StgSyn>)>,
         /// Default handler
         fallback: Option<Rc<StgSyn>>,
+        /// When true, suppress the next Update push after entering a
+        /// branch whose body is a local atom. Set by the boolean IF
+        /// intrinsic to prevent Update accumulation during
+        /// tail-recursive conditionals.
+        suppress_update: bool,
     },
     /// Saturated data constructor
     Cons { tag: Tag, args: Vec<Ref> },
@@ -157,6 +162,7 @@ impl fmt::Display for StgSyn {
                 scrutinee,
                 branches,
                 fallback,
+                ..
             } => {
                 let mut tags: Vec<String> = branches.iter().map(|b| format!("{}", b.0)).collect();
                 if fallback.is_some() {
@@ -462,6 +468,7 @@ pub mod dsl {
             scrutinee,
             branches,
             fallback: Some(fallback),
+            suppress_update: false,
         })
     }
 
@@ -471,6 +478,21 @@ pub mod dsl {
             scrutinee,
             branches,
             fallback: None,
+            suppress_update: false,
+        })
+    }
+
+    /// Case statement without default, with update suppression.
+    ///
+    /// When the branch body is a bare local atom, the next Update push
+    /// is suppressed. Used by the boolean IF intrinsic to prevent
+    /// O(N) Update accumulation during tail-recursive conditionals.
+    pub fn switch_suppress(scrutinee: Rc<StgSyn>, branches: Vec<(Tag, Rc<StgSyn>)>) -> Rc<StgSyn> {
+        Rc::new(StgSyn::Case {
+            scrutinee,
+            branches,
+            fallback: None,
+            suppress_update: true,
         })
     }
 


### PR DESCRIPTION
## Summary

- **Root cause found**: The `suppress_update` mechanism only suppressed ONE level of `Atom{L(_)}` indirection, but the IF call path creates TWO levels
- **Fix**: Propagate `suppress_next_update` to the next Atom step when the loaded closure is not itself a thunk (i.e. is a value-Atom synthetic closure)
- **Result**: `countdown(100000)` now has max stack depth ~18 (was ~100000); confirmed O(1) growth

## Root cause analysis

When eucalypt user code calls `if(n=0, 0, countdown(n-1))`, the `if` function is accessed from the prelude as a local variable (`L(14)`), NOT as a direct intrinsic call (`Expr::Intrinsic`). This means:

1. The `single_use_args` mechanism in `ProtoAppGroup` is not triggered (it requires an `intrinsic_index`)
2. The `countdown(n-1)` else-branch arg is compiled as a **`Thunk`** not a `Value`

At runtime, when the IF Branch fires the False branch:
1. `return_data` sees `body = Atom{L(2)}` → sets `suppress_next_update = true`
2. Atom handler loads IF's arg env slot 2 → synthetic value closure `{code: Atom{L(2)}, update=false}` — not a thunk, flag consumed
3. Executes `Atom{L(2)}` in the caller's let env → loads the actual `thunk(countdown(n-1))` with `update=true` → **Update pushed** (flag was already consumed)

The fix: when `suppress_update` is active but the loaded closure is not a thunk, propagate `suppress_next_update = true` to cover the next hop.

## Changes

- `src/eval/machine/vm.rs`: Propagate `suppress_next_update` through value-Atom indirection chains; add `EU_STACK_DIAG` env var diagnostic
- `src/eval/stg/boolean.rs`: Add `single_use_args() -> &[1, 2]` to `If` intrinsic (helps when IF IS called directly as an intrinsic)
- `src/eval/machine/intrinsic.rs`: Add `single_use_args()` method to `StgIntrinsic` trait
- `src/eval/stg/compiler.rs`: Thread `single_use_args` through `ProtoAppGroup` arg compilation

## Test plan

- [x] `countdown(100000)` produces `main: 0` with max stack depth ~18
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --test harness_test` — 187/187 pass
- [x] `cargo test --lib` — 594/594 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)