### PR TITLE
refactor(aoc25): pipeline and cons-destructuring improvements

### DIFF
--- a/examples/aoc25/day06.eu
+++ b/examples/aoc25/day06.eu
@@ -13,7 +13,7 @@ row-oriented data. Part 1 transposes number rows; Part 2 transposes
 the character grid and folds right-to-left with state accumulation.
 
 Notable eucalypt techniques:
-- `transpose` for matrix pivoting
+- `transpose` for matrix pivoting (pipeline form `padded transpose`)
 - `zip-with` to pair operators with number lists
 - `foldl` with `[total, nums]` state for right-to-left grouping
 - expression anaphora `_0 * 10 + _1` as inline two-arg function
@@ -67,7 +67,7 @@ solve2(data): {
   grid: lines map(chars)
   w: grid map(count) max-of
   padded: grid map(pad-to(w))
-  cols: transpose(padded) reverse map(parse-col) filter(non-nil?)
+  cols: padded transpose reverse map(parse-col) filter(non-nil?)
 }.(cols foldl(col-step, [0, []]) first)
 
 ` { target: :test

--- a/examples/aoc25/day08.eu
+++ b/examples/aoc25/day08.eu
@@ -17,6 +17,7 @@ Notable eucalypt techniques:
 - `graph.union-find` and `graph.kruskal-edges` prelude intrinsics
 - single-number encoding for sort-by-distance without callbacks
 - `tails` and `zip-with` for candidate-pair generation
+- cons destructuring `[h : t]` in `pairs-at` to split head from tail
 - `;` for point-free function definition: `group-consecutive ; map(count)`
 - `iota` and `ℕ` for index generation alongside `zip-with`
 - dynamic generalised lookup: `prepare` returns a block used as namespace for solver pipelines
@@ -47,7 +48,7 @@ encode-pair(p, i, q, j): encode(dist2(p, q), i, j)
 point-pairs(p, window, i, j): zip-with(encode-pair(p, i), window, iota(j))
 
 ` "Encoded pairs for the head of ps (index i) against the next w points."
-pairs-at(w, i, ps): point-pairs(ps head, (ps tail) take(w), i, i + 1)
+pairs-at(w, i, [h : t]): point-pairs(h, t take(w), i, i + 1)
 
 ` "Generate candidate pairs: each point paired with the next w points.
 Requires pts to be x-sorted so that nearby indices approximate spatial

--- a/examples/aoc25/day10.eu
+++ b/examples/aoc25/day10.eu
@@ -26,6 +26,7 @@ Notable eucalypt techniques:
 - deep nesting of block intermediates for solver state
 - juxtaposed list-destructuring syntax `solve-machine[target, buttons]:`
 - juxtaposed empty-list call syntax `eval-free[]`
+- `str.matches-of` (pipeline-friendly) for pattern matching
 
 Running time: ~6s (part 1), ~80s (part 2)
 "
@@ -37,7 +38,7 @@ bit-vec(n, indices): {
 
 ` "Parse a machine line into [target, buttons]."
 parse-machine(line): {
-  parts: str.matches(line, "[.#]+|[(][0-9,]+[)]")
+  parts: line str.matches-of("[.#]+|[(][0-9,]+[)]")
   target: parts head str.letters map((= "#") ; then(1, 0))
   n: target count
   parse-btn(s): str.matches(s, "[0-9]+") map(num) bit-vec(n)
@@ -84,7 +85,7 @@ parse-machine2(line): {
   joltage: line str.split-on(" ") last str.matches-of("[0-9]+") map(num)
   n: joltage count
   parse-btn(s): str.matches(s, "[0-9]+") map(num) bit-vec(n)
-  buttons: str.matches(line, "[(][0-9,]+[)]") map(parse-btn)
+  buttons: line str.matches-of("[(][0-9,]+[)]") map(parse-btn)
 }.[joltage, buttons]
 
 ` "Gaussian elimination on an augmented matrix.


### PR DESCRIPTION
## Summary

Applies three idiomatic improvements to AoC 2025 examples, making the code more consistent with eucalypt's pipeline and destructuring conventions:

- **day06**: `transpose(padded)` → `padded transpose` — use pipeline style consistently
- **day08**: `pairs-at` now uses cons destructuring `[h : t]` instead of `ps head` / `ps tail` — cleaner and demonstrates the cons pattern syntax
- **day10**: `str.matches(line, pat)` → `line str.matches-of(pat)` at both call sites — use the pipeline-friendly variant

## Test plan

- [x] `eu -t test examples/aoc25/day06.eu` → PASS
- [x] `eu -t test examples/aoc25/day08.eu` → PASS
- [x] `eu -t test examples/aoc25/day10.eu` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)