### PR TITLE
fix(eu-9vzc): deep-find takes symbol keys only

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -448,11 +448,8 @@ merge({ a: 1 }, { b: 2 })    # { a: 1 b: 2 }
 
 #### `deep-find(k, b)` — find all values for key k at any depth
 
-Key `k` may be a symbol (preferred) or string.
-
 ```
 { a: { x: 1 } b: { x: 2 } } deep-find(:x)    # [1, 2]
-{ a: { x: 1 } b: { x: 2 } } deep-find("x")   # [1, 2] (also works)
 ```
 
 #### `deep-query(pattern, b)` — query with dot-separated glob pattern
@@ -745,18 +742,15 @@ variable.
 
 Use `sym("a")` to convert a string to a symbol if needed.
 
-### 5.8 deep-find Accepts Both Symbols and Strings
+### 5.8 deep-find Takes a Symbol, Not a String
 
 ```eu,notest
-{ a: { x: 1 } } deep-find(:x)     # [1] — correct (symbol, preferred)
-{ a: { x: 1 } } deep-find("x")    # [1] — also correct (string, legacy)
+{ a: { x: 1 } } deep-find(:x)     # [1] — correct
+{ a: { x: 1 } } deep-find("x")    # WRONG — takes a symbol
 ```
 
-`deep-find`, `deep-find-first`, and `deep-find-paths` accept either a
-symbol (`:key`) or a string (`"key"`) as the key argument. Symbols are
-preferred, matching the rest of the prelude convention (`has(:key)`,
-`lookup-or(:key, ...)`). Strings are accepted for backwards
-compatibility.
+`deep-find`, `deep-find-first`, and `deep-find-paths` take a symbol key,
+matching the rest of the prelude (`has(:key)`, `lookup-or(:key, ...)`).
 
 ### 5.9 Self-Reference Creates Infinite Recursion
 

--- a/docs/reference/prelude/supplements/blocks/deep-find-and-query.md
+++ b/docs/reference/prelude/supplements/blocks/deep-find-and-query.md
@@ -8,8 +8,8 @@ config: {
   db: { host: "db.local" port: 5432 }
 }
 
-hosts: config deep-find("host")  # ["localhost", "db.local"]
-first-host: config deep-find-first("host", "unknown")  # "localhost"
+hosts: config deep-find(:host)  # ["localhost", "db.local"]
+first-host: config deep-find-first(:host, "unknown")  # "localhost"
 ```
 
 ### Deep Query

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -216,9 +216,9 @@ lookup-path(ks, b): foldl(lookup-in, b, ks)
 ## Deep find — recursive key search
 ##
 
-` "`deep-find(k, b)` - return list of all values for key `k` at any depth in block `b`, depth-first. `k` may be a symbol or string."
+` "`deep-find(k, b)` - return list of all values for key `k` (a symbol) at any depth in block `b`, depth-first."
 deep-find(k, b): {
-  s: sym(str.of(k))
+  s: k
   children(v): v elements map({el: •}.(el value)) mapcat(walk)
   walk(v): if(v block?,
               if(v has(s),
@@ -229,12 +229,12 @@ deep-find(k, b): {
                  []))
 }.walk(b)
 
-` "`deep-find-first(k, d, b)` - return first value for key `k` at any depth in block `b`, or default `d`. `k` may be a symbol or string."
+` "`deep-find-first(k, d, b)` - return first value for key `k` (a symbol) at any depth in block `b`, or default `d`."
 deep-find-first(k, d, b): b deep-find(k) head-or(d)
 
-` "`deep-find-paths(k, b)` - return list of key paths to all occurrences of key `k` at any depth in block `b`. `k` may be a symbol or string."
+` "`deep-find-paths(k, b)` - return list of key paths to all occurrences of key `k` (a symbol) at any depth in block `b`."
 deep-find-paths(k, b): {
-  s: sym(str.of(k))
+  s: k
   walk-children(path, v): v keys mapcat({ck: •}.(walk(path ++ [ck], v lookup(ck))))
   walk(path, v): if(v block?,
                     if(v has(s),

--- a/tests/harness/072_deep_find.eu
+++ b/tests/harness/072_deep_find.eu
@@ -20,63 +20,63 @@ type-pred-checks: {
 ` "deep-find"
 deep-find-checks: {
   trues: [
-    ({a: 1, b: 2, c: 3} deep-find("a")) = [1],
-    ({a: 1, b: {a: 2, c: 3}} deep-find("a")) = [1, 2],
-    ({a: 1, b: 2} deep-find("z")) = [],
-    ({x: {y: {z: 42}}} deep-find("z")) = [42],
-    ({} deep-find("x")) = [],
-    (deep-find("name", {name: "top", child: { name: "mid", child: { name: "deep" } }})) = ["top", "mid", "deep"],
-    (deep-find("a", {items: [{a: 10}, {a: 20}], a: 99})) = [99, 10, 20],
-    ({a: "hello", b: {a: true}} deep-find("a")) = ["hello", true],
-    ({x: {n: 3.14}, y: {n: 42}} deep-find("n")) = [3.14, 42],
-    (deep-find("x", {a: [[{x: 1}], [{x: 2}]]})) = [1, 2]
+    ({a: 1, b: 2, c: 3} deep-find(:a)) = [1],
+    ({a: 1, b: {a: 2, c: 3}} deep-find(:a)) = [1, 2],
+    ({a: 1, b: 2} deep-find(:z)) = [],
+    ({x: {y: {z: 42}}} deep-find(:z)) = [42],
+    ({} deep-find(:x)) = [],
+    (deep-find(:name, {name: "top", child: { name: "mid", child: { name: "deep" } }})) = ["top", "mid", "deep"],
+    (deep-find(:a, {items: [{a: 10}, {a: 20}], a: 99})) = [99, 10, 20],
+    ({a: "hello", b: {a: true}} deep-find(:a)) = ["hello", true],
+    ({x: {n: 3.14}, y: {n: 42}} deep-find(:n)) = [3.14, 42],
+    (deep-find(:x, {a: [[{x: 1}], [{x: 2}]]})) = [1, 2]
   ]
 }
 
 ` "deep-find-first"
 deep-find-first-checks: {
   trues: [
-    ({a: 1, b: {a: 2}} deep-find-first("a", null)) = 1,
-    ({b: 1, c: 2} deep-find-first("a", "default")) = "default",
-    ({x: {y: {a: 42}}} deep-find-first("a", 0)) = 42,
-    ({b: 1} deep-find-first("a", null)) = null
+    ({a: 1, b: {a: 2}} deep-find-first(:a, null)) = 1,
+    ({b: 1, c: 2} deep-find-first(:a, "default")) = "default",
+    ({x: {y: {a: 42}}} deep-find-first(:a, 0)) = 42,
+    ({b: 1} deep-find-first(:a, null)) = null
   ]
 }
 
 ` "deep-find-paths"
 deep-find-paths-checks: {
   trues: [
-    ({a: 1} deep-find-paths("a")) = [[:a]],
-    ({a: 1, b: {a: 2}} deep-find-paths("a")) = [[:a], [:b, :a]],
-    ({x: {y: {z: 1}}} deep-find-paths("z")) = [[:x, :y, :z]],
-    ({a: 1} deep-find-paths("z")) = []
+    ({a: 1} deep-find-paths(:a)) = [[:a]],
+    ({a: 1, b: {a: 2}} deep-find-paths(:a)) = [[:a], [:b, :a]],
+    ({x: {y: {z: 1}}} deep-find-paths(:z)) = [[:x, :y, :z]],
+    ({a: 1} deep-find-paths(:z)) = []
   ]
 }
 
 ` "Realistic fixture"
 fixture-checks: {
   trues: [
-    (deep-find("host", {
+    (deep-find(:host, {
       server: {
         host: "10.0.0.1"
         database: { host: "10.0.0.2" }
         cache: { host: "10.0.0.5" }
       }
     })) = ["10.0.0.1", "10.0.0.2", "10.0.0.5"],
-    (deep-find("port", {
+    (deep-find(:port, {
       server: {
         port: 8080
         database: { port: 5432 }
         cache: { port: 6379 }
       }
     })) = [8080, 5432, 6379],
-    (deep-find-first("host", "unknown", {
+    (deep-find-first(:host, "unknown", {
       server: { host: "10.0.0.1", database: { host: "10.0.0.2" } }
     })) = "10.0.0.1",
-    (deep-find-first("missing", "fallback", {
+    (deep-find-first(:missing, "fallback", {
       server: { host: "10.0.0.1", database: { host: "10.0.0.2" } }
     })) = "fallback",
-    (deep-find-paths("host", {
+    (deep-find-paths(:host, {
       server: { host: "a", db: { host: "b" } }
     })) = [[:server, :host], [:server, :db, :host]]
   ]


### PR DESCRIPTION
## Summary
- Corrects PR #381 which incorrectly accepted both symbols and strings
- `deep-find`, `deep-find-first`, `deep-find-paths` now take symbol keys only (`:key`)
- Matches the rest of the prelude convention (`has(:key)`, `lookup-or(:key, ...)`)
- Removes `sym(str.of(k))` conversion — just uses `k` directly since it's already a symbol
- Updates docs to remove "also accepts strings" language

## Test plan
- [ ] Existing harness tests pass
- [ ] `deep-find(:x, { a: { x: 1 } })` returns `[1]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)