### PR TITLE
fix(eu-9vzc): make deep-find accept symbol keys

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -448,8 +448,11 @@ merge({ a: 1 }, { b: 2 })    # { a: 1 b: 2 }
 
 #### `deep-find(k, b)` — find all values for key k at any depth
 
+Key `k` may be a symbol (preferred) or string.
+
 ```
-{ a: { x: 1 } b: { x: 2 } } deep-find("x")  # [1, 2]
+{ a: { x: 1 } b: { x: 2 } } deep-find(:x)    # [1, 2]
+{ a: { x: 1 } b: { x: 2 } } deep-find("x")   # [1, 2] (also works)
 ```
 
 #### `deep-query(pattern, b)` — query with dot-separated glob pattern
@@ -739,14 +742,18 @@ variable.
 
 Use `sym("a")` to convert a string to a symbol if needed.
 
-### 5.8 deep-find Takes a String, Not a Symbol
+### 5.8 deep-find Accepts Both Symbols and Strings
 
 ```eu,notest
-{ a: { x: 1 } } deep-find("x")    # [1] — correct
-{ a: { x: 1 } } deep-find(:x)     # WRONG
+{ a: { x: 1 } } deep-find(:x)     # [1] — correct (symbol, preferred)
+{ a: { x: 1 } } deep-find("x")    # [1] — also correct (string, legacy)
 ```
 
-`deep-find` internally converts the string to a symbol via `sym(k)`.
+`deep-find`, `deep-find-first`, and `deep-find-paths` accept either a
+symbol (`:key`) or a string (`"key"`) as the key argument. Symbols are
+preferred, matching the rest of the prelude convention (`has(:key)`,
+`lookup-or(:key, ...)`). Strings are accepted for backwards
+compatibility.
 
 ### 5.9 Self-Reference Creates Infinite Recursion
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -219,9 +219,9 @@ lookup-path(ks, b): foldl(lookup-in, b, ks)
 ## Deep find — recursive key search
 ##
 
-` "`deep-find(k, b)` - return list of all values for key `k` at any depth in block `b`, depth-first."
+` "`deep-find(k, b)` - return list of all values for key `k` at any depth in block `b`, depth-first. `k` may be a symbol or string."
 deep-find(k, b): {
-  s: sym(k)
+  s: sym(str.of(k))
   children(v): v elements map({el: •}.(el value)) mapcat(walk)
   walk(v): if(v block?,
               if(v has(s),
@@ -232,12 +232,12 @@ deep-find(k, b): {
                  []))
 }.walk(b)
 
-` "`deep-find-first(k, d, b)` - return first value for key `k` at any depth in block `b`, or default `d`."
+` "`deep-find-first(k, d, b)` - return first value for key `k` at any depth in block `b`, or default `d`. `k` may be a symbol or string."
 deep-find-first(k, d, b): b deep-find(k) head-or(d)
 
-` "`deep-find-paths(k, b)` - return list of key paths to all occurrences of key `k` at any depth in block `b`."
+` "`deep-find-paths(k, b)` - return list of key paths to all occurrences of key `k` at any depth in block `b`. `k` may be a symbol or string."
 deep-find-paths(k, b): {
-  s: sym(k)
+  s: sym(str.of(k))
   walk-children(path, v): v keys mapcat({ck: •}.(walk(path ++ [ck], v lookup(ck))))
   walk(path, v): if(v block?,
                     if(v has(s),


### PR DESCRIPTION
## Summary

- Changes `deep-find`, `deep-find-first`, and `deep-find-paths` to accept either symbol (`:key`) or string (`"key"`) as the key argument
- Previously only strings were accepted; symbols now work via `sym(str.of(k))`
- Matches the rest of the prelude convention where `has(:key)`, `lookup-or(:key, ...)` etc. all take symbols
- String keys continue to work for backwards compatibility

## Examples

```eu
# Symbol key (preferred, now works)
{ a: { x: 1 } b: { x: 2 } } deep-find(:x)          # [1, 2]
{ a: { x: 1 } b: { x: 2 } } deep-find-first(:x, 0)  # 1
{ a: { x: 1 } b: { x: 2 } } deep-find-paths(:x)     # [[:a, :x], [:b, :x]]

# String key (backwards compatible)
{ a: { x: 1 } b: { x: 2 } } deep-find("x")          # [1, 2]
```

## Documentation

- Updated section 5.8 in `docs/reference/agent-reference.md` from "takes a string, not a symbol" to note both are accepted
- Updated `deep-find` example in section 3.2 to show symbol syntax

## Test plan

- [x] `deep-find(:x, block)` works
- [x] `deep-find("x", block)` still works (backwards compat)
- [x] `deep-find-first(:x, default, block)` works
- [x] `deep-find-paths(:x, block)` works
- [x] `cargo test --lib` passes (595 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

Closes eu-9vzc

🤖 Generated with [Claude Code](https://claude.com/claude-code)