### PR TITLE
fix(gc): IoBind GC safety — correct mark_region and extend block coverage

### DIFF
--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -697,6 +697,13 @@ impl HeapState {
             }
         }
 
+        if let Some(overflow) = &mut self.overflow {
+            if overflow.base_address() == base {
+                overflow.mark_line(ptr);
+                return;
+            }
+        }
+
         for block in &mut self.rest {
             if block.base_address() == base {
                 block.mark_line(ptr);
@@ -705,6 +712,13 @@ impl HeapState {
         }
 
         for block in &mut self.unswept {
+            if block.base_address() == base {
+                block.mark_line(ptr);
+                return;
+            }
+        }
+
+        for block in &mut self.recycled {
             if block.base_address() == base {
                 block.mark_line(ptr);
                 return;
@@ -724,6 +738,13 @@ impl HeapState {
             }
         }
 
+        if let Some(overflow) = &mut self.overflow {
+            if overflow.base_address() == base {
+                overflow.mark_region(ptr, bytes);
+                return;
+            }
+        }
+
         for block in &mut self.rest {
             if block.base_address() == base {
                 block.mark_region(ptr, bytes);
@@ -732,6 +753,13 @@ impl HeapState {
         }
 
         for block in &mut self.unswept {
+            if block.base_address() == base {
+                block.mark_region(ptr, bytes);
+                return;
+            }
+        }
+
+        for block in &mut self.recycled {
             if block.base_address() == base {
                 block.mark_region(ptr, bytes);
                 return;
@@ -2342,6 +2370,10 @@ impl Heap {
             head.reset_region_marks();
         }
 
+        if let Some(overflow) = &mut heap_state.overflow {
+            overflow.reset_region_marks();
+        }
+
         for block in &mut heap_state.rest {
             block.reset_region_marks();
         }
@@ -2349,6 +2381,14 @@ impl Heap {
         // Also reset unswept blocks (may still contain live objects
         // from a previous collection that haven't been lazily swept yet)
         for block in &mut heap_state.unswept {
+            block.reset_region_marks();
+        }
+
+        // Also reset recycled blocks — they may contain live objects in
+        // lines that were marked by a previous GC cycle.  Without resetting
+        // and re-marking them the stale marks become invisible to the new GC
+        // cycle and the live data can be overwritten once the block is reused.
+        for block in &mut heap_state.recycled {
             block.reset_region_marks();
         }
     }


### PR DESCRIPTION
## Summary

- Fixes `BumpBlock::mark_region` line-count calculation: the previous formula `bytes / LINE_SIZE_BYTES + 1` failed to mark the last line when an array's backing store did not start at a line boundary, allowing that line to be incorrectly treated as a free hole and filled with 0xFF (debug poison). The fix derives `last_line` from the last byte offset: `(offset + bytes - 1) / LINE_SIZE_BYTES + 1`.
- Extends `mark_line_in_block` and `mark_region_in_block` to search `overflow` and `recycled` block lists (previously only `head`, `rest`, `unswept` were searched), so medium-sized backing stores in overflow and live objects in recycled blocks are properly marked each GC cycle.
- Extends `reset_region_marks` to reset `overflow` and `recycled` blocks so stale line marks do not persist across GC cycles.

The root bug caused `test_harness_105` (`io.bind` chaining test) to crash with `assertion failed: obj.as_ptr() as usize != usize::MAX` at `collect.rs:126` during the third GC cycle. The 105-binding prelude letrec frame's backing store allocated at a non-line-aligned offset, leaving binding[104] in an unmarked line that was subsequently recycled and poisoned.

## Test plan

- [ ] `cargo test test_harness_105` passes 5+ consecutive times
- [ ] `cargo test test_harness_103`, `test_harness_104`, `test_error_094` pass
- [ ] `cargo test` — all 196 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)