### PR TITLE
fix: bare-expression desugaring for monadic unit files

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -310,6 +310,47 @@ first: xs head    # = 1
 rest: xs tail     # = [2, 3]
 ```
 
+## IO Monad Block Syntax
+
+When using monadic block syntax `{ :io r: cmd }.(return_expr)`, the return
+expression must be parenthesised or a single name:
+
+```eu
+# Parenthesised return expression (recommended for complex expressions)
+{ :io r: io.shell("echo hello") }.(
+  if(r.stdout str.matches?("hello.*"), :PASS, :FAIL))
+
+# Single-name return — accesses the bound variable directly
+{ :io r: io.shell("echo hello") }.r
+```
+
+**Desugaring**: `{ :io r: cmd }.(expr)` desugars to:
+
+```eu
+io.bind(cmd, lambda(r). io.return(expr))
+```
+
+**Gotcha**: Dot-chained field access like `{ :io r: cmd }.r.stdout` is NOT
+currently supported as sugar — the `.stdout` after `.r` is not consumed into
+the return expression. Instead, use an extra binding or the parenthesised form:
+
+```eu
+# Recommended: extra binding
+{ :io r: io.shell("echo hello"), out: io.return(r.stdout) }.out
+
+# Also works: parenthesised field access
+{ :io r: io.shell("echo hello") }.(r.stdout)
+```
+
+**Bare-expression files**: A `.eu` file containing only a monadic block
+expression (no outer `key:` declaration) is supported when the expression
+starts with a block literal `{...}`:
+
+```eu
+# This works as a standalone .eu file:
+{ :io r: io.shell("echo hello") }.(r.stdout)
+```
+
 ## Future Improvements
 
 These gotchas highlight areas where the language could benefit from:

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -2163,6 +2163,27 @@ impl Desugarable for rowan_ast::Block {
     }
 }
 
+/// Return true if the raw metadata soup of a `Unit` begins with a block-like
+/// element (`Block`, `BracketBlock`, or `ParenExpr`).
+///
+/// Used to distinguish genuine bare-expression evaluands such as
+/// `{ :io r: cmd }.(r.stdout)` (first element: Block) from erroneous
+/// assignment-style declarations like `result = 42` (first element: Name).
+fn unit_meta_starts_with_block(unit: &rowan_ast::Unit) -> bool {
+    unit.meta()
+        .and_then(|m| m.soup())
+        .and_then(|s| s.elements().next())
+        .map(|e| {
+            matches!(
+                e,
+                rowan_ast::Element::Block(_)
+                    | rowan_ast::Element::BracketBlock(_)
+                    | rowan_ast::Element::ParenExpr(_)
+            )
+        })
+        .unwrap_or(false)
+}
+
 /// Unit desugaring - proper implementation following legacy architecture
 impl Desugarable for rowan_ast::Unit {
     fn desugar(&self, desugarer: &mut Desugarer) -> Result<RcExpr, CoreError> {
@@ -2250,6 +2271,9 @@ impl Desugarable for rowan_ast::Unit {
             })
             .collect();
 
+        // Remember whether there are any declarations before body_elements is moved.
+        let has_no_declarations = body_elements.is_empty();
+
         // Create body - check for parse-embed override
         let body = if let Some(embed_key) = unit_meta.parse_embed {
             let fv_opt = desugarer.env().get(&embed_key).cloned();
@@ -2271,11 +2295,34 @@ impl Desugarable for rowan_ast::Unit {
             LetType::DefaultBlockLet,
         ));
 
-        // Attach metadata if present
+        // Attach metadata if present.
+        //
+        // Special case: when a file contains only a bare block-dot expression
+        // (no declarations) and the raw metadata soup starts with a block-like
+        // element, use that expression directly as the unit body.  This allows
+        // single-expression files such as
+        //
+        //   { :io result: io.shell("echo hello") }.(result.stdout)
+        //
+        // to behave like an `-e` evaluand.  The raw-element check restricts
+        // this path to soups that start with `{`, `[`, or `(`, excluding
+        // assignment-style mistakes like `result = 42` whose first element is
+        // a name.
         if let Some(m) = metadata {
             let stripped_meta = strip_desugar_phase_metadata(&m);
             if !matches!(&*stripped_meta.inner, Expr::ErrEliminated) {
-                expr = RcExpr::from(Expr::Meta(desugarer.new_smid(span), expr, stripped_meta));
+                let is_bare_expression = has_no_declarations
+                    && !matches!(&*stripped_meta.inner, Expr::Block(_, _))
+                    && unit_meta_starts_with_block(self);
+                if is_bare_expression {
+                    expr = RcExpr::from(Expr::Let(
+                        desugarer.new_smid(span),
+                        Scope::new(Rec::new(vec![]), stripped_meta),
+                        LetType::DefaultBlockLet,
+                    ));
+                } else {
+                    expr = RcExpr::from(Expr::Meta(desugarer.new_smid(span), expr, stripped_meta));
+                }
             }
         }
 

--- a/tests/harness/106_io_block_chain.eu
+++ b/tests/harness/106_io_block_chain.eu
@@ -1,0 +1,10 @@
+"IO monad: monadic block syntax with parenthesised return expression. Uses --allow-io."
+
+# Test that { :io r: cmd }.(return_expr) correctly desugars to
+# io.bind(cmd, lambda(r). io.return(return_expr))
+` { target: :test }
+test:
+  { :io r: io.shell("echo hello") }.(
+    if(r.stdout str.matches?("hello.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness/106_io_block_chain.eu
+++ b/tests/harness/106_io_block_chain.eu
@@ -2,7 +2,7 @@
 
 # Test that { :io r: cmd }.(return_expr) correctly desugars to
 # io.bind(cmd, lambda(r). io.return(return_expr))
-` { target: :test }
+` { target: :test requires-io: true }
 test:
   { :io r: io.shell("echo hello") }.(
     if(r.stdout str.matches?("hello.*"),

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -527,6 +527,11 @@ pub fn test_harness_105() {
 }
 
 #[test]
+pub fn test_harness_106() {
+    run_test(&io_opts("106_io_block_chain.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

Supersedes #409 and #410 (both closed). Minimal, focused fix with no dot-chain desugaring.

- **Bug fixed**: A `.eu` file containing only a monadic block expression (no outer `key:` declaration) now evaluates correctly as the programme body. Previously such files were parsed as metadata with no body, producing "unresolved variable 'io'".
- **Scope reduced vs previous PRs**: Dropped `desugar_return_chain` and test 107 (dot-chained field access). The dot-chain form `{ :io r: cmd }.r.stdout` is tracked separately as a design question. Users should use the parenthesised form `{ :io r: cmd }.(r.stdout)` or an extra binding.
- **test 106**: Added `requires-io: true` metadata so the test is skipped gracefully in environments without IO permissions.

## Changes

- `src/core/desugar/rowan_ast.rs`: Added `unit_meta_starts_with_block` helper; bare-expression path in `Unit::desugar` now only fires when the raw metadata soup starts with `Block`/`BracketBlock`/`ParenExpr`, preventing regression on `result = 42`.
- `tests/harness/106_io_block_chain.eu`: New test — monadic block with parenthesised return expression. Has `requires-io: true` so it skips in restricted CI environments.
- `tests/harness_test.rs`: Registered test 106.
- `docs/appendices/syntax-gotchas.md`: Added "IO Monad Block Syntax" section documenting the supported forms and the dot-chain limitation.

## Test plan

- [x] `cargo test --test harness_test test_error_043 --release` passes (regression check)
- [x] `cargo test --test harness_test test_harness_106 --release` passes
- [x] All 195 harness tests pass (`cargo test --test harness_test --release`)
- [x] All 596 lib tests pass (`cargo test --lib --release`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)