### PR TITLE
fix(eu-5pe9): fix compiler panic on list destructuring in prelude functions

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -257,8 +257,7 @@ deep-query-fold(pattern, b): {
   norm: if((segs head) = "**", segs, cons("**", segs))
 
   child-pair(path, el): [path ++ [el key], el value]
-
-  desc-child(path, el): desc-pairs([path ++ [el key], el value])
+  desc-child(path, el): desc-pairs(child-pair(path, el))
   desc-pairs(p):
     (p second) block? then(
        cons(p, (p second) elements mapcat(desc-child(p first))),

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -217,110 +217,77 @@ lookup-across(s, d, bs): {
 lookup-path(ks, b): foldl(lookup-in, b, ks)
 
 ##
+## Deep fold — stateful DFS over nested block/list structures
+##
+
+` "`deep-fold(emit, next-state, s, b)` - depth-first fold over nested blocks and lists. `emit(state, block)` returns a list of results at each block node. `next-state(state, child-key)` updates state for recursion into a child. `s` is the initial state."
+deep-fold(emit, next-state, s, b): {
+  walk-child(s, [ck, cv]): walk(next-state(s, ck), cv)
+  walk(s, v): if(v block?,
+                emit(s, v) ++ (v elements mapcat(walk-child(s))),
+                if(v list?, v mapcat(walk(s)), []))
+}.walk(s, b)
+
+##
 ## Deep find — recursive key search
 ##
 
 ` "`deep-find(k, b)` - return list of all values for key `k` (a symbol) at any depth in block `b`, depth-first."
 deep-find(k, b): {
-  s: k
-  children(v): v elements map({el: •}.(el value)) mapcat(walk)
-  walk(v): if(v block?,
-              if(v has(s),
-                 cons(v lookup(s), children(v)),
-                 children(v)),
-              if(v list?,
-                 v mapcat(walk),
-                 []))
-}.walk(b)
+  emit(s, v): if(v has(k), [v lookup(k)], [])
+  next(s, ck): null
+}.(deep-fold(emit, next, null, b))
 
 ` "`deep-find-first(k, d, b)` - return first value for key `k` (a symbol) at any depth in block `b`, or default `d`."
 deep-find-first(k, d, b): b deep-find(k) head-or(d)
 
 ` "`deep-find-paths(k, b)` - return list of key paths to all occurrences of key `k` (a symbol) at any depth in block `b`."
 deep-find-paths(k, b): {
-  s: k
-  walk-children(path, v): v keys mapcat({ck: •}.(walk(path ++ [ck], v lookup(ck))))
-  walk(path, v): if(v block?,
-                    if(v has(s),
-                       cons(path ++ [s], walk-children(path, v)),
-                       walk-children(path, v)),
-                    if(v list?,
-                       v mapcat(walk(path)),
-                       []))
-}.walk([], b)
+  emit(path, v): if(v has(k), [path ++ [k]], [])
+  next(path, ck): path ++ [ck]
+}.(deep-fold(emit, next, [], b))
 
 ##
 ## Deep query — pattern-based data querying
 ##
 
-` "`deep-query(pattern, b)` - query block `b` using dot-separated pattern string. `*` matches one level, `**` matches any depth. Bare `foo` is sugar for `**.foo`."
-deep-query(pattern, b): {
+` "`deep-query-fold(pattern, b)` - core query engine returning `[path, value]` pairs matching the dot-separated `pattern` in block `b`."
+deep-query-fold(pattern, b): {
   segs: pattern str.split-on("[.]")
-  first-seg: segs head
-  norm: if(first-seg = "**", segs, cons("**", segs))
-  all-values(v): if(v block?, v elements map({el: •}.(el value)), [])
-  match-key(seg, v): if(v block?, if(v has(sym(seg)), [v lookup(sym(seg))], []), [])
-  descendants(v): if(v block?,
-                     cons(v, all-values(v) mapcat(descendants)),
-                     [])
-  step(vals, remaining):
-    if(remaining nil?,
-       vals,
-       {
-         seg: remaining head
-         rest: remaining tail
-       }.(if(seg = "**",
-             step(vals mapcat(descendants), rest),
-             if(seg = "*",
-                step(vals mapcat(all-values), rest),
-                step(vals mapcat(match-key(seg)), rest)))))
-  result: step([b], norm)
+  norm: if((segs head) = "**", segs, cons("**", segs))
+
+  child-pair(path, el): [path ++ [el key], el value]
+
+  desc-child(path, el): desc-pairs([path ++ [el key], el value])
+  desc-pairs(p):
+    (p second) block? then(
+       cons(p, (p second) elements mapcat(desc-child(p first))),
+       [])
+
+  expand-star(p):
+    (p second) block? then((p second) elements map(child-pair(p first)), [])
+
+  match-sym(s, p):
+    (p second) block? then(
+       (p second) has(s) then([[(p first) ++ [s], (p second) lookup(s)]], []),
+       [])
+
+  apply-segment(pairs, seg):
+    if(seg = "**", pairs mapcat(desc-pairs),
+       if(seg = "*", pairs mapcat(expand-star),
+          pairs mapcat(match-sym(sym(seg)))))
+
+  result: foldl(apply-segment, [[[], b]], norm)
 }.result
+
+` "`deep-query(pattern, b)` - query block `b` using dot-separated pattern string. `*` matches one level, `**` matches any depth. Bare `foo` is sugar for `**.foo`."
+deep-query(pattern, b): b deep-query-fold(pattern) map(second)
 
 ` "`deep-query-first(pattern, d, b)` - return first match for `pattern` in block `b`, or default `d`."
 deep-query-first(pattern, d, b): b deep-query(pattern) head-or(d)
 
 ` "`deep-query-paths(pattern, b)` - return list of key paths matching `pattern` in block `b`."
-deep-query-paths(pattern, b): {
-
-  segs: pattern str.split-on("[.]")
-  norm: if((segs head) = "**", segs, cons("**", segs))
-
-  pair(v, k): [k, v lookup(k)]
-  all-keyed(v): if(v block?, v keys map(pair(v)), [])
-
-  prepend-path(path, kv): [path ++ [kv first], kv second]
-
-  match-key-pair(seg, [path, val]):
-    if(val block?,
-       if(val has(sym(seg)), [[path ++ [sym(seg)], val lookup(sym(seg))]], []),
-       [])
-
-  expand-star([path, val]):
-    if(val block?,
-       val keys map(pair(val)) map(prepend-path(path)),
-       [])
-
-  desc-pairs(p): {path: p first, val: p second}.(
-    if(val block?,
-       cons(p, all-keyed(val) mapcat({kv: •}.(desc-pairs([path ++ [kv first], kv second])))),
-       []))
-
-  step(pairs, remaining):
-    if(remaining nil?,
-       pairs map(first),
-       {
-         seg: remaining head
-         rest: remaining tail
-       }.(if(seg = "**",
-             step(pairs mapcat(desc-pairs), rest),
-             if(seg = "*",
-                step(pairs mapcat(expand-star), rest),
-                step(pairs mapcat(match-key-pair(seg)), rest)))))
-
-  result: step([[[], b]], norm)
-
-}.result
+deep-query-paths(pattern, b): b deep-query-fold(pattern) map(first)
 
 ##
 ## Boolean

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -268,8 +268,8 @@ deep-query-fold(pattern, b): {
     (p second) block? then((p second) elements map(child-pair(p first)), [])
 
   match-sym(s, p):
-    (p second) block? then(
-       (p second) has(s) then([[(p first) ++ [s], (p second) lookup(s)]], []),
+    if((p second) block?,
+       if((p second) has(s), [[(p first) ++ [s], (p second) lookup(s)]], []),
        [])
 
   apply-segment(pairs, seg):

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -258,17 +258,17 @@ deep-query-fold(pattern, b): {
 
   child-pair(path, el): [path ++ [el key], el value]
   desc-child(path, el): desc-pairs(child-pair(path, el))
-  desc-pairs(p):
-    (p second) block? then(
-       cons(p, (p second) elements mapcat(desc-child(p first))),
+  desc-pairs([path, val]):
+    val block? then(
+       cons([path, val], val elements mapcat(desc-child(path))),
        [])
 
-  expand-star(p):
-    (p second) block? then((p second) elements map(child-pair(p first)), [])
+  expand-star([path, val]):
+    val block? then(val elements map(child-pair(path)), [])
 
-  match-sym(s, p):
-    if((p second) block?,
-       if((p second) has(s), [[(p first) ++ [s], (p second) lookup(s)]], []),
+  match-sym(s, [path, val]):
+    if(val block?,
+       if(val has(s), [[path ++ [s], val lookup(s)]], []),
        [])
 
   apply-segment(pairs, seg):

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -4,6 +4,85 @@ use crate::core::expr::*;
 use crate::core::transform::succ;
 use moniker::*;
 
+/// Depth-aware substitution for beta reduction.
+///
+/// Unlike `RcExpr::substs`, this function correctly handles the case
+/// where a replacement expression contains scope-relative bound
+/// variables (`BV(scope=k, binder=j)`) that are placed inside nested
+/// scope boundaries (Let or Lam).  Each time we descend into a new
+/// scope boundary, we increment the scope indices in the replacement
+/// by one to keep them pointing at the same binding in the outer
+/// context.
+///
+/// This is necessary when beta-reducing a destructuring lambda such as
+/// `([a, b]) -> body` where the body contains a `DestructureListLet`.
+/// The Embed values in that Let are inside one additional scope
+/// boundary relative to the call site, so any BV substituted in there
+/// must have its scope incremented.
+fn substs_depth<N: PartialEq<Var<String>>>(
+    expr: &RcExpr,
+    mappings: &[(N, RcExpr)],
+    depth: u32,
+) -> Result<RcExpr, CoreError> {
+    match &*expr.inner {
+        Expr::Var(_, v) => match mappings.iter().find(|&(n, _)| n == v) {
+            Some((_, replacement)) => {
+                // Replacement is from the call site (depth == 0).
+                // If we are now inside `depth` additional scope
+                // boundaries, we must increment all outer BVs in the
+                // replacement by `depth`.
+                let mut adjusted = replacement.clone();
+                for _ in 0..depth {
+                    adjusted = succ::succ(&adjusted)?;
+                }
+                Ok(adjusted)
+            }
+            None => Ok(expr.clone()),
+        },
+        // Descend into Let: the Embed values are inside the new scope
+        // boundary, so depth increases by 1.
+        Expr::Let(s, scope, t) => {
+            let new_bindings: Result<Vec<_>, CoreError> = scope
+                .unsafe_pattern
+                .unsafe_pattern
+                .iter()
+                .map(|(n, Embed(value))| {
+                    substs_depth(value, mappings, depth + 1).map(|v| (n.clone(), Embed(v)))
+                })
+                .collect();
+            let new_body = substs_depth(&scope.unsafe_body, mappings, depth + 1)?;
+            Ok(RcExpr::from(Expr::Let(
+                *s,
+                Scope {
+                    unsafe_pattern: Rec {
+                        unsafe_pattern: new_bindings?,
+                    },
+                    unsafe_body: new_body,
+                },
+                *t,
+            )))
+        }
+        // Descend into Lam body: also a new scope boundary.
+        Expr::Lam(s, inl, scope) => {
+            let new_body = substs_depth(&scope.unsafe_body, mappings, depth + 1)?;
+            Ok(RcExpr::from(Expr::Lam(
+                *s,
+                *inl,
+                Scope {
+                    unsafe_pattern: scope.unsafe_pattern.clone(),
+                    unsafe_body: new_body,
+                },
+            )))
+        }
+        _ => {
+            // Non-binding nodes: walk children at the same depth.
+            let children_result: Result<RcExpr, CoreError> =
+                expr.try_walk_safe(&mut |e| substs_depth(e, mappings, depth));
+            children_result
+        }
+    }
+}
+
 #[allow(clippy::redundant_closure)]
 pub fn inline_pass(expr: &RcExpr) -> Result<RcExpr, CoreError> {
     distribute(expr).and_then(|ref e| beta_reduce(e))
@@ -85,7 +164,7 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 
                         let mappings = <_>::zip(binders.into_iter(), args).collect::<Vec<_>>();
 
-                        Ok(body.substs(&mappings))
+                        substs_depth(&body, &mappings, 0)
                     }
                 }
                 // Use optimized try_walk_safe
@@ -101,6 +180,7 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 pub mod tests {
 
     use super::*;
+    use crate::common::sourcemap::Smid;
     use crate::core::expr::acore::*;
     use crate::core::verify::binding;
     use std::iter;
@@ -314,5 +394,81 @@ pub mod tests {
         let inlined = inline_pass(&original).unwrap();
         binding::verify(&inlined).unwrap();
         assert_term_eq!(inlined, expected);
+    }
+
+    /// Regression test for eu-5pe9: beta-reducing a destructuring
+    /// lambda (one whose body is a `DestructureListLet`) must
+    /// correctly adjust scope indices in the replacement when it is
+    /// placed inside the nested scope boundary of the Let.
+    ///
+    /// Previously `substs` was scope-unaware and would leave
+    /// `BV(scope=k, binder=j)` unchanged inside the Let's Embed
+    /// values, causing `compress::compress` to panic with "eliminating
+    /// used var" because prune had marked the originally-referenced
+    /// binder as eliminated.
+    #[test]
+    pub fn test_beta_reduce_destructuring_lambda_with_bound_arg() {
+        // Build:
+        //   let outer =
+        //     let
+        //       f = inline([__p0]) ->
+        //             DestructureListLet (a = HEAD(__p0), b = HEAD(TAIL(__p0))) in
+        //             a + b
+        //       x = 99
+        //     in f([x, 42])
+        //   in outer
+        //
+        // After inline_pass, f is beta-reduced at the call site and
+        // `x` (a BV in the argument) must be correctly placed inside
+        // the DestructureListLet with an incremented scope index.
+
+        let f = free("f");
+        let p0 = free("__p0");
+        let a = free("a");
+        let b = free("b");
+        let x = free("x");
+
+        // Destructuring let body: a + b  (simplified as app for test purposes)
+        let add_a_b = app(bif("ADD"), vec![var(a.clone()), var(b.clone())]);
+
+        // DestructureListLet: a = HEAD(__p0), b = HEAD(TAIL(__p0))
+        let destr_let = RcExpr::from(Expr::Let(
+            Smid::default(),
+            Scope::new(
+                Rec::new(vec![
+                    (
+                        Binder(a.clone()),
+                        Embed(app(bif("HEAD"), vec![var(p0.clone())])),
+                    ),
+                    (
+                        Binder(b.clone()),
+                        Embed(app(
+                            bif("HEAD"),
+                            vec![app(bif("TAIL"), vec![var(p0.clone())])],
+                        )),
+                    ),
+                ]),
+                add_a_b,
+            ),
+            LetType::DestructureListLet,
+        ));
+
+        // f is an inlinable lambda with single param __p0
+        let f_def = inline(vec![p0.clone()], destr_let);
+
+        // x = 99
+        let x_val = num(99);
+
+        // f([x, 42]) — note x is a free var that will become a BV
+        // after the outer let is closed
+        let call = app(var(f.clone()), vec![list(vec![var(x.clone()), num(42)])]);
+
+        // Inner let: let f = ..., x = 99 in f([x, 42])
+        let inner = let_(vec![(f.clone(), f_def), (x.clone(), x_val)], call);
+
+        // Verify inline_pass does not panic and produces a
+        // binding-valid result
+        let result = inline_pass(&inner).expect("inline_pass should not panic");
+        binding::verify(&result).expect("result should have valid bindings");
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `compress::compress` panicked with "eliminating used var" when list destructuring was used in prelude function parameters (e.g. `f([path, val]): body`)
- **Root cause**: `beta_reduce` in `src/core/inline/reduce.rs` used `body.substs(&mappings)` which is scope-unaware. When a destructuring lambda is beta-reduced, the Embed values of the `DestructureListLet` sit inside one additional scope boundary. A bound variable in the argument (BV(scope=k, binder=j)) was placed there without incrementing its scope index, causing it to point at a different (now-eliminated) binder after the inline pass.
- **Fix**: Replace `body.substs(&mappings)` with `substs_depth(&body, &mappings, 0)`, a new depth-tracking variant that applies `succ::succ` to each replacement once per scope boundary descended into (Let or Lam).
- **Refactor**: The prelude `deep-query-fold` helpers (`desc-pairs`, `expand-star`, `match-sym`) are updated to use proper `[path, val]` list destructuring instead of workarounds.
- **Test**: New unit test `test_beta_reduce_destructuring_lambda_with_bound_arg` directly exercises the fixed code path; harness test 075 exercises the full pipeline end-to-end.

## Files changed

- `src/core/inline/reduce.rs` — add `substs_depth`, use it in `beta_reduce`, add regression test
- `lib/prelude.eu` — use `[path, val]` destructuring in `deep-query-fold` helpers (four commits from previous session)

## Test plan

- [x] `cargo test` — all 188 tests pass (previously test_harness_075 panicked)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)