### PR TITLE
feat(stg): IO monad data constructor tags (F1)

### DIFF
--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -69,6 +69,10 @@ fn format_ref(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref
                     .get(0)
                     .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
                     .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
+                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
+                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
+                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
                 Err(_) => "<value>".to_string(),
             }
         }

--- a/src/eval/stg/pretty.rs
+++ b/src/eval/stg/pretty.rs
@@ -24,6 +24,10 @@ fn tag_name(tag: u8) -> String {
         Ok(DataConstructor::BlockPair) => "Pair".to_string(),
         Ok(DataConstructor::BlockKvList) => "KvList".to_string(),
         Ok(DataConstructor::BoxedZdt) => "Zdt".to_string(),
+        Ok(DataConstructor::IoReturn) => "IoReturn".to_string(),
+        Ok(DataConstructor::IoBind) => "IoBind".to_string(),
+        Ok(DataConstructor::IoAction) => "IoAction".to_string(),
+        Ok(DataConstructor::IoFail) => "IoFail".to_string(),
         Err(()) => format!("#{tag}"),
     }
 }

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -539,6 +539,29 @@ pub mod dsl {
     pub fn ann(smid: Smid, body: Rc<StgSyn>) -> Rc<StgSyn> {
         Rc::new(StgSyn::Ann { smid, body })
     }
+
+    /// IO monad: wrap a pure value — IoReturn(world, value)
+    pub fn io_return(world: Ref, value: Ref) -> Rc<StgSyn> {
+        data(DataConstructor::IoReturn.tag(), vec![world, value])
+    }
+
+    /// IO monad: sequence an action — IoBind(world, action, continuation)
+    pub fn io_bind(world: Ref, action: Ref, continuation: Ref) -> Rc<StgSyn> {
+        data(
+            DataConstructor::IoBind.tag(),
+            vec![world, action, continuation],
+        )
+    }
+
+    /// IO monad: construct a primitive action — IoAction(world, spec_block)
+    pub fn io_action(world: Ref, spec_block: Ref) -> Rc<StgSyn> {
+        data(DataConstructor::IoAction.tag(), vec![world, spec_block])
+    }
+
+    /// IO monad: represent a failure — IoFail(world, error)
+    pub fn io_fail(world: Ref, error: Ref) -> Rc<StgSyn> {
+        data(DataConstructor::IoFail.tag(), vec![world, error])
+    }
 }
 
 /// Example STG expression for use in tests

--- a/src/eval/stg/tags.rs
+++ b/src/eval/stg/tags.rs
@@ -31,6 +31,14 @@ pub enum DataConstructor {
     BlockKvList = 10,
     /// Boxed zoned datetime
     BoxedZdt = 11,
+    /// IO monad: pure value wrapper — (world, value)
+    IoReturn = 12,
+    /// IO monad: sequenced action — (world, action, continuation)
+    IoBind = 13,
+    /// IO monad: primitive action — (world, spec_block)
+    IoAction = 14,
+    /// IO monad: failure — (world, error)
+    IoFail = 15,
 }
 
 impl fmt::Display for DataConstructor {
@@ -48,6 +56,10 @@ impl fmt::Display for DataConstructor {
             DataConstructor::BlockPair => write!(f, "key-value pair"),
             DataConstructor::BlockKvList => write!(f, "key-value list"),
             DataConstructor::BoxedZdt => write!(f, "datetime"),
+            DataConstructor::IoReturn => write!(f, "io-return"),
+            DataConstructor::IoBind => write!(f, "io-bind"),
+            DataConstructor::IoAction => write!(f, "io-action"),
+            DataConstructor::IoFail => write!(f, "io-fail"),
         }
     }
 }
@@ -71,6 +83,10 @@ impl DataConstructor {
             DataConstructor::BlockPair => 2,
             DataConstructor::BlockKvList => 2,
             DataConstructor::BoxedZdt => 1,
+            DataConstructor::IoReturn => 2,
+            DataConstructor::IoBind => 3,
+            DataConstructor::IoAction => 2,
+            DataConstructor::IoFail => 2,
         }
     }
 }
@@ -100,6 +116,10 @@ impl TryFrom<Tag> for DataConstructor {
                 Ok(DataConstructor::BlockKvList)
             }
             value if value == DataConstructor::BoxedZdt as Tag => Ok(DataConstructor::BoxedZdt),
+            value if value == DataConstructor::IoReturn as Tag => Ok(DataConstructor::IoReturn),
+            value if value == DataConstructor::IoBind as Tag => Ok(DataConstructor::IoBind),
+            value if value == DataConstructor::IoAction as Tag => Ok(DataConstructor::IoAction),
+            value if value == DataConstructor::IoFail as Tag => Ok(DataConstructor::IoFail),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
## Summary

- Adds four new `DataConstructor` variants to `src/eval/stg/tags.rs`: `IoReturn` (tag 12, arity 2), `IoBind` (tag 13, arity 3), `IoAction` (tag 14, arity 2), `IoFail` (tag 15, arity 2)
- Updates `Display`, `arity()`, and `TryFrom<Tag>` for all four variants
- Adds DSL helpers `io_return()`, `io_bind()`, `io_action()`, `io_fail()` to `src/eval/stg/syntax.rs`
- Adds named arms for IO constructors in `pretty.rs` `tag_name()` and `assert.rs` `format_ref()`
- GC scanning in `src/eval/memory/syntax.rs` is tag-agnostic; no changes required

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 590 tests pass

This is task F1 from the IO monad design doc (`docs/plans/2026-03-09-io-monad-design.md`). It unblocks F2 (IO intrinsics) and F4 (VM WHNF yield).

🤖 Generated with [Claude Code](https://claude.com/claude-code)