### PR TITLE
refactor(eu-h8sq): improve deep-query-paths style and idiom

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -281,20 +281,30 @@ deep-query-first(pattern, d, b): b deep-query(pattern) head-or(d)
 
 ` "`deep-query-paths(pattern, b)` - return list of key paths matching `pattern` in block `b`."
 deep-query-paths(pattern, b): {
+
   segs: pattern str.split-on("[.]")
-  first-seg: segs head
-  norm: if(first-seg = "**", segs, cons("**", segs))
-  all-keyed(v): if(v block?, v keys map({k: •}.[k, v lookup(k)]), [])
-  match-key-pair(seg, p): {path: p first, val: p second}.(
-    if(val block?, if(val has(sym(seg)), [[path ++ [sym(seg)], val lookup(sym(seg))]], []), []))
-  expand-star(p): {path: p first, val: p second}.(
+  norm: if((segs head) = "**", segs, cons("**", segs))
+
+  pair(v, k): [k, v lookup(k)]
+  all-keyed(v): if(v block?, v keys map(pair(v)), [])
+
+  prepend-path(path, kv): [path ++ [kv first], kv second]
+
+  match-key-pair(seg, [path, val]):
     if(val block?,
-       val keys map({k: •}.[path ++ [k], val lookup(k)]),
-       []))
+       if(val has(sym(seg)), [[path ++ [sym(seg)], val lookup(sym(seg))]], []),
+       [])
+
+  expand-star([path, val]):
+    if(val block?,
+       val keys map(pair(val)) map(prepend-path(path)),
+       [])
+
   desc-pairs(p): {path: p first, val: p second}.(
     if(val block?,
        cons(p, all-keyed(val) mapcat({kv: •}.(desc-pairs([path ++ [kv first], kv second])))),
        []))
+
   step(pairs, remaining):
     if(remaining nil?,
        pairs map(first),
@@ -306,7 +316,9 @@ deep-query-paths(pattern, b): {
              if(seg = "*",
                 step(pairs mapcat(expand-star), rest),
                 step(pairs mapcat(match-key-pair(seg)), rest)))))
+
   result: step([[[], b]], norm)
+
 }.result
 
 ##


### PR DESCRIPTION
## Summary

Refactors `deep-query-paths` in `lib/prelude.eu` to follow `docs/eucalypt-style.md` conventions:

- Adds blank lines between local function bindings for readability
- Fixes catenation precedence trap: `(segs head) = "**"` with explicit parentheses
- Replaces block-anaphora pseudo-lambdas (`{k: •}.[...]`) with named helper functions (`pair`, `prepend-path`)
- Uses list destructuring parameters (`[path, val]`) in `match-key-pair` and `expand-star`
- Removes unused intermediate binding `first-seg`

## Test plan

- [x] `deep-query-paths("x", ...)` works correctly
- [x] `deep-query-paths("*.x", ...)` works correctly
- [x] `cargo test --lib` passes (595 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

Closes eu-h8sq

🤖 Generated with [Claude Code](https://claude.com/claude-code)