### PR TITLE
feat(eu-v9no): add ‼ postfix non-nil predicate operator

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -202,6 +202,7 @@ From highest to lowest binding:
 | 95 | -- | prefix | `↑` | Tight prefix (head) |
 | 90 | lookup | left | `.` | Field access / lookup |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
+| 88 | bool-unary | postfix | `‼` | Non-nil predicate (true if non-nil) |
 | 85 | exp | right | `^`, `∘`, `;` | Power, composition |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -242,6 +242,7 @@ From highest (tightest) to lowest binding:
 | 90 | lookup | left | `.` (built-in) | Property lookup |
 | 90 | call | left | (built-in) | Function call |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
+| 88 | bool-unary | postfix | `‼` | Non-nil predicate (true if non-nil) |
 | 88 | -- | -- | `∘`, `;` | Composition (actual prec 88 from prelude) |
 | 85 | exp | right | `^` | Power |
 | 85 | exp | -- | `!!` (nth) | Indexing |

--- a/docs/reference/prelude/lists.md
+++ b/docs/reference/prelude/lists.md
@@ -8,6 +8,8 @@
 | `head` | Return the head item of list `xs`, panic if empty |
 | `(↑ xs)` | Return first element of list `xs`. Tight-binding prefix operator |
 | `nil?` | `true` if list `xs` is empty, `false` otherwise |
+| `non-nil?` | `true` if list `xs` is non-empty, `false` otherwise |
+| `(x ‼)` | `true` if `x` is non-nil, `false` otherwise. Postfix non-nil predicate (precedence 88) |
 | `head-or(d, xs)` | Return the head item of list `xs` or default `d` if empty |
 | `tail` | Return list `xs` without the head item. [] causes error |
 | `tail-or(d, xs)` | Return list `xs` without the head item or `d` for empty list |

--- a/editors/tree-sitter-eucalypt/grammar.js
+++ b/editors/tree-sitter-eucalypt/grammar.js
@@ -12,10 +12,11 @@
 // Includes: standard punctuation operators, Unicode math/arrows, and
 // special characters used in the prelude.
 // Notable inclusions: ? (for //=?, //!?), $ (for <$>), ∸ (unary minus),
-// ‖ (U+2016 DOUBLE VERTICAL LINE — the cons operator).
+// ‖ (U+2016 DOUBLE VERTICAL LINE — the cons operator),
+// ‼ (U+203C DOUBLE EXCLAMATION MARK — postfix non-nil predicate).
 // Note: bracket characters (⟦⟧⟨⟩⟪⟫⌈⌉⌊⌋) are intentionally excluded here;
 // they are handled by the bracket_expr rule instead.
-const OPER_CHARS = /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘‖→←⊕⊗⊙⊡⊞⊟¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/;
+const OPER_CHARS = /[.!@£%^&*|><\/+\=\-~;?$∸∧∨∘‖‼→←⊕⊗⊙⊡⊞⊟¬∀∃∈∉⊂⊃⊆⊇∪∩∼≈≠≡≤≥≪≫±×÷√∞∂∫∑∏∇△▽⊥⊤⊢⊣⊨⊩⊸⊺⋀⋁⋂⋃⋄⋅⋆⋈⋉⋊⋮⋯⋰⋱⟵⟶⟷⟸⟹⟺⟻⟼⟽⟾⟿←→↑↓↔↕↖↗↘↙↚↛↜↝↞↟↠↡↢↣↤↥↦↧↨↩↪↫↬↭↮↯↰↱↲↳↴↵↶↷↸↹↺↻⇐⇑⇒⇓⇔⇕⇖⇗⇘⇙⇚⇛⇜⇝⇞⇟⇠⇡⇢⇣⇤⇥⇦⇧⇨⇩⇪⊂⊃⊄⊅⊆⊇⊈⊉⊊⊋¡££€⨈∅∏]+/;
 
 // Unicode idiot bracket open characters (must match brackets.rs BUILTIN_BRACKET_PAIRS).
 //

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -134,6 +134,10 @@ nil?: = []
 ` "`non-nil?(xs)` - `true` if list `xs` is non-empty, `false` otherwise."
 non-nil?: nil? complement
 
+` { doc: "`x‼` - `true` if `x` is non-nil, `false` otherwise. Postfix non-nil predicate operator."
+    precedence: :bool-unary }
+(x ‼): x non-nil?
+
 ` "`head-or(xs, d)` - return the head item of list `xs` or default `d` if empty."
 head-or(d, xs): xs nil? then(d, xs head)
 

--- a/tests/harness/101_non_nil_postfix.eu
+++ b/tests/harness/101_non_nil_postfix.eu
@@ -1,0 +1,14 @@
+#!/usr/bin/env eu
+
+# Tests for the ‼ postfix non-nil predicate operator (U+203C DOUBLE EXCLAMATION MARK)
+
+t1: []‼ = false
+t2: [1]‼ = true
+t3: [1, 2, 3]‼ = true
+t4: 42‼ = true
+t5: "hello"‼ = true
+t6: :sym‼ = true
+t7: {}‼ = true
+t8: not([]‼)
+
+RESULT: [t1, t2, t3, t4, t5, t6, t7, t8] all-true? then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -495,6 +495,11 @@ pub fn test_harness_100() {
 }
 
 #[test]
+pub fn test_harness_101() {
+    run_test(&opts("101_non_nil_postfix.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds `‼` (U+203C DOUBLE EXCLAMATION MARK) as a postfix operator at precedence 88 (`:bool-unary`)
- Returns `true` if the operand is non-nil, `false` otherwise — defined as `x non-nil?`
- Enables expressions like `filter(_.key‼)` and `xs‼ && xs count > 3`

## Documentation

- Updated operator table in `docs/appendices/cheat-sheet.md`
- Updated operator table in `docs/reference/agent-reference.md`
- Added entry to `docs/reference/prelude/lists.md`

## Test plan

- [x] `[] ‼` returns `false`
- [x] `[1] ‼` returns `true`
- [x] `[{k: 1}] filter(_.k‼)` works correctly
- [x] `cargo test --lib` passes (595 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

Closes eu-v9no

🤖 Generated with [Claude Code](https://claude.com/claude-code)