### PR TITLE
feat(stg): IO monad intrinsics IO_RETURN, IO_BIND, IO_ACTION (F2)

### DIFF
--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -814,6 +814,21 @@ lazy_static! {
             ty: function(vec![list(), list(), num(), unk(), list()]).unwrap(),
             strict: vec![0, 1, 2, 3],
     },
+    Intrinsic { // 153
+            name: "IO_RETURN",
+            ty: function(vec![unk(), unk(), unk()]).unwrap(),
+            strict: vec![],
+    },
+    Intrinsic { // 154
+            name: "IO_BIND",
+            ty: function(vec![unk(), unk(), unk(), unk()]).unwrap(),
+            strict: vec![],
+    },
+    Intrinsic { // 155
+            name: "IO_ACTION",
+            ty: function(vec![unk(), unk(), unk()]).unwrap(),
+            strict: vec![],
+    },
     ];
 }
 

--- a/src/eval/stg/io.rs
+++ b/src/eval/stg/io.rs
@@ -1,0 +1,90 @@
+//! IO monad intrinsics: IO_RETURN, IO_BIND, IO_ACTION
+//!
+//! These intrinsics are STG-only — their wrappers construct IO data
+//! constructors directly without a BIF call. They are the primitive
+//! building blocks for the IO monad and are called from the eucalypt
+//! `io` prelude.
+
+use crate::{
+    common::sourcemap::Smid,
+    eval::machine::intrinsic::{CallGlobal2, CallGlobal3, StgIntrinsic},
+};
+
+use super::{
+    syntax::{
+        dsl::{annotated_lambda, data, lref},
+        LambdaForm,
+    },
+    tags::DataConstructor,
+};
+
+/// IO_RETURN(world, value) → IoReturn(world, value)
+///
+/// Wraps a pure value in the IO monad. The world token is threaded
+/// through unchanged.
+pub struct IoReturn;
+
+impl StgIntrinsic for IoReturn {
+    fn name(&self) -> &str {
+        "IO_RETURN"
+    }
+
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        annotated_lambda(
+            2, // [world value]
+            data(DataConstructor::IoReturn.tag(), vec![lref(1), lref(0)]),
+            annotation,
+        )
+    }
+}
+
+impl CallGlobal2 for IoReturn {}
+
+/// IO_BIND(world, action, continuation) → IoBind(world, action, continuation)
+///
+/// Sequences two IO actions: evaluates `action` then passes its result
+/// to `continuation`. The io-run driver interprets the resulting IoBind
+/// constructor.
+pub struct IoBind;
+
+impl StgIntrinsic for IoBind {
+    fn name(&self) -> &str {
+        "IO_BIND"
+    }
+
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        annotated_lambda(
+            3, // [world action continuation]
+            data(
+                DataConstructor::IoBind.tag(),
+                vec![lref(2), lref(1), lref(0)],
+            ),
+            annotation,
+        )
+    }
+}
+
+impl CallGlobal3 for IoBind {}
+
+/// IO_ACTION(world, spec_block) → IoAction(world, spec_block)
+///
+/// Constructs a primitive IO action from a spec block. The spec block
+/// must carry a recognised tag (e.g. `:io-shell`, `:io-exec`) for the
+/// io-run driver to dispatch on.
+pub struct IoAction;
+
+impl StgIntrinsic for IoAction {
+    fn name(&self) -> &str {
+        "IO_ACTION"
+    }
+
+    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+        annotated_lambda(
+            2, // [world spec_block]
+            data(DataConstructor::IoAction.tag(), vec![lref(1), lref(0)]),
+            annotation,
+        )
+    }
+}
+
+impl CallGlobal2 for IoAction {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -14,6 +14,7 @@ pub mod encoding;
 pub mod eq;
 pub mod force;
 pub mod graph;
+pub mod io;
 pub mod json_to_stg;
 pub mod list;
 pub mod meta;
@@ -198,6 +199,9 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(array::ArrayDiv));
     rt.add(Box::new(array::ArrayIndices));
     rt.add(Box::new(array::ArrayNeighbours));
+    rt.add(Box::new(io::IoReturn));
+    rt.add(Box::new(io::IoBind));
+    rt.add(Box::new(io::IoAction));
     rt.prepare(source_map);
     Box::new(rt)
 }


### PR DESCRIPTION
## Summary

- Adds three new intrinsic entries to `src/eval/intrinsics.rs`: `IO_RETURN` (153), `IO_BIND` (154), `IO_ACTION` (155)
- New module `src/eval/stg/io.rs` implements `StgIntrinsic` for each — wrappers build IO data constructors directly in STG without a BIF call
- Registers all three in `make_standard_runtime()` in `src/eval/stg/mod.rs`

### Intrinsic signatures

| Index | Name | Arity | Constructs |
|-------|------|-------|-----------|
| 153 | `IO_RETURN` | 2 | `IoReturn(world, value)` |
| 154 | `IO_BIND` | 3 | `IoBind(world, action, continuation)` |
| 155 | `IO_ACTION` | 2 | `IoAction(world, spec_block)` |

All intrinsics are STG-only (lazy, no strict args, no `execute()` implementation). The wrapper is a saturated `Cons` application.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 590 tests pass

This is task F2 from `docs/plans/2026-03-09-io-monad-design.md`. Depends on #396 (F1, merged). Unblocks Q1 (prelude io namespace) and F4 (VM WHNF yield).

🤖 Generated with [Claude Code](https://claude.com/claude-code)