### PR TITLE
fix(gc): keep IoBind closures stashed during BuildApply2

### DIFF
--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -1058,9 +1058,12 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                 // cont(action_result) gives a PAP; applying world produces
                 // the next IO constructor.
                 // Stash order (top to bottom): action_result, world, cont
-                let action_result = machine.stash_pop();
-                let world = machine.stash_pop();
-                let cont = machine.stash_pop();
+                // Peek (not pop) so the values remain GC-rooted during the
+                // BuildApply2 allocation; a GC triggered inside mutate would
+                // otherwise sweep these closures from the Rust stack.
+                let action_result = machine.stash_peek(0);
+                let world = machine.stash_peek(1);
+                let cont = machine.stash_peek(2);
 
                 let cont_call = machine
                     .mutate(
@@ -1073,6 +1076,11 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                         (),
                     )
                     .map_err(IoRunError::from)?;
+
+                // Now safe to pop — allocation is complete.
+                machine.stash_pop(); // action_result
+                machine.stash_pop(); // world
+                machine.stash_pop(); // cont
 
                 // Stash cont_call as a GC root across machine.run() for the
                 // same reason as action_with_world above: belt-and-suspenders


### PR DESCRIPTION
## Summary

- Fix intermittent release-mode crash in the IoBind handler
- `action_result`, `world`, and `cont` were popped from the GC stash before the `BuildApply2` mutator call
- If GC fired during the mutator's heap allocation, these closures on the Rust stack were invisible to the collector and could be swept, producing undefined behaviour (`ptr::offset` overflow crash on CI)
- Fix: use `stash_peek` instead of `stash_pop` so values remain GC-rooted throughout the allocation; pop all three after `mutate()` returns

Resolves eu-9vi8.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (596 tests)
- [x] `cargo test --release test_harness_105` passes 10/10 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)