### PR TITLE
feat(prelude): render and render-as functions (Q2)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -718,6 +718,16 @@ str: {
 }
 
 ##
+## Serialisation
+##
+
+` "render(value) - serialise value to a YAML string."
+render(value): __RENDER_TO_STRING(value, :yaml)
+
+` "render-as(value, fmt) - serialise value to a string in the named format. Supported formats: :yaml, :json, :toml, :text, :edn, :html."
+render-as(value, fmt): __RENDER_TO_STRING(value, fmt)
+
+##
 ## Combinators
 ##
 


### PR DESCRIPTION
## Summary

- Add `render(value)` and `render-as(value, fmt)` to the prelude as pure top-level functions
- `render` serialises a value to YAML string (calls `__RENDER_TO_STRING(value, :yaml)`)
- `render-as` accepts a format symbol: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`
- Both wrap the `RENDER_TO_STRING` intrinsic registered in `make_standard_runtime()`
- Documentation already present in `docs/reference/prelude/strings.md` (Serialisation section added by F6)

Part of eu-jnk8 / IO monad design.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (596 tests)