### PR TITLE
fix(gc): align evacuation allocations to 16 bytes

### DIFF
--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -284,12 +284,17 @@ impl CollectorHeapView<'_> {
         }
 
         let payload_size = header.length() as usize;
-        let alloc_size = size_of::<AllocHeader>() + payload_size;
+        // Round up to 16-byte alignment to match the normal allocation path
+        // (Heap::alloc_size_of). The bump block must receive aligned sizes so
+        // that consecutive evacuated objects remain 16-byte aligned.
+        const ALIGN: usize = 16;
+        let alloc_size = (size_of::<AllocHeader>() + payload_size + ALIGN - 1) & !(ALIGN - 1);
 
         // Allocate space in evacuation target
         let new_raw = self.heap.bump_allocate_in_target(alloc_size)?;
 
-        // SAFETY: Byte-level copy of the complete allocation (header + payload).
+        // SAFETY: Byte-level copy of the header + payload (excluding alignment
+        // padding, which need not be copied).
         //
         // Invariants:
         // 1. Source (`src`) is the start of the AllocHeader, which is
@@ -297,17 +302,21 @@ impl CollectorHeapView<'_> {
         //    are allocated with an AllocHeader prefix by `Heap::alloc()`.
         // 2. Destination (`new_raw`) is freshly bump-allocated in the
         //    evacuation target block, guaranteed non-overlapping with the
-        //    source (different block).
-        // 3. `alloc_size = size_of::<AllocHeader>() + header.length()` covers
-        //    the complete allocation. `header.length()` stores the object's
-        //    payload size, set by `alloc<T>()` to `size_of::<T>()`.
+        //    source (different block). `alloc_size` is >= `copy_size`.
+        // 3. `copy_size = size_of::<AllocHeader>() + header.length()` covers
+        //    the header and all payload bytes. `header.length()` stores the
+        //    object's payload size, set by `alloc<T>()` to `size_of::<T>()`.
+        //    The remaining `alloc_size - copy_size` bytes are alignment padding
+        //    and need not be initialised.
         //
         // If violated: partial copy would leave the evacuated object with
         // uninitialised fields, causing segfaults when `scan_and_update`
         // reads internal pointers.
         unsafe {
             let src = (obj.as_ptr() as *const u8).sub(size_of::<AllocHeader>());
-            std::ptr::copy_nonoverlapping(src, new_raw.as_ptr(), alloc_size);
+            // Copy only header + payload, not the alignment padding
+            let copy_size = size_of::<AllocHeader>() + payload_size;
+            std::ptr::copy_nonoverlapping(src, new_raw.as_ptr(), copy_size);
         }
 
         // Compute new object pointer (after the copied header)


### PR DESCRIPTION
## Summary

- `evacuate()` in `src/eval/memory/collect.rs` computed `alloc_size` as `size_of::<AllocHeader>() + payload_size` without alignment padding
- The bump allocator requires 16-byte aligned sizes (the normal `Heap::alloc` path uses `alloc_size_of()` which rounds up to 16 bytes)
- When `alloc_size` was not a multiple of 16, consecutive evacuated objects were placed at misaligned offsets, causing a `misaligned pointer dereference` panic in `mark_object()` during the evacuation mark phase

## Root Cause

`BumpBlock::bump()` has no alignment logic — it simply does `cursor - size`. For allocations to stay aligned, callers must pass aligned sizes. The normal `Heap::alloc` path calls `alloc_size_of()` which rounds up:

```rust
// Normal alloc path — aligned:
let alloc_size = Self::alloc_size_of(header_size + object_size);
// = (16 + header_size + object_size) rounded up to 16 bytes

// Evacuation path — NOT aligned (before this fix):
let alloc_size = size_of::<AllocHeader>() + payload_size;
// = 16 + payload_size, no rounding
```

## Fix

Round `alloc_size` up to 16 bytes before calling `bump_allocate_in_target()`. The `copy_nonoverlapping` call copies only `header + payload` bytes; the padding tail is uninitialised but never read.

## Verification

Confirmed the crash introduced by PR #412 (`test_harness_106` — `{ :io r: io.shell("echo hello") }.r`) is resolved by this fix. The test passes with the aligned size.

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo test --lib` passes (596 tests)
- [ ] `cargo test test_harness_106` passes when applied to `fix/quill-io-eflag-v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)