### PR TITLE
fix(tester): skip IO tests when --allow-io is not set

### DIFF
--- a/src/core/analyse/testplan.rs
+++ b/src/core/analyse/testplan.rs
@@ -154,6 +154,8 @@ pub struct TestPlan {
     targets: Vec<(Target, Vec<String>)>,
     /// Error test expectations from `.expect` sidecar (if any)
     error_expectation: Option<ErrorExpectation>,
+    /// Whether this test requires `--allow-io` to run
+    requires_io: bool,
 }
 
 impl TestPlan {
@@ -180,6 +182,14 @@ impl TestPlan {
     /// Whether this is an error test with sidecar expectations
     pub fn is_error_test(&self) -> bool {
         self.error_expectation.is_some()
+    }
+
+    /// Whether this test requires `--allow-io` to run.
+    ///
+    /// When true, `eu test` skips the test rather than failing if
+    /// `--allow-io` is not set.
+    pub fn requires_io(&self) -> bool {
+        self.requires_io
     }
 
     /// Whether this plan contains any benchmark targets
@@ -270,6 +280,7 @@ impl TestPlan {
                 .unwrap_or_else(|| "untitled".to_string()),
             targets,
             error_expectation: None,
+            requires_io: header.requires_io,
         })
     }
 
@@ -309,6 +320,7 @@ impl TestPlan {
             title,
             targets: vec![(target, vec!["yaml".to_string()])],
             error_expectation: Some(expectation),
+            requires_io: false,
         }
     }
 
@@ -325,6 +337,7 @@ impl TestPlan {
             title,
             targets: vec![(Target::default(), vec!["yaml".to_string()])],
             error_expectation: None,
+            requires_io: false,
         }
     }
 }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -216,6 +216,11 @@ pub struct TestHeaderMetadata {
     pub formats: Vec<String>,
     /// Shell process to run prior to test expection
     pub shell: Option<String>,
+    /// Whether this test requires `--allow-io` to run.
+    ///
+    /// When `true` and `--allow-io` is not set, `eu test` skips the
+    /// test rather than failing.
+    pub requires_io: bool,
 }
 
 impl ReadMetadata<TestHeaderMetadata> for RcExpr {
@@ -232,6 +237,10 @@ impl ReadMetadata<TestHeaderMetadata> for RcExpr {
                     .and_then(|e| e.extract())
                     .unwrap_or_default(),
                 shell: imap.get("test-shell").and_then(|e| e.extract()),
+                requires_io: imap
+                    .get("requires-io")
+                    .and_then(|e| e.extract())
+                    .unwrap_or(false),
             }),
             Expr::Let(_, _, _) => {
                 self.inner = self.clone().instantiate_lets().inner;

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -125,6 +125,14 @@ pub fn run_plans(opt: &EucalyptOptions, tests: &[TestPlan]) -> Result<i32, Eucal
             .with_explicit_inputs(vec![input])
             .with_lib_path(lib_path.clone());
 
+        // Skip tests that require --allow-io when it has not been granted.
+        // Failing here would incorrectly penalise CI environments that do
+        // not enable shell execution by default.
+        if test.requires_io() && !opt.allow_io() {
+            println!("{}...SKIP (requires --allow-io)", test.title());
+            continue;
+        }
+
         test.prepare_directory()?;
 
         print!("{}...", test.title());

--- a/tests/harness/104_io_basic.eu
+++ b/tests/harness/104_io_basic.eu
@@ -1,4 +1,4 @@
 "Basic IO monad test: io.return wraps a pure value. Uses --allow-io."
 
-` { target: :test }
+` { target: :test requires-io: true }
 test: io.return({ RESULT: :PASS })

--- a/tests/harness/105_io_chain.eu
+++ b/tests/harness/105_io_chain.eu
@@ -1,6 +1,6 @@
 "IO monad chain test: io.bind sequences two IO actions. Uses --allow-io."
 
-` { target: :test }
+` { target: :test requires-io: true }
 test: io.bind(io.shell("echo hello"), check-result)
 
 check-result(r):


### PR DESCRIPTION
## Summary

- IO monad tests (104, 105) require `--allow-io` but `eu test` was failing rather than skipping them when the flag wasn't set
- Add `requires-io: true` to the metadata blocks of `104_io_basic.eu` and `105_io_chain.eu`
- Add `requires_io` field to `TestHeaderMetadata` (parsed from `requires-io` block key) and propagate to `TestPlan`
- In `run_plans()`, skip plans with `requires_io = true` when `allow_io` is false, printing `SKIP (requires --allow-io)` rather than failing

This is a graceful skip, not a FAIL, so CI environments that do not grant shell execution are not penalised. The `eu test --allow-io` invocation continues to run these tests normally.

Fixes CI failure from the `eu test tests/harness` step.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (596 tests)
- [x] `cargo test --release test_harness_105` passes