### PR TITLE
feat(prelude): add monad() utility for deriving standard monad operations (eu-q34c)

### DIFF
--- a/docs/reference/prelude/index.md
+++ b/docs/reference/prelude/index.md
@@ -19,6 +19,6 @@ in the prelude).
 - [Sets](sets.md) -- set operations (11 entries)
 - [Random Numbers](random.md) -- random number generation (5 entries)
 - [Metadata](metadata.md) -- metadata and assertion functions (7 entries)
-- [IO](io.md) -- environment, time, and argument access (9 entries)
+- [IO](io.md) -- environment, time, argument access, and monad utility (16 entries)
 
-*218 documented entries in total.*
+*225 documented entries in total.*

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -60,6 +60,60 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 | `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
 
+## Monad Utility
+
+`monad(m)` derives standard monad combinators from a minimal block `m`
+containing `bind` and `return` fields. This allows monad authors to define
+only those two primitives and obtain the full set of derived operations for
+free.
+
+```eu,notest
+my-io: monad({bind: io.bind, return: io.return}) {
+  # merge in specialised implementations or extra operations
+  shell(c): io.shell(c)
+}
+```
+
+The left block (derived defaults) is merged with the right block via
+catenation; specialised implementations in the right block override
+the defaults.
+
+| Function | Description |
+|----------|-------------|
+| `monad(m)` | Derive standard monad combinators from `m.bind` and `m.return` |
+| `monad(m).map(f, action)` | Apply pure function `f` to the result of a monadic action (fmap) |
+| `monad(m).then(a, b)` | Sequence two monadic actions, discarding the result of the first |
+| `monad(m).join(mm)` | Flatten a nested monadic value |
+| `monad(m).sequence(ms)` | Sequence a list of monadic actions, collecting results into a list |
+| `monad(m).map-m(f, xs)` | Apply `f` to each element of `xs` (producing actions), then sequence |
+| `monad(m).filter-m(p, xs)` | Monadic filter: apply predicate `p` (returning a monadic bool) to each element |
+
+### Example: IO monad via monad()
+
+```eu,notest
+` :suppress
+my-io: monad({bind: io.bind, return: io.return})
+
+result: { :io
+  r: my-io.map(.stdout, io.shell("echo hello"))
+}.(r)
+```
+
+### Example: Pure identity monad
+
+```eu
+` :suppress
+id-bind(m, f): f(m)
+` :suppress
+id-return(a): a
+` :suppress
+id-monad: monad({bind: id-bind, return: id-return})
+
+` { target: :example }
+example: id-monad.map-m(inc, [1, 2, 3])
+# => [2, 3, 4]
+```
+
 ## Other
 
 | Function | Description |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -82,6 +82,58 @@ __io-exec-spec(opts, c, as): {
   stdin: opts lookup-or(:stdin, null)
 }
 
+##
+## Monad utility
+##
+
+` :suppress
+__monad-return-of(m, f, x): m.return(f(x))
+
+` :suppress
+__monad-sequence-put(m, hd, xs): m.return(cons(hd, xs))
+
+` :suppress
+__monad-sequence-step(m, rest-ms, hd): m.bind(__monad-sequence(m, rest-ms), __monad-sequence-put(m, hd))
+
+` :suppress
+__monad-sequence(m, ms):
+  if(ms nil?, m.return([]), m.bind(ms head, __monad-sequence-step(m, ms tail)))
+
+` :suppress
+__monad-filter-put(m, elt, flag, rest): m.return(if(flag, cons(elt, rest), rest))
+
+` :suppress
+__monad-filter-gate(m, p, elt, rest-ms, flag):
+  m.bind(__monad-filter-m(m, p, rest-ms), __monad-filter-put(m, elt, flag))
+
+` :suppress
+__monad-filter-m(m, p, xs):
+  if(xs nil?, m.return([]), m.bind(p(xs head), __monad-filter-gate(m, p, xs head, xs tail)))
+
+` :suppress
+__monad-map-m(m, f, xs): __monad-sequence(m, map(f, xs))
+
+` "monad(m) - derive standard monad combinators from a block m with bind and return fields.
+Returns a block with map, then, join, sequence, map-m, and filter-m."
+monad(m): {
+  ` "map(f, action) - apply pure function f to the result of a monadic action (fmap)."
+  map(f, action): m.bind(action, __monad-return-of(m, f))
+
+  ` "then(a, b) - sequence two monadic actions, discarding the result of the first."
+  then(a, b): m.bind(a, -> b)
+
+  ` "join(mm) - flatten a nested monadic value."
+  join(mm): m.bind(mm, identity)
+
+  ` "sequence(ms) - sequence a list of monadic actions, collecting results into a list."
+  sequence(ms): __monad-sequence(m, ms)
+
+  ` "map-m(f, xs) - apply f to each element of xs (producing actions), then sequence."
+  map-m(f, xs): __monad-map-m(m, f, xs)
+
+  ` "filter-m(p, xs) - monadic filter: apply predicate p (returning a monadic bool) to each element."
+  filter-m(p, xs): __monad-filter-m(m, p, xs)
+}
 
 ##
 ## Random number generation

--- a/tests/harness/119_monad_utility.eu
+++ b/tests/harness/119_monad_utility.eu
@@ -1,0 +1,91 @@
+"monad(): derive standard monad combinators from bind and return. Uses --allow-io."
+
+##
+## A simple identity monad for pure tests (no IO needed)
+##
+# For identity monad: bind(m, f) = f(m), return(a) = a
+` :suppress
+id-bind(m, f): f(m)
+
+` :suppress
+id-return(a): a
+
+` :suppress
+id-monad: monad({bind: id-bind, return: id-return})
+
+##
+## map: apply a pure function to a wrapped value
+##
+` { target: :test-map-pure }
+test-map-pure:
+  if(id-monad.map(inc, 41) = 42,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## then: sequence two actions, discard the first result
+##
+` { target: :test-then-pure }
+test-then-pure:
+  if(id-monad.then(99, 42) = 42,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## join: flatten a nested wrapped value
+##
+` { target: :test-join-pure }
+test-join-pure:
+  if(id-monad.join(42) = 42,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## sequence: sequence a list of wrapped values, collecting results
+##
+` { target: :test-sequence-pure }
+test-sequence-pure:
+  if(id-monad.sequence([1, 2, 3]) = [1, 2, 3],
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## map-m: map a function over a list then sequence
+##
+` { target: :test-map-m-pure }
+test-map-m-pure:
+  if(id-monad.map-m(inc, [1, 2, 3]) = [2, 3, 4],
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## filter-m: monadic filter using the identity monad
+##
+` { target: :test-filter-m-pure }
+test-filter-m-pure:
+  if(id-monad.filter-m(> 2, [1, 2, 3, 4]) = [3, 4],
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## IO: derived monad map matches io.map
+##
+` :suppress
+io-monad: monad({bind: io.bind, return: io.return})
+
+` { target: :test-io-map requires-io: true }
+test-io-map:
+  { :io
+    r1: io-monad.map(.stdout, io.shell("echo hello"))
+    r2: io.map(.stdout, io.shell("echo hello"))
+  }.(if(r1 = r2, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## IO: derived monad then sequences two IO actions
+##
+` { target: :test-io-then requires-io: true }
+test-io-then:
+  { :io r: io-monad.then(io.shell("echo first"), io.shell("echo second")) }.(
+    if(r.stdout str.matches?("second.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness/119_monad_utility.eu
+++ b/tests/harness/119_monad_utility.eu
@@ -70,13 +70,10 @@ test-filter-m-pure:
 ##
 ## IO: derived monad map matches io.map
 ##
-` :suppress
-io-monad: monad({bind: io.bind, return: io.return})
-
 ` { target: :test-io-map requires-io: true }
 test-io-map:
   { :io
-    r1: io-monad.map(.stdout, io.shell("echo hello"))
+    r1: monad({bind: io.bind, return: io.return}).map(.stdout, io.shell("echo hello"))
     r2: io.map(.stdout, io.shell("echo hello"))
   }.(if(r1 = r2, { RESULT: :PASS }, { RESULT: :FAIL }))
 
@@ -85,7 +82,7 @@ test-io-map:
 ##
 ` { target: :test-io-then requires-io: true }
 test-io-then:
-  { :io r: io-monad.then(io.shell("echo first"), io.shell("echo second")) }.(
+  { :io r: monad({bind: io.bind, return: io.return}).then(io.shell("echo first"), io.shell("echo second")) }.(
     if(r.stdout str.matches?("second.*"),
       { RESULT: :PASS },
       { RESULT: :FAIL }))

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -592,6 +592,11 @@ pub fn test_harness_118() {
 }
 
 #[test]
+pub fn test_harness_119() {
+    run_test(&io_opts("119_monad_utility.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds `monad(m)` to `lib/prelude.eu`: derives `map`, `then`, `join`, `sequence`, `map-m`, and `filter-m` from a block with `bind` and `return` fields
- Includes top-level recursive helpers `__monad-sequence`, `__monad-filter-m`, and supporting functions (all suppressed from output)
- Adds harness test 119 covering: pure identity monad tests for all six combinators, and IO monad tests for `map` and `then`
- Documents `monad()` in `docs/reference/prelude/io.md` with examples

## Design notes

`monad(m)` returns a block that can be merged via catenation with specialised implementations:

```eu
my-io: monad({bind: io.bind, return: io.return}) {
  shell(c): io.shell(c)
}
```

The block-field shadowing pitfall was encountered during implementation: `map` inside the returned block shadowed the prelude `map`, causing `map-m` to call the derived monadic map instead of the list map. Fixed by extracting `__monad-map-m` as a top-level helper that explicitly calls `map(f, xs)`.

## Test plan

- [x] `cargo test test_harness_119` passes
- [x] All 210 harness tests pass (`cargo test --test harness_test`)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Pure monad tests (identity monad, no IO required): map, then, join, sequence, map-m, filter-m
- [x] IO monad tests (`--allow-io`): derived map matches `io.map`, derived then sequences correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)