### PR TITLE
fix(emacs): correct indentation of backtick metadata in declarations

### DIFF
--- a/editors/emacs/eucalypt-mode.el
+++ b/editors/emacs/eucalypt-mode.el
@@ -270,7 +270,9 @@ Set via file-local variables, e.g.:
      ((parent-is "parameter_list") parent-bol eucalypt-indent-offset)
      ;; Soup continuation
      ((parent-is "soup") parent-bol eucalypt-indent-offset)
-     ;; Metadata is part of declaration — don't indent the body extra
+     ;; Backtick metadata begins a declaration — align with declaration, not inside it
+     ((node-is "metadata") parent-bol 0)
+     ;; Content within a metadata annotation (e.g. block after backtick)
      ((parent-is "metadata") parent-bol 0)
      ;; Declaration body continuation
      ((parent-is "declaration") parent-bol eucalypt-indent-offset)


### PR DESCRIPTION
## Summary

- `eucalypt-mode` was incorrectly indenting backtick metadata annotations (`\`` \"...\"``) that appear as the first element of a declaration by `eucalypt-indent-offset` (2 spaces) instead of aligning them at column zero.
- This manifested most visibly when a file began with unit-level string metadata (a bare string like `\"Description\"` at the top), as those files commonly have annotated declarations immediately following.
- Fix: add `((node-is \"metadata\") parent-bol 0)` before the `(parent-is \"declaration\")` rule so that the backtick metadata node aligns with its containing declaration rather than being indented inside it.

## Root cause

In `treesit-simple-indent`, the indentation system walks up the tree from the node at the beginning of the line. For a backtick metadata line like `` \` \"comment\" ``:

- Node = `metadata`
- Parent = `declaration`
- Previous rule: `(parent-is \"declaration\") parent-bol eucalypt-indent-offset` — gives column 2 (wrong)
- With fix: `(node-is \"metadata\") parent-bol 0` fires first — gives column 0 (correct)

## Test plan

- [ ] Open `tests/harness/089_sharing.eu` in Emacs with eucalypt-mode active
- [ ] Verify the backtick metadata line after the bare string is at column 0
- [ ] Press TAB on that line and confirm it stays at column 0
- [ ] Byte-compile `eucalypt-mode.el` — no warnings

Closes eu-1uvc

🤖 Generated with [Claude Code](https://claude.com/claude-code)