### PR TITLE
fix(emacs): disable smartparens backtick auto-pairing (eu-jrua)

### DIFF
--- a/editors/emacs/eucalypt-mode.el
+++ b/editors/emacs/eucalypt-mode.el
@@ -45,6 +45,7 @@
 (declare-function rainbow-delimiters-mode "rainbow-delimiters" ())
 (declare-function yaml-mode "yaml-mode" ())
 (declare-function json-mode "json-mode" ())
+(declare-function sp-local-pair "smartparens" (modes open close &rest keys))
 
 ;;; Group
 
@@ -588,6 +589,11 @@ region is active.  Skips replacements inside strings and comments."
 
 (with-eval-after-load 'rainbow-delimiters
   (add-hook 'eucalypt-mode-hook #'rainbow-delimiters-mode))
+
+;; Backtick is a metadata marker in eucalypt, not a paired quote.
+;; Disable smartparens auto-pairing for ` in eucalypt buffers.
+(with-eval-after-load 'smartparens
+  (sp-local-pair 'eucalypt-mode "`" nil :actions nil))
 
 ;;; Mode definition
 


### PR DESCRIPTION
## Summary

- Adds a `with-eval-after-load 'smartparens` guard that calls `sp-local-pair` to suppress backtick auto-pairing in `eucalypt-mode` buffers. Backtick is a metadata marker in eucalypt, not a paired quote character.
- The guard is a no-op when smartparens is not installed — no error is raised.
- Adds `(declare-function sp-local-pair ...)` alongside the other optional dependency declarations to keep byte-compile warnings clean.

## Test plan

- [ ] Byte-compiles cleanly: `emacs -Q -batch -f batch-byte-compile editors/emacs/eucalypt-mode.el`
- [ ] Loads without errors: `emacs -Q -batch -l editors/emacs/eucalypt-mode.el`
- [ ] With smartparens installed, typing backtick in a eucalypt buffer inserts a single backtick with no auto-paired closing backtick
- [ ] Without smartparens installed, mode loads and behaves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)