### PR TITLE
fix(eu-5pe9): depth-aware substitution in beta_reduce for destructuring lambdas

### DIFF
--- a/tests/harness/102_destructure_list_in_block.eu
+++ b/tests/harness/102_destructure_list_in_block.eu
@@ -1,0 +1,58 @@
+"Regression test for eu-5pe9: list destructuring inside a block expression.
+
+Previously, beta-reducing a destructuring lambda (one whose body is a
+DestructureListLet) would fail to adjust scope indices in the
+replacement, causing compress to panic with 'eliminating used var' when
+the lambda was used inside a DefaultBlockLet context (e.g., a prelude
+function or any block expression)."
+
+# Test 1: list destructuring inside a block, both parameters used
+test1: {
+  f([a, b]): a + b
+  result: f([3, 4])
+}.result
+
+# Test 2: list destructuring inside a block, used via mapcat
+test2: {
+  pairs: [[1, 2], [3, 4], [5, 6]]
+  f([a, b]): [a + b]
+  result: pairs mapcat(f)
+}.result
+
+# Test 3: list destructuring inside a block with mutual recursion
+# (the key pattern from deep-query-fold that triggered the original bug)
+test3: {
+  child([path, val]): [[path, val]]
+  expand(x): x mapcat(child)
+  result: expand([[[], 1], [[], 2]])
+}.result
+
+# Test 4: list destructuring inside a block referencing outer bindings
+test4: {
+  base: 10
+  f([a, b]): a + b + base
+  result: f([1, 2])
+}.result
+
+# Test 5: the triggering pattern — list destructuring inside a block
+# with indirect recursion through another function (mirrors deep-query-fold).
+# Both `path` and `val` are used in the body of desc-pairs.
+test5: {
+  make-pair(path, el): [path ++ [el key], el value]
+  desc-child(path, el): desc-pairs(make-pair(path, el))
+  desc-pairs([path, val]):
+    if(val block?,
+       cons([path, val], val elements mapcat(desc-child(path))),
+       [])
+  result: desc-pairs([[], {a: 1}])
+}.result
+
+tests: {
+  a: test1 //= 7
+  b: (test2 head) //= 3
+  c: (test3 count) //= 2
+  d: test4 //= 13
+  e: (test5 count) //= 1
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -495,6 +495,11 @@ pub fn test_harness_101() {
 }
 
 #[test]
+pub fn test_harness_102() {
+    run_test(&opts("102_destructure_list_in_block.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Fixes a panic in `compress::compress` ("eliminating used var") triggered when beta-reducing a destructuring lambda whose body is a `DestructureListLet` with a bound-variable argument
- The root cause: `body.substs(&mappings)` in `beta_reduce` placed replacement expressions inside nested scope boundaries without adjusting bound variable scope indices, corrupting the index space and causing the second eliminate pass to see invalid binder references
- Fix: introduces `substs_depth`, a depth-tracking variant that applies `succ::succ` to each replacement once per additional scope boundary (Let or Lam) descended during substitution

## Root Cause

When a destructuring lambda `([a, b]) -> DestructureListLet(...)` is beta-reduced at a call site, the argument (e.g., `[Var{scope=k, binder=j}, ...]`) contains bound variables that are valid at the call site's scope depth. The lambda body contains a `DestructureListLet` — a nested `Let` scope. When the argument is substituted into the `Embed` values of that inner let, each `BV(scope=k, binder=j)` now sits one additional scope boundary deeper. Without incrementing `scope`, the variable refers to the wrong enclosing scope, which the prune pass may mark as eliminated, causing compress to panic.

## Test Plan

- [ ] Unit test `test_beta_reduce_destructuring_lambda_with_bound_arg` in `src/core/inline/reduce.rs` directly exercises the fixed code path
- [ ] Harness test `102_destructure_list_in_block` covers: list destructuring inside a block (simple, mapcat, mutual recursion, outer binding reference, and the deep-query-fold recursive pattern)
- [ ] All 189 harness tests pass
- [ ] All 590 lib tests pass
- [ ] Clippy clean with `-D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)