### PR TITLE
diag(gc): CI instrumentation for aarch64 SIGSEGV (eu-rdfu)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -236,8 +236,25 @@ jobs:
           mv -f build-meta.yaml.new build-meta.yaml
 
           echo "TAG_NAME=$(eu build.eu -t version)" >> $GITHUB_ENV
-      - name: Run release tests
-        run: cargo test --release
+      # eu-rdfu: run release tests sequentially with full backtraces so that
+      # the aarch64 SIGSEGV produces a useful crash report rather than a
+      # silent test-runner process exit.  catchsegv provides a signal handler
+      # that prints a backtrace when SIGSEGV is received.
+      - name: Run release tests (sequential, with backtrace)
+        env:
+          RUST_BACKTRACE: full
+        run: |
+          which catchsegv && WRAP="catchsegv" || WRAP=""
+          $WRAP cargo test --release -- --test-threads=1
+      # eu-rdfu: run IO harness tests under GC stress (forced evacuation on
+      # every cycle) to surface pointer-update bugs on all platforms.
+      - name: Run IO tests under GC stress
+        env:
+          RUST_BACKTRACE: full
+          EU_GC_STRESS: "1"
+        run: |
+          which catchsegv && WRAP="catchsegv" || WRAP=""
+          $WRAP cargo test --release test_harness_104 test_harness_105 test_harness_106 test_harness_107 -- --test-threads=1
       - name: Build release
         run: cargo build --all --release
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,8 @@ crate-type = ["cdylib", "rlib"]
 [[bench]]
 harness = false
 name = "benches"
+
+# Temporarily retain debug symbols in release builds so that backtraces on
+# the aarch64 CI runner include function names.  Revert once eu-rdfu is fixed.
+[profile.release]
+debug = true

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1622,6 +1622,41 @@ impl Heap {
 
     /// Analyze fragmentation across all blocks and determine optimal collection strategy
     pub fn analyze_collection_strategy(&self) -> CollectionStrategy {
+        // GC stress mode: force SelectiveEvacuation on every collection so
+        // that evacuation bugs (dangling pointers after object moves) surface
+        // on any platform, not just aarch64 release builds.  Enable by setting
+        // EU_GC_STRESS=1 in the environment.
+        if std::env::var("EU_GC_STRESS").as_deref() == Ok("1") {
+            // SAFETY: Read-only borrow to enumerate block indices.
+            let heap_state = unsafe { &*self.state.get() };
+            let mut candidates: Vec<usize> = Vec::new();
+            if heap_state.head.is_some() {
+                candidates.push(0);
+            }
+            if heap_state.overflow.is_some() {
+                candidates.push(1);
+            }
+            for i in 0..heap_state.rest.len() {
+                candidates.push(i + 2);
+            }
+            // Exclude pinned blocks.
+            let unpinned: Vec<usize> = candidates
+                .into_iter()
+                .filter(|&idx| {
+                    let heap_state = unsafe { &*self.state.get() };
+                    let base = match idx {
+                        0 => heap_state.head.as_ref().map(|b| b.base_address()),
+                        1 => heap_state.overflow.as_ref().map(|b| b.base_address()),
+                        n => heap_state.rest.get(n - 2).map(|b| b.base_address()),
+                    };
+                    base.is_none_or(|addr| !self.is_block_pinned(addr))
+                })
+                .collect();
+            if !unpinned.is_empty() {
+                return CollectionStrategy::SelectiveEvacuation(unpinned);
+            }
+        }
+
         // SAFETY: Read-only borrow of heap state for analysis.
         // Single-threaded access, no mutation occurs during analysis.
         let heap_state = unsafe { &*self.state.get() };


### PR DESCRIPTION
## Summary

Information-gathering PR to get a real backtrace from the aarch64 CI runner before diagnosing the SIGSEGV further. No code fix yet.

- Sequential release tests with `RUST_BACKTRACE=full` and `catchsegv` on the `release-candidate-linux-arm` job, so the crash produces a named backtrace
- `debug = true` in `[profile.release]` so backtraces include function names on aarch64
- `EU_GC_STRESS=1` env var that forces `SelectiveEvacuation` on every GC cycle (makes evacuation bugs reproducible cross-platform); IO tests 104–107 run under this flag in a dedicated CI step

## What we expect from CI

- The sequential backtrace step will show exactly which function segfaults
- The GC stress step will either fail on x86 too (confirming an evacuation pointer-update bug), or pass (narrowing to an aarch64-specific issue)

## Revert plan

Remove `debug = true` from `[profile.release]` once eu-rdfu is diagnosed and fixed. The `EU_GC_STRESS` env var is harmless to leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)