### PR TITLE
fix(io-run): reuse render_closure_to_emitter for spec field reading (eu-lfvi)

### DIFF
--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -33,8 +33,9 @@ use crate::eval::{
         symbol::SymbolPool,
         syntax::{HeapSyn, Native, Ref, RefPtr, StgBuilder},
     },
-    stg::tags::DataConstructor,
+    stg::{render_to_string::render_closure_to_emitter, tags::DataConstructor},
 };
+use crate::export;
 
 // ─── Public error type ────────────────────────────────────────────────────────
 
@@ -293,8 +294,8 @@ fn peel_meta(
 
 /// Convenience wrapper: follow indirection atoms and return just the closure.
 ///
-/// For cases that do not need the container env (list walking, `read_as_string`,
-/// etc.), this avoids cluttering every call site with `let (c, _) = …`.
+/// For cases that do not need the container env (list walking, etc.),
+/// this avoids cluttering every call site with `let (c, _) = …`.
 #[inline]
 fn deref(view: &MutatorHeapView<'_>, closure: SynClosure) -> SynClosure {
     dereference(view, closure).0
@@ -355,75 +356,102 @@ fn block_list_inner(view: &MutatorHeapView<'_>, c: SynClosure, depth: usize) -> 
     }
 }
 
-/// Try to read a closure's WHNF value as a plain Rust `String`.
+/// If the WHNF closure is a boxed scalar (`BoxedString`, `BoxedNumber`,
+/// `BoxedSymbol`, `BoxedZdt`), extract the inner closure so it can be
+/// evaluated further.  Returns `None` if the closure is not a box.
 ///
-/// Handles: Atom(Str), Atom(Num), BoxedString, BoxedNumber, and
-/// cons-lists of strings (stored NUL-separated for exec args).
-///
-/// `globals` is optional; it is required to resolve `G(i)` refs (e.g. the
-/// global nil `ListNil` that appears as the tail of a compiled list).
-fn read_as_string(
-    view: &MutatorHeapView<'_>,
-    closure: SynClosure,
-    globals: Option<RefPtr<EnvFrame>>,
-) -> Option<String> {
-    let code = view.scoped(closure.code());
-    match &*code {
-        HeapSyn::Atom {
-            evaluand: Ref::V(Native::Str(s)),
-        } => Some(view.scoped(*s).as_str().to_string()),
-        HeapSyn::Atom {
-            evaluand: Ref::V(Native::Num(n)),
-        } => Some(n.to_string()),
-        HeapSyn::Cons { tag, args } if *tag == DataConstructor::BoxedString.tag() => {
-            let r = args.get(0)?;
-            match r {
-                Ref::V(Native::Str(s)) => Some(view.scoped(s).as_str().to_string()),
-                _ => None,
-            }
-        }
-        HeapSyn::Cons { tag, args } if *tag == DataConstructor::BoxedNumber.tag() => {
-            let r = args.get(0)?;
-            match r {
-                Ref::V(Native::Num(n)) => Some(n.to_string()),
-                _ => None,
-            }
-        }
-        HeapSyn::Cons { tag, .. }
-            if *tag == DataConstructor::ListCons.tag()
-                || *tag == DataConstructor::ListNil.tag() =>
-        {
-            // Collect list elements as NUL-separated string.
-            // G-refs (e.g. the global ListNil used as the list terminator)
-            // are resolved via the globals frame when provided.
-            let mut parts: Vec<String> = Vec::new();
-            let mut cur = closure.clone();
-            loop {
-                let c = view.scoped(cur.code());
-                match &*c {
-                    HeapSyn::Cons { tag: t, .. } if *t == DataConstructor::ListNil.tag() => break,
-                    HeapSyn::Cons { tag: t, args } if *t == DataConstructor::ListCons.tag() => {
-                        let hr = args.get(0)?;
-                        let tr = args.get(1)?;
-                        let head = resolve_ref_with_globals(view, &cur, hr, globals).ok()?;
-                        let tail = resolve_ref_with_globals(view, &cur, tr, globals).ok()?;
-                        if let Some(s) = read_as_string(view, deref(view, head), globals) {
-                            parts.push(s);
-                        }
-                        cur = deref(view, tail);
+/// This is needed when the STG intrinsic wrapper produces
+/// `let [b0 = bif_result] in BoxedString(L(0))`: after `evaluate_to_whnf_for_io`
+/// returns this `BoxedString`, the inner `L(0)` is still an unevaluated thunk.
+/// Peeling and re-evaluating yields the actual string value.
+fn peel_box_inner(machine: &Machine<'_>, closure: SynClosure) -> Option<SynClosure> {
+    struct PeelBox(SynClosure);
+    impl Mutator for PeelBox {
+        type Input = ();
+        type Output = Option<SynClosure>;
+        fn run(&self, view: &MutatorHeapView, _: ()) -> Result<Option<SynClosure>, ExecutionError> {
+            let c = deref(view, self.0.clone());
+            let code = view.scoped(c.code());
+            match &*code {
+                HeapSyn::Cons { tag, args }
+                    if *tag == DataConstructor::BoxedString.tag()
+                        || *tag == DataConstructor::BoxedNumber.tag()
+                        || *tag == DataConstructor::BoxedSymbol.tag()
+                        || *tag == DataConstructor::BoxedZdt.tag() =>
+                {
+                    let inner_ref = match args.get(0) {
+                        Some(r) => r,
+                        None => return Ok(None),
+                    };
+                    // Only peel L(i) refs — V(native) refs are already evaluated
+                    // and render_closure_to_emitter handles them directly.
+                    if matches!(inner_ref, Ref::L(_)) {
+                        Ok(resolve_ref(view, &c, inner_ref).ok())
+                    } else {
+                        Ok(None)
                     }
-                    _ => break,
                 }
+                _ => Ok(None),
             }
-            Some(parts.join("\x00"))
         }
-        HeapSyn::Meta { body, .. } => {
-            let body_closure =
-                resolve_ref_with_globals(view, &closure, body.clone(), globals).ok()?;
-            read_as_string(view, deref(view, body_closure), globals)
-        }
-        _ => None,
     }
+    machine.mutate(PeelBox(closure), ()).ok().flatten()
+}
+
+/// Render a WHNF closure to a Rust `String` using the text emitter.
+///
+/// Returns `None` if the result is empty or consists only of the YAML document
+/// separator `---` (which the text emitter emits for null/unit values).
+///
+/// This is the canonical way to extract a string value from an evaluated spec
+/// block field.  It uses `render_closure_to_emitter` so it correctly handles
+/// all value forms, including `BoxedString(L(i))` closures produced by the STG
+/// intrinsic wrapper.
+fn render_whnf_to_string(
+    machine: &Machine<'_>,
+    closure: SynClosure,
+) -> Result<Option<String>, ExecutionError> {
+    struct RenderField {
+        closure: SynClosure,
+        pool: SymbolPool,
+        root_env: RefPtr<EnvFrame>,
+    }
+    impl Mutator for RenderField {
+        type Input = ();
+        type Output = Option<String>;
+        fn run(&self, view: &MutatorHeapView, _: ()) -> Result<Option<String>, ExecutionError> {
+            let mut buffer: Vec<u8> = Vec::new();
+            {
+                let mut emitter = export::create_emitter("text", &mut buffer)
+                    .ok_or_else(|| ExecutionError::Panic("text emitter unavailable".to_string()))?;
+                render_closure_to_emitter(
+                    self.closure.clone(),
+                    &self.pool,
+                    self.root_env,
+                    *view,
+                    emitter.as_mut(),
+                )?;
+            }
+            let s = match String::from_utf8(buffer) {
+                Ok(s) => s,
+                Err(_) => return Ok(None),
+            };
+            let trimmed = s.trim().to_string();
+            if trimmed.is_empty() || trimmed == "---" {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.trim_start_matches("---").trim().to_string()))
+            }
+        }
+    }
+    machine.mutate(
+        RenderField {
+            closure,
+            pool: machine.symbol_pool().clone(),
+            root_env: machine.root_env(),
+        },
+        (),
+    )
 }
 
 // ─── Mutator: extract raw (unevaluated) field closures from a spec block ──────
@@ -499,29 +527,69 @@ fn collect_raw_pair(
     }
 }
 
-// ─── Mutator: read a single WHNF closure as a string ─────────────────────────
+// ─── Mutators: list inspection for field evaluation ───────────────────────────
 
-/// Mutator that reads a WHNF closure as a Rust `String`.
-///
-/// Used after `evaluate_to_whnf_for_io` to extract the string value from an
-/// evaluated spec block field.  The `Input` carries an optional globals env
-/// frame so that list tails using `G(i)` refs (e.g. the compiled `ListNil`)
-/// can be resolved.
-struct ReadClosureAsString {
-    closure: SynClosure,
+/// Mutator that returns `true` if the closure is a `ListCons` or `ListNil`.
+struct IsList(SynClosure);
+
+impl Mutator for IsList {
+    type Input = ();
+    type Output = bool;
+
+    fn run(&self, view: &MutatorHeapView, _: ()) -> Result<bool, ExecutionError> {
+        let c = deref(view, self.0.clone());
+        let code = view.scoped(c.code());
+        Ok(matches!(
+            &*code,
+            HeapSyn::Cons { tag, .. }
+                if *tag == DataConstructor::ListCons.tag()
+                    || *tag == DataConstructor::ListNil.tag()
+        ))
+    }
 }
 
-impl Mutator for ReadClosureAsString {
+/// Mutator that collects the raw closures of all elements in a `ListCons` chain.
+///
+/// Does not evaluate the elements — returns unevaluated closures so the caller
+/// can force each one to WHNF using the machine separately.
+///
+/// The `Input` is the globals env frame, needed to resolve `G(i)` refs that
+/// appear as the list tail sentinel (the compiled `ListNil` global).
+struct CollectListElements(SynClosure);
+
+impl Mutator for CollectListElements {
     type Input = Option<RefPtr<EnvFrame>>;
-    type Output = Option<String>;
+    type Output = Vec<SynClosure>;
 
     fn run(
         &self,
         view: &MutatorHeapView,
-        globals: Option<RefPtr<EnvFrame>>,
-    ) -> Result<Option<String>, ExecutionError> {
-        let c = deref(view, self.closure.clone());
-        Ok(read_as_string(view, c, globals))
+        globals_env: Option<RefPtr<EnvFrame>>,
+    ) -> Result<Vec<SynClosure>, ExecutionError> {
+        let mut result = Vec::new();
+        let mut current = deref(view, self.0.clone());
+        loop {
+            let code = view.scoped(current.code());
+            match &*code {
+                HeapSyn::Cons { tag, .. } if *tag == DataConstructor::ListNil.tag() => break,
+                HeapSyn::Cons { tag, args } if *tag == DataConstructor::ListCons.tag() => {
+                    let head_ref = args
+                        .get(0)
+                        .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
+                    let tail_ref = args
+                        .get(1)
+                        .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
+                    let head = resolve_ref_with_globals(view, &current, head_ref, globals_env)?;
+                    result.push(deref(view, head));
+                    current = deref(
+                        view,
+                        resolve_ref_with_globals(view, &current, tail_ref, globals_env)?,
+                    );
+                }
+                _ => break,
+            }
+        }
+        Ok(result)
     }
 }
 
@@ -611,22 +679,63 @@ fn evaluate_spec_block(
         .mutate(ReadBlockFields(evaluated_block), pool)
         .map_err(IoRunError::from)?;
 
-    // ── Evaluate each field closure to WHNF and read its string value ─────────
+    // ── Evaluate each field closure to WHNF and render its string value ──────
+    //
+    // Each field is forced to WHNF by the machine, then rendered to a plain
+    // string via the text emitter.  Using `render_closure_to_emitter` handles
+    // all WHNF forms correctly, including `BoxedString(L(i))` closures produced
+    // by the STG intrinsic wrapper (e.g. when the cmd is a format expression).
+    //
+    // For list-valued fields (e.g. `args` in io.exec) we walk the cons list and
+    // render each element individually, then join with NUL as a separator.
     let mut eval_fields: HashMap<String, Option<String>> = HashMap::new();
     for (key, raw_closure) in raw_fields {
         let whnf = machine
             .evaluate_to_whnf_for_io(raw_closure)
             .map_err(IoRunError::from)?;
 
-        // For list-valued fields (e.g. `args` in exec), use ReadListAsStrings
-        // to collect list elements before reading as a NUL-separated string.
-        // ReadClosureAsString handles simple string/num values directly.
-        // The globals env frame is needed to resolve G(i) refs in list tails
-        // (e.g. the compiled ListNil global used as the end-of-list sentinel).
-        let globals = machine.globals_env();
-        let value_str = machine
-            .mutate(ReadClosureAsString { closure: whnf }, Some(globals))
-            .map_err(IoRunError::from)?;
+        // If the WHNF is a boxed scalar with an unevaluated inner thunk
+        // (e.g. `BoxedString(L(0))` produced by the STG intrinsic wrapper
+        // when `cmd` is a format expression), peel the box and evaluate the
+        // inner closure to get the actual native value.
+        let whnf = if let Some(inner) = peel_box_inner(machine, whnf.clone()) {
+            machine
+                .evaluate_to_whnf_for_io(inner)
+                .map_err(IoRunError::from)?
+        } else {
+            whnf
+        };
+
+        // Check whether the WHNF is a list (ListCons or ListNil).
+        // List-valued fields (e.g. `args`) need each element rendered separately.
+        let is_list = machine.mutate(IsList(whnf.clone()), ()).unwrap_or(false);
+
+        let value_str = if is_list {
+            // Collect list element closures, evaluate each to WHNF, render.
+            // Pass globals env so G(i) list tail refs (compiled ListNil) resolve.
+            let globals = machine.globals_env();
+            let elements = machine
+                .mutate(CollectListElements(whnf), Some(globals))
+                .map_err(IoRunError::from)?;
+            let mut parts: Vec<String> = Vec::new();
+            for elem in elements {
+                let elem_whnf = machine
+                    .evaluate_to_whnf_for_io(elem)
+                    .map_err(IoRunError::from)?;
+                if let Some(s) =
+                    render_whnf_to_string(machine, elem_whnf).map_err(IoRunError::from)?
+                {
+                    parts.push(s);
+                }
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\x00"))
+            }
+        } else {
+            render_whnf_to_string(machine, whnf).map_err(IoRunError::from)?
+        };
         eval_fields.insert(key, value_str);
     }
 
@@ -1021,16 +1130,7 @@ fn run_spec(spec: &ActionSpec) -> Result<CommandResult, IoRunError> {
 
 /// Try to read an error string from an IoFail error closure.
 fn extract_error_string(machine: &Machine<'_>, closure: &SynClosure) -> String {
-    struct ExtractStr(SynClosure);
-    impl Mutator for ExtractStr {
-        type Input = ();
-        type Output = Option<String>;
-        fn run(&self, view: &MutatorHeapView, _: ()) -> Result<Option<String>, ExecutionError> {
-            Ok(read_as_string(view, deref(view, self.0.clone()), None))
-        }
-    }
-    machine
-        .mutate(ExtractStr(closure.clone()), ())
+    render_whnf_to_string(machine, closure.clone())
         .ok()
         .flatten()
         .unwrap_or_else(|| "IO monad failure".to_string())

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -28,7 +28,8 @@ use crate::{
             mutator::MutatorHeapView,
             ndarray::HeapNdArray,
             set::Primitive as SetPrimitive,
-            syntax::{HeapSyn, Native, Ref},
+            symbol::SymbolPool,
+            syntax::{HeapSyn, Native, Ref, RefPtr},
         },
         primitive::Primitive,
     },
@@ -55,7 +56,7 @@ fn resolve_cons_arg(
     closure: &SynClosure,
     view: &MutatorHeapView<'_>,
     r: Ref,
-    root_env: crate::eval::memory::syntax::RefPtr<EnvFrame>,
+    root_env: RefPtr<EnvFrame>,
 ) -> Result<SynClosure, ExecutionError> {
     match r {
         Ref::L(i) => {
@@ -74,10 +75,7 @@ fn resolve_cons_arg(
 }
 
 /// Convert a set primitive to a render primitive
-fn set_primitive_to_render_primitive(
-    prim: &SetPrimitive,
-    machine: &dyn IntrinsicMachine,
-) -> Primitive {
+fn set_primitive_to_render_primitive(prim: &SetPrimitive, pool: &SymbolPool) -> Primitive {
     match prim {
         SetPrimitive::Num(n) => {
             let num = serde_json::Number::from_f64(n.into_inner())
@@ -85,14 +83,14 @@ fn set_primitive_to_render_primitive(
             Primitive::Num(num)
         }
         SetPrimitive::Str(s) => Primitive::Str(s.clone()),
-        SetPrimitive::Sym(id) => Primitive::Sym(machine.symbol_pool().resolve(*id).to_string()),
+        SetPrimitive::Sym(id) => Primitive::Sym(pool.resolve(*id).to_string()),
     }
 }
 
 /// Render a native value to the emitter
 fn render_native(
     native: &Native,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) {
@@ -105,7 +103,7 @@ fn render_native(
             emitter.scalar(&RenderMetadata::empty(), &Primitive::Str(text));
         }
         Native::Sym(id) => {
-            let sym = machine.symbol_pool().resolve(*id).to_string();
+            let sym = pool.resolve(*id).to_string();
             emitter.scalar(&RenderMetadata::empty(), &Primitive::Sym(sym));
         }
         Native::Zdt(dt) => {
@@ -115,7 +113,7 @@ fn render_native(
             let set = view.scoped(*ptr);
             emitter.sequence_start(&RenderMetadata::empty());
             for elem in set.sorted_elements() {
-                let prim = set_primitive_to_render_primitive(elem, machine);
+                let prim = set_primitive_to_render_primitive(elem, pool);
                 emitter.scalar(&RenderMetadata::empty(), &prim);
             }
             emitter.sequence_end();
@@ -166,15 +164,19 @@ fn render_ndarray_data(emitter: &mut dyn Emitter, arr: &HeapNdArray, metadata: &
 /// logic of the STG `Render` wrapper but executes it entirely in Rust
 /// by walking the heap directly.
 ///
+/// `pool` provides symbol resolution; `root_env` is used when wrapping
+/// inline `V` or `G` refs in fresh `Atom` closures.
+///
 /// # Recursion depth
 ///
 /// This function recurses proportionally to the nesting depth of the
 /// eucalypt value.  Very deeply nested structures may overflow the Rust
 /// stack.  In practice eucalypt programs rarely produce nesting depths
 /// that would be problematic.
-fn render_closure_to_emitter(
+pub(crate) fn render_closure_to_emitter(
     closure: SynClosure,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
+    root_env: RefPtr<EnvFrame>,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) -> Result<(), ExecutionError> {
@@ -184,14 +186,14 @@ fn render_closure_to_emitter(
     match &*code {
         HeapSyn::Atom { evaluand } => match evaluand {
             Ref::V(native) => {
-                render_native(native, machine, view, emitter);
+                render_native(native, pool, view, emitter);
                 Ok(())
             }
             Ref::L(i) => {
                 let inner = (*env)
                     .get(&view, *i)
                     .ok_or(ExecutionError::BadEnvironmentIndex(*i))?;
-                render_closure_to_emitter(inner, machine, view, emitter)
+                render_closure_to_emitter(inner, pool, root_env, view, emitter)
             }
             Ref::G(_) => {
                 // Global refs are wrappers (lambda forms) — not directly
@@ -223,13 +225,13 @@ fn render_closure_to_emitter(
                     let inner_ref = args
                         .get(0)
                         .ok_or_else(|| ExecutionError::Panic("empty boxed value".to_string()))?;
-                    let inner = resolve_cons_arg(&closure, &view, inner_ref, machine.root_env())?;
-                    render_closure_to_emitter(inner, machine, view, emitter)
+                    let inner = resolve_cons_arg(&closure, &view, inner_ref, root_env)?;
+                    render_closure_to_emitter(inner, pool, root_env, view, emitter)
                 }
                 Ok(DataConstructor::ListCons) => {
                     // List: emit a sequence by traversing the cons chain
                     emitter.sequence_start(&RenderMetadata::empty());
-                    render_list_from_cons(closure.clone(), args, machine, view, emitter)?;
+                    render_list_from_cons(closure.clone(), args, pool, root_env, view, emitter)?;
                     emitter.sequence_end();
                     Ok(())
                 }
@@ -243,17 +245,16 @@ fn render_closure_to_emitter(
                     let items_ref = args
                         .get(0)
                         .ok_or_else(|| ExecutionError::Panic("block missing items".to_string()))?;
-                    let items_closure =
-                        resolve_cons_arg(&closure, &view, items_ref, machine.root_env())?;
+                    let items_closure = resolve_cons_arg(&closure, &view, items_ref, root_env)?;
                     emitter.block_start(&RenderMetadata::empty());
-                    render_block_items(items_closure, machine, view, emitter)?;
+                    render_block_items(items_closure, pool, root_env, view, emitter)?;
                     emitter.block_end();
                     Ok(())
                 }
                 Ok(DataConstructor::BlockPair) => {
                     // Standalone BlockPair: render as a single-entry block
                     emitter.block_start(&RenderMetadata::empty());
-                    render_block_pair_args(&closure, args, machine, view, emitter)?;
+                    render_block_pair_args(&closure, args, pool, root_env, view, emitter)?;
                     emitter.block_end();
                     Ok(())
                 }
@@ -262,8 +263,8 @@ fn render_closure_to_emitter(
                     let inner_ref = args.get(0).ok_or_else(|| {
                         ExecutionError::Panic("block-kv-list missing cons".to_string())
                     })?;
-                    let inner = resolve_cons_arg(&closure, &view, inner_ref, machine.root_env())?;
-                    render_list_items_raw(inner, machine, view, emitter)
+                    let inner = resolve_cons_arg(&closure, &view, inner_ref, root_env)?;
+                    render_list_items_raw(inner, pool, root_env, view, emitter)
                 }
                 _ => {
                     // Unknown / IO constructors — emit null
@@ -288,7 +289,8 @@ fn render_closure_to_emitter(
 fn render_list_from_cons(
     mut current: SynClosure,
     initial_args: &Array<Ref>,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
+    root_env: RefPtr<EnvFrame>,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) -> Result<(), ExecutionError> {
@@ -300,11 +302,11 @@ fn render_list_from_cons(
         .get(1)
         .ok_or_else(|| ExecutionError::Panic("malformed list cons (no tail)".to_string()))?;
 
-    let head = resolve_cons_arg(&current, &view, head_ref, machine.root_env())?;
-    render_closure_to_emitter(head, machine, view, emitter)?;
+    let head = resolve_cons_arg(&current, &view, head_ref, root_env)?;
+    render_closure_to_emitter(head, pool, root_env, view, emitter)?;
 
     // Walk the remaining tail without recursion
-    let mut tail = resolve_cons_arg(&current, &view, tail_ref, machine.root_env())?;
+    let mut tail = resolve_cons_arg(&current, &view, tail_ref, root_env)?;
 
     loop {
         let tail_code = view.scoped(tail.code());
@@ -318,9 +320,9 @@ fn render_list_from_cons(
                     let t_ref = args
                         .get(1)
                         .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
-                    let head = resolve_cons_arg(&tail, &view, h_ref, machine.root_env())?;
-                    render_closure_to_emitter(head, machine, view, emitter)?;
-                    let next_tail = resolve_cons_arg(&tail, &view, t_ref, machine.root_env())?;
+                    let head = resolve_cons_arg(&tail, &view, h_ref, root_env)?;
+                    render_closure_to_emitter(head, pool, root_env, view, emitter)?;
+                    let next_tail = resolve_cons_arg(&tail, &view, t_ref, root_env)?;
                     current = tail;
                     tail = next_tail;
                     let _ = current; // keep borrow checker happy
@@ -337,7 +339,8 @@ fn render_list_from_cons(
 /// Render list items without sequence delimiters (used for BlockKvList).
 fn render_list_items_raw(
     mut current: SynClosure,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
+    root_env: RefPtr<EnvFrame>,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) -> Result<(), ExecutionError> {
@@ -353,9 +356,9 @@ fn render_list_items_raw(
                     let t_ref = args
                         .get(1)
                         .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
-                    let head = resolve_cons_arg(&current, &view, h_ref, machine.root_env())?;
-                    render_closure_to_emitter(head, machine, view, emitter)?;
-                    current = resolve_cons_arg(&current, &view, t_ref, machine.root_env())?;
+                    let head = resolve_cons_arg(&current, &view, h_ref, root_env)?;
+                    render_closure_to_emitter(head, pool, root_env, view, emitter)?;
+                    current = resolve_cons_arg(&current, &view, t_ref, root_env)?;
                 }
                 _ => break,
             },
@@ -368,7 +371,8 @@ fn render_list_items_raw(
 /// Traverse a list of block items (BlockPair or BlockKvList) and render each.
 fn render_block_items(
     mut current: SynClosure,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
+    root_env: RefPtr<EnvFrame>,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) -> Result<(), ExecutionError> {
@@ -385,7 +389,7 @@ fn render_block_items(
                         ExecutionError::Panic("malformed block items list (no tail)".to_string())
                     })?;
 
-                    let head = resolve_cons_arg(&current, &view, h_ref, machine.root_env())?;
+                    let head = resolve_cons_arg(&current, &view, h_ref, root_env)?;
                     let head_code = view.scoped(head.code());
 
                     if let HeapSyn::Cons {
@@ -394,20 +398,21 @@ fn render_block_items(
                     } = &*head_code
                     {
                         if *item_tag == DataConstructor::BlockPair.tag() {
-                            render_block_pair_args(&head, item_args, machine, view, emitter)?;
+                            render_block_pair_args(
+                                &head, item_args, pool, root_env, view, emitter,
+                            )?;
                         } else if *item_tag == DataConstructor::BlockKvList.tag() {
                             // BlockKvList nested in a block: render its items inline
                             let inner_ref = item_args.get(0).ok_or_else(|| {
                                 ExecutionError::Panic("empty block-kv-list".to_string())
                             })?;
-                            let inner =
-                                resolve_cons_arg(&head, &view, inner_ref, machine.root_env())?;
-                            render_list_items_raw(inner, machine, view, emitter)?;
+                            let inner = resolve_cons_arg(&head, &view, inner_ref, root_env)?;
+                            render_list_items_raw(inner, pool, root_env, view, emitter)?;
                         }
                         // Other tags: skip
                     }
 
-                    current = resolve_cons_arg(&current, &view, t_ref, machine.root_env())?;
+                    current = resolve_cons_arg(&current, &view, t_ref, root_env)?;
                 }
                 _ => break,
             },
@@ -424,7 +429,8 @@ fn render_block_items(
 fn render_block_pair_args(
     closure: &SynClosure,
     args: &Array<Ref>,
-    machine: &dyn IntrinsicMachine,
+    pool: &SymbolPool,
+    root_env: RefPtr<EnvFrame>,
     view: MutatorHeapView<'_>,
     emitter: &mut dyn Emitter,
 ) -> Result<(), ExecutionError> {
@@ -438,7 +444,7 @@ fn render_block_pair_args(
     // The key is an unboxed symbol (or string) ref
     let key_native = closure.navigate_local_native(&view, key_ref);
     let key_str = match key_native {
-        Native::Sym(id) => machine.symbol_pool().resolve(id).to_string(),
+        Native::Sym(id) => pool.resolve(id).to_string(),
         Native::Str(s) => (*view.scoped(s)).as_str().to_string(),
         _ => "<key>".to_string(),
     };
@@ -447,8 +453,8 @@ fn render_block_pair_args(
     emitter.scalar(&RenderMetadata::empty(), &Primitive::Sym(key_str));
 
     // Emit value
-    let val = resolve_cons_arg(closure, &view, val_ref, machine.root_env())?;
-    render_closure_to_emitter(val, machine, view, emitter)
+    let val = resolve_cons_arg(closure, &view, val_ref, root_env)?;
+    render_closure_to_emitter(val, pool, root_env, view, emitter)
 }
 
 /// RENDER_TO_STRING(value, format_sym) → Str
@@ -479,6 +485,10 @@ impl StgIntrinsic for RenderToString {
         // Resolve args[0] to a closure for traversal
         let value_closure = machine.nav(view).resolve(&args[0])?;
 
+        // Extract pool and root_env before entering the render traversal
+        let pool = machine.symbol_pool().clone();
+        let root_env = machine.root_env();
+
         // Capture output into a Vec<u8> buffer
         let mut buffer: Vec<u8> = Vec::new();
         let mut string_emitter =
@@ -490,7 +500,13 @@ impl StgIntrinsic for RenderToString {
         string_emitter.stream_start();
         string_emitter.doc_start();
 
-        render_closure_to_emitter(value_closure, machine, view, string_emitter.as_mut())?;
+        render_closure_to_emitter(
+            value_closure,
+            &pool,
+            root_env,
+            view,
+            string_emitter.as_mut(),
+        )?;
 
         string_emitter.doc_end();
         string_emitter.stream_end();


### PR DESCRIPTION
## Summary

- Refactors `render_closure_to_emitter` in `render_to_string.rs` to accept `(pool: &SymbolPool, root_env: RefPtr<EnvFrame>)` instead of `machine: &dyn IntrinsicMachine`, making it callable from `io_run.rs` inside a `Mutator::run` where the machine cannot be accessed
- Replaces the fragile `read_as_string` pattern-matching approach in `evaluate_spec_block` with `render_closure_to_emitter` via a text emitter
- Fixes eu-lfvi: `io.shell("{} {}"("echo", "hello"))` no longer fails with "io-shell spec missing 'cmd'" — format expressions as shell commands now work correctly

## Root Cause

The STG intrinsic wrapper boxes results as `let [b0 = bif_result] in BoxedString(L(0))`. After `evaluate_to_whnf_for_io`, the machine stops at the `BoxedString` constructor (WHNF). The inner `L(0)` is still an unevaluated Bif thunk. The old `read_as_string` only matched `BoxedString(V(Str(s)))` (inline native ref) and returned `None` for `BoxedString(L(0))`, causing the "missing 'cmd'" error.

## Approach

1. `peel_box_inner`: detects when a WHNF closure is a boxed scalar with an unevaluated `L(i)` inner — peels the box and returns the inner closure
2. Call `evaluate_to_whnf_for_io` again on the peeled inner to force it
3. Then use `render_closure_to_emitter` with a text emitter to produce a string — handles all WHNF forms robustly
4. List-valued fields (`args` in `io.exec`) are collected element-by-element via `CollectListElements`, each element evaluated to WHNF individually, then joined with NUL

## Test plan

- [ ] `cargo test` — all 209 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — applied
- [ ] Manual: `eu -I -e '{ :io r: io.shell("{} {}"("echo", "hello")) }.r.stdout'` produces `"hello\n"` (previously failed)
- [ ] `test_harness_117` (io_exec) and `test_harness_118` (io_exec_with) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)