### PR TITLE
chore(build): remove temporary debug symbols from release profile (eu-rdfu)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,3 @@ crate-type = ["cdylib", "rlib"]
 harness = false
 name = "benches"
 
-# Temporarily retain debug symbols in release builds so that backtraces on
-# the aarch64 CI runner include function names.  Revert once eu-rdfu is fixed.
-[profile.release]
-debug = true


### PR DESCRIPTION
## Summary

- Removes the temporary `[profile.release] debug = true` override added during the aarch64 SIGSEGV investigation (eu-rdfu)
- The root cause was fixed in PR #429 and #430; the debug symbols are no longer needed

## What was kept

- `--test-threads=1` for aarch64 release tests
- `RUST_BACKTRACE=full` on aarch64
- `EU_GC_STRESS` CI step and implementation
- `catchsegv` wrapper
- The stash fix in `src/eval/machine/vm.rs`

## Test plan

- [x] `cargo test --lib` — all 596 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)