### PR TITLE
feat: add parse-as prelude function and harness tests

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -325,6 +325,19 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | `str.replace(from, to)` | Replace occurrences |
 | `str.trim` | Remove surrounding whitespace |
 
+### Serialisation and Parsing
+
+| Function | Description |
+|----------|-------------|
+| `render(value)` | Serialise to YAML string |
+| `render-as(value, fmt)` | Serialise to string in named format |
+| `parse-as(fmt, str)` | Parse string as structured data (inverse of `render-as`) |
+
+Formats for `render-as`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.
+Formats for `parse-as`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jsonl`.
+
+`parse-as` is safe for untrusted input — YAML `!eu` tags are never evaluated.
+
 ### Combinators
 
 | Function | Description |

--- a/docs/reference/prelude/strings.md
+++ b/docs/reference/prelude/strings.md
@@ -69,3 +69,41 @@ json-str: render-as({a: 1, b: 2}, :json) # "{\"a\":1,\"b\":2}"
 These functions are backed by the `RENDER_TO_STRING` intrinsic, which
 traverses the evaluated heap value and serialises it using the same
 emitter pipeline as normal output.
+
+## Parsing
+
+Parse a string of structured data back into eucalypt data.  This is the
+inverse of `render-as` and is a pure function — no IO is required.
+
+| Function | Description |
+|----------|-------------|
+| `parse-as(fmt, str)` | Parse `str` as structured data in format `fmt` |
+
+Supported formats for `fmt`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`,
+`:edn`, `:jsonl`.
+
+`:json` and `:yaml` share the same parser.
+
+**Safety**: `parse-as` always uses data-only mode.  YAML `!eu` tags and
+other embedded-code constructs are returned as plain string values and
+never evaluated.  It is safe to parse untrusted input (e.g. shell command
+output) with this function.
+
+### Parsing Examples
+
+```eu,notest
+# Parse JSON
+data: "{\"x\": 1}" parse-as(:json)
+data.x  # 1
+
+# Round-trip
+original: {x: 1, y: 2}
+recovered: render-as(original, :json) parse-as(:json)
+recovered.x  # 1
+
+# Pipeline style (parse-as with first arg partially applied)
+{ :io r: io.shell("kubectl get configmap foo -o json") }.r.stdout
+  parse-as(:json)
+```
+
+`parse-as` is backed by the `PARSE_STRING` intrinsic.

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -727,6 +727,9 @@ render(value): __RENDER_TO_STRING(value, :yaml)
 ` "render-as(value, fmt) - serialise value to a string in the named format. Supported formats: :yaml, :json, :toml, :text, :edn, :html."
 render-as(value, fmt): __RENDER_TO_STRING(value, fmt)
 
+` "parse-as(fmt, str) - parse a string of structured data in the named format and return eucalypt data. The inverse of render-as. Supported formats: :json, :yaml, :toml, :csv, :xml, :edn, :jsonl. Content is parsed as inert data; embedded eucalypt expressions (e.g. YAML !eu tags) are never evaluated."
+parse-as(fmt, str): __PARSE_STRING(fmt, str)
+
 ##
 ## Combinators
 ##

--- a/tests/harness/107_parse_as_json.eu
+++ b/tests/harness/107_parse_as_json.eu
@@ -1,0 +1,12 @@
+"parse-as: parse a JSON string into eucalypt data."
+
+# Use a variable to avoid eucalypt treating braces in string literals as interpolation
+json-str: render-as({x: 1, y: 2}, :json)
+data: json-str parse-as(:json)
+
+tests: {
+  key-x: data.x //= 1
+  key-y: data.y //= 2
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/108_parse_as_yaml.eu
+++ b/tests/harness/108_parse_as_yaml.eu
@@ -1,0 +1,12 @@
+"parse-as: parse a YAML string into eucalypt data."
+
+# Use render-as to produce a valid YAML string, then parse it back
+yaml-str: render-as({x: 10, y: 20}, :yaml)
+data: yaml-str parse-as(:yaml)
+
+tests: {
+  key-x: data.x //= 10
+  key-y: data.y //= 20
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/109_parse_as_toml.eu
+++ b/tests/harness/109_parse_as_toml.eu
@@ -1,0 +1,12 @@
+"parse-as: parse a TOML string into eucalypt data."
+
+# Use render-as to produce a valid TOML string, then parse it back
+toml-str: render-as({x: 7, y: 8}, :toml)
+data: toml-str parse-as(:toml)
+
+tests: {
+  key-x: data.x //= 7
+  key-y: data.y //= 8
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/110_parse_as_csv.eu
+++ b/tests/harness/110_parse_as_csv.eu
@@ -1,0 +1,17 @@
+"parse-as: parse a CSV string into a list of blocks (one block per row, keys from header)."
+
+# Eucalypt strings support embedded literal newlines.
+csv-str: "name,age
+alice,30
+bob,25
+"
+
+parsed: csv-str parse-as(:csv)
+
+tests: {
+  name-ok: (parsed head).name //= "alice"
+  age-ok: (parsed head).age //= "30"
+  row-count: (parsed count) //= 2
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/111_parse_as_xml.eu
+++ b/tests/harness/111_parse_as_xml.eu
@@ -1,0 +1,11 @@
+"parse-as: parse an XML string into hiccup-style list [tag, attrs, children...]."
+
+# XML is parsed into hiccup-style lists: [tag-name (symbol), attrs-block, child...]
+data: "<root><item>hello</item></root>" parse-as(:xml)
+
+tests: {
+  # Root element name is the symbol :root (first element of the hiccup list)
+  root-tag: (data head) //= :root
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/112_parse_as_edn.eu
+++ b/tests/harness/112_parse_as_edn.eu
@@ -1,0 +1,13 @@
+"parse-as: parse an EDN string into eucalypt data."
+
+# Use {{ and }} to write literal braces (not string interpolation).
+edn-str: "{{:x 1 :y 2}}"
+
+data: edn-str parse-as(:edn)
+
+tests: {
+  x-val: data.x //= 1
+  y-val: data.y //= 2
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/113_parse_as_jsonl.eu
+++ b/tests/harness/113_parse_as_jsonl.eu
@@ -1,0 +1,14 @@
+"parse-as: parse a JSONL string (newline-delimited JSON) into a list of values."
+
+# Use simple scalar JSON values to avoid brace/escape complexity.
+# Each line is a valid JSON number; result is a list of numbers.
+jsonl-str: c"10\n20\n30"
+
+data: jsonl-str parse-as(:jsonl)
+
+tests: {
+  row-count: (data count) //= 3
+  first-val: (data head) //= 10
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/114_parse_as_roundtrip.eu
+++ b/tests/harness/114_parse_as_roundtrip.eu
@@ -1,0 +1,20 @@
+"parse-as: round-trip test — render-as then parse-as produces equivalent data."
+
+original: {x: 1, y: 2}
+
+# Round-trip via JSON
+json-str: render-as(original, :json)
+recovered: json-str parse-as(:json)
+
+# Round-trip via YAML
+yaml-str: render-as(original, :yaml)
+recovered-yaml: yaml-str parse-as(:yaml)
+
+tests: {
+  json-x: recovered.x //= 1
+  json-y: recovered.y //= 2
+  yaml-x: recovered-yaml.x //= 1
+  yaml-y: recovered-yaml.y //= 2
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/115_parse_as_data_only.eu
+++ b/tests/harness/115_parse_as_data_only.eu
@@ -1,0 +1,18 @@
+"parse-as: data-only safety test — YAML !eu tags must produce plain strings, not evaluated expressions."
+
+# A YAML string containing a !eu tag. In data-only mode (parse-as), the !eu
+# content must be returned as a plain string, not executed as eucalypt code.
+# If the tag were evaluated, it would produce the number 42. We verify it
+# produces a string "6 * 7" instead.
+yaml-with-eu-tag: "result: !eu '6 * 7'"
+
+data: yaml-with-eu-tag parse-as(:yaml)
+
+result-val: data.result
+
+tests: {
+  # The string content must be preserved as-is (not evaluated to 42)
+  content: result-val //= "6 * 7"
+}
+
+RESULT: tests values all-true? then(:PASS, :FAIL)

--- a/tests/harness/errors/095_parse_as_bad_format.eu
+++ b/tests/harness/errors/095_parse_as_bad_format.eu
@@ -1,0 +1,2 @@
+# Error: parse-as with an unrecognised format symbol triggers a runtime panic.
+x: "hello" parse-as(:badformat)

--- a/tests/harness/errors/095_parse_as_bad_format.eu.expect
+++ b/tests/harness/errors/095_parse_as_bad_format.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "parse-as"

--- a/tests/harness/errors/096_parse_as_bad_input.eu
+++ b/tests/harness/errors/096_parse_as_bad_input.eu
@@ -1,0 +1,3 @@
+# Error: parse-as with malformed TOML triggers a runtime panic.
+# TOML requires key = value syntax; this is not valid TOML.
+x: "this is not valid toml = = =" parse-as(:toml)

--- a/tests/harness/errors/096_parse_as_bad_input.eu.expect
+++ b/tests/harness/errors/096_parse_as_bad_input.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "parse-as"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -532,6 +532,51 @@ pub fn test_harness_106() {
 }
 
 #[test]
+pub fn test_harness_107() {
+    run_test(&opts("107_parse_as_json.eu"));
+}
+
+#[test]
+pub fn test_harness_108() {
+    run_test(&opts("108_parse_as_yaml.eu"));
+}
+
+#[test]
+pub fn test_harness_109() {
+    run_test(&opts("109_parse_as_toml.eu"));
+}
+
+#[test]
+pub fn test_harness_110() {
+    run_test(&opts("110_parse_as_csv.eu"));
+}
+
+#[test]
+pub fn test_harness_111() {
+    run_test(&opts("111_parse_as_xml.eu"));
+}
+
+#[test]
+pub fn test_harness_112() {
+    run_test(&opts("112_parse_as_edn.eu"));
+}
+
+#[test]
+pub fn test_harness_113() {
+    run_test(&opts("113_parse_as_jsonl.eu"));
+}
+
+#[test]
+pub fn test_harness_114() {
+    run_test(&opts("114_parse_as_roundtrip.eu"));
+}
+
+#[test]
+pub fn test_harness_115() {
+    run_test(&opts("115_parse_as_data_only.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }
@@ -1063,4 +1108,14 @@ pub fn test_error_094() {
         .with_target(Some("result".to_string()))
         .build();
     run_error_test(&opt);
+}
+
+#[test]
+pub fn test_error_095() {
+    run_error_test(&error_opts("095_parse_as_bad_format.eu"));
+}
+
+#[test]
+pub fn test_error_096() {
+    run_error_test(&error_opts("096_parse_as_bad_input.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds `parse-as(fmt, str)` to `lib/prelude.eu` — the inverse of `render-as`, backed by the `PARSE_STRING` intrinsic from P2 (Furnace)
- Adds 9 harness tests (107–115) covering all supported formats: json, yaml, toml, csv, xml, edn, jsonl, plus round-trip and data-only safety
- Adds 2 error tests (095–096) for invalid format symbol and malformed input
- Updates `docs/reference/prelude/strings.md` and `docs/appendices/cheat-sheet.md` with parse-as documentation

## Test plan

- [ ] `cargo test test_harness_107` — JSON parse
- [ ] `cargo test test_harness_108` — YAML parse
- [ ] `cargo test test_harness_109` — TOML parse
- [ ] `cargo test test_harness_110` — CSV parse
- [ ] `cargo test test_harness_111` — XML parse (hiccup-style)
- [ ] `cargo test test_harness_112` — EDN parse
- [ ] `cargo test test_harness_113` — JSONL parse
- [ ] `cargo test test_harness_114` — round-trip (render-as then parse-as)
- [ ] `cargo test test_harness_115` — data-only safety (YAML !eu tags must not execute)
- [ ] `cargo test test_error_095` — invalid format symbol → runtime panic
- [ ] `cargo test test_error_096` — malformed input → runtime panic
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)