### PR TITLE
refactor(aoc25): apply juxtaposed list-destructuring syntax to AoC 2025 examples

### DIFF
--- a/examples/aoc25/day01.eu
+++ b/examples/aoc25/day01.eu
@@ -15,14 +15,14 @@ Notable eucalypt techniques:
 - `scanl` for running totals
 - sections `(% 100 = 0)` for divisibility predicates
 - `window(2, 1)` for consecutive-pair analysis
-- list destructuring in `to-offset([dir, mag])` and `zeros([a, b])`
+- juxtaposed call syntax in `to-offset[dir, mag]:` and `zeros[a, b]:`
 - scoped imports with target metadata
 
 Running time: ~3s (part 1), ~10s (part 2)
 "
 
 ` "Convert Lxx / Rxx instructions to numeric offsets."
-to-offset([dir, mag]): ((dir = "L") then(-1, 1)) * (mag num)
+to-offset[dir, mag]: ((dir = "L") then(-1, 1)) * (mag num)
 
 parse-instruction(s): s str.match-with("([LR])([0-9]+)") tail to-offset
 
@@ -30,7 +30,7 @@ solve(data): data map(parse-instruction) scanl(+, 50) filter(% 100 = 0) count
 
 ` "Count zero crossings between consecutive positions. Shift by 1 when
 moving left so that starting on a multiple of 100 is not counted."
-zeros([a, b]): {
+zeros[a, b]: {
   s: (b < a) then(1, 0)
 }.(abs((b - s) / 100 - (a - s) / 100))
 

--- a/examples/aoc25/day04.eu
+++ b/examples/aoc25/day04.eu
@@ -15,6 +15,7 @@ Notable eucalypt techniques:
 - `zip-with` for element-wise grid arithmetic
 - padding with zero rows/columns for uniform edge handling
 - recursive grid simulation for iterative removal
+- juxtaposed list-destructuring syntax `remove-step[grid, _]:`
 
 Running time: ~3s (part 1), ~3.5 min (part 2)
 "
@@ -57,7 +58,7 @@ parse(data): data map(to-bits)
 solve(grid): survivals(grid) map(sum) sum
 
 ` "One removal step: returns [new-grid, count-removed]."
-remove-step([grid, _]): {
+remove-step[grid, _]: {
   removed: survivals(grid)
   n: removed map(sum) sum
   new-grid: zip-with(zip-with(-), grid, removed)

--- a/examples/aoc25/day05.eu
+++ b/examples/aoc25/day05.eu
@@ -14,6 +14,7 @@ Notable eucalypt techniques:
 - `bimap` to apply different parsers to each section
 - `uncurry` to feed a parsed pair into a two-argument solver
 - partial application for predicate filtering: `is-fresh?(ranges)`
+- juxtaposed list-destructuring syntax `range-size[lo, hi]:`
 
 Running time: ~3s (part 1), < 1s (part 2)
 "
@@ -46,7 +47,7 @@ merge-ranges(ranges): {
   last: result second
 }.(completed ++ [last])
 
-range-size([lo, hi]): hi - lo + 1
+range-size[lo, hi]: hi - lo + 1
 
 solve2(ranges): merge-ranges(ranges) map(range-size) sum
 

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -22,6 +22,7 @@ Notable eucalypt techniques:
 - `foldr` with accumulator for gap-level insertion
 - list destructuring in function parameters: `v-spans?(y, [_, y_lo, y_hi])`,
   `inner-step(... [left, right, best], [lv-y, lv-l, lv-r, tiles])`
+- juxtaposed list-destructuring syntax `vertical?[p, q]:`, `vert-edge[p, q]:`
 
 Running time: ~3 min (part 1), ~3 min (part 2)
 "
@@ -73,14 +74,14 @@ levels: {
   make-edges(pts): zip(pts, pts rotate(1))
 
   ` "Is edge vertical / horizontal?"
-  vertical?([p, q]): first(p) = first(q)
-  horizontal?([p, q]): second(p) = second(q)
+  vertical?[p, q]: first(p) = first(q)
+  horizontal?[p, q]: second(p) = second(q)
 
   ` "Extract vertical edges as [x, y-lo, y-hi]."
-  vert-edge([p, q]): [first(p), min(second(p), second(q)), max(second(p), second(q))]
+  vert-edge[p, q]: [first(p), min(second(p), second(q)), max(second(p), second(q))]
 
   ` "Extract horizontal edges as [y, x-lo, x-hi]."
-  horiz-edge([p, q]): [second(p), min(first(p), first(q)), max(first(p), first(q))]
+  horiz-edge[p, q]: [second(p), min(first(p), first(q)), max(first(p), first(q))]
 
   ` "Cross-section at `y`: [left, right] assuming single interval."
   xsect(y, ves, hes): {

--- a/examples/aoc25/day10.eu
+++ b/examples/aoc25/day10.eu
@@ -24,6 +24,8 @@ Notable eucalypt techniques:
 - lazy `∨` for short-circuit DFS (part 1)
 - `range` and `map` for matrix construction and row operations
 - deep nesting of block intermediates for solver state
+- juxtaposed list-destructuring syntax `solve-machine[target, buttons]:`
+- juxtaposed empty-list call syntax `eval-free[]`
 
 Running time: ~6s (part 1), ~80s (part 2)
 "
@@ -58,7 +60,7 @@ has-solution?(k, target, buttons): {
 
 ` "Minimum presses for one machine (Part 1).
 Find the smallest subset size k with a valid solution."
-solve-machine([target, buttons]): {
+solve-machine[target, buttons]: {
   nb: buttons count
   solved?(k): has-solution?(k, target, buttons)
 }.(ℕ take(nb + 1) filter(solved?) min-of-or(nb + 1))
@@ -206,7 +208,7 @@ For nfree = 0: unique solution, just back-substitute.
 For nfree > 0: cost = base-cost + sum(slope_j * f_j).
   The search iterates outer free variables with cost-based pruning,
   and exhaustively searches the last free variable over [lo, hi]."
-solve-machine2([target, buttons]): {
+solve-machine2[target, buttons]: {
   nc: target count
   nb: buttons count
   INF: 999999
@@ -359,7 +361,7 @@ solve-machine2([target, buttons]): {
 
   }.(last-free-var? then(min(best, inner-solve(fvs)), try(0, best)))
 
-}.(nfree = 0 then(eval-free([]), search(0, [], 0, INF)))
+}.(nfree = 0 then(eval-free[], search(0, [], 0, INF)))
 
 solve2(data):
   data filter(!= "") map(parse-machine2 ; solve-machine2) sum

--- a/examples/aoc25/day12.eu
+++ b/examples/aoc25/day12.eu
@@ -57,12 +57,12 @@ solve-all(data): {
   sizes: shapes map(count)
 
   # cell check
-  needed([w, h, counts]): zip-with(*, counts, sizes) sum
-  total([w, h, _]): w * h
+  needed[w, h, counts]: zip-with(*, counts, sizes) sum
+  total[w, h, _]: w * h
   area-ok?(r): needed(r) <= total(r)
 
   # box check
-  min-dim([w, h, _]): min(w, h)
+  min-dim[w, h, _]: min(w, h)
   box-ok?(r): min-dim(r) >= 3
 
   fits?(r): area-ok?(r) ∧ box-ok?(r)


### PR DESCRIPTION
## Summary

- Converts single-parameter list-destructured function definitions from `f([a, b]):` to `f[a, b]:` syntax (0.4.0 juxtaposed call syntax) across 6 example files
- Also includes previous list destructuring improvements to day01 (`to-offset`, `zeros`) and day09 (edge functions using pair destructuring)
- Converts the `eval-free([])` call site in day10 to `eval-free[]`
- Updates notable-techniques comments in each file to mention the juxtaposed syntax

Files changed: day01, day04, day05, day09, day10, day12.

## Functions converted

| File | Function |
|------|----------|
| day01 | `to-offset[dir, mag]:`, `zeros[a, b]:` |
| day04 | `remove-step[grid, _]:` |
| day05 | `range-size[lo, hi]:` |
| day09 | `vertical?[p, q]:`, `horizontal?[p, q]:`, `vert-edge[p, q]:`, `horiz-edge[p, q]:` |
| day10 | `solve-machine[target, buttons]:`, `solve-machine2[target, buttons]:`, `eval-free[]` call |
| day12 | `needed[w, h, counts]:`, `total[w, h, _]:`, `min-dim[w, h, _]:` |

Note: functions with multiple parameters where only one is a list (e.g. `f(x, [a, b]):`) are intentionally left unchanged — juxtaposed syntax only applies when the sole argument is a list literal.

## Test plan

- [ ] `cargo test` passes
- [ ] Existing harness tests pass
- [ ] AoC example test targets (`:test`) still evaluate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)