### PR TITLE
fix: reorder IO prelude API args for idiomatic pipeline usage

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -393,13 +393,21 @@ either operand is an array. Scalar broadcasting is supported.
 
 ### IO
 
-| Binding | Description |
-|---------|-------------|
+| Binding / Function | Description |
+|--------------------|-------------|
 | `io.env` | Block of environment variables |
 | `io.epoch-time` | Unix timestamp at launch |
 | `io.args` | Command-line arguments (after `--`) |
 | `io.random` | Infinite lazy stream of random floats |
 | `io.RANDOM_SEED` | Current random seed |
+| `io.return(a)` | Wrap a pure value in the IO monad |
+| `io.bind(action, cont)` | Sequence two IO actions |
+| `io.shell(cmd)` | Run `cmd` via `sh -c`; returns `{stdout, stderr, exit-code}` |
+| `io.shell-with(opts, cmd)` | Run `cmd` with extra options (e.g. `{stdin: s, timeout: 60}`). Pipeline: `"cmd" shell-with(opts)` |
+| `io.exec([cmd : args])` | Run `cmd` directly (no shell); argument is a list `[cmd, arg1, arg2, ...]` |
+| `io.exec-with(opts, [cmd : args])` | Run `cmd` directly with extra options. Pipeline: `["git", "log"] exec-with(opts)` |
+| `io.check(result)` | Fail with stderr if `exit-code` is non-zero; otherwise return result |
+| `io.map(f, action)` | Apply pure function to result of IO action (fmap) |
 
 ## Assertion Operators
 

--- a/docs/plans/2026-03-09-io-monad-design.md
+++ b/docs/plans/2026-03-09-io-monad-design.md
@@ -79,9 +79,9 @@ io: {
   return(a): __io_return(a)
 
   shell(cmd): __io_action({:io-shell cmd: cmd, timeout: 30})
-  shell-with(cmd, opts): __io_action({:io-shell cmd: cmd} << opts)
-  exec(cmd, args): __io_action({:io-exec cmd: cmd, args: args, timeout: 30})
-  exec-with(cmd, args, opts): __io_action({:io-exec cmd: cmd, args: args} << opts)
+  shell-with(opts, cmd): __io_action({:io-shell cmd: cmd} << opts)
+  exec([cmd : args]): __io_action({:io-exec cmd: cmd, args: args, timeout: 30})
+  exec-with(opts, [cmd : args]): __io_action({:io-exec cmd: cmd, args: args} << opts)
 
   check(result): ...  # IoFail if exit-code != 0, else IoReturn(result)
 
@@ -105,20 +105,20 @@ files: { :io result: io.shell("ls -la") }.result.stdout
 
 # Chained with failure check
 rev: { :io
-  r: io.exec("git", ["rev-parse", "HEAD"])
+  r: io.exec(["git", "rev-parse", "HEAD"])
   _: io.check(r)
 }.r.stdout
 
 # Piping stdout of one command as stdin to another
 sorted: { :io
   listing: io.shell("ls")
-  result: io.shell-with("sort", {stdin: listing.stdout})
+  result: io.shell-with({stdin: listing.stdout}, "sort")
 }.result.stdout
 
 # Render data and post
 posted: { :io
   json: io.return(render-as(my-data, :json))
-  r: io.shell-with("curl -X POST http://example.com", {stdin: json})
+  r: io.shell-with({stdin: json}, "curl -X POST http://example.com")
   _: io.check(r)
 }.r.stdout
 ```

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -46,9 +46,9 @@ IO operations require the `--allow-io` / `-I` flag at the command line.
 | Function | Description |
 |----------|-------------|
 | `io.shell(cmd)` | Run `cmd` via `sh -c`. Returns `{stdout: Str, stderr: Str, exit-code: Num}` |
-| `io.shell-with(cmd, opts)` | Run `cmd` via `sh -c` with extra options merged in (e.g. `{stdin: s, timeout: 60}`) |
-| `io.exec(cmd, args)` | Run `cmd` directly (no shell). `args` is a list of strings |
-| `io.exec-with(cmd, args, opts)` | Run `cmd` directly with extra options merged in |
+| `io.shell-with(opts, cmd)` | Run `cmd` via `sh -c` with extra options merged in (e.g. `{stdin: s, timeout: 60}`). Pipeline: `"ls" shell-with({timeout: 60})` |
+| `io.exec([cmd : args])` | Run `cmd` directly (no shell). Argument is a single list: first element is the command, rest are args |
+| `io.exec-with(opts, [cmd : args])` | Run `cmd` directly with extra options merged in. Pipeline: `["git", "rev-parse", "HEAD"] exec-with({timeout: 60})` |
 
 Default timeout is 30 seconds. Override with `{timeout: N}` in `opts`.
 Optional `{stdin: s}` pipes string `s` to the command's standard input.

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -46,13 +46,13 @@ io: {
   shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
 
   ` "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
-  shell-with(cmd, opts): __IO_ACTION({:io-shell cmd: cmd} << opts)
+  shell-with(opts, cmd): __IO_ACTION({:io-shell cmd: cmd} << opts)
 
   ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
-  exec(cmd, args): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
+  exec([cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
 
   ` "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
-  exec-with(cmd, args, opts): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
+  exec-with(opts, [cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
   check(result): if(result.'exit-code' = 0,


### PR DESCRIPTION
## Summary

- `shell-with(opts, cmd)` — opts first so the command string is the natural pipeline subject: `"ls -la" shell-with({timeout: 60})`
- `exec([cmd : args])` — single list argument with cons destructuring, so the whole invocation is one list: `io.exec(["git", "rev-parse", "HEAD"])`
- `exec-with(opts, [cmd : args])` — opts first for pipeline use: `["git", "log"] exec-with({timeout: 60})`

Updates all documentation to match: `docs/reference/prelude/io.md`, `docs/appendices/cheat-sheet.md`, `docs/plans/2026-03-09-io-monad-design.md`.

## Test plan

- [x] `cargo test --lib` — 596 tests pass
- [x] `cargo test --test harness_test` — 206 tests pass (including 104–106 IO monad tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)