### PR TITLE
fix(errors): propagate call-site source locations through operator applications

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -222,6 +222,21 @@ impl SourceMap {
         }
     }
 
+    /// Find the first Smid in a trace slice that has a concrete file/span location.
+    ///
+    /// Used as a fallback when an error's own Smid is synthetic (e.g. an
+    /// intrinsic label) and the diagnostic would otherwise show no source
+    /// location.
+    pub fn first_source_smid(&self, trace: &[Smid]) -> Option<Smid> {
+        trace.iter().copied().find(|smid| {
+            if let Some(info) = self.source_info_for_smid(*smid) {
+                info.file.is_some() && info.span.is_some()
+            } else {
+                false
+            }
+        })
+    }
+
     /// Format a stack / environment trace
     ///
     /// Produces source-level references where file locations are

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -88,14 +88,18 @@ impl Distributor {
 
                 Ok(ret)
             }
-            Expr::Var(_, Free(fv)) => {
-                if let Some((smid, fixity, precedence)) = self.env.get(fv) {
-                    Ok(RcExpr::from(Expr::Operator(
-                        *smid,
-                        *fixity,
-                        *precedence,
-                        expr,
-                    )))
+            Expr::Var(call_smid, Free(fv)) => {
+                if let Some((def_smid, fixity, precedence)) = self.env.get(fv) {
+                    // Prefer the call-site Smid (from the user's source) over the
+                    // definition-site Smid (from the prelude) so that infix operator
+                    // applications carry a source location pointing at the actual
+                    // usage, not the operator's definition.
+                    let smid = if call_smid.is_valid() {
+                        *call_smid
+                    } else {
+                        *def_smid
+                    };
+                    Ok(RcExpr::from(Expr::Operator(smid, *fixity, *precedence, expr)))
                 } else {
                     Ok(expr)
                 }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1102,9 +1102,22 @@ impl RcExpr {
     /// Uses optimized try_walk to avoid unnecessary allocations.
     pub fn substs_free<F: Fn(&str) -> Option<RcExpr>>(&self, substitute: &F) -> RcExpr {
         match &*self.inner {
-            Expr::Var(_, Free(f)) => {
+            Expr::Var(original_smid, Free(f)) => {
                 if let Some(ref name) = f.pretty_name {
                     if let Some(replacement) = substitute(name) {
+                        // If the replacement was built with Smid::default() but the
+                        // original Var carried a meaningful call-site Smid, re-stamp
+                        // the Smid so that source locations are not lost during merge.
+                        if original_smid.is_valid() {
+                            if let Expr::Var(rep_smid, rep_var) = &*replacement.inner {
+                                if !rep_smid.is_valid() {
+                                    return RcExpr::from(Expr::Var(
+                                        *original_smid,
+                                        rep_var.clone(),
+                                    ));
+                                }
+                            }
+                        }
                         replacement
                     } else {
                         self.clone()

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -140,7 +140,7 @@ fn distribute(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 /// Apply lambdas which have been distribute to function positions
 fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
     match &*expr.inner {
-        Expr::App(_, f, xs) => {
+        Expr::App(call_smid, f, xs) => {
             match &*f.inner {
                 // as substs doesn't succ, we can only handle
                 // inlinable lambdas here
@@ -164,7 +164,26 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 
                         let mappings = <_>::zip(binders.into_iter(), args).collect::<Vec<_>>();
 
-                        substs_depth(&body, &mappings, 0)
+                        let reduced = substs_depth(&body, &mappings, 0)?;
+
+                        // Preserve the call-site source location on the reduced
+                        // expression. After beta reduction, the top-level
+                        // expression carries the callee's (prelude) Smid rather
+                        // than the user's call site. If the outer App had a
+                        // valid Smid, re-tag the result so that subsequent
+                        // compiler passes (e.g. STG compiler) can annotate the
+                        // code with the correct source location.
+                        if call_smid.is_valid() {
+                            if let Expr::App(_, rf, rargs) = &*reduced.inner {
+                                return Ok(RcExpr::from(Expr::App(
+                                    *call_smid,
+                                    rf.clone(),
+                                    rargs.clone(),
+                                )));
+                            }
+                        }
+
+                        Ok(reduced)
                     }
                 }
                 // Use optimized try_walk_safe

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -587,16 +587,42 @@ impl HasSmid for ExecutionError {
 
 impl ExecutionError {
     pub fn to_diagnostic(&self, source_map: &SourceMap) -> Diagnostic<usize> {
+        use codespan_reporting::diagnostic::Label;
+
         // Delegate CompileError to its own diagnostic
         if let ExecutionError::Compile(e) = self {
             return e.to_diagnostic(source_map);
         }
-        let diag = source_map.diagnostic(self);
+        let mut diag = source_map.diagnostic(self);
         // Unwrap Traced to get at the inner error for note generation
-        let inner = match self {
-            ExecutionError::Traced(e, _, _) => e.as_ref(),
-            other => other,
+        let (inner, env_trace, stack_trace) = match self {
+            ExecutionError::Traced(e, env, stack) => (e.as_ref(), env.as_slice(), stack.as_slice()),
+            other => (other, [].as_slice(), [].as_slice()),
         };
+
+        // If the error's own Smid has no file location (e.g. it points to a
+        // synthetic intrinsic label), try to find a source location from the
+        // environment trace.  The env trace contains annotations from the let
+        // frames that were live at the time of the error, including any Ann
+        // nodes the compiler injected at call sites.
+        let has_source_label = source_map
+            .source_info(inner)
+            .map(|info| info.file.is_some())
+            .unwrap_or(false);
+
+        if !has_source_label {
+            // Prefer the env trace (innermost call site) over the stack trace
+            let fallback_smid = source_map
+                .first_source_smid(env_trace)
+                .or_else(|| source_map.first_source_smid(stack_trace));
+            if let Some(smid) = fallback_smid {
+                if let Some(info) = source_map.source_info_for_smid(smid) {
+                    if let (Some(file), Some(span)) = (info.file, info.span) {
+                        diag = diag.with_labels(vec![Label::primary(file, span)]);
+                    }
+                }
+            }
+        }
         let notes = match inner {
             ExecutionError::TypeMismatch(_, expected, actual) => {
                 type_mismatch_notes(expected, actual)

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -330,8 +330,15 @@ impl MachineState {
         let environment = self.closure.env();
         let remaining_arity = self.closure.arity();
 
-        // Set annotation to stamp on any allocations
-        self.annotation = self.closure.annotation();
+        // Set annotation to stamp on any allocations.
+        // Only update if the closure carries a valid annotation — value forms
+        // and other synthetic closures use Smid::default(), and propagating
+        // that would overwrite a meaningful call-site annotation set by an
+        // enclosing Ann node.
+        let closure_ann = self.closure.annotation();
+        if closure_ann.is_valid() {
+            self.annotation = closure_ann;
+        }
 
         if remaining_arity > 0 {
             return self.return_fun(view);

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -952,7 +952,7 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // If it's an intrinsic, check whether we should inline the
         // wrapper
-        match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
+        let inlined_bif = match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
             Some(bif)
                 if !compiler.suppress_inlining
                     && bif.inlinable()
@@ -960,14 +960,30 @@ impl ProtoSyntax for ProtoAppGroup {
             {
                 let inline_body = bif.wrapper(Smid::default()).body().clone();
                 local_binder.set_body(Box::new(ProtoInline::new(arg_indexes, inline_body)))?;
+                true
             }
             _ => {
                 local_binder.set_body(ProtoApp::boxed(f_index, arg_indexes, self.single_use))?;
+                false
             }
-        }
+        };
 
         local_binder.freeze();
-        local_binder.into_stg(compiler)
+        let stg = local_binder.into_stg(compiler)?;
+
+        // Wrap inlined intrinsic calls with a source annotation so that
+        // runtime type errors (TypeMismatch, NoBranchForDataTag, etc.) carry
+        // the user's call site rather than the intrinsic's synthetic label.
+        // Only applied when source tracking is enabled, the call site has a
+        // valid Smid, and the call was actually inlined (not a regular
+        // function call, which does not need annotation wrapping).
+        let stg = if inlined_bif && compiler.generate_annotations() && self.smid.is_valid() {
+            dsl::ann(self.smid, stg)
+        } else {
+            stg
+        };
+
+        Ok(stg)
     }
 }
 


### PR DESCRIPTION
## Error message: runtime errors on infix operators show wrong file location

### Scenario
Any user code using an infix operator that causes a runtime error — `1 / 0`, `5 + "hello"`, `x % 0` — previously showed the prelude's operator definition location rather than the user's call site.

### Before
```
$ eu test.eu   # test.eu contains: bomb: 1 / 0
error: division by zero in floor division (/)
  help: the divisor evaluated to zero
    ┌─ [prelude]:441:10
    │
441 │ (l / r): __DIV(l, r)
    │          ^^^^^^^^^^^
```

### After
```
$ eu test.eu   # test.eu contains: bomb: 1 / 0
error: division by zero in floor division (/)
  help: the divisor evaluated to zero
    ┌─ test.eu:1:9
    │
  1 │ bomb: 1 / 0
    │         ^
```

Similarly for type errors:
```
$ eu test.eu   # test.eu contains: x: 5 + "hello"
error: type mismatch: expected number, found string
    ┌─ test.eu:1:6
    │
  1 │ x: 5 + "hello"
    │        ^
```

### Assessment
- Human diagnosability: poor → excellent
- LLM diagnosability: poor → excellent

The previous behaviour pointed at the prelude's internal operator wiring,
which is both confusing and unhelpful. The fix points directly at the
operator in the user's source.

### Change
Four separate places in the pipeline were stripping or replacing the
user's call-site Smid (source location handle):

1. **`src/core/expr.rs` — `substs_free`**: When merging translation units,
   `rebody_int` called `substs_free` which replaced free-variable `Var`
   nodes with `core::var(Smid::default(), ...)`, silently discarding the
   user's source Smid. Fixed by re-stamping the replacement with the
   original Smid when the substitute was built with `Smid::default()`.

2. **`src/core/cook/fixity.rs` — `dist`**: When converting a `Var(user_smid, /)`
   to an `Operator(...)` node, the prelude's definition-site Smid was
   always used. Fixed to prefer the call-site Smid when valid.

3. **`src/core/inline/reduce.rs` — `beta_reduce`**: After reducing an inlined
   operator lambda, the resulting `App` node carried the prelude's Smid.
   Fixed to re-stamp the result `App` with the call-site Smid.

4. **`src/eval/machine/vm.rs`**: Synthetic closures with `Smid::default()` were
   overwriting the VM's current annotation (set by `Ann` nodes) with an
   invalid value. Fixed to only update the annotation when the incoming
   value is valid.

Additionally, the STG compiler (`src/eval/stg/compiler.rs`) now wraps
inlined BIF calls with `Ann` nodes so the call-site annotation is visible
to the VM at runtime. Only BIF inlining is wrapped (not all calls) to
avoid breaking IO spec block navigation in `io_run.rs`.

Source location tracking is also improved in error reporting
(`src/eval/error.rs`, `src/common/sourcemap.rs`): when the error's own
Smid lacks a file location, the reporter falls back to env/stack trace
Smids to find a user-file location.

### Risks
- `substs_free` is a general utility used throughout the core pipeline.
  The change is conservative: it only re-stamps when the original Smid
  is valid AND the replacement was built with `Smid::default()`. This
  avoids interfering with cases where the replacement was intentionally
  built with a specific Smid.
- All 209 tests pass; all 90 error tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)