### PR TITLE
feat(prelude): monadic random: namespace with state monad (eu-duwr)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,6 +24,7 @@
 - [YAML Embedding](guide/yaml-embedding.md)
 - [Testing with Eucalypt](guide/testing.md)
 - [Date, Time, and Random Numbers](guide/date-time-random.md)
+- [Monads and the monad() Utility](guide/monads.md)
 - [Advanced Topics](guide/advanced-topics.md)
 
 # Reference

--- a/docs/guide/monads.md
+++ b/docs/guide/monads.md
@@ -1,0 +1,318 @@
+# Monads and the monad() Utility
+
+Eucalypt has first-class support for monadic programming. Two built-in
+namespaces — `io` and `random` — are monads, and the `monad()` utility
+lets you build additional ones from just `bind` and `return`.
+
+## What is a monad in eucalypt?
+
+A *monad* is a namespace (block) that provides two primitives:
+
+| Primitive | Role |
+|-----------|------|
+| `return(v)` | Wrap a pure value as a monadic action |
+| `bind(action, f)` | Run an action, pass its result to `f`, return a new action |
+
+Everything else — `map`, `then`, `join`, `sequence`, `map-m`,
+`filter-m` — can be derived automatically from those two.
+
+---
+
+## The monad() utility
+
+`monad(m)` takes a block with `bind` and `return` fields and returns a
+block of derived combinators:
+
+```eu,notest
+my-monad: monad({
+  bind: my-bind
+  return: my-return
+})
+```
+
+The returned block provides:
+
+| Combinator | Description |
+|-----------|-------------|
+| `map(f, action)` | Apply pure function `f` to the result of an action (fmap) |
+| `then(a, b)` | Sequence two actions, discarding the result of the first |
+| `join(mm)` | Flatten a nested monadic value |
+| `sequence(ms)` | Run a list of actions in order, collecting results |
+| `map-m(f, xs)` | Apply `f` to each element of `xs`, then sequence |
+| `filter-m(p, xs)` | Monadic filter: keep elements where `p` returns a truthy action |
+
+---
+
+## Building a monadic namespace
+
+The typical pattern is to use `monad()` to produce the derived
+operations and then **catenate** (merge) specialised implementations or
+domain-specific operations on top:
+
+```eu,notest
+my-ns: monad({bind: my-bind, return: my-return}) {
+  bind: my-bind
+  return: my-return
+  some-extra-op(x): ...
+}
+```
+
+**Why catenation (not `<<`)?**  Catenation is shallow merge — the
+right-hand block's fields override the left-hand block's fields at the
+top level. `<<` is deep merge and is not appropriate here because the
+derived combinators are not nested blocks.
+
+The fields `bind` and `return` are included explicitly in the
+right-hand block so that callers can access `my-ns.bind` and
+`my-ns.return` directly. The `monad()` call itself only uses
+`m.bind`/`m.return` internally; the returned block does not
+automatically re-export them.
+
+**Overriding a derived combinator** — put the specialised
+implementation in the right-hand block; it shadows the derived one:
+
+```eu,notest
+my-ns: monad({bind: my-bind, return: my-return}) {
+  bind: my-bind
+  return: my-return
+  # override map with a more efficient implementation
+  map(f, action): my-efficient-map(f, action)
+}
+```
+
+---
+
+## The IO monad
+
+The `io` namespace is a monad built around effect execution. IO
+operations are not called for their return value alone — they cause
+side effects (shell commands, reads, writes). The eucalypt runtime
+sequences them strictly.
+
+### Primitives
+
+```eu,notest
+io.return(v)             # wrap a pure value; no side effects
+io.bind(action, f)       # run action, pass result to f
+```
+
+### The { :io ... } monadic block syntax
+
+Eucalypt provides syntactic sugar for chaining IO actions. A block
+tagged `:io` is desugared into nested `io.bind` calls automatically:
+
+```eu,notest
+{ :io
+  r: io.shell("ls -la")
+  _: io.check(r)
+}.r.stdout
+```
+
+desugars to:
+
+```eu,notest
+io.bind(io.shell("ls -la"),
+  λr. io.bind(io.check(r),
+    λ_. io.return(r.stdout)))
+```
+
+The `.expr` after the closing brace is the return expression, wrapped
+in `io.return`. Each field in the block becomes a `bind` step; the
+bound name is the lambda parameter for all subsequent steps.
+
+**IO operations require `--allow-io` / `-I` at the command line.**
+Test targets that use IO should include `requires-io: true` in their
+target metadata so the test runner skips them gracefully in
+environments without IO permission.
+
+### Practical IO example
+
+```eu,notest
+result: { :io
+  r: io.shell("git rev-parse HEAD")
+  _: io.check(r)
+}.(r.stdout)
+```
+
+### Using monad() with the IO monad
+
+You can derive the full set of combinators for the IO monad:
+
+```eu,notest
+` :suppress
+io-m: monad({bind: io.bind, return: io.return})
+
+# sequence two IO actions and collect results
+both: io-m.sequence([io.shell("echo a"), io.shell("echo b")])
+```
+
+Or extend the IO monad with domain-specific operations via catenation:
+
+```eu,notest
+app-io: monad({bind: io.bind, return: io.return}) {
+  bind: io.bind
+  return: io.return
+  read-file(path): io.shell("cat {path}")
+  git-hash: io.shell("git rev-parse HEAD")
+}
+```
+
+### IO combinators reference
+
+| Function | Description |
+|----------|-------------|
+| `io.return(a)` | Wrap a pure value in the IO monad |
+| `io.bind(action, f)` | Sequence two IO actions |
+| `io.map(f, action)` | Apply pure function `f` to the result of an IO action |
+| `io.check(result)` | Fail if `exit-code` is non-zero; otherwise return result |
+
+See [IO reference](../reference/prelude/io.md) for the full API
+including `io.shell`, `io.exec`, and related operations.
+
+---
+
+## The random state monad
+
+The `random` namespace implements a *state monad* over a PRNG stream.
+Each operation is a *function* from stream to a result-plus-new-stream
+block — the state threads through automatically via `bind`.
+
+### Without the monad: manual threading
+
+```eu,notest
+# Thread the stream manually through each step
+r1: random-int(6, io.random)
+r2: random-int(6, r1.rest)
+total: r1.value + r2.value + 2
+```
+
+Every call must pass the `.rest` from the previous call. This is
+error-prone and verbose.
+
+### With the monad: automatic threading
+
+```eu,notest
+# random.sequence handles the threading
+two-dice: random.sequence([random.int(6), random.int(6)])
+result: two-dice(random.stream(42)).value  # list of two rolls
+```
+
+### Running an action
+
+An action is a function from stream to `{value, rest}`. Call it with
+`random.stream(seed)` to run it:
+
+```eu,notest
+roll: random.int(6)(random.stream(42)).value   # integer in [0,6)
+```
+
+Only extract `.value` — rendering the full result block would try to
+print the infinite `.rest` stream.
+
+### Chaining with map-m
+
+Roll five dice of different sizes:
+
+```eu,notest
+dice: random.map-m(random.int, [4, 6, 8, 10, 20])
+rolls: dice(random.stream(42)).value   # e.g. [2, 4, 1, 7, 15]
+```
+
+### Implementing the state monad pattern
+
+The state monad return and bind are:
+
+```eu,notest
+# return: wrap a pure value as a do-nothing action
+random-ret(v, stream): { value: v, rest: stream }
+
+# bind: run m, pass result to f, run f's action with remaining stream
+random-bind(m, f, stream): {
+  r: m(stream)
+  run: f(r.value)(r.rest)
+  value: run.value
+  rest: run.rest
+}
+```
+
+`random-bind(m, f)` is a 3-arg function; calling it with only two
+arguments returns an action (function of `stream`). This is the curried
+partial application pattern used throughout eucalypt.
+
+### Random combinators reference
+
+| Function | Description |
+|----------|-------------|
+| `random.stream(seed)` | Create a PRNG stream from an integer seed |
+| `random.bind(m, f)` | State monad bind |
+| `random.return(v)` | State monad return |
+| `random.float` | Action: random float in [0,1) |
+| `random.int(n)` | Action: random integer in [0,n) |
+| `random.choice(list)` | Action: random element from list |
+| `random.shuffle(list)` | Action: shuffled copy of list |
+| `random.sample(n, list)` | Action: n elements sampled without replacement |
+
+Derived combinators (`map`, `then`, `join`, `sequence`, `map-m`,
+`filter-m`) are also available — see
+[Random Numbers reference](../reference/prelude/random.md).
+
+---
+
+## Writing your own monad
+
+Any pair of functions satisfying the monad laws can be wrapped with
+`monad()`. Here is a minimal example — the identity monad, where
+"wrapping" a value is a no-op:
+
+```eu
+` :suppress
+id-bind(m, f): f(m)
+` :suppress
+id-return(a): a
+` :suppress
+id-monad: monad({bind: id-bind, return: id-return})
+
+` { target: :example }
+example: id-monad.map-m(inc, [1, 2, 3])
+# => [2, 3, 4]
+```
+
+A more useful example — a "maybe" monad where `null` short-circuits
+the computation:
+
+```eu,notest
+` :suppress
+maybe-return(v): v
+
+` :suppress
+maybe-bind(m, f): if(m = null, null, f(m))
+
+` :suppress
+maybe: monad({bind: maybe-bind, return: maybe-return}) {
+  bind: maybe-bind
+  return: maybe-return
+}
+
+safe-head(xs): if(xs nil?, null, xs head)
+
+# Chain operations that may return null — short-circuits on first null
+result: maybe.bind(safe-head([]), inc)   # => null (list was empty)
+ok:     maybe.bind(safe-head([42]), inc) # => 43
+```
+
+---
+
+## Key concepts
+
+- `monad(m)` takes `{bind, return}` and returns a block with six
+  derived combinators
+- Use **catenation** (juxtaposition) to merge derived and specialised
+  operations — NOT `<<`
+- Include `bind` and `return` explicitly in the right-hand block so
+  they are accessible as fields on the result
+- The `{ :io ... }` syntax is syntactic sugar for nested `io.bind`
+  calls; it is currently IO-specific
+- The `random:` namespace is a state monad — actions are functions of a
+  stream, `bind` threads the stream automatically
+- When running random actions, always extract `.value` before
+  rendering; the `.rest` field is an infinite stream

--- a/docs/reference/prelude/index.md
+++ b/docs/reference/prelude/index.md
@@ -17,8 +17,8 @@ in the prelude).
 - [Combinators](combinators.md) -- function composition, application, utilities (12 entries)
 - [Calendar](calendar.md) -- date and time functions (5 entries)
 - [Sets](sets.md) -- set operations (11 entries)
-- [Random Numbers](random.md) -- random number generation (5 entries)
+- [Random Numbers](random.md) -- random number generation, monadic random: namespace (20 entries)
 - [Metadata](metadata.md) -- metadata and assertion functions (7 entries)
 - [IO](io.md) -- environment, time, argument access, and monad utility (16 entries)
 
-*225 documented entries in total.*
+*240 documented entries in total.*

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -62,21 +62,11 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 
 ## Monad Utility
 
-`monad(m)` derives standard monad combinators from a minimal block `m`
-containing `bind` and `return` fields. This allows monad authors to define
-only those two primitives and obtain the full set of derived operations for
-free.
-
-```eu,notest
-my-io: monad({bind: io.bind, return: io.return}) {
-  # merge in specialised implementations or extra operations
-  shell(c): io.shell(c)
-}
-```
-
-The left block (derived defaults) is merged with the right block via
-catenation; specialised implementations in the right block override
-the defaults.
+The `monad(m)` function derives standard monad combinators (`map`,
+`then`, `join`, `sequence`, `map-m`, `filter-m`) from a block containing
+`bind` and `return`. See the
+[Monads guide](../../guide/monads.md) for full documentation, the
+catenation merge pattern, and examples using the IO and random monads.
 
 | Function | Description |
 |----------|-------------|
@@ -87,32 +77,6 @@ the defaults.
 | `monad(m).sequence(ms)` | Sequence a list of monadic actions, collecting results into a list |
 | `monad(m).map-m(f, xs)` | Apply `f` to each element of `xs` (producing actions), then sequence |
 | `monad(m).filter-m(p, xs)` | Monadic filter: apply predicate `p` (returning a monadic bool) to each element |
-
-### Example: IO monad via monad()
-
-```eu,notest
-` :suppress
-my-io: monad({bind: io.bind, return: io.return})
-
-result: { :io
-  r: my-io.map(.stdout, io.shell("echo hello"))
-}.(r)
-```
-
-### Example: Pure identity monad
-
-```eu
-` :suppress
-id-bind(m, f): f(m)
-` :suppress
-id-return(a): a
-` :suppress
-id-monad: monad({bind: id-bind, return: id-return})
-
-` { target: :example }
-example: id-monad.map-m(inc, [1, 2, 3])
-# => [2, 3, 4]
-```
 
 ## Other
 

--- a/docs/reference/prelude/random.md
+++ b/docs/reference/prelude/random.md
@@ -1,7 +1,8 @@
 # Random Numbers
 
 Eucalypt provides pseudo-random number generation through the `io.random`
-stream and a set of prelude functions.
+stream and a set of prelude functions. There are two APIs: the legacy
+functional threading API and the newer monadic `random:` namespace.
 
 ## The Random Stream
 
@@ -20,7 +21,76 @@ results:
 eu --seed 42 example.eu
 ```
 
-## Random Number Generation
+---
+
+## Monadic API — `random:` namespace
+
+The `random:` namespace provides a state-monad interface where each
+random operation is a *function* from a PRNG stream to a result block.
+Use `random.bind` and `random.return` (plus the derived combinators from
+`monad()`) to compose operations without manually threading the stream.
+
+### Creating the stream
+
+```eu,notest
+my-stream: random.stream(42)   # deterministic, seeded stream
+```
+
+### Running an action
+
+An action is called with a stream; it returns a block with `value` and
+`rest`:
+
+```eu,notest
+r: random.int(6)(random.stream(42))
+die-roll: r.value    # integer in [0,6)
+next-stream: r.rest  # stream for further operations
+```
+
+### Composing actions with sequence
+
+```eu,notest
+two-dice: random.sequence([random.int(6), random.int(6)])(random.stream(42)).value
+# => e.g. [4, 0]
+```
+
+### Deriving a monad variant
+
+Use `monad()` catenation to override or extend the namespace:
+
+```eu,notest
+dice: monad({bind: random.bind, return: random.return}) {
+  d6: random.int(6)
+  d20: random.int(20)
+}
+roll: dice.sequence([dice.d6, dice.d20])(random.stream(42)).value
+```
+
+### Reference
+
+| Function | Description |
+|----------|-------------|
+| `random.stream(seed)` | Create a PRNG stream from an integer seed |
+| `random.bind(m, f)` | State monad bind: run action m, pass result to f, thread stream |
+| `random.return(v)` | State monad return: wrap a pure value as an action |
+| `random.float` | Action returning a random float in [0,1) |
+| `random.int(n)` | Action returning a random integer in [0,n) |
+| `random.choice(list)` | Action returning a random element from list |
+| `random.shuffle(list)` | Action returning a shuffled copy of list |
+| `random.sample(n, list)` | Action returning n elements sampled without replacement |
+| `random.map(f, action)` | Apply pure function f to the result of an action (derived) |
+| `random.then(a, b)` | Sequence two actions, discard first result (derived) |
+| `random.join(mm)` | Flatten a nested action (derived) |
+| `random.sequence(ms)` | Sequence a list of actions, collect results (derived) |
+| `random.map-m(f, xs)` | Map f over list producing actions, then sequence (derived) |
+| `random.filter-m(p, xs)` | Monadic filter over a list of actions (derived) |
+
+---
+
+## Legacy API — stream threading
+
+The legacy API manually threads a PRNG stream through `{value: ..., rest: ...}`
+blocks. These functions remain available for backward compatibility.
 
 | Function | Description |
 |----------|-------------|
@@ -30,11 +100,7 @@ eu --seed 42 example.eu
 | `shuffle(list, stream)` | Shuffle a list using repeated selection. Returns block with value and rest |
 | `sample(n, list, stream)` | Sample n elements from a list without replacement. Returns block with value and rest |
 
-## Usage Pattern
-
-The random functions use a functional random stream pattern. Each
-function consumes some random values and returns both a result and the
-remaining stream in a block with `value` and `rest` keys:
+### Usage pattern
 
 ```eu,notest
 result: random-int(6, io.random)
@@ -53,32 +119,19 @@ rolls: {
 two-dice: rolls.value
 ```
 
-## Shuffling and Sampling
-
-```eu,notest
-deck: range(1, 53)
-shuffled: shuffle(deck, io.random)
-hand: shuffled.value take(5)
-```
-
-```eu,notest
-colours: ["red", "green", "blue", "yellow", "purple"]
-picked: sample(2, colours, io.random)
-two-colours: picked.value
-```
+---
 
 ## Deterministic Seeds
 
-For reproducible output (useful in tests), pass a fixed seed:
-
-```eu,notest
-stream: random-stream(12345)
-x: random-int(100, stream)
-# x.value is always the same for seed 12345
-```
-
-Or use `--seed` on the command line, which sets `io.RANDOM_SEED`:
+For reproducible output, pass a fixed seed to `random.stream` or use
+`--seed` on the command line (which sets `io.RANDOM_SEED`):
 
 ```sh
 eu --seed 42 my-template.eu
+```
+
+```eu,notest
+stream: random.stream(12345)
+x: random.int(100)(stream).value
+# x is always the same for seed 12345
 ```

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -180,6 +180,101 @@ sample(n, list, stream): {
   rest: shuffled.rest
 }
 
+##
+## Monadic random: namespace (state monad over a PRNG stream)
+##
+## Each random "action" is a function: stream -> {value: ..., rest: ...}
+## random.bind and random.return thread the stream automatically.
+##
+
+` :suppress
+random-ret(v, stream): { value: v, rest: stream }
+
+` :suppress
+__random-bind-run(m, f, stream): {
+  r: m(stream)
+  run: f(r.value)(r.rest)
+  value: run.value
+  rest: run.rest
+}
+
+` :suppress
+random-bind(m, f): __random-bind-run(m, f)
+
+` :suppress
+__random-float-action(stream): { value: stream head, rest: stream tail }
+
+` :suppress
+__random-int-action(n, stream): {
+  value: floor((stream head) * n)
+  rest: stream tail
+}
+
+` :suppress
+__random-choice-pick(list, idx): random-ret(list nth(idx))
+
+` :suppress
+__random-choice-action(lst, stream): {
+  r: __random-int-action(lst count, stream)
+  next: __random-choice-pick(lst, r.value)(r.rest)
+  value: next.value
+  rest: next.rest
+}
+
+` :suppress
+__random-shuffle-action(lst, stream): __random-shuffle-impl(lst, lst count, [], stream)
+
+` :suppress
+__random-shuffle-impl(remaining, n, acc, stream):
+  if(n = 0,
+    { value: acc, rest: stream },
+    __random-shuffle-step(remaining, n, acc, stream))
+
+` :suppress
+__random-shuffle-step(remaining, n, acc, stream): {
+  r: __random-int-action(n, stream)
+  picked: remaining nth(r.value)
+  without: (remaining take(r.value)) ++ (remaining drop(r.value + 1))
+  next: __random-shuffle-impl(without, n - 1, cons(picked, acc), r.rest)
+  value: next.value
+  rest: next.rest
+}
+
+` :suppress
+__random-sample-action(n, lst, stream): {
+  shuffled: __random-shuffle-action(lst, stream)
+  value: shuffled.value take(n)
+  rest: shuffled.rest
+}
+
+` "Monadic random: namespace. Each operation is a state-monad action: a function from stream to a value/rest block.
+Use random.stream(seed) to create the initial stream, then run actions by calling them with the stream."
+random: monad({bind: random-bind, return: random-ret}) {
+  ` "The bind primitive for the random state monad."
+  bind: random-bind
+
+  ` "The return primitive for the random state monad."
+  return: random-ret
+
+  ` "random.stream(seed) - create the initial PRNG stream from integer seed."
+  stream(seed): random-stream(seed)
+
+  ` "random.float - action returning a random float in [0,1)."
+  float: __random-float-action
+
+  ` "random.int(n) - action returning a random integer in [0,n)."
+  int(n): __random-int-action(n)
+
+  ` "random.choice(list) - action returning a random element from list."
+  choice(lst): __random-choice-action(lst)
+
+  ` "random.shuffle(list) - action returning a shuffled copy of list."
+  shuffle(lst): __random-shuffle-action(lst)
+
+  ` "random.sample(n, list) - action returning n elements sampled without replacement."
+  sample(n, lst): __random-sample-action(n, lst)
+}
+
 
 ##
 ## Error / debug support

--- a/tests/harness/120_random_monad.eu
+++ b/tests/harness/120_random_monad.eu
@@ -1,0 +1,114 @@
+"random: monadic random namespace — state monad over a PRNG stream."
+
+seed: 42
+
+##
+## random.stream produces the same underlying stream as random-stream
+##
+` { target: :test-stream }
+test-stream:
+  if((random.stream(seed) head) = (random-stream(seed) head),
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## random.float returns a value in [0,1)
+##
+` { target: :test-float }
+test-float: {
+  v: random.float(random.stream(seed)).value
+  ok: (v >= 0) && (v < 1)
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.int(n) returns a value in [0,n)
+##
+` { target: :test-int }
+test-int: {
+  v: random.int(10)(random.stream(seed)).value
+  ok: (v >= 0) && (v < 10)
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.int result matches existing random-int
+##
+` { target: :test-int-matches }
+test-int-matches:
+  if(random.int(10)(random.stream(seed)).value = random-int(10, random-stream(seed)).value,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## random.choice picks an element present in the list
+##
+` { target: :test-choice }
+test-choice: {
+  xs: [:a, :b, :c, :d]
+  v: random.choice(xs)(random.stream(seed)).value
+}.(if(xs any(_ = v), { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.shuffle preserves count and elements
+##
+` { target: :test-shuffle }
+test-shuffle: {
+  xs: [1, 2, 3, 4, 5]
+  v: random.shuffle(xs)(random.stream(seed)).value
+  count-ok: (v count) = (xs count)
+  elems-ok: (v sort-nums) = (xs sort-nums)
+  ok: count-ok && elems-ok
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.sample returns n elements all in the original list
+##
+` { target: :test-sample }
+test-sample: {
+  xs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  v: random.sample(3, xs)(random.stream(seed)).value
+  count-ok: (v count) = 3
+  range-ok: (v all(_ >= 1)) && (v all(_ <= 10))
+  ok: count-ok && range-ok
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.map: derived combinator applies a pure function to the result
+##
+` { target: :test-map }
+test-map: {
+  raw: random.int(10)(random.stream(seed)).value
+  mapped: random.map(inc, random.int(10))(random.stream(seed)).value
+}.(if(mapped = (raw + 1), { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.sequence: collect results of a list of actions
+##
+` { target: :test-sequence }
+test-sequence: {
+  result: random.sequence([random.int(6), random.int(6)])(random.stream(seed)).value
+  count-ok: (result count) = 2
+  range-ok: (result all(_ >= 0)) && (result all(_ < 6))
+  ok: count-ok && range-ok
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.map-m: map over a list producing actions then sequence
+##
+` { target: :test-map-m }
+test-map-m: {
+  result: random.map-m(random.int, [6, 6, 6])(random.stream(seed)).value
+  count-ok: (result count) = 3
+  range-ok: (result all(_ >= 0)) && (result all(_ < 6))
+  ok: count-ok && range-ok
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## Monadic bind threads state: two sequential int draws use different stream positions
+##
+` { target: :test-bind-threads-state }
+test-bind-threads-state: {
+  pair: random.sequence([random.int(100), random.int(100)])(random.stream(seed)).value
+  first: pair head
+  second: pair tail head
+  ok: first != second
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -597,6 +597,11 @@ pub fn test_harness_119() {
 }
 
 #[test]
+pub fn test_harness_120() {
+    run_test(&opts("120_random_monad.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds `random:` namespace to `lib/prelude.eu` built on a state monad over the PRNG stream
- Each operation (`float`, `int`, `choice`, `shuffle`, `sample`) is an *action*: a function `stream -> {value, rest}` that can be composed with `random.bind`/`random.return` and the combinators derived by `monad()`
- All six derived combinators (`map`, `then`, `join`, `sequence`, `map-m`, `filter-m`) come for free from `monad()`
- Legacy API (`random-stream`, `random-int`, `random-choice`, `shuffle`, `sample`) retained unchanged for backward compatibility — harness test 078 passes unmodified
- Adds harness test 120 covering: stream creation, all five primitive actions, derived `map`, `sequence`, `map-m`, and state threading correctness
- Documentation rewritten in `docs/reference/prelude/random.md` with monadic API first, legacy API second

## Design notes

The state monad bind is implemented as a three-argument curried function:
```
random-bind(m, f, stream) = let r = m(stream) in f(r.value)(r.rest)
```
`random-bind(m, f)` is then the composed action. The `{value: v, rest: stream}` shadowing pitfall was avoided by naming the function parameters differently from the block fields.

## Test plan

- [x] `cargo test test_harness_120` — passes (11 targets)
- [x] `cargo test test_harness_078` — backward compat, passes unchanged
- [x] `cargo test --test harness_test` — all 211 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)