### PR TITLE
fix(io): fix io.shell panic and shell-with spec block unreadable (eu-vc32)

### DIFF
--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -53,6 +53,11 @@ IO operations require the `--allow-io` / `-I` flag at the command line.
 Default timeout is 30 seconds. Override with `{timeout: N}` in `opts`.
 Optional `{stdin: s}` pipes string `s` to the command's standard input.
 
+**Current limitation**: The `timeout` and `stdin` fields in `opts` for
+`shell-with` and `exec-with` are accepted by the parser but not yet applied
+by the io-run driver (they default to 30 s and no stdin). This will be fixed
+in a future driver update. The `cmd` argument is always applied correctly.
+
 ### Combinators
 
 | Function | Description |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -46,13 +46,13 @@ io: {
   shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
 
   ` "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
-  shell-with(opts, cmd): __IO_ACTION(__io-shell-spec(opts, cmd))
+  shell-with(opts, cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: opts lookup-or(:timeout, 30), stdin: opts lookup-or(:stdin, null)})
 
   ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
   exec([cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
 
   ` "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
-  exec-with(opts, [cmd : args]): __IO_ACTION(__io-exec-spec(opts, cmd, args))
+  exec-with(opts, [cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: opts lookup-or(:timeout, 30), stdin: opts lookup-or(:stdin, null)})
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
   check(result): if(result.'exit-code' = 0,
@@ -64,23 +64,6 @@ io: {
 }
 
 __io-return-of(f, x): io.return(f(x))
-
-` :suppress
-__io-shell-spec(opts, cmd): {
-  :io-shell
-  cmd: cmd
-  timeout: opts lookup-or(:timeout, 30)
-  stdin: opts lookup-or(:stdin, null)
-}
-
-` :suppress
-__io-exec-spec(opts, cmd, args): {
-  :io-exec
-  cmd: cmd
-  args: args
-  timeout: opts lookup-or(:timeout, 30)
-  stdin: opts lookup-or(:stdin, null)
-}
 
 
 ##

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -948,6 +948,17 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                 // Execute the shell action
                 let result = run_spec(&spec)?;
 
+                // Pre-intern the result block key symbols into the machine's
+                // pool so that the IDs embedded by BuildResultBlock are
+                // already present in the machine pool.  Without this,
+                // BuildResultBlock interns into a cloned pool and the heap
+                // objects contain IDs that the machine pool doesn't know
+                // about, causing index-out-of-bounds panics in pool.resolve()
+                // when the machine later accesses the result block.
+                machine.intern_symbol("stdout");
+                machine.intern_symbol("stderr");
+                machine.intern_symbol("exit-code");
+
                 // Build the result block closure.  World remains stashed as a GC root.
                 let pool = machine.symbol_pool().clone();
                 let result_c = machine

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1124,6 +1124,18 @@ impl<'a> Machine<'a> {
         &self.state.symbol_pool
     }
 
+    /// Intern a symbol string into the machine's symbol pool and return its ID.
+    ///
+    /// Used by the io-run driver to pre-register symbols (e.g. "stdout",
+    /// "stderr", "exit-code") before they are embedded in heap objects by a
+    /// mutator.  Pre-interning ensures the IDs assigned during mutator heap
+    /// construction are already present in the machine's pool, so that later
+    /// LOOKUP and render operations (which use the machine pool) can resolve
+    /// them.
+    pub fn intern_symbol(&mut self, s: &str) -> crate::eval::memory::symbol::SymbolId {
+        self.state.symbol_pool.intern(s)
+    }
+
     /// Access the heap for allocation
     pub fn heap(&self) -> &Heap {
         &self.heap


### PR DESCRIPTION
## Summary

- **Bug 1 (spec block unreadable)**: `shell-with` and `exec-with` previously called helper functions `__io-shell-spec`/`__io-exec-spec` to build spec blocks. These produced `App` thunks in the STG closure. The io-run driver's `ReadSpecBlock` does static heap navigation and cannot follow `App` nodes, producing "IoAction spec block is not a Block constructor". Fix: inline block literals directly so the spec is a literal in the closure environment.
- **Bug 2 (symbol pool OOB panic)**: `BuildResultBlock` interns "stdout", "stderr", "exit-code" into a *cloned* `SymbolPool` passed as input. The machine's own pool is never updated, so `pool.resolve(id)` panics (index out of bounds) when the machine later accesses the result block. Fix: add `Machine::intern_symbol()` and pre-intern the three keys before cloning the pool for `BuildResultBlock`.
- **Documentation**: Added limitation note to `docs/reference/prelude/io.md` — the `timeout`/`stdin` fields in opts are parsed but not yet applied by the static spec reader; full fix requires driver evaluation (deferred to Furnace).

## Test plan

- [ ] `cargo test --lib` — all 596 lib tests pass
- [ ] `cargo test --test harness_test` — all 206 harness tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] Manual: `eu -I -e 'io.shell("echo hello") io.map(.stdout)'` no longer panics
- [ ] Manual: `eu -I -e 'io.shell-with({}, "echo hello world") io.map(.stdout)'` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)