### PR TITLE
fix(io-run): evaluate spec block fields to WHNF (eu-vc32)

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -340,6 +340,41 @@ starts with a block literal `{...}`:
 { :io r: io.shell("echo hello") }.(r.stdout)
 ```
 
+## Block Field Names Shadow Outer Bindings — `{x: x}` Is Always Self-Reference
+
+**Problem**: Every declaration inside a block literal introduces a new binding
+that is visible to all other expressions in that block, including its own
+right-hand side.  The name on the left of `:` immediately shadows any outer
+binding with the same name, so `{x: x}` does **not** copy an outer `x` into the
+block — it creates a self-referential binding that refers to itself:
+
+```eu,notest
+# WRONG — infinite loop: cmd refers to itself, not the function parameter
+shell-spec(cmd): {:io-shell cmd: cmd, timeout: 30}
+```
+
+Running `eu -e '{cmd: cmd}'` gives `error: infinite loop detected: binding
+refers to itself`.
+
+**Why it bites functions**: When a function parameter has the same name as a
+block field you want to populate, the RHS expression sees the block's own
+binding rather than the parameter:
+
+```eu,notest
+fn(cmd): {cmd: cmd}   # cmd: cmd is self-reference — fn's parameter is invisible
+```
+
+**Fix**: Use a different name for the function parameter so it is not shadowed:
+
+```eu,notest
+# Correct: parameter c is not shadowed by the block field cmd
+shell-spec(c): {:io-shell cmd: c, timeout: 30}
+```
+
+**Rule**: Never write `{key: key}` expecting it to read an outer binding named
+`key`.  If you need a block field to hold a value from an outer scope, the outer
+name and the field name must differ.
+
 ## Future Improvements
 
 These gotchas highlight areas where the language could benefit from:

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -318,13 +318,15 @@ list-head([h : t]): h
 bad: [1 : rest]   # parse error
 ```
 
-In expression context, use the `|:` cons operator or prelude functions:
+In expression context, use the `‖` cons operator (precedence 55) or the
+`cons` prelude function:
 
 ```eu
 xs: [1, 2, 3]
-first: xs head      # = 1
-rest: xs tail       # = [2, 3]
-built: 1 |: [2, 3]  # = [1, 2, 3]
+first: xs head         # = 1
+rest: xs tail          # = [2, 3]
+built: 1 ‖ [2, 3]     # = [1, 2, 3]
+also: cons(1, [2, 3])  # = [1, 2, 3]
 ```
 
 ## Block-Dot Lookup Applies to Any Block Literal

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -310,28 +310,41 @@ first: xs head    # = 1
 rest: xs tail     # = [2, 3]
 ```
 
-## IO Monad Block Syntax
+## Block-Dot Lookup Applies to Any Block Literal
 
-Monadic block syntax uses `{ :io r: cmd }.(return_expr)` or
-`{ :io r: cmd }.return_name.field`:
+The generalised lookup syntax `{...}.field` and `{...}.(expr)` works on any
+block literal, not only IO monadic blocks.  The dot binds the lookup to the
+block immediately to its left:
 
 ```eu,notest
-# Parenthesised return expression (recommended for complex expressions)
-{ :io r: io.shell("echo hello") }.(
-  if(r.stdout str.matches?("hello.*"), :PASS, :FAIL))
+# Field lookup on a plain block
+{ x: 1, y: 2 }.x          # → 1
 
-# Dot-chained field access in return expression
+# Parenthesised expression scoped over the block's bindings
+{ x: 1, y: 2 }.(x + y)    # → 3
+
+# The same syntax is used for IO monadic block return expressions
+{ :io r: io.shell("echo hello") }.(r.stdout)
 { :io r: io.shell("echo hello") }.r.stdout
 ```
 
-**Desugaring**: both forms desugar to `io.bind(cmd, lambda(r). io.return(expr))`:
+**Precedence**: `.` binds tightly (precedence 90), so the lookup attaches to
+the block literal, not to the result of any surrounding expression.  Use
+parentheses when you need to apply a lookup to a computed value:
 
 ```eu,notest
-# { :io r: cmd }.(expr) → io.bind(cmd, lambda(r). io.return(expr))
-# { :io r: cmd }.r.field → io.bind(cmd, lambda(r). io.return(r.field))
+# Parsed as: list (head.name)  — probably not what you want
+list head.name
+
+# Correct: (list head).name
+(list head).name
 ```
 
-**Bare-expression files**: A `.eu` file containing only a monadic block
+**IO monadic block desugaring**: `{ :io r: cmd }.(expr)` desugars to
+`io.bind(cmd, lambda(r). io.return(expr))`.  The `.()` return expression is
+part of the general block-dot syntax, not IO-specific.
+
+**Bare-expression files**: A `.eu` file containing only a block-dot
 expression (no outer `key:` declaration) is supported when the expression
 starts with a block literal `{...}`:
 

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -301,13 +301,13 @@ list-head([h : t]): h
 bad: [1 : rest]   # parse error
 ```
 
-In expression context, use `cons`, `head`, and `tail` from the prelude
-instead:
+In expression context, use the `|:` cons operator or prelude functions:
 
 ```eu
 xs: [1, 2, 3]
-first: xs head    # = 1
-rest: xs tail     # = [2, 3]
+first: xs head      # = 1
+rest: xs tail       # = [2, 3]
+built: 1 |: [2, 3]  # = [1, 2, 3]
 ```
 
 ## Block-Dot Lookup Applies to Any Block Literal

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -340,38 +340,6 @@ starts with a block literal `{...}`:
 { :io r: io.shell("echo hello") }.(r.stdout)
 ```
 
-## Merge Operators Strip Block Metadata Tags
-
-**Problem**: The `<<` (deep merge) and catenation merge operators match on the
-`Block` data constructor directly. A block with a metadata annotation such as
-`{:io-shell cmd: cmd}` is represented at runtime as `Meta(:io-shell, Block(...))`
-— a `Meta` wrapper around a `Block`. Neither merge operator unwraps `Meta`
-before pattern-matching, so:
-
-```eu,notest
-# This does NOT work as intended:
-{:io-shell cmd: cmd} << opts   # returns opts unchanged — the left side is
-                                # a Meta node, not a Block, so << returns r
-```
-
-**Solution**: When you need to merge fields into a metadata-tagged block,
-build the final block explicitly using `lookup-or` to extract individual
-fields from the options block:
-
-```eu,notest
-# Correct: build spec block directly, preserving the :io-shell tag
-my-shell-spec(opts, cmd): {
-  :io-shell
-  cmd: cmd
-  timeout: opts lookup-or(:timeout, 30)
-  stdin: opts lookup-or(:stdin, null)
-}
-```
-
-**Rule**: Never use `<<` or catenation merge on a block that has a metadata
-tag (`:name` as first entry). Build the result block with explicit field
-declarations instead.
-
 ## Future Improvements
 
 These gotchas highlight areas where the language could benefit from:

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -209,6 +209,23 @@ avg2(a, b): (a + b) / 2
 zip-with(avg2, xs, ys)
 ```
 
+**Expanding scope with subsumption**: The subsumption rule can be
+exploited to make the outer expression anaphoric, causing inner paren
+groups to become transparent.  A common idiom is to place a direct
+anaphor — such as a not-nil check `_0✓` — at the outer level:
+
+```eu,notest
+# _0✓ makes the whole expression anaphoric in _0,
+# so _0 inside count(_0) is subsumed — both refer to the same parameter.
+_0✓ && count(_0) >= 4    # λ(a). a != null && count(a) >= 4
+```
+
+Without the outer `_0✓`, the `_0` inside `count(_0)` would form a
+separate lambda at the ArgTuple level, and the outer `&&` would see a
+function value rather than a boolean.  The not-nil postfix `✓` is
+often the most natural way to introduce the outer anaphor when you
+want to also guard against null.
+
 ## Metadata vs Comments
 
 ### Backtick Is Metadata, Not a Comment

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -43,16 +43,16 @@ io: {
   return(a): __IO_RETURN(a)
 
   ` "Run a shell command via sh -c. Returns a block with stdout, stderr, and exit-code fields."
-  shell(cmd): __IO_ACTION({:io-shell cmd: cmd, timeout: 30})
+  shell(c): __IO_ACTION({:io-shell cmd: c, timeout: 30})
 
   ` "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
-  shell-with(opts, cmd): __IO_ACTION(__io-shell-spec(opts, cmd))
+  shell-with(opts, c): __IO_ACTION(__io-shell-spec(opts, c))
 
   ` "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
-  exec([cmd : args]): __IO_ACTION({:io-exec cmd: cmd, args: args, timeout: 30})
+  exec([c : as]): __IO_ACTION({:io-exec cmd: c, args: as, timeout: 30})
 
   ` "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
-  exec-with(opts, [cmd : args]): __IO_ACTION(__io-exec-spec(opts, cmd, args))
+  exec-with(opts, [c : as]): __IO_ACTION(__io-exec-spec(opts, c, as))
 
   ` "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
   check(result): if(result.'exit-code' = 0,
@@ -66,18 +66,18 @@ io: {
 __io-return-of(f, x): io.return(f(x))
 
 ` :suppress
-__io-shell-spec(opts, cmd): {
+__io-shell-spec(opts, c): {
   :io-shell
-  cmd: cmd
+  cmd: c
   timeout: opts lookup-or(:timeout, 30)
   stdin: opts lookup-or(:stdin, null)
 }
 
 ` :suppress
-__io-exec-spec(opts, cmd, args): {
+__io-exec-spec(opts, c, as): {
   :io-exec
-  cmd: cmd
-  args: args
+  cmd: c
+  args: as
   timeout: opts lookup-or(:timeout, 30)
   stdin: opts lookup-or(:stdin, null)
 }

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -96,11 +96,24 @@ enum ActionSpec {
 /// Resolve a `Ref` relative to a closure's environment, producing a new closure.
 ///
 /// `Ref::V` values are wrapped in an atom closure.
-/// `Ref::G` is not supported outside the machine and returns an error.
+/// `Ref::G` requires the globals env frame to be passed separately.
 fn resolve_ref(
     view: &MutatorHeapView<'_>,
     parent: &SynClosure,
     r: Ref,
+) -> Result<SynClosure, ExecutionError> {
+    resolve_ref_with_globals(view, parent, r, None)
+}
+
+/// Resolve a `Ref` with optional access to the globals env frame.
+///
+/// When `globals` is `Some`, `G(i)` refs are resolved via that frame.
+/// When `globals` is `None`, `G(i)` refs return an error.
+fn resolve_ref_with_globals(
+    view: &MutatorHeapView<'_>,
+    parent: &SynClosure,
+    r: Ref,
+    globals: Option<RefPtr<EnvFrame>>,
 ) -> Result<SynClosure, ExecutionError> {
     match r {
         Ref::L(i) => {
@@ -116,9 +129,17 @@ fn resolve_ref(
                 .as_ptr();
             Ok(SynClosure::new(atom_ptr, parent.env()))
         }
-        Ref::G(i) => Err(ExecutionError::Panic(format!(
-            "unexpected global ref G({i}) in io spec block"
-        ))),
+        Ref::G(i) => {
+            if let Some(g) = globals {
+                let genv = view.scoped(g);
+                genv.get(view, i)
+                    .ok_or(ExecutionError::BadEnvironmentIndex(i))
+            } else {
+                Err(ExecutionError::Panic(format!(
+                    "unexpected global ref G({i}) in io spec block"
+                )))
+            }
+        }
     }
 }
 
@@ -334,89 +355,18 @@ fn block_list_inner(view: &MutatorHeapView<'_>, c: SynClosure, depth: usize) -> 
     }
 }
 
-/// Walk a cons-list of `BlockPair` nodes, extracting string key-value pairs.
-///
-/// Symbol keys are resolved to their text via `pool`.
-fn collect_block_fields(
-    view: &MutatorHeapView<'_>,
-    pool: &SymbolPool,
-    list_closure: SynClosure,
-) -> HashMap<String, String> {
-    let mut fields = HashMap::new();
-    let mut current = deref(view, list_closure);
-
-    loop {
-        let code = view.scoped(current.code());
-        match &*code {
-            HeapSyn::Cons { tag, .. } if *tag == DataConstructor::ListNil.tag() => break,
-            HeapSyn::Cons { tag, args } if *tag == DataConstructor::ListCons.tag() => {
-                let head_ref = match args.get(0) {
-                    Some(r) => r,
-                    None => break,
-                };
-                let tail_ref = match args.get(1) {
-                    Some(r) => r,
-                    None => break,
-                };
-                if let Ok(head) = resolve_ref(view, &current, head_ref) {
-                    collect_pair(view, pool, deref(view, head), &mut fields);
-                }
-                match resolve_ref(view, &current, tail_ref) {
-                    Ok(tail) => current = deref(view, tail),
-                    Err(_) => break,
-                }
-            }
-            _ => break,
-        }
-    }
-
-    fields
-}
-
-/// Read a single `BlockPair` node into the fields map.
-///
-/// Symbol keys are resolved to their text via `pool`.
-fn collect_pair(
-    view: &MutatorHeapView<'_>,
-    pool: &SymbolPool,
-    pair: SynClosure,
-    fields: &mut HashMap<String, String>,
-) {
-    let code = view.scoped(pair.code());
-    match &*code {
-        HeapSyn::Cons { tag, args } if *tag == DataConstructor::BlockPair.tag() => {
-            let key_ref = match args.get(0) {
-                Some(r) => r,
-                None => return,
-            };
-            let val_ref = match args.get(1) {
-                Some(r) => r,
-                None => return,
-            };
-
-            let key_name = match &key_ref {
-                Ref::V(Native::Sym(id)) => pool.resolve(*id).to_string(),
-                _ => return,
-            };
-            let val_ref_clone = val_ref.clone();
-
-            if let Ok(val_closure) = resolve_ref(view, &pair, val_ref_clone) {
-                let derefed = deref(view, val_closure);
-                if let Some(val_str) = read_as_string(view, derefed) {
-                    fields.insert(key_name, val_str);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Try to read a closure's WHNF value as a plain Rust `String`.
 ///
 /// Handles: Atom(Str), Atom(Num), BoxedString, BoxedNumber, and
-/// cons-lists of strings (stored NUL-separated under `__args_list`
-/// semantics by the caller).
-fn read_as_string(view: &MutatorHeapView<'_>, closure: SynClosure) -> Option<String> {
+/// cons-lists of strings (stored NUL-separated for exec args).
+///
+/// `globals` is optional; it is required to resolve `G(i)` refs (e.g. the
+/// global nil `ListNil` that appears as the tail of a compiled list).
+fn read_as_string(
+    view: &MutatorHeapView<'_>,
+    closure: SynClosure,
+    globals: Option<RefPtr<EnvFrame>>,
+) -> Option<String> {
     let code = view.scoped(closure.code());
     match &*code {
         HeapSyn::Atom {
@@ -443,7 +393,9 @@ fn read_as_string(view: &MutatorHeapView<'_>, closure: SynClosure) -> Option<Str
             if *tag == DataConstructor::ListCons.tag()
                 || *tag == DataConstructor::ListNil.tag() =>
         {
-            // Collect list elements as NUL-separated string
+            // Collect list elements as NUL-separated string.
+            // G-refs (e.g. the global ListNil used as the list terminator)
+            // are resolved via the globals frame when provided.
             let mut parts: Vec<String> = Vec::new();
             let mut cur = closure.clone();
             loop {
@@ -453,9 +405,9 @@ fn read_as_string(view: &MutatorHeapView<'_>, closure: SynClosure) -> Option<Str
                     HeapSyn::Cons { tag: t, args } if *t == DataConstructor::ListCons.tag() => {
                         let hr = args.get(0)?;
                         let tr = args.get(1)?;
-                        let head = resolve_ref(view, &cur, hr).ok()?;
-                        let tail = resolve_ref(view, &cur, tr).ok()?;
-                        if let Some(s) = read_as_string(view, deref(view, head)) {
+                        let head = resolve_ref_with_globals(view, &cur, hr, globals).ok()?;
+                        let tail = resolve_ref_with_globals(view, &cur, tr, globals).ok()?;
+                        if let Some(s) = read_as_string(view, deref(view, head), globals) {
                             parts.push(s);
                         }
                         cur = deref(view, tail);
@@ -466,93 +418,289 @@ fn read_as_string(view: &MutatorHeapView<'_>, closure: SynClosure) -> Option<Str
             Some(parts.join("\x00"))
         }
         HeapSyn::Meta { body, .. } => {
-            let body_closure = resolve_ref(view, &closure, body.clone()).ok()?;
-            read_as_string(view, deref(view, body_closure))
+            let body_closure =
+                resolve_ref_with_globals(view, &closure, body.clone(), globals).ok()?;
+            read_as_string(view, deref(view, body_closure), globals)
         }
         _ => None,
     }
 }
 
-// ─── Mutator: read action spec from a yielded IoAction spec_block closure ────
+// ─── Mutator: extract raw (unevaluated) field closures from a spec block ──────
 
-/// Mutator that reads an `IoAction` spec block from the heap.
-///
-/// The spec_block closure is a `Block` potentially wrapped in `Meta(sym, body)`.
-/// We strip metadata, walk the block's cons-list to extract `cmd`, `args`,
-/// `stdin`, `timeout`, and read the metadata tag to distinguish `:io-shell`
-/// from `:io-exec`.
-struct ReadSpecBlock {
-    spec_block: SynClosure,
+/// Walk a cons-list of `BlockPair` nodes and collect the raw (unevaluated)
+/// value closure for each field.  Keys that cannot be read as symbol strings
+/// are silently skipped.
+fn collect_raw_block_fields(
+    view: &MutatorHeapView<'_>,
+    pool: &SymbolPool,
+    list_closure: SynClosure,
+) -> HashMap<String, SynClosure> {
+    let mut fields = HashMap::new();
+    let mut current = deref(view, list_closure);
+
+    loop {
+        let code = view.scoped(current.code());
+        match &*code {
+            HeapSyn::Cons { tag, .. } if *tag == DataConstructor::ListNil.tag() => break,
+            HeapSyn::Cons { tag, args } if *tag == DataConstructor::ListCons.tag() => {
+                let head_ref = match args.get(0) {
+                    Some(r) => r,
+                    None => break,
+                };
+                let tail_ref = match args.get(1) {
+                    Some(r) => r,
+                    None => break,
+                };
+                if let Ok(head) = resolve_ref(view, &current, head_ref) {
+                    collect_raw_pair(view, pool, deref(view, head), &mut fields);
+                }
+                match resolve_ref(view, &current, tail_ref) {
+                    Ok(tail) => current = deref(view, tail),
+                    Err(_) => break,
+                }
+            }
+            _ => break,
+        }
+    }
+
+    fields
 }
 
-impl Mutator for ReadSpecBlock {
-    type Input = SymbolPool;
-    type Output = ActionSpec;
-
-    fn run(&self, view: &MutatorHeapView, pool: SymbolPool) -> Result<ActionSpec, ExecutionError> {
-        let (meta_sym, body_closure) = peel_meta(view, &pool, self.spec_block.clone());
-
-        // Extract the cons-list from the block
-        let list_closure = block_list(view, body_closure.clone()).ok_or_else(|| {
-            ExecutionError::Panic("IoAction spec block is not a Block constructor".to_string())
-        })?;
-
-        // Walk the list to collect fields
-        let fields = collect_block_fields(view, &pool, list_closure);
-
-        // Identify action type from metadata symbol
-        let tag_name = meta_sym.ok_or_else(|| {
-            ExecutionError::Panic("IO action spec block has no metadata tag".to_string())
-        })?;
-
-        let timeout_secs = fields
-            .get("timeout")
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(30);
-
-        let stdin = fields.get("stdin").filter(|s| !s.is_empty()).cloned();
-
-        let is_shell =
-            tag_name == "io-shell" || (fields.contains_key("cmd") && !fields.contains_key("args"));
-        let is_exec =
-            tag_name == "io-exec" || (fields.contains_key("cmd") && fields.contains_key("args"));
-
-        if is_shell && !fields.contains_key("args") {
-            let cmd = fields
-                .get("cmd")
-                .cloned()
-                .ok_or_else(|| ExecutionError::Panic("io-shell spec missing 'cmd'".to_string()))?;
-            Ok(ActionSpec::Shell {
-                cmd,
-                stdin,
-                timeout_secs,
-            })
-        } else if is_exec {
-            let cmd = fields
-                .get("cmd")
-                .cloned()
-                .ok_or_else(|| ExecutionError::Panic("io-exec spec missing 'cmd'".to_string()))?;
-            let args = fields
-                .get("args")
-                .map(|s| {
-                    if s.is_empty() {
-                        vec![]
-                    } else {
-                        s.split('\x00').map(|x| x.to_string()).collect()
-                    }
-                })
-                .unwrap_or_default();
-            Ok(ActionSpec::Exec {
-                cmd,
-                args,
-                stdin,
-                timeout_secs,
-            })
-        } else {
-            Err(ExecutionError::Panic(format!(
-                "unrecognised IO action tag: {tag_name}"
-            )))
+/// Read a single `BlockPair` node: resolve the key to a string and record the
+/// raw (unevaluated) value closure.  Symbol keys only; others are skipped.
+fn collect_raw_pair(
+    view: &MutatorHeapView<'_>,
+    pool: &SymbolPool,
+    pair: SynClosure,
+    fields: &mut HashMap<String, SynClosure>,
+) {
+    let code = view.scoped(pair.code());
+    if let HeapSyn::Cons { tag, args } = &*code {
+        if *tag != DataConstructor::BlockPair.tag() {
+            return;
         }
+        let key_ref = match args.get(0) {
+            Some(r) => r,
+            None => return,
+        };
+        let val_ref = match args.get(1) {
+            Some(r) => r,
+            None => return,
+        };
+        let key_name = match &key_ref {
+            Ref::V(Native::Sym(id)) => pool.resolve(*id).to_string(),
+            _ => return,
+        };
+        let val_ref_clone = val_ref.clone();
+        if let Ok(val_closure) = resolve_ref(view, &pair, val_ref_clone) {
+            fields.insert(key_name, deref(view, val_closure));
+        }
+    }
+}
+
+// ─── Mutator: read a single WHNF closure as a string ─────────────────────────
+
+/// Mutator that reads a WHNF closure as a Rust `String`.
+///
+/// Used after `evaluate_to_whnf_for_io` to extract the string value from an
+/// evaluated spec block field.  The `Input` carries an optional globals env
+/// frame so that list tails using `G(i)` refs (e.g. the compiled `ListNil`)
+/// can be resolved.
+struct ReadClosureAsString {
+    closure: SynClosure,
+}
+
+impl Mutator for ReadClosureAsString {
+    type Input = Option<RefPtr<EnvFrame>>;
+    type Output = Option<String>;
+
+    fn run(
+        &self,
+        view: &MutatorHeapView,
+        globals: Option<RefPtr<EnvFrame>>,
+    ) -> Result<Option<String>, ExecutionError> {
+        let c = deref(view, self.closure.clone());
+        Ok(read_as_string(view, c, globals))
+    }
+}
+
+/// Build an `ActionSpec` from an `IoAction` spec block by evaluating each field
+/// closure to WHNF using the machine.
+///
+/// Handles two cases:
+///
+/// 1. **Inline block** (`io.shell`, `io.exec`): the spec block is a LetRec thunk
+///    with a `Meta(tag, Block(...))` body that is statically visible.  The tag
+///    is extracted via `peel_meta` and the body closure is evaluated to WHNF.
+///
+/// 2. **Function-application block** (`io.shell-with`, `io.exec-with`): the spec
+///    block is an App thunk (e.g. `__io-shell-spec(opts, cmd)`).  Evaluating it
+///    strips the Meta wrapper (the machine discards metadata when nothing consumes
+///    it), so the tag must be inferred from the resulting field set: a block with
+///    `cmd` but no `args` is an `io-shell` action; a block with both is `io-exec`.
+///
+/// In both cases, field closures are extracted from the evaluated block and each
+/// is forced to WHNF before reading, so `opts lookup-or(...)` thunks are resolved.
+fn evaluate_spec_block(
+    machine: &mut Machine<'_>,
+    spec_block: SynClosure,
+) -> Result<ActionSpec, IoRunError> {
+    // ── Try to extract the metadata tag statically ────────────────────────────
+    //
+    // For inline blocks the Meta node is directly visible after dereferencing
+    // letrec atoms.  For App thunks the Meta is only produced during evaluation
+    // and `peel_meta` returns `None`.
+    let pool = machine.symbol_pool().clone();
+
+    struct PeekMeta(SynClosure);
+    impl Mutator for PeekMeta {
+        type Input = SymbolPool;
+        type Output = (Option<String>, SynClosure);
+        fn run(
+            &self,
+            view: &MutatorHeapView,
+            pool: SymbolPool,
+        ) -> Result<(Option<String>, SynClosure), ExecutionError> {
+            let (tag_opt, body) = peel_meta(view, &pool, self.0.clone());
+            Ok((tag_opt, body))
+        }
+    }
+
+    let (static_tag, body_or_spec) = machine
+        .mutate(PeekMeta(spec_block), pool)
+        .map_err(IoRunError::from)?;
+
+    // ── Evaluate the block body to WHNF ──────────────────────────────────────
+    //
+    // For inline blocks `body_or_spec` is the block body (LetRec thunk that
+    // produces the Block cons).  For App thunks it is the whole spec block
+    // (which evaluates to the Block cons, stripping the Meta).
+    //
+    // After this call the machine is back in IO yield state.
+    let evaluated_block = machine
+        .evaluate_to_whnf_for_io(body_or_spec)
+        .map_err(IoRunError::from)?;
+
+    // ── Extract raw field closures from the evaluated block ───────────────────
+    //
+    // The evaluated block is a Block constructor.  Its field values are either
+    // already WHNF atoms or fresh thunks (e.g. `opts lookup-or(:timeout, 30)`)
+    // created during the evaluation above.  Static navigation returns closures
+    // that can safely be evaluated by the machine.
+    struct ReadBlockFields(SynClosure);
+    impl Mutator for ReadBlockFields {
+        type Input = SymbolPool;
+        type Output = HashMap<String, SynClosure>;
+        fn run(
+            &self,
+            view: &MutatorHeapView,
+            pool: SymbolPool,
+        ) -> Result<HashMap<String, SynClosure>, ExecutionError> {
+            let list_closure = block_list(view, self.0.clone()).ok_or_else(|| {
+                ExecutionError::Panic(
+                    "IoAction spec block did not evaluate to a Block constructor".to_string(),
+                )
+            })?;
+            Ok(collect_raw_block_fields(view, &pool, list_closure))
+        }
+    }
+
+    let pool = machine.symbol_pool().clone();
+    let raw_fields = machine
+        .mutate(ReadBlockFields(evaluated_block), pool)
+        .map_err(IoRunError::from)?;
+
+    // ── Evaluate each field closure to WHNF and read its string value ─────────
+    let mut eval_fields: HashMap<String, Option<String>> = HashMap::new();
+    for (key, raw_closure) in raw_fields {
+        let whnf = machine
+            .evaluate_to_whnf_for_io(raw_closure)
+            .map_err(IoRunError::from)?;
+
+        // For list-valued fields (e.g. `args` in exec), use ReadListAsStrings
+        // to collect list elements before reading as a NUL-separated string.
+        // ReadClosureAsString handles simple string/num values directly.
+        // The globals env frame is needed to resolve G(i) refs in list tails
+        // (e.g. the compiled ListNil global used as the end-of-list sentinel).
+        let globals = machine.globals_env();
+        let value_str = machine
+            .mutate(ReadClosureAsString { closure: whnf }, Some(globals))
+            .map_err(IoRunError::from)?;
+        eval_fields.insert(key, value_str);
+    }
+
+    // ── Determine tag ─────────────────────────────────────────────────────────
+    //
+    // For inline blocks the tag was captured statically above.
+    // For App-thunk blocks the Meta was stripped by evaluation; infer from fields.
+    let tag_name = static_tag.unwrap_or_else(|| {
+        if eval_fields.contains_key("args") {
+            "io-exec".to_string()
+        } else {
+            "io-shell".to_string()
+        }
+    });
+
+    // Step 4: build ActionSpec from evaluated fields.
+    let timeout_secs = eval_fields
+        .get("timeout")
+        .and_then(|opt| opt.as_deref())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(30);
+
+    let stdin = eval_fields
+        .get("stdin")
+        .and_then(|opt| opt.clone())
+        .filter(|s| !s.is_empty() && s != "null");
+
+    let is_shell = tag_name == "io-shell";
+    let is_exec = tag_name == "io-exec";
+
+    if is_shell {
+        let cmd = eval_fields
+            .get("cmd")
+            .and_then(|opt| opt.clone())
+            .ok_or_else(|| {
+                IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                    "io-shell spec missing 'cmd'".to_string(),
+                )))
+            })?;
+        Ok(ActionSpec::Shell {
+            cmd,
+            stdin,
+            timeout_secs,
+        })
+    } else if is_exec {
+        let cmd = eval_fields
+            .get("cmd")
+            .and_then(|opt| opt.clone())
+            .ok_or_else(|| {
+                IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                    "io-exec spec missing 'cmd'".to_string(),
+                )))
+            })?;
+        let args = eval_fields
+            .get("args")
+            .and_then(|opt| opt.clone())
+            .map(|s| {
+                if s.is_empty() {
+                    vec![]
+                } else {
+                    s.split('\x00').map(|x| x.to_string()).collect()
+                }
+            })
+            .unwrap_or_default();
+        Ok(ActionSpec::Exec {
+            cmd,
+            args,
+            stdin,
+            timeout_secs,
+        })
+    } else {
+        Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
+            format!("unrecognised IO action tag: {tag_name}"),
+        ))))
     }
 }
 
@@ -878,7 +1026,7 @@ fn extract_error_string(machine: &Machine<'_>, closure: &SynClosure) -> String {
         type Input = ();
         type Output = Option<String>;
         fn run(&self, view: &MutatorHeapView, _: ()) -> Result<Option<String>, ExecutionError> {
-            Ok(read_as_string(view, deref(view, self.0.clone())))
+            Ok(read_as_string(view, deref(view, self.0.clone()), None))
         }
     }
     machine
@@ -932,21 +1080,27 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                 let world = args[0].clone();
                 let spec_block = args[1].clone();
 
-                // Stash world so it survives GC across the mutator calls below.
+                // Stash world so it survives GC across the calls below.
                 machine.stash_push(world);
 
-                // Read the action spec by static heap navigation.  The spec_block
-                // is an unevaluated closure (Meta wrapping a LetRec block thunk).
-                // `ReadSpecBlock` navigates the heap structure without machine
-                // evaluation, using cycle-breaking in `dereference` to read
-                // lambda-captured values from letrec bindings.
-                let pool = machine.symbol_pool().clone();
-                let spec = machine
-                    .mutate(ReadSpecBlock { spec_block }, pool)
-                    .map_err(IoRunError::from)?;
+                // Evaluate the action spec block.  `evaluate_spec_block` uses
+                // machine evaluation to force each field to WHNF before reading,
+                // so it handles parameterised spec blocks (shell-with, exec-with)
+                // that contain unevaluated thunks (lookup-or calls, etc.).
+                let spec = evaluate_spec_block(machine, spec_block)?;
 
                 // Execute the shell action
                 let result = run_spec(&spec)?;
+
+                // Pre-intern the result block key symbols into the machine's
+                // pool so that the IDs embedded by BuildResultBlock are already
+                // present in the machine pool.  Without this, BuildResultBlock
+                // interns into a cloned pool and the heap objects contain IDs
+                // the machine pool doesn't know, causing index-out-of-bounds
+                // panics when the machine later resolves the result block.
+                machine.intern_symbol("stdout");
+                machine.intern_symbol("stderr");
+                machine.intern_symbol("exit-code");
 
                 // Build the result block closure.  World remains stashed as a GC root.
                 let pool = machine.symbol_pool().clone();

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1124,6 +1124,18 @@ impl<'a> Machine<'a> {
         &self.state.symbol_pool
     }
 
+    /// Intern a symbol string into the machine's symbol pool and return its ID.
+    ///
+    /// Used by the io-run driver to pre-register symbols (e.g. `"stdout"`,
+    /// `"stderr"`, `"exit-code"`) before they are embedded in heap objects by
+    /// a mutator.  Pre-interning ensures the IDs assigned during mutator heap
+    /// construction are already present in the machine's pool, so that later
+    /// LOOKUP and render operations (which use the machine pool) can resolve
+    /// them.
+    pub fn intern_symbol(&mut self, s: &str) -> crate::eval::memory::symbol::SymbolId {
+        self.state.symbol_pool.intern(s)
+    }
+
     /// Access the heap for allocation
     pub fn heap(&self) -> &Heap {
         &self.heap
@@ -1133,6 +1145,14 @@ impl<'a> Machine<'a> {
     /// root newly constructed closures that have no enclosing environment.
     pub fn root_env(&self) -> RefPtr<EnvFrame> {
         self.state.root_env
+    }
+
+    /// Return the globals environment frame.
+    ///
+    /// The globals frame holds the closures for all global bindings
+    /// (intrinsics, prelude, etc.) indexed by their `G(i)` ref.
+    pub fn globals_env(&self) -> RefPtr<EnvFrame> {
+        self.state.globals
     }
 
     /// Access the metrics (ticks, allocs, etc.)
@@ -1481,6 +1501,63 @@ impl<'a> Machine<'a> {
         self.state.terminated = false;
         self.state.yielded_io = false;
         self.state.closure = new_closure;
+    }
+
+    /// Evaluate a closure to WHNF while the machine is in IO yield state.
+    ///
+    /// Temporarily suspends the IO yield state, evaluates `closure` to
+    /// WHNF (normal termination), and restores the yielded IO state
+    /// (including the original `state.closure`).  The continuation stack
+    /// must be empty when called (which is always the case at an IO yield).
+    ///
+    /// Used by the io-run driver to force-evaluate spec block field
+    /// closures that contain unevaluated thunks (e.g. `lookup-or` calls
+    /// produced by `__io-shell-spec` / `__io-exec-spec`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the sub-evaluation encounters a machine error or
+    /// if it unexpectedly yields on an IO constructor (spec block fields
+    /// must not produce IO).
+    pub fn evaluate_to_whnf_for_io(
+        &mut self,
+        closure: SynClosure,
+    ) -> Result<SynClosure, ExecutionError> {
+        assert!(
+            self.state.yielded_io,
+            "evaluate_to_whnf_for_io called when machine is not in IO yield state"
+        );
+        assert!(
+            self.state.stack.is_empty(),
+            "evaluate_to_whnf_for_io called with non-empty continuation stack"
+        );
+
+        // Save the current IO yield closure.
+        let saved_closure = self.state.closure.clone();
+
+        // Temporarily evaluate the given closure to WHNF.
+        self.state.terminated = false;
+        self.state.yielded_io = false;
+        self.state.closure = closure;
+
+        self.run(None)?;
+
+        // Capture the result before restoring state.
+        let sub_yielded = self.state.yielded_io;
+        let result = self.state.closure.clone();
+
+        // Restore the IO yield state unconditionally.
+        self.state.terminated = true;
+        self.state.yielded_io = true;
+        self.state.closure = saved_closure;
+
+        if sub_yielded {
+            return Err(ExecutionError::Panic(
+                "spec block field evaluation unexpectedly yielded an IO constructor".to_string(),
+            ));
+        }
+
+        Ok(result)
     }
 
     /// Assertion helper for machine unit tests

--- a/tests/harness/116_io_shell_with.eu
+++ b/tests/harness/116_io_shell_with.eu
@@ -1,0 +1,8 @@
+"io.shell-with: parameterised spec block evaluates correctly. Uses --allow-io."
+
+` { target: :test requires-io: true }
+test:
+  { :io r: io.shell-with({timeout: 120}, "echo hello") }.(
+    if(r.stdout str.matches?("hello.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness/117_io_exec.eu
+++ b/tests/harness/117_io_exec.eu
@@ -1,0 +1,8 @@
+"io.exec: direct list-based exec spec block evaluates correctly. Uses --allow-io."
+
+` { target: :test requires-io: true }
+test:
+  { :io r: io.exec(["echo", "hello"]) }.(
+    if(r.stdout str.matches?("hello.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness/118_io_exec_with.eu
+++ b/tests/harness/118_io_exec_with.eu
@@ -1,0 +1,8 @@
+"io.exec-with: parameterised exec spec block evaluates correctly. Uses --allow-io."
+
+` { target: :test requires-io: true }
+test:
+  { :io r: io.exec-with({timeout: 120}, ["echo", "hello"]) }.(
+    if(r.stdout str.matches?("hello.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -577,6 +577,21 @@ pub fn test_harness_115() {
 }
 
 #[test]
+pub fn test_harness_116() {
+    run_test(&io_opts("116_io_shell_with.eu"));
+}
+
+#[test]
+pub fn test_harness_117() {
+    run_test(&io_opts("117_io_exec.eu"));
+}
+
+#[test]
+pub fn test_harness_118() {
+    run_test(&io_opts("118_io_exec_with.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- **Root cause 1 (driver)**: `ReadSpecBlock` in `io_run.rs` did static heap navigation and could not handle parameterised spec blocks (`io.shell-with`, `io.exec`, `io.exec-with`) whose fields are unevaluated App thunks. Replaced with `evaluate_spec_block` which uses `machine.evaluate_to_whnf_for_io()` to force both the spec block itself and each of its fields before reading. Adds `resolve_ref_with_globals` to handle `G(i)` refs (compiled `ListNil`) in list-valued fields such as `exec` args.

- **Root cause 2 (prelude)**: In eucalypt, `{cmd: cmd, ...}` creates a self-referential binding — the RHS `cmd` resolves to the block-scope binding, not the outer function parameter. Renamed parameters in `shell`/`exec` helpers (`cmd→c`, `args→as`) to avoid the collision.

- **Harness tests**: Added tests 116–118 covering `io.shell-with`, `io.exec`, and `io.exec-with` inside monadic blocks.

## Changes

- `src/driver/io_run.rs` — evaluate spec block and fields to WHNF; handle G-refs in list args
- `src/eval/machine/vm.rs` — add `evaluate_to_whnf_for_io` and `globals_env` methods
- `lib/prelude.eu` — rename parameters to avoid self-referential block bindings
- `tests/harness/116_io_shell_with.eu`, `117_io_exec.eu`, `118_io_exec_with.eu` — new harness tests
- `tests/harness_test.rs` — register new tests

## Test plan

- [x] `cargo test --release` — all 209 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — no changes
- [x] Manual: `io.shell`, `io.shell-with`, `io.exec`, `io.exec-with` all produce correct output
- [x] New harness tests 116, 117, 118 all pass

Fixes eu-vc32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)