### PR TITLE
fix: avoid << merge on Meta-tagged spec blocks in shell-with and exec-with

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -340,6 +340,38 @@ starts with a block literal `{...}`:
 { :io r: io.shell("echo hello") }.(r.stdout)
 ```
 
+## Merge Operators Strip Block Metadata Tags
+
+**Problem**: The `<<` (deep merge) and catenation merge operators match on the
+`Block` data constructor directly. A block with a metadata annotation such as
+`{:io-shell cmd: cmd}` is represented at runtime as `Meta(:io-shell, Block(...))`
+— a `Meta` wrapper around a `Block`. Neither merge operator unwraps `Meta`
+before pattern-matching, so:
+
+```eu,notest
+# This does NOT work as intended:
+{:io-shell cmd: cmd} << opts   # returns opts unchanged — the left side is
+                                # a Meta node, not a Block, so << returns r
+```
+
+**Solution**: When you need to merge fields into a metadata-tagged block,
+build the final block explicitly using `lookup-or` to extract individual
+fields from the options block:
+
+```eu,notest
+# Correct: build spec block directly, preserving the :io-shell tag
+my-shell-spec(opts, cmd): {
+  :io-shell
+  cmd: cmd
+  timeout: opts lookup-or(:timeout, 30)
+  stdin: opts lookup-or(:stdin, null)
+}
+```
+
+**Rule**: Never use `<<` or catenation merge on a block that has a metadata
+tag (`:name` as first entry). Build the result block with explicit field
+declarations instead.
+
 ## Future Improvements
 
 These gotchas highlight areas where the language could benefit from:

--- a/docs/plans/2026-03-09-io-monad-design.md
+++ b/docs/plans/2026-03-09-io-monad-design.md
@@ -79,9 +79,12 @@ io: {
   return(a): __io_return(a)
 
   shell(cmd): __io_action({:io-shell cmd: cmd, timeout: 30})
-  shell-with(opts, cmd): __io_action({:io-shell cmd: cmd} << opts)
+  # shell-with and exec-with use helper functions to build the spec block.
+  # Using << on a Meta-tagged block ({:io-shell ...}) strips the metadata tag,
+  # so the spec is built explicitly via lookup-or to extract known opt fields.
+  shell-with(opts, cmd): __io_action(__io-shell-spec(opts, cmd))
   exec([cmd : args]): __io_action({:io-exec cmd: cmd, args: args, timeout: 30})
-  exec-with(opts, [cmd : args]): __io_action({:io-exec cmd: cmd, args: args} << opts)
+  exec-with(opts, [cmd : args]): __io_action(__io-exec-spec(opts, cmd, args))
 
   check(result): ...  # IoFail if exit-code != 0, else IoReturn(result)
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -46,13 +46,13 @@ io: {
   shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
 
   ` "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
-  shell-with(opts, cmd): __IO_ACTION({:io-shell cmd: cmd} << opts)
+  shell-with(opts, cmd): __IO_ACTION(__io-shell-spec(opts, cmd))
 
   ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
   exec([cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
 
   ` "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
-  exec-with(opts, [cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args} << opts)
+  exec-with(opts, [cmd : args]): __IO_ACTION(__io-exec-spec(opts, cmd, args))
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
   check(result): if(result.'exit-code' = 0,
@@ -64,6 +64,23 @@ io: {
 }
 
 __io-return-of(f, x): io.return(f(x))
+
+` :suppress
+__io-shell-spec(opts, cmd): {
+  :io-shell
+  cmd: cmd
+  timeout: opts lookup-or(:timeout, 30)
+  stdin: opts lookup-or(:stdin, null)
+}
+
+` :suppress
+__io-exec-spec(opts, cmd, args): {
+  :io-exec
+  cmd: cmd
+  args: args
+  timeout: opts lookup-or(:timeout, 30)
+  stdin: opts lookup-or(:stdin, null)
+}
 
 
 ##


### PR DESCRIPTION
## Summary

Fixes bug eu-vc32: `io.shell-with` (and `io.exec-with`) were broken because the spec block construction used `<<` on a metadata-tagged block literal.

**Root cause**: `<<` (deep merge) and catenation merge both pattern-match on `DataConstructor::Block.tag()` in their STG wrappers. A metadata-tagged block literal `{:io-shell cmd: cmd}` compiles to `Meta(:io-shell, Block(...))` at runtime — neither merge operator unwraps the `Meta` node. So `{:io-shell cmd: cmd} << opts` hit the default fallthrough branch and returned `opts` unchanged, discarding both the `cmd` field and the `:io-shell` tag. The io-run driver then got an untagged block and failed with `IoAction spec block is not a Block constructor`.

**Fix**: Replace `<<` in `shell-with` and `exec-with` with two suppressed helper functions `__io-shell-spec` / `__io-exec-spec` that build the spec block explicitly, using `lookup-or` to extract `timeout` and `stdin` from `opts`. Since `null` values are not inserted into the fields map by `collect_block_fields` (they fail `read_as_string`), absent opts fields default correctly.

**Documentation**: New "Merge Operators Strip Block Metadata Tags" section added to `docs/appendices/syntax-gotchas.md`.

## Test plan

- [x] `cargo test --lib` — 596 tests pass
- [x] `cargo test --test harness_test` — 206 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)