### PR TITLE
refactor(eu-jl10): make assert accept a predicate

### DIFF
--- a/docs/reference/prelude/booleans.md
+++ b/docs/reference/prelude/booleans.md
@@ -16,7 +16,7 @@
 | Function | Description |
 |----------|-------------|
 | `panic` | Raise runtime error with message string `s` |
-| `assert(c, s, v)` | If `c` is true then value `v` otherwise error with message `s` |
+| `assert(p?, s, v)` | If `v p?` is true then return `v` otherwise error with message `s`. Composable in pipelines: `x assert(non-nil?, "expected non-nil")` |
 
 ## Boolean Logic
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -87,9 +87,6 @@ sample(n, list, stream): {
 ` "`panic(s)` - raise runtime error with message string `s`."
 panic: __PANIC
 
-` "`assert(c, s, v)` - if `c` is true then value `v` otherwise error with message `s`."
-assert(c, s, v): if(c, v, panic(s))
-
 ##
 ## Essentials
 ##
@@ -795,6 +792,13 @@ merge-meta(m, e): e // (meta(e) m)
     associates: :left
     precedence: :meta }
 (e //<< m): e merge-meta(m)
+
+##
+## Assertions
+##
+
+` "`assert(p?, s, v)` - if `v p?` is true then return `v` otherwise error with message `s`."
+assert(p?, s, v): if(v p?, v, panic(s))
 
 assertions: {
   # In debug mode maybe the machine checks every return value against


### PR DESCRIPTION
## Summary

- Changes `assert(c, s, v)` to `assert(p?, s, v)` — the predicate `p?` is now applied to `v` rather than taking a bare boolean condition
- Makes `assert` composable in pipelines: `x assert(non-nil?, "expected non-nil")`
- Moves `assert` to be adjacent to the `assertions` block with a clear `## Assertions ##` section header for cohesion

## Examples

```eu
# Assert list is non-empty (pipeline style)
[1, 2, 3] assert(non-nil?, "list must be non-empty")  # => [1, 2, 3]

# Assert a value is positive
42 assert(pos?, "expected positive number")  # => 42

# Failing assertion
[] assert(non-nil?, "expected non-nil")  # => panic: expected non-nil
```

## Documentation

- Updated `docs/reference/prelude/booleans.md` with new signature and pipeline example

## Test plan

- [x] `[1, 2, 3] assert(non-nil?, "expected non-nil")` returns the list
- [x] `[] assert(non-nil?, "expected non-nil")` panics with the message
- [x] `42 assert(pos?, "expected positive")` returns 42
- [x] `cargo test --lib` passes (595 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

Closes eu-jl10

🤖 Generated with [Claude Code](https://claude.com/claude-code)