### PR TITLE
fix(errors): emit source annotation for all function calls

### DIFF
--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -99,7 +99,12 @@ impl Distributor {
                     } else {
                         *def_smid
                     };
-                    Ok(RcExpr::from(Expr::Operator(smid, *fixity, *precedence, expr)))
+                    Ok(RcExpr::from(Expr::Operator(
+                        smid,
+                        *fixity,
+                        *precedence,
+                        expr,
+                    )))
                 } else {
                     Ok(expr)
                 }

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -352,6 +352,12 @@ fn block_list_inner(view: &MutatorHeapView<'_>, c: SynClosure, depth: usize) -> 
             let body_deref = deref(view, body_closure);
             block_list_inner(view, body_deref, depth - 1)
         }
+        // Source annotation node: transparent to IO spec block navigation.
+        HeapSyn::Ann { body, .. } => {
+            let body_closure = SynClosure::new(*body, c.env());
+            let body_deref = deref(view, body_closure);
+            block_list_inner(view, body_deref, depth - 1)
+        }
         _ => None,
     }
 }

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -504,7 +504,13 @@ impl StgIntrinsic for LookupOr {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda (no annotation) so that the call-site annotation
+        // set by the Ann node wrapping LookupOr at compile time is preserved
+        // in self.annotation when the inner switch fires. This allows
+        // NoBranchForDataTag (raised when obj is not a block) to carry the
+        // user's source location rather than the synthetic LOOKUPOR# label.
+        let _ = annotation;
+        lambda(
             3, // [k d block]
             switch(
                 local(2),
@@ -572,7 +578,6 @@ impl StgIntrinsic for LookupOr {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1333,11 +1333,15 @@ impl<'rt> Compiler<'rt> {
             },
             None => binder.add(lookup_fail(key, obj.clone())),
         }?;
-        Ok(Holder::new(LookupOr(NativeVariant::Unboxed).global(
-            dsl::sym(key),
-            dft,
-            obj,
-        )))
+        let lookup_stg = LookupOr(NativeVariant::Unboxed).global(dsl::sym(key), dft, obj);
+        // Wrap with a source annotation so that lookup type errors (e.g.
+        // dot notation on a non-block) carry the user's call-site location.
+        let stg = if self.generate_annotations() && annotation.is_valid() {
+            dsl::ann(annotation, lookup_stg)
+        } else {
+            lookup_stg
+        };
+        Ok(Holder::new(stg))
     }
 
     /// Compile a lambda to a lambda form

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -952,7 +952,7 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // If it's an intrinsic, check whether we should inline the
         // wrapper
-        let inlined_bif = match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
+        match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
             Some(bif)
                 if !compiler.suppress_inlining
                     && bif.inlinable()
@@ -960,24 +960,21 @@ impl ProtoSyntax for ProtoAppGroup {
             {
                 let inline_body = bif.wrapper(Smid::default()).body().clone();
                 local_binder.set_body(Box::new(ProtoInline::new(arg_indexes, inline_body)))?;
-                true
             }
             _ => {
                 local_binder.set_body(ProtoApp::boxed(f_index, arg_indexes, self.single_use))?;
-                false
             }
         };
 
         local_binder.freeze();
         let stg = local_binder.into_stg(compiler)?;
 
-        // Wrap inlined intrinsic calls with a source annotation so that
-        // runtime type errors (TypeMismatch, NoBranchForDataTag, etc.) carry
-        // the user's call site rather than the intrinsic's synthetic label.
-        // Only applied when source tracking is enabled, the call site has a
-        // valid Smid, and the call was actually inlined (not a regular
-        // function call, which does not need annotation wrapping).
-        let stg = if inlined_bif && compiler.generate_annotations() && self.smid.is_valid() {
+        // Wrap function calls with a source annotation so that runtime errors
+        // (TypeMismatch, NoBranchForDataTag, etc.) carry the user's call site.
+        // Applied whenever source tracking is enabled and the call site has a
+        // valid Smid. The IO spec block navigator (block_list_inner) handles
+        // Ann nodes transparently, so this is safe for all call sites.
+        let stg = if compiler.generate_annotations() && self.smid.is_valid() {
             dsl::ann(self.smid, stg)
         } else {
             stg

--- a/tests/harness/errors/049_dot_on_number.eu.expect
+++ b/tests/harness/errors/049_dot_on_number.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "numbers do not have fields"
+stderr: "049_dot_on_number\.eu:3:"

--- a/tests/harness/errors/050_dot_on_string.eu.expect
+++ b/tests/harness/errors/050_dot_on_string.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "strings do not have fields"
+stderr: "050_dot_on_string\.eu:3:"


### PR DESCRIPTION
## Error message: function calls and dot-notation on non-blocks lack source locations

> **Stacked on #432** — depends on that PR merging first.

### Scenario 1: namespace calls and direct function calls

Any function call that goes through a namespace lookup (e.g. `str.letters(42)`,
`arr.get([5,0])`) or a direct call on a non-function (e.g. `items(2)`)
produced runtime errors with no source location pointer.

### Before (namespace/direct calls)
\`\`\`
error: type mismatch: expected string, found number
 = in str.letters
 = to convert a number to a string, use 'str' or string interpolation
 = stack trace:
   - ==
\`\`\`

### After (namespace/direct calls)
\`\`\`
error: type mismatch: expected string, found number
  ┌─ test.eu:1:9
  │
1 │ result: str.letters(42)
  │         ^^^^^^^^^^^
  │
 = in str.letters
 = to convert a number to a string, use 'str' or string interpolation
\`\`\`

---

### Scenario 2: dot-notation on a non-block (`x.abs` where `x` is a number)

Writing `x.abs` (or `s.length`) where the left-hand side is a number or
string previously produced "type mismatch: expected block, found number"
with no source pointer.

### Before (dot-notation)
\`\`\`
error: type mismatch: expected block, found number
 = the '.' operator performs key lookup on blocks; numbers do not have fields
 = to apply a function to a number, use pipeline catenation, e.g. 'x abs' instead of 'x.abs'
 = stack trace:
   - ==
\`\`\`

### After (dot-notation)
\`\`\`
error: type mismatch: expected block, found number
  ┌─ 049_dot_on_number.eu:3:9
  │
3 │ result: x.abs
  │         ^
  │
 = the '.' operator performs key lookup on blocks; numbers do not have fields
 = to apply a function to a number, use pipeline catenation, e.g. 'x abs' instead of 'x.abs'
\`\`\`

### Assessment

**Scenario 1 (namespace calls):**
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

**Scenario 2 (dot-notation on scalar):**
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change

**Scenario 1:** `compiler.rs` — emit Ann nodes wrapping ALL compiled
function calls (not just inlined BIFs), so the call-site Smid reaches
the VM annotation register.

**Scenario 2, part A:** `compiler.rs compile_lookup` — wrap the LookupOr
STG expression with Ann carrying the field's source Smid.

**Scenario 2, part B:** `block.rs LookupOr::wrapper` — change from
`annotated_lambda` to plain `lambda`, so the wrapper's synthetic LOOKUPOR#
annotation does not overwrite the call-site Ann that was just set. Without
its own lambda annotation, the VM preserves the user's source Smid when
the inner `switch` pushes a Branch continuation, so `NoBranchForDataTag`
correctly carries the user's file location.

**`io_run.rs`:** added transparent pass-through for `HeapSyn::Ann` in
`block_list_inner` to prevent SIGSEGV when Ann nodes wrap IO spec blocks.

### Risks
- The `LookupOr` wrapper no longer carries `LOOKUPOR#` in stack traces.
  The intrinsic name disappears from traces but the call-site location is
  more useful to users.
- Changes to source annotation propagation may affect edge cases in
  deeply nested expressions; full test suite validates no regressions.