### PR TITLE
fix(gc): prevent heap string corruption in release builds

### DIFF
--- a/src/eval/memory/array.rs
+++ b/src/eval/memory/array.rs
@@ -140,6 +140,21 @@ impl<T: Sized> RawArray<T> {
             None => None,
         }
     }
+
+    /// Return the backing pointer as a `NonNull<u8>` for GC marking.
+    pub fn allocated_data(&self) -> Option<RefPtr<u8>> {
+        self.ptr.map(|p| p.cast())
+    }
+
+    /// Update the backing pointer after evacuation.
+    ///
+    /// # Safety
+    ///
+    /// `new_ptr` must point to a valid heap allocation of at least
+    /// `self.capacity` elements of type `T`.
+    pub unsafe fn set_backing_ptr(&mut self, new_ptr: RefPtr<T>) {
+        self.ptr = Some(new_ptr);
+    }
 }
 
 /// Array

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -166,6 +166,23 @@ impl CollectorHeapView<'_> {
         }
     }
 
+    /// Mark a raw byte allocation (e.g. a `RawArray<u8>` backing buffer)
+    /// if not already marked, covering all lines spanned by the bytes.
+    ///
+    /// Returns `true` if the object was newly marked (i.e. it should be
+    /// pushed onto the scan queue as an `OpaqueHeapBytes` object).
+    pub fn mark_raw_bytes(&mut self, ptr: NonNull<u8>) -> bool {
+        debug_assert!(ptr != NonNull::dangling());
+        debug_assert!(ptr.as_ptr() as usize != usize::MAX);
+        if !self.heap.is_marked(ptr) {
+            self.heap.mark_object(ptr);
+            self.heap.mark_lines_for_bytes(ptr);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Mark object if not already marked and return whether marked
     pub fn mark_array<T: Clone>(&mut self, arr: &Array<T>) -> bool {
         if let Some(ptr) = arr.allocated_data() {

--- a/src/eval/memory/string.rs
+++ b/src/eval/memory/string.rs
@@ -5,6 +5,7 @@ use std::slice::from_raw_parts;
 use super::{
     alloc::{ScopedAllocator, StgObject},
     array::RawArray,
+    collect::{CollectorHeapView, CollectorScope, GcScannable, OpaqueHeapBytes, ScanPtr},
 };
 
 /// UTF-8 string data stored in the heap
@@ -14,6 +15,42 @@ pub struct HeapString {
 }
 
 impl StgObject for HeapString {}
+
+/// `HeapString` holds a separate heap allocation for the backing byte
+/// array (`RawArray<u8>`).  Without scanning, that allocation is
+/// invisible to the GC: the `HeapString` struct is marked but its
+/// backing bytes are never traced, so the sweep can reclaim them while
+/// the `HeapString` still holds a dangling pointer.
+///
+/// This `GcScannable` implementation fixes the bug by:
+/// - `scan`: marking the backing byte allocation and pushing it as a
+///   heap object so the evacuating collector can move it.
+/// - `scan_and_update`: rewriting the backing pointer when the byte
+///   array has been evacuated to a new location.
+impl GcScannable for HeapString {
+    fn scan<'a>(
+        &'a self,
+        scope: &'a dyn CollectorScope,
+        marker: &mut CollectorHeapView<'a>,
+        out: &mut Vec<ScanPtr<'a>>,
+    ) {
+        if let Some(ptr) = self.data.allocated_data() {
+            if marker.mark_raw_bytes(ptr) {
+                out.push(ScanPtr::from_non_null(scope, ptr.cast::<OpaqueHeapBytes>()));
+            }
+        }
+    }
+
+    fn scan_and_update(&mut self, heap: &CollectorHeapView<'_>) {
+        if let Some(old_ptr) = self.data.allocated_data() {
+            if let Some(new_ptr) = heap.forwarded_to(old_ptr) {
+                // SAFETY: new_ptr is a valid evacuated copy of the same
+                // backing byte allocation.
+                unsafe { self.data.set_backing_ptr(new_ptr.cast()) };
+            }
+        }
+    }
+}
 
 impl HeapString {
     pub fn from_str<'guard, A: ScopedAllocator<'guard>>(mem: &A, source: &str) -> Self {

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -291,15 +291,28 @@ impl GcScannable for LambdaForm {
     }
 }
 
-/// Mark any heap pointers embedded in a Ref value.
+/// Mark any heap pointers embedded in a Ref value and push them for scanning.
 ///
 /// `Native::Str`, `Native::Set`, and `Native::NdArray` contain heap
 /// pointers that must be traced to ensure their lines are marked.
 /// Without this, evacuation cannot discover and update these pointers.
-fn mark_ref_heap_pointers(r: &Ref, marker: &mut CollectorHeapView<'_>) {
+///
+/// `Native::Str` is pushed onto the scan queue so that `HeapString::scan`
+/// is called and the backing byte allocation is also marked and evacuated.
+/// This prevents the backing bytes from being swept while the `HeapString`
+/// struct still holds a pointer to them.
+fn mark_ref_heap_pointers<'a>(
+    r: &'a Ref,
+    scope: &'a dyn CollectorScope,
+    marker: &mut CollectorHeapView<'a>,
+    out: &mut Vec<ScanPtr<'a>>,
+) {
     match r {
         Ref::V(Native::Str(ptr)) => {
-            marker.mark(*ptr);
+            if marker.mark(*ptr) {
+                // Push for scanning so HeapString::scan marks the backing bytes
+                out.push(ScanPtr::from_non_null(scope, *ptr));
+            }
         }
         Ref::V(Native::Set(ptr)) => {
             marker.mark(*ptr);
@@ -312,9 +325,14 @@ fn mark_ref_heap_pointers(r: &Ref, marker: &mut CollectorHeapView<'_>) {
 }
 
 /// Mark heap pointers in all elements of a Ref array.
-fn mark_ref_array_heap_pointers(args: &Array<Ref>, marker: &mut CollectorHeapView<'_>) {
+fn mark_ref_array_heap_pointers<'a>(
+    args: &'a Array<Ref>,
+    scope: &'a dyn CollectorScope,
+    marker: &mut CollectorHeapView<'a>,
+    out: &mut Vec<ScanPtr<'a>>,
+) {
     for r in args.iter() {
-        mark_ref_heap_pointers(r, marker);
+        mark_ref_heap_pointers(r, scope, marker, out);
     }
 }
 
@@ -356,7 +374,7 @@ impl GcScannable for HeapSyn {
     ) {
         match self {
             HeapSyn::Atom { evaluand } => {
-                mark_ref_heap_pointers(evaluand, marker);
+                mark_ref_heap_pointers(evaluand, scope, marker, out);
             }
             HeapSyn::Case {
                 scrutinee,
@@ -382,16 +400,16 @@ impl GcScannable for HeapSyn {
             }
             HeapSyn::Cons { tag: _, args } => {
                 marker.mark_array(args);
-                mark_ref_array_heap_pointers(args, marker);
+                mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::App { callable, args } => {
-                mark_ref_heap_pointers(callable, marker);
+                mark_ref_heap_pointers(callable, scope, marker, out);
                 marker.mark_array(args);
-                mark_ref_array_heap_pointers(args, marker);
+                mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::Bif { intrinsic: _, args } => {
                 marker.mark_array(args);
-                mark_ref_array_heap_pointers(args, marker);
+                mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::Let { bindings, body } => {
                 if marker.mark_array(bindings) {
@@ -439,8 +457,8 @@ impl GcScannable for HeapSyn {
                 }
             }
             HeapSyn::Meta { meta, body } => {
-                mark_ref_heap_pointers(meta, marker);
-                mark_ref_heap_pointers(body, marker);
+                mark_ref_heap_pointers(meta, scope, marker, out);
+                mark_ref_heap_pointers(body, scope, marker, out);
             }
             HeapSyn::DeMeta {
                 scrutinee,


### PR DESCRIPTION
## Summary

- `HeapString` stores its backing bytes as a separate `RawArray<u8>` heap object
- Before this fix, the GC marked the `HeapString` struct but never called `HeapString::scan()`, so the backing byte allocation was invisible to the collector and could be swept
- In debug mode the reclaimed bytes were often still intact; in release mode they were reliably overwritten, causing the `Utf8Error` panic in `test_harness_105`

**Root cause**: `mark_ref_heap_pointers()` called `marker.mark()` on the `HeapString` pointer but never pushed it onto the scan queue — so `HeapString::scan()` was never invoked and the backing bytes were never marked.

**Fix**:
1. Implement `GcScannable` for `HeapString`: `scan()` marks the backing byte allocation; `scan_and_update()` rewrites the backing pointer after evacuation
2. Add `mark_raw_bytes()` to `CollectorHeapView` for marking raw `NonNull<u8>` byte allocations
3. Add `allocated_data()` and `set_backing_ptr()` to `RawArray<T>` (mirrors `Array<T>` API)
4. Update `mark_ref_heap_pointers()` to push `Native::Str` pointers onto the scan queue

Fixes eu-9f7r (P0).

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (no warnings)
- [x] `cargo test --lib` passes (596 tests)
- [x] `cargo test --release test_harness_105` passes 20/20 runs