### PR TITLE
feat(eu-76sv): move NdArray dispatch from prelude to arithmetic intrinsics

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -365,13 +365,13 @@ or: __OR
     export: :suppress
     associates: :left
     precedence: :sum }
-(l + r): if(is-array?(l) || is-array?(r), arr.add(l, r), __ADD(l, r))
+(l + r): __ADD(l, r)
 
 ` { doc: "`l - r` - subtracts `r` from `l`. For numbers, both must be numeric. For arrays, performs element-wise subtraction; one operand may be a scalar."
     export: :suppress
     associates: :left
     precedence: :sum }
-(l - r): if(is-array?(l) || is-array?(r), arr.sub(l, r), __SUB(l, r))
+(l - r): __SUB(l, r)
 
 ` { doc: "`l ^ r` - raise `l` to the power `r`."
     export: :suppress
@@ -383,13 +383,13 @@ or: __OR
     export: :suppress
     associates: :left
     precedence: :prod }
-(l * r): if(is-array?(l) || is-array?(r), arr.mul(l, r), __MUL(l, r))
+(l * r): __MUL(l, r)
 
 ` { doc: "`l / r` - floor division of `l` by `r` for numbers (rounds toward negative infinity; always returns integer). For arrays, performs element-wise division; one operand may be a scalar."
     export: :suppress
     associates: :left
     precedence: :prod }
-(l / r): if(is-array?(l) || is-array?(r), arr.div(l, r), __DIV(l, r))
+(l / r): __DIV(l, r)
 
 ` { doc: "`l ÷ r` - precise division of `l` by `r`; returns exact result."
     export: :suppress

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -18,7 +18,8 @@ use crate::{
 };
 
 use super::{
-    support::{machine_return_bool, machine_return_num, num_arg},
+    array::array_binop,
+    support::{machine_return_bool, machine_return_boxed_num, machine_return_num, num_arg},
     syntax::{
         dsl::{annotated_lambda, app_bif, case, force, local, lref},
         LambdaForm, StgSyn,
@@ -80,6 +81,10 @@ impl StgIntrinsic for Add {
         "ADD"
     }
 
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index(), annotation)
+    }
+
     fn execute(
         &self,
         machine: &mut dyn IntrinsicMachine,
@@ -87,6 +92,15 @@ impl StgIntrinsic for Add {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
+        // Dispatch to array arithmetic if either operand is an NdArray
+        let a_native = machine.nav(view).resolve_native(&args[0]);
+        let b_native = machine.nav(view).resolve_native(&args[1]);
+        if let (Ok(ref a), Ok(ref b)) = (&a_native, &b_native) {
+            if matches!(a, Native::NdArray(_)) || matches!(b, Native::NdArray(_)) {
+                return array_binop(machine, view, &args[0], &args[1], |a, b| a + b);
+            }
+        }
+
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
 
@@ -94,15 +108,15 @@ impl StgIntrinsic for Add {
             let total = l
                 .checked_add(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(total))
+            machine_return_boxed_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let total = l
                 .checked_add(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(total))
+            machine_return_boxed_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l + r) {
-                machine_return_num(machine, view, ret)
+                machine_return_boxed_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(x, y))
             }
@@ -122,6 +136,10 @@ impl StgIntrinsic for Sub {
         "SUB"
     }
 
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index(), annotation)
+    }
+
     fn execute(
         &self,
         machine: &mut dyn IntrinsicMachine,
@@ -129,6 +147,15 @@ impl StgIntrinsic for Sub {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
+        // Dispatch to array arithmetic if either operand is an NdArray
+        let a_native = machine.nav(view).resolve_native(&args[0]);
+        let b_native = machine.nav(view).resolve_native(&args[1]);
+        if let (Ok(ref a), Ok(ref b)) = (&a_native, &b_native) {
+            if matches!(a, Native::NdArray(_)) || matches!(b, Native::NdArray(_)) {
+                return array_binop(machine, view, &args[0], &args[1], |a, b| a - b);
+            }
+        }
+
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
 
@@ -136,15 +163,15 @@ impl StgIntrinsic for Sub {
             let result = l
                 .checked_sub(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(result))
+            machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let result = l
                 .checked_sub(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(result))
+            machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l - r) {
-                machine_return_num(machine, view, ret)
+                machine_return_boxed_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(x, y))
             }
@@ -164,6 +191,10 @@ impl StgIntrinsic for Mul {
         "MUL"
     }
 
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index(), annotation)
+    }
+
     fn execute(
         &self,
         machine: &mut dyn IntrinsicMachine,
@@ -171,6 +202,15 @@ impl StgIntrinsic for Mul {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
+        // Dispatch to array arithmetic if either operand is an NdArray
+        let a_native = machine.nav(view).resolve_native(&args[0]);
+        let b_native = machine.nav(view).resolve_native(&args[1]);
+        if let (Ok(ref a), Ok(ref b)) = (&a_native, &b_native) {
+            if matches!(a, Native::NdArray(_)) || matches!(b, Native::NdArray(_)) {
+                return array_binop(machine, view, &args[0], &args[1], |a, b| a * b);
+            }
+        }
+
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
 
@@ -178,15 +218,15 @@ impl StgIntrinsic for Mul {
             let product = l
                 .checked_mul(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(product))
+            machine_return_boxed_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let product = l
                 .checked_mul(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(product))
+            machine_return_boxed_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l * r) {
-                machine_return_num(machine, view, ret)
+                machine_return_boxed_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(x, y))
             }
@@ -206,6 +246,10 @@ impl StgIntrinsic for Div {
         "DIV"
     }
 
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index(), annotation)
+    }
+
     fn execute(
         &self,
         machine: &mut dyn IntrinsicMachine,
@@ -213,6 +257,15 @@ impl StgIntrinsic for Div {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
+        // Dispatch to array arithmetic if either operand is an NdArray
+        let a_native = machine.nav(view).resolve_native(&args[0]);
+        let b_native = machine.nav(view).resolve_native(&args[1]);
+        if let (Ok(ref a), Ok(ref b)) = (&a_native, &b_native) {
+            if matches!(a, Native::NdArray(_)) || matches!(b, Native::NdArray(_)) {
+                return array_binop(machine, view, &args[0], &args[1], |a, b| a / b);
+            }
+        }
+
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
 
@@ -224,16 +277,16 @@ impl StgIntrinsic for Div {
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
             let result = floor_div_i64(l, r).ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(result))
+            machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let result = l
                 .checked_div(r)
                 .ok_or(ExecutionError::NumericRangeError(x, y))?;
-            machine_return_num(machine, view, Number::from(result))
+            machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             let result = (l / r).floor();
             if let Some(n) = num_from_floored(result) {
-                machine_return_num(machine, view, n)
+                machine_return_boxed_num(machine, view, n)
             } else {
                 Err(ExecutionError::NumericDomainError(x, y))
             }
@@ -324,6 +377,37 @@ fn comparison_wrapper(index: usize, annotation: Smid) -> LambdaForm {
     //   force inner_y:                  [raw_y] [inner_y]     [raw_x] [inner_x] [x, y]
     //
     //   BIF args: raw_x = lref(2), raw_y = lref(0)
+    let bif_call = app_bif(index as u8, vec![lref(2), lref(0)]);
+    let force_y = force(local(0), bif_call);
+    let unbox_y = unbox_any(local(3), force_y);
+    let force_x = force(local(0), unbox_y);
+    let unbox_x = unbox_any(local(0), force_x);
+    annotated_lambda(2, unbox_x, annotation)
+}
+
+/// Build a wrapper for a polymorphic two-argument arithmetic intrinsic.
+///
+/// Unboxes and forces both arguments accepting any boxed native type or
+/// unboxed native atoms (e.g. NdArray), then calls the BIF with the raw
+/// native values. The execute method is responsible for boxing numeric
+/// results via `machine_return_boxed_num` and returning NdArray results
+/// via `machine_return_ndarray`.
+fn arithmetic_wrapper(index: usize, annotation: Smid) -> LambdaForm {
+    // Environment evolution is identical to comparison_wrapper:
+    //
+    //   lambda args:                                          [x, y]
+    //   unbox_any x:  case on local(0)
+    //     branch matches BoxedXxx → inner ref at local(0):    [inner_x] [x, y]
+    //   force inner_x:                              [raw_x]   [inner_x] [x, y]
+    //   unbox_any y:  case on local(3) (= y from lambda args)
+    //     branch matches BoxedXxx → inner ref:  [inner_y]     [raw_x] [inner_x] [x, y]
+    //   force inner_y:                  [raw_y] [inner_y]     [raw_x] [inner_x] [x, y]
+    //
+    //   BIF args: raw_x = lref(2), raw_y = lref(0)
+    //
+    // After this wrapper, execute receives raw native atoms in both args:
+    // - V(Num(n))      for numeric arguments
+    // - V(NdArray(p))  for array arguments
     let bif_call = app_bif(index as u8, vec![lref(2), lref(0)]);
     let force_y = force(local(0), bif_call);
     let unbox_y = unbox_any(local(3), force_y);

--- a/src/eval/stg/array.rs
+++ b/src/eval/stg/array.rs
@@ -775,7 +775,7 @@ fn f64_vec_to_list(
 }
 
 /// Dispatch a binary operation on arrays, supporting array+array and array+scalar
-fn array_binop<F: Fn(f64, f64) -> f64>(
+pub(crate) fn array_binop<F: Fn(f64, f64) -> f64>(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     a_ref: &Ref,

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -36,21 +36,53 @@ fn native_type(native: &Native) -> IntrinsicType {
     }
 }
 
-/// Helper for intrinsics to access a numeric arg
+/// Attempt to classify a ref as a data constructor tag, for error reporting.
+///
+/// Used when `resolve_native` fails to provide a `NoBranchForDataTag` error
+/// with the right tag so that contextual notes (e.g. "blocks cannot be used
+/// in arithmetic") are generated correctly.
+fn cons_tag_of(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    arg: &Ref,
+) -> Option<u8> {
+    let nav = machine.nav(view);
+    let closure = nav.resolve(arg).ok()?;
+    let code = view.scoped(closure.code());
+    match &*code {
+        HeapSyn::Cons { tag, .. } => Some(*tag),
+        _ => None,
+    }
+}
+
+/// Helper for intrinsics to access a numeric arg.
+///
+/// When the argument is a data constructor (e.g. a block or list) rather than
+/// a native numeric atom, produces a `NoBranchForDataTag` error so that the
+/// contextual error notes (e.g. "blocks cannot be used in arithmetic",
+/// "to concatenate two lists, use 'append'") are generated correctly.
 pub fn num_arg(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     arg: &Ref,
 ) -> Result<Number, ExecutionError> {
-    let native = machine.nav(view).resolve_native(arg)?;
-    if let Native::Num(n) = native {
-        Ok(n)
-    } else {
-        Err(ExecutionError::TypeMismatch(
+    match machine.nav(view).resolve_native(arg) {
+        Ok(Native::Num(n)) => Ok(n),
+        Ok(native) => Err(ExecutionError::TypeMismatch(
             machine.annotation(),
             IntrinsicType::Number,
             native_type(&native),
-        ))
+        )),
+        Err(_) => {
+            // resolve_native failed — likely a Cons (block/list). Inspect the
+            // tag so the error message includes useful context.
+            let tag = cons_tag_of(machine, view, arg).unwrap_or(DataConstructor::Block.tag());
+            Err(ExecutionError::NoBranchForDataTag(
+                machine.annotation(),
+                tag,
+                vec![DataConstructor::BoxedNumber.tag()],
+            ))
+        }
     }
 }
 
@@ -315,6 +347,29 @@ pub fn machine_return_num(
         .as_ptr(),
         machine.root_env(),
     ))
+}
+
+/// Return a boxed number from an intrinsic whose wrapper does not box
+/// the result.
+///
+/// The default wrapper for `num -> num -> num` intrinsics wraps the result
+/// in a `BoxedNumber` data constructor automatically. When an intrinsic
+/// overrides `wrapper` with a custom form (e.g. `arithmetic_wrapper`) that
+/// does not box the result, the `execute` method must call this function
+/// instead of `machine_return_num` to produce the correct `BoxedNumber`
+/// constructor directly from the execute method.
+pub fn machine_return_boxed_num(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView,
+    n: Number,
+) -> Result<(), ExecutionError> {
+    let ptr = view
+        .data(
+            DataConstructor::BoxedNumber.tag(),
+            Array::from_slice(&view, &[Ref::V(Native::Num(n))]),
+        )?
+        .as_ptr();
+    machine.set_closure(SynClosure::new(ptr, machine.root_env()))
 }
 
 /// Return string from intrinsic


### PR DESCRIPTION
## Summary

- Moves NdArray dispatch for `+`, `-`, `*`, `/` from `lib/prelude.eu` into the STG intrinsic `execute` methods in `src/eval/stg/arith.rs`
- Eliminates ~10x performance regression introduced by commit `016429c`, which added `is-array?` guards in the prelude causing every arithmetic operation to evaluate interpreted `if(is-array?(...))` checks even when no arrays are involved
- Reverts the four arithmetic operators in `lib/prelude.eu` back to direct `__ADD`, `__SUB`, `__MUL`, `__DIV` calls

## Changes

- `src/eval/stg/array.rs`: Made `array_binop` `pub(crate)` so `arith.rs` can call it
- `src/eval/stg/arith.rs`:
  - Added `arithmetic_wrapper` (using `unbox_any` + fallback, like `comparison_wrapper`) so NdArray atoms pass through to `execute` without triggering `NoBranchForNative`
  - Added NdArray dispatch at top of each `execute` method for Add, Sub, Mul, Div
  - Changed `machine_return_num` → `machine_return_boxed_num` (custom wrapper no longer boxes the result)
- `src/eval/stg/support.rs`:
  - Added `machine_return_boxed_num` helper
  - Added `cons_tag_of` helper for inspecting Cons tags on unresolved refs
  - Updated `num_arg` to produce `NoBranchForDataTag` (preserving error messages like "blocks cannot be used in arithmetic") when passed a non-numeric data constructor
- `lib/prelude.eu`: Reverted `+`, `-`, `*`, `/` to direct intrinsic calls

## Test plan

- [ ] All 188 harness tests pass (`cargo test`)
- [ ] Test 087 (NdArray operations) passes
- [ ] All error tests pass (031, 045, 053, 078 — type mismatch messages preserved)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] AoC day03 benchmark completes well within 60s (was timing out pre-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)