### PR TITLE
fix: pass --allow-io to eu test in CI and accept flag in TestArgs

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: run final test with release binary
         run: |
           target/release/eu_amd64 version
-          target/release/eu_amd64 test tests/harness
+          target/release/eu_amd64 test --allow-io tests/harness
       - name: Generate release notes
         run: |
           # Fetch tags created by GitHub releases
@@ -199,7 +199,7 @@ jobs:
       - name: Run final test with release binary
         run: |
           target/release/eu_darwin version
-          target/release/eu_darwin test tests/harness
+          target/release/eu_darwin test --allow-io tests/harness
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
@@ -246,7 +246,7 @@ jobs:
       - name: Run final test with release binary
         run: |
           target/release/eu_aarch64 version
-          target/release/eu_aarch64 test tests/harness
+          target/release/eu_aarch64 test --allow-io tests/harness
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -208,6 +208,10 @@ pub struct TestArgs {
     #[arg(long = "open")]
     pub open_browser: bool,
 
+    /// Allow IO monad operations (shell execution) in tests
+    #[arg(short = 'I', long = "allow-io")]
+    pub allow_io: bool,
+
     /// Files to test
     #[arg(value_name = "FILES")]
     pub files: Vec<String>,
@@ -578,9 +582,10 @@ impl From<EucalyptCli> for EucalyptOptions {
             _ => Vec::new(),
         };
 
-        // Extract allow-io flag from Run command
+        // Extract allow-io flag from Run or Test command
         let allow_io = match &cli.command {
             Some(Commands::Run(run_args)) => run_args.allow_io,
+            Some(Commands::Test(test_args)) => test_args.allow_io,
             _ => false,
         };
 


### PR DESCRIPTION
## Summary

- Adds `--allow-io` / `-I` flag to `TestArgs` (the `eu test` subcommand) so the flag is accepted at the CLI level
- Updates `From<EucalyptCli>` to propagate `allow_io` from `Commands::Test` as well as `Commands::Run`
- Updates all three CI release jobs (`release-candidate-linux`, `release-candidate-macos`, `release-candidate-linux-arm`) to run `eu test --allow-io tests/harness` instead of `eu test tests/harness`, so IO tests (104, 105) execute rather than being skipped

## Context

PR #411 added skip behaviour for IO tests (those with `requires-io: true` metadata) when `--allow-io` is absent. This PR ensures CI actually runs those tests by:
1. Making `eu test` accept the `--allow-io` flag (previously only `eu run` had it)
2. Passing it in all three CI release test steps

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo test --lib` passes (596 tests)
- [ ] CI release builds run IO tests rather than skipping them

🤖 Generated with [Claude Code](https://claude.com/claude-code)