### PR TITLE
feat(prelude): IO monad namespace in prelude (Q1)

### DIFF
--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -8,14 +8,57 @@
 | `eu.build` | Metadata about this version of the eucalypt executable |
 | `eu.requires` | Assert that the eucalypt version satisfies the given semver constraint (e.g. '>=0.2.0') |
 
-## IO Functions
+## Runtime IO Values
+
+| Name | Description |
+|------|-------------|
+| `io.env` | Read access to environment variables at time of launch |
+| `io.epoch-time` | Unix epoch time at time of launch |
+| `io.args` | Command-line arguments passed after `--` separator |
+| `io.RANDOM_SEED` | Seed for random number generation (from `--seed` or system time) |
+| `io.random` | Infinite lazy stream of random floats in [0,1) |
+
+## IO Monad
+
+The `io` namespace is a monad. Blocks tagged with `:io` are desugared
+into monadic bind chains automatically:
+
+```eu,notest
+result: { :io
+  r: io.shell("ls -la")
+  _: io.check(r)
+}.r.stdout
+```
+
+...desugars to `io.bind(io.shell("ls -la"), λr. io.bind(io.check(r), λ_. io.return(r.stdout)))`.
+
+IO operations require the `--allow-io` / `-I` flag at the command line.
+
+### Monad primitives
 
 | Function | Description |
 |----------|-------------|
-| `io.env` | Read access to environent variables at time of launch |
-| `io.args` | Line arguments passed after -- separator |
-| `io.RANDOM_SEED` | Seed for random number generation (from --seed or system time) |
-| `io.random` | Infinite lazy stream of random floats in [0,1), seeded from system entropy or --seed flag |
+| `io.return(a)` | Wrap a pure value in the IO monad |
+| `io.bind(action, continuation)` | Sequence two IO actions |
+
+### Shell execution
+
+| Function | Description |
+|----------|-------------|
+| `io.shell(cmd)` | Run `cmd` via `sh -c`. Returns `{stdout: Str, stderr: Str, exit-code: Num}` |
+| `io.shell-with(cmd, opts)` | Run `cmd` via `sh -c` with extra options merged in (e.g. `{stdin: s, timeout: 60}`) |
+| `io.exec(cmd, args)` | Run `cmd` directly (no shell). `args` is a list of strings |
+| `io.exec-with(cmd, args, opts)` | Run `cmd` directly with extra options merged in |
+
+Default timeout is 30 seconds. Override with `{timeout: N}` in `opts`.
+Optional `{stdin: s}` pipes string `s` to the command's standard input.
+
+### Combinators
+
+| Function | Description |
+|----------|-------------|
+| `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
+| `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
 
 ## Other
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -36,22 +36,22 @@ io: {
   ## IO monad
   ##
 
-  ` "Sequence two IO actions: run `action` and pass its result to `continuation`."
+  ` "Sequence two IO actions: run action and pass its result to continuation."
   bind(action, continuation): __IO_BIND(action, continuation)
 
   ` "Wrap a pure value in the IO monad."
   return(a): __IO_RETURN(a)
 
-  ` "Run a shell command via `sh -c`. Returns `{stdout: Str, stderr: Str, exit-code: Num}`."
+  ` "Run a shell command via sh -c. Returns a block with stdout, stderr, and exit-code fields."
   shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
 
-  ` "Run a shell command with extra options merged in (e.g. `{stdin: s, timeout: 60}`)."
+  ` "Run a shell command via sh -c with extra options merged in (e.g. {stdin: s, timeout: 60})."
   shell-with(cmd, opts): __IO_ACTION({:io-shell cmd: cmd} << opts)
 
-  ` "Run a command directly (no shell). Returns `{stdout: Str, stderr: Str, exit-code: Num}`."
+  ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
   exec(cmd, args): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
 
-  ` "Run a command directly with extra options merged in (e.g. `{stdin: s, timeout: 60}`)."
+  ` "Run a command directly without a shell, with extra options merged in (e.g. {stdin: s, timeout: 60})."
   exec-with(cmd, args, opts): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -31,7 +31,39 @@ io: {
 
   ` "Infinite lazy stream of random floats in [0,1), seeded from system entropy or --seed flag."
   random: random-stream(io.RANDOM_SEED)
+
+  ##
+  ## IO monad
+  ##
+
+  ` "Sequence two IO actions: run `action` and pass its result to `continuation`."
+  bind(action, continuation): __IO_BIND(action, continuation)
+
+  ` "Wrap a pure value in the IO monad."
+  return(a): __IO_RETURN(a)
+
+  ` "Run a shell command via `sh -c`. Returns `{stdout: Str, stderr: Str, exit-code: Num}`."
+  shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
+
+  ` "Run a shell command with extra options merged in (e.g. `{stdin: s, timeout: 60}`)."
+  shell-with(cmd, opts): __IO_ACTION({:io-shell cmd: cmd} << opts)
+
+  ` "Run a command directly (no shell). Returns `{stdout: Str, stderr: Str, exit-code: Num}`."
+  exec(cmd, args): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
+
+  ` "Run a command directly with extra options merged in (e.g. `{stdin: s, timeout: 60}`)."
+  exec-with(cmd, args, opts): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
+
+  ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
+  check(result): if(result.'exit-code' = 0,
+    io.return(result),
+    __IO_ACTION({:io-fail message: result.stderr}))
+
+  ` "Apply a pure function to the result of an IO action (fmap)."
+  map(f, action): io.bind(action, __io-return-of(f))
 }
+
+__io-return-of(f, x): io.return(f(x))
 
 
 ##

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -45,13 +45,13 @@ io: {
   ` "Run a shell command via sh -c. Returns a block with stdout, stderr, and exit-code fields."
   shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
 
-  ` "Run a shell command via sh -c with extra options merged in (e.g. {stdin: s, timeout: 60})."
+  ` "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
   shell-with(cmd, opts): __IO_ACTION({:io-shell cmd: cmd} << opts)
 
   ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
   exec(cmd, args): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
 
-  ` "Run a command directly without a shell, with extra options merged in (e.g. {stdin: s, timeout: 60})."
+  ` "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
   exec-with(cmd, args, opts): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."

--- a/src/driver/lsp/diagnostics.rs
+++ b/src/driver/lsp/diagnostics.rs
@@ -198,11 +198,35 @@ impl<'a> LineIndex<'a> {
 }
 
 /// Count UTF-16 code units in the source text between two byte offsets.
+///
+/// Both `byte_start` and `byte_end` are clamped to char boundaries to
+/// guard against rowan `TextSize` values that land inside a multi-byte
+/// character (which can occur with non-ASCII operator symbols such as
+/// `∘`, `•`, and `÷` in the prelude).
 fn byte_col_to_utf16(source: &str, byte_start: u32, byte_end: u32) -> u32 {
-    let start = byte_start as usize;
-    let end = byte_end as usize;
-    let slice = &source[start..end.min(source.len())];
+    let source_len = source.len();
+    let start = (byte_start as usize).min(source_len);
+    let end = (byte_end as usize).min(source_len);
+    // Walk back to the nearest char boundary if needed
+    let start = floor_char_boundary(source, start);
+    let end = floor_char_boundary(source, end);
+    if start >= end {
+        return 0;
+    }
+    let slice = &source[start..end];
     slice.chars().map(|ch| ch.len_utf16() as u32).sum()
+}
+
+/// Return the largest index `<= pos` that is a char boundary in `s`.
+fn floor_char_boundary(s: &str, pos: usize) -> usize {
+    if pos >= s.len() {
+        return s.len();
+    }
+    let mut p = pos;
+    while p > 0 && !s.is_char_boundary(p) {
+        p -= 1;
+    }
+    p
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Extends `io` block in `lib/prelude.eu` with IO monad primitives: `bind`, `return`, `shell`, `shell-with`, `exec`, `exec-with`, `check`, `map`
- Adds top-level helper `__io-return-of` used by `io.map`
- `{ :io x: io.shell("ls") }.x` blocks desugar automatically via `MonadSpec::Namespace("io")` using the existing machinery
- Updates `docs/reference/prelude/io.md` with the full IO monad API reference
- Fixes a latent bug in `src/driver/lsp/diagnostics.rs` — `byte_col_to_utf16` now safely handles byte offsets that land inside multi-byte characters (exposed by shifting prelude byte offsets)

This is task Q1 from `docs/plans/2026-03-09-io-monad-design.md`. Depends on #397 (IO intrinsics, merged).

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --lib` — 590 tests pass (was 579 before LSP diagnostics fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)