### PR TITLE
feat(eu-solv): add deep-merge-at prelude function

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -611,8 +611,11 @@ config alter([:server, :db, :port], 3306)
 # Apply a function to a nested value
 config update([:server, :db, :port], inc)
 
-# Merge into a nested block
+# Shallow merge into a nested block (replaces nested blocks)
 config merge-at([:server, :db], { host: "10.0.0.1" })
+
+# Deep merge into a nested block (preserves nested blocks)
+config deep-merge-at([:server, :db], { host: "10.0.0.1" })
 ```
 
 ### 4.8 Grouping and Sorting

--- a/docs/reference/prelude/blocks.md
+++ b/docs/reference/prelude/blocks.md
@@ -60,6 +60,7 @@
 | `set-value(k, v)` | Set `b.k` to `v`, adding if absent |
 | `tongue(ks, v)` | Construct block with a single nested path-of-keys `ks` down to value `v` |
 | `merge-at(ks, v, b)` | Shallow merge block `v` into block value at path-of-keys `ks` |
+| `deep-merge-at(ks, v, b)` | Deep merge block `v` into block value at path-of-keys `ks` (preserves nested blocks) |
 
 ## Deep Find and Query
 
@@ -82,8 +83,8 @@ config: {
   db: { host: "db.local" port: 5432 }
 }
 
-hosts: config deep-find("host")  # ["localhost", "db.local"]
-first-host: config deep-find-first("host", "unknown")  # "localhost"
+hosts: config deep-find(:host)  # ["localhost", "db.local"]
+first-host: config deep-find-first(:host, "unknown")  # "localhost"
 ```
 
 ### Deep Query

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1267,6 +1267,13 @@ merge-at(ks, v, b): if(ks nil?,
 		                                        merge-at(ks tail, v),
                                             tongue(ks tail, v)))
 
+` "deep-merge-at(ks, v, b) - deep merge block `v` into block value at path-of-keys `ks`"
+deep-merge-at(ks, v, b): if(ks nil?,
+                             deep-merge(b, v),
+                             b update-value-or(ks head,
+                                               deep-merge-at(ks tail, v),
+                                               tongue(ks tail, v)))
+
 
 
 ` { export: :suppress


### PR DESCRIPTION
## Summary

- Adds `deep-merge-at(ks, v, b)` to the prelude, analogous to `merge-at` but using deep merge
- Unlike `merge-at` (which does a shallow merge), `deep-merge-at` recursively merges nested blocks at the target path
- Implemented by changing `merge` to `deep-merge` in the recursive structure of `merge-at`

## Examples

```eu
config: { server: { host: "localhost" db: { host: "dbhost" } } }

# merge-at replaces the entire db block
config merge-at([:server], { db: { port: 5432 } })
# => { server: { host: "localhost" db: { port: 5432 } } }

# deep-merge-at preserves existing keys in db
config deep-merge-at([:server], { db: { port: 5432 } })
# => { server: { host: "localhost" db: { host: "dbhost" port: 5432 } } }
```

## Documentation

- Added `deep-merge-at` to `docs/reference/prelude/blocks.md` Block Alteration table
- Added `deep-merge-at` to nested block modification example in `docs/reference/agent-reference.md`
- Updated Deep Find examples in blocks.md to use symbol keys (following eu-9vzc)

## Test plan

- [x] `deep-merge-at([:server], ...)` correctly merges into nested block
- [x] `deep-merge-at([:a, :b], ...)` works with multi-level path
- [x] Existing keys in the target path are preserved (unlike `merge-at`)
- [x] `cargo test --lib` passes (595 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

Closes eu-solv

🤖 Generated with [Claude Code](https://claude.com/claude-code)