### PR TITLE
test(eu-cwdh): verify HeapNdArray GC evacuation correctness

### DIFF
--- a/harness/test/gc/gc_011_ndarray_evacuation.eu
+++ b/harness/test/gc/gc_011_ndarray_evacuation.eu
@@ -1,0 +1,58 @@
+##
+## GC 011 — ndarray object GC survival test
+##
+## Verifies that HeapNdArray objects survive GC collection and evacuation
+## with their data intact. Creates ndarray objects early, forces GC
+## pressure with many allocations, then checks array correctness.
+##
+
+# Helper: create many cons-cell/block/string allocations to force GC
+alloc-noise(n): if(n <= 0, [], cons({id: n, s: str.of(n)}, alloc-noise(n - 1)))
+
+# Create ndarray early — it will be in an early block candidate for evacuation
+a: arr.from-flat([4, 4], [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16])
+
+# Force GC pressure (100 blocks+string allocations)
+_gc-noise-1: alloc-noise(100) count
+
+# Now verify array data survived GC
+a-checks: {
+  a-shape: a arr.shape
+  a-len: a arr.length
+  a-sum: (a arr.to-list) sum
+  trues: [
+    a-shape = [4, 4],
+    a-len = 16,
+    a-sum = 136
+  ]
+}
+
+# Create another ndarray after GC pressure and verify it
+b: arr.from-flat([2, 2], [10, 20, 30, 40])
+b-checks: {
+  b-sum: (b arr.to-list) sum
+  trues: [
+    b-sum = 100
+  ]
+}
+
+# arr.map under GC pressure
+c: arr.from-flat([3], [1, 2, 3])
+_gc-noise-2: alloc-noise(50) count
+c-doubled: c arr.map(_ * 2)
+map-checks: {
+  cd-sum: (c-doubled arr.to-list) sum
+  cd-shape: c-doubled arr.shape
+  trues: [
+    cd-sum = 12,
+    cd-shape = [3]
+  ]
+}
+
+pass: [
+  a-checks.trues all-true?,
+  b-checks.trues all-true?,
+  map-checks.trues all-true?
+] all-true?
+
+RESULT: if(pass, :PASS, :FAIL)

--- a/src/eval/memory/ndarray.rs
+++ b/src/eval/memory/ndarray.rs
@@ -213,6 +213,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn heap_ndarray_fits_in_gc_block() {
+        // HeapNdArray must fit in a GC bump block (32 KiB).
+        // ndarray 0.16 ArrayD<f64>: OwnedRepr<f64> (24 bytes) + 2×IxDyn.
+        // IxDyn uses a small-vec-like structure; on 64-bit this is ≤ 64 bytes each.
+        // The GC block is 32 KiB so any reasonable struct size is fine — this
+        // assertion just guards against a future ndarray version balloon.
+        assert!(
+            std::mem::size_of::<HeapNdArray>() < 1024,
+            "HeapNdArray unexpectedly large: {} bytes",
+            std::mem::size_of::<HeapNdArray>()
+        );
+    }
+
+    #[test]
     fn zeros_creates_correct_shape() {
         let a = HeapNdArray::zeros(&[2, 3]);
         assert_eq!(a.shape(), &[2, 3]);

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -544,6 +544,11 @@ pub fn test_gc_010() {
     run_test(&opts("gc/gc_010_comprehensive_stress.eu"));
 }
 
+#[test]
+pub fn test_gc_011() {
+    run_test(&opts("gc/gc_011_ndarray_evacuation.eu"));
+}
+
 // Error tests — validate against `.expect` sidecars when present
 
 #[test]


### PR DESCRIPTION
## Summary

- Investigated reported GC corruption crashes with ndarray objects (eu-cwdh, eu-7p9k)
- Analysis confirms GC correctly handles `HeapNdArray` evacuation:
  - Mark phase traces `Native::NdArray(ptr)` correctly via `mark_ref_heap_pointers`
  - Evacuation byte-copy is safe: `ArrayD<f64>` internal buffers are on the Rust heap, not GC-managed; GC does not call `Drop` on reclaimed objects
  - Update phase correctly updates `Native::NdArray` pointers via `update_ref_heap_pointers`
- The reported crash repros in eu-46ip and eu-i45b were eucalypt precedence errors: `a arr.to-list ++ [1]` parses as `a (arr.to-list ++ [1])` because `++` binds tighter than catenation — not a GC bug

## Changes

- `harness/test/gc/gc_011_ndarray_evacuation.eu` — regression test: creates ndarray objects, forces GC pressure with 150 cons-cell/block/string allocations, verifies array data integrity (`sum`, `shape`, `length`, `arr.map`) survives collection
- `src/eval/memory/ndarray.rs` — adds `heap_ndarray_fits_in_gc_block` unit test: asserts `sizeof::<HeapNdArray>() < 1024` to guard against future ndarray crate layout changes
- `tests/harness_test.rs` — registers `test_gc_011`

## Test plan

- [x] `cargo test` — 188 harness tests pass, 595 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `test_gc_011` passes with RESULT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)