### PR TITLE
fix(gc): stash IO yield closure during evaluate_to_whnf_for_io (eu-rdfu)

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1532,15 +1532,31 @@ impl<'a> Machine<'a> {
             "evaluate_to_whnf_for_io called with non-empty continuation stack"
         );
 
-        // Save the current IO yield closure.
-        let saved_closure = self.state.closure.clone();
+        // Push the current IO yield closure onto the GC stash so that the
+        // collector can trace and update its heap pointers if evacuation occurs
+        // during self.run() below.  Without this, `saved_closure` is an
+        // invisible Rust-stack root: the GC does not scan it, so any objects
+        // it references that reside in a fragmented candidate block will be
+        // evacuated and their forwarding pointers set — but `saved_closure`
+        // still holds the old (now-dead) addresses, causing a SIGSEGV when
+        // we later restore it as the machine closure.
+        self.stash_push(self.state.closure.clone());
 
         // Temporarily evaluate the given closure to WHNF.
         self.state.terminated = false;
         self.state.yielded_io = false;
         self.state.closure = closure;
 
-        self.run(None)?;
+        let run_result = self.run(None);
+
+        // Pop the (possibly-updated) saved closure from the stash.  The GC
+        // may have rewritten its internal heap pointers during run(), so we
+        // must use the stash copy rather than the Rust-stack copy.
+        let saved_closure = self.stash_pop();
+
+        // Propagate any run error only after restoring the GC-safe saved
+        // closure, to leave the machine in a consistent state.
+        run_result?;
 
         // Capture the result before restoring state.
         let sub_yielded = self.state.yielded_io;


### PR DESCRIPTION
## Root cause

`evaluate_to_whnf_for_io` in `src/eval/machine/vm.rs` saved the current IO yield closure as a plain Rust-stack local before calling `self.run(None)`. `self.run()` always calls `collect::collect` at the end, which may perform evacuating GC when heap fragmentation exceeds the 10% threshold that triggers `SelectiveEvacuation`.

During evacuation, live objects in candidate blocks are copied to the evacuation target and forwarding pointers are written into the old headers. The GC scans `self.state` as the root set — but `saved_closure` is invisible to it (a Rust local, not part of `self.state`). As a result, `saved_closure` retains stale pointers to the old (now-dead) object locations. When the function restores it as `self.state.closure` after `run()` returns, the next machine step dereferences those stale pointers → **SIGSEGV**.

### Why aarch64-linux release only

- **Larger prelude post-PR-#420**: The two new helper functions (`__io-shell-spec`, `__io-exec-spec`) increase heap pressure during IO spec evaluation, pushing fragmentation above the 10% `SelectiveEvacuation` threshold.
- **Release builds**: LTO and inlining change object layout, increasing the probability of fragmented blocks reaching the evacuation threshold.
- **macOS ARM**: Different memory allocation patterns (pages returned at different addresses, different `mmap` behaviour) keep fragmentation below the threshold in practice even with the larger prelude. Linux aarch64 does not.

### Why this was invisible before PR #420

Before the prelude grew, the IO tests used `io.shell(cmd)` (an inline spec block), which hit the existing `ReadSpecBlock` static heap navigation path. `__io-shell-spec` and `__io-exec-spec` produce parameterised spec blocks evaluated via `evaluate_to_whnf_for_io`, which exercises the stash-missing code path more intensively.

## Fix

Push the current IO yield closure onto the GC stash (`self.state.stash: Vec<SynClosure>`) before calling `self.run()`. The stash is part of `MachineState` and is scanned by the collector. After `run()` returns, pop the stash entry (which the GC has updated with any forwarded pointers) and restore it as the machine closure.

This is the same pattern already used by the io-run driver (`stash_push`/`stash_pop` in `io_run.rs`) to protect closures across `machine.run()` calls.

## Test plan

- `cargo test --lib` — 596 tests pass
- `cargo test --test harness_test` — 209 tests pass
- `cargo clippy --all-targets -- -D warnings` — zero warnings
- `cargo fmt --all` — no changes
- CI on aarch64-linux will validate the fix against the actual crash scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)