### PR TITLE
fix(gc): move MARK_STATE from global static into Heap struct (eu-84nz)

### DIFF
--- a/src/eval/memory/header.rs
+++ b/src/eval/memory/header.rs
@@ -7,38 +7,13 @@ use std::ptr::NonNull;
 
 use bitmaps::Bitmap;
 
-use super::mark::mark_state;
-
 #[derive(Debug)]
 pub struct HeaderBits(Bitmap<2>);
 
 const MARK_BIT: usize = 0;
 const FORWARDED_BIT: usize = 1;
 
-impl Default for HeaderBits {
-    /// Return 'unmarked' header bits according to the current value
-    /// of unmarked (which flips on each collection)
-    fn default() -> HeaderBits {
-        let mut m = HeaderBits(Bitmap::default());
-        m.unmark();
-        m
-    }
-}
-
 impl HeaderBits {
-    fn mark(&mut self) {
-        self.0.set(MARK_BIT, mark_state());
-    }
-
-    fn unmark(&mut self) {
-        self.0.set(MARK_BIT, !mark_state());
-    }
-
-    fn is_marked(&self) -> bool {
-        self.0.get(MARK_BIT) == mark_state()
-    }
-
-    // New methods that take mark state as parameter
     fn mark_with_state(&mut self, mark_state: bool) {
         self.0.set(MARK_BIT, mark_state);
     }
@@ -51,7 +26,7 @@ impl HeaderBits {
         self.0.get(MARK_BIT) == mark_state
     }
 
-    // Create unmarked header bits for given mark state
+    /// Create unmarked header bits for the given mark state
     fn new_unmarked(mark_state: bool) -> HeaderBits {
         let mut m = HeaderBits(Bitmap::default());
         m.unmark_with_state(mark_state);
@@ -79,7 +54,7 @@ impl HeaderBits {
 ///  - forwarding pointer (to support evacuation)
 ///  - pinning (supported at the block level via Heap::pin_block /
 ///    Heap::unpin_block, not per-object)
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct AllocHeader {
     /// Header bits for object state
     bits: HeaderBits,
@@ -91,14 +66,6 @@ pub struct AllocHeader {
 }
 
 impl AllocHeader {
-    pub fn new(byte_length: u32) -> Self {
-        AllocHeader {
-            bits: HeaderBits::default(),
-            alloc_length: byte_length,
-            forwarded_to: None,
-        }
-    }
-
     pub fn new_with_mark_state(byte_length: u32, mark_state: bool) -> Self {
         AllocHeader {
             bits: HeaderBits::new_unmarked(mark_state),
@@ -107,19 +74,6 @@ impl AllocHeader {
         }
     }
 
-    pub fn mark(&mut self) {
-        self.bits.mark()
-    }
-
-    pub fn unmark(&mut self) {
-        self.bits.unmark()
-    }
-
-    pub fn is_marked(&self) -> bool {
-        self.bits.is_marked()
-    }
-
-    // New methods that take mark state as parameter
     pub fn mark_with_state(&mut self, mark_state: bool) {
         self.bits.mark_with_state(mark_state)
     }

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -28,7 +28,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::ptr::NonNull;
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+
 use std::time::{Duration, Instant};
 use std::{cell::UnsafeCell, mem::size_of};
 use std::{ptr::write, slice::from_raw_parts_mut};
@@ -1050,8 +1050,9 @@ impl EmergencyState {
 pub struct Heap {
     state: UnsafeCell<HeapState>,
     limit: Option<usize>,
-    /// Mark state for this heap instance - flipped each collection to avoid clearing marks
-    mark_state: AtomicBool,
+    /// Mark state for this heap instance - flipped each collection to avoid clearing marks.
+    /// Plain bool suffices as each Heap is used from a single thread.
+    mark_state: bool,
     /// Emergency collection state tracking
     emergency_state: UnsafeCell<EmergencyState>,
     /// GC performance metrics and telemetry
@@ -1519,7 +1520,7 @@ impl Heap {
         Heap {
             state: UnsafeCell::new(HeapState::new()),
             limit: None,
-            mark_state: AtomicBool::new(false),
+            mark_state: false,
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
             pin_counts: UnsafeCell::new(HashMap::new()),
@@ -1531,7 +1532,7 @@ impl Heap {
         Heap {
             state: UnsafeCell::new(HeapState::new()),
             limit: Some(block_limit),
-            mark_state: AtomicBool::new(false),
+            mark_state: false,
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
             pin_counts: UnsafeCell::new(HashMap::new()),
@@ -1551,12 +1552,12 @@ impl Heap {
 
     /// Get the current mark state for this heap
     pub fn mark_state(&self) -> bool {
-        self.mark_state.load(SeqCst)
+        self.mark_state
     }
 
     /// Flip the mark state for this heap (called after each collection)
-    pub fn flip_mark_state(&self) {
-        self.mark_state.fetch_xor(true, SeqCst);
+    pub fn flip_mark_state(&mut self) {
+        self.mark_state = !self.mark_state;
     }
 
     /// Increment the pin count for the block containing `ptr`.
@@ -2603,7 +2604,7 @@ pub mod tests {
         assert_eq!(difference, size_of::<AllocHeader>());
 
         unsafe {
-            assert!(!(*header_ptr.as_ptr()).is_marked());
+            assert!(!(*header_ptr.as_ptr()).is_marked_with_state(heap.mark_state()));
         }
     }
 

--- a/src/eval/memory/mark.rs
+++ b/src/eval/memory/mark.rs
@@ -1,20 +1,6 @@
 //! Mark state
 //!
-//! Global setting of whether true or false indicates a mark. This is
-//! flipped on every trace so as to avoid blanking out all marks.
-//!
-
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
-
-/// The boolean value that indicates marked (known live) objects.
-pub static MARK_STATE: AtomicBool = AtomicBool::new(false);
-
-/// Flip the boolean value that represents marked live objects.
-pub fn flip_mark_state() {
-    MARK_STATE.fetch_xor(true, SeqCst);
-}
-
-/// Current boolean value that represents marked live objects.
-pub fn mark_state() -> bool {
-    MARK_STATE.load(SeqCst)
-}
+//! The mark state is now held per-`Heap` instance (see `Heap::mark_state` and
+//! `Heap::flip_mark_state`) rather than as a process-wide global.  This module
+//! is retained as a placeholder so that existing `use` paths compile during any
+//! transitional period; it may be removed once all references are confirmed gone.


### PR DESCRIPTION
## Summary

- Removes the process-wide `AtomicBool MARK_STATE` from `mark.rs` and replaces it with a plain `bool` field on `Heap`
- This is the root cause of the aarch64 parallel test SIGSEGV: when two `Heap` instances ran GC concurrently (as `cargo test` does with default thread count), they shared the global mark sense. A flip by one could cause the other's live objects to be classified as dead and swept
- `flip_mark_state` is now `&mut self` (plain bool, no atomics needed — each `Heap` is single-threaded)
- Removes all global-depending `mark`/`unmark`/`is_marked` methods from `AllocHeader` and `HeaderBits`; only the `*_with_state` variants remain
- `mark.rs` is emptied of the global and retained as a placeholder comment

## What was kept

- `--test-threads=1` CI workaround remains until this fix is verified on aarch64 in CI

## Test plan

- [x] `cargo test --lib` — 596 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `test_per_heap_mark_state_isolation` confirms heap1 flip does not affect heap2

🤖 Generated with [Claude Code](https://claude.com/claude-code)