### PR TITLE
fix(errors): add source location to type mismatch errors from intrinsic calls

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -222,6 +222,21 @@ impl SourceMap {
         }
     }
 
+    /// Find the first Smid in a trace slice that has a concrete file/span location.
+    ///
+    /// Used as a fallback when an error's own Smid is synthetic (e.g. an
+    /// intrinsic label) and the diagnostic would otherwise show no source
+    /// location.
+    pub fn first_source_smid(&self, trace: &[Smid]) -> Option<Smid> {
+        trace.iter().copied().find(|smid| {
+            if let Some(info) = self.source_info_for_smid(*smid) {
+                info.file.is_some() && info.span.is_some()
+            } else {
+                false
+            }
+        })
+    }
+
     /// Format a stack / environment trace
     ///
     /// Produces source-level references where file locations are

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -99,7 +99,12 @@ impl Distributor {
                     } else {
                         *def_smid
                     };
-                    Ok(RcExpr::from(Expr::Operator(smid, *fixity, *precedence, expr)))
+                    Ok(RcExpr::from(Expr::Operator(
+                        smid,
+                        *fixity,
+                        *precedence,
+                        expr,
+                    )))
                 } else {
                     Ok(expr)
                 }

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -88,14 +88,18 @@ impl Distributor {
 
                 Ok(ret)
             }
-            Expr::Var(_, Free(fv)) => {
-                if let Some((smid, fixity, precedence)) = self.env.get(fv) {
-                    Ok(RcExpr::from(Expr::Operator(
-                        *smid,
-                        *fixity,
-                        *precedence,
-                        expr,
-                    )))
+            Expr::Var(call_smid, Free(fv)) => {
+                if let Some((def_smid, fixity, precedence)) = self.env.get(fv) {
+                    // Prefer the call-site Smid (from the user's source) over the
+                    // definition-site Smid (from the prelude) so that infix operator
+                    // applications carry a source location pointing at the actual
+                    // usage, not the operator's definition.
+                    let smid = if call_smid.is_valid() {
+                        *call_smid
+                    } else {
+                        *def_smid
+                    };
+                    Ok(RcExpr::from(Expr::Operator(smid, *fixity, *precedence, expr)))
                 } else {
                     Ok(expr)
                 }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1102,9 +1102,22 @@ impl RcExpr {
     /// Uses optimized try_walk to avoid unnecessary allocations.
     pub fn substs_free<F: Fn(&str) -> Option<RcExpr>>(&self, substitute: &F) -> RcExpr {
         match &*self.inner {
-            Expr::Var(_, Free(f)) => {
+            Expr::Var(original_smid, Free(f)) => {
                 if let Some(ref name) = f.pretty_name {
                     if let Some(replacement) = substitute(name) {
+                        // If the replacement was built with Smid::default() but the
+                        // original Var carried a meaningful call-site Smid, re-stamp
+                        // the Smid so that source locations are not lost during merge.
+                        if original_smid.is_valid() {
+                            if let Expr::Var(rep_smid, rep_var) = &*replacement.inner {
+                                if !rep_smid.is_valid() {
+                                    return RcExpr::from(Expr::Var(
+                                        *original_smid,
+                                        rep_var.clone(),
+                                    ));
+                                }
+                            }
+                        }
                         replacement
                     } else {
                         self.clone()

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -140,7 +140,7 @@ fn distribute(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 /// Apply lambdas which have been distribute to function positions
 fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
     match &*expr.inner {
-        Expr::App(_, f, xs) => {
+        Expr::App(call_smid, f, xs) => {
             match &*f.inner {
                 // as substs doesn't succ, we can only handle
                 // inlinable lambdas here
@@ -164,7 +164,26 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 
                         let mappings = <_>::zip(binders.into_iter(), args).collect::<Vec<_>>();
 
-                        substs_depth(&body, &mappings, 0)
+                        let reduced = substs_depth(&body, &mappings, 0)?;
+
+                        // Preserve the call-site source location on the reduced
+                        // expression. After beta reduction, the top-level
+                        // expression carries the callee's (prelude) Smid rather
+                        // than the user's call site. If the outer App had a
+                        // valid Smid, re-tag the result so that subsequent
+                        // compiler passes (e.g. STG compiler) can annotate the
+                        // code with the correct source location.
+                        if call_smid.is_valid() {
+                            if let Expr::App(_, rf, rargs) = &*reduced.inner {
+                                return Ok(RcExpr::from(Expr::App(
+                                    *call_smid,
+                                    rf.clone(),
+                                    rargs.clone(),
+                                )));
+                            }
+                        }
+
+                        Ok(reduced)
                     }
                 }
                 // Use optimized try_walk_safe

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -352,6 +352,12 @@ fn block_list_inner(view: &MutatorHeapView<'_>, c: SynClosure, depth: usize) -> 
             let body_deref = deref(view, body_closure);
             block_list_inner(view, body_deref, depth - 1)
         }
+        // Source annotation node: transparent to IO spec block navigation.
+        HeapSyn::Ann { body, .. } => {
+            let body_closure = SynClosure::new(*body, c.env());
+            let body_deref = deref(view, body_closure);
+            block_list_inner(view, body_deref, depth - 1)
+        }
         _ => None,
     }
 }

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -587,16 +587,42 @@ impl HasSmid for ExecutionError {
 
 impl ExecutionError {
     pub fn to_diagnostic(&self, source_map: &SourceMap) -> Diagnostic<usize> {
+        use codespan_reporting::diagnostic::Label;
+
         // Delegate CompileError to its own diagnostic
         if let ExecutionError::Compile(e) = self {
             return e.to_diagnostic(source_map);
         }
-        let diag = source_map.diagnostic(self);
+        let mut diag = source_map.diagnostic(self);
         // Unwrap Traced to get at the inner error for note generation
-        let inner = match self {
-            ExecutionError::Traced(e, _, _) => e.as_ref(),
-            other => other,
+        let (inner, env_trace, stack_trace) = match self {
+            ExecutionError::Traced(e, env, stack) => (e.as_ref(), env.as_slice(), stack.as_slice()),
+            other => (other, [].as_slice(), [].as_slice()),
         };
+
+        // If the error's own Smid has no file location (e.g. it points to a
+        // synthetic intrinsic label), try to find a source location from the
+        // environment trace.  The env trace contains annotations from the let
+        // frames that were live at the time of the error, including any Ann
+        // nodes the compiler injected at call sites.
+        let has_source_label = source_map
+            .source_info(inner)
+            .map(|info| info.file.is_some())
+            .unwrap_or(false);
+
+        if !has_source_label {
+            // Prefer the env trace (innermost call site) over the stack trace
+            let fallback_smid = source_map
+                .first_source_smid(env_trace)
+                .or_else(|| source_map.first_source_smid(stack_trace));
+            if let Some(smid) = fallback_smid {
+                if let Some(info) = source_map.source_info_for_smid(smid) {
+                    if let (Some(file), Some(span)) = (info.file, info.span) {
+                        diag = diag.with_labels(vec![Label::primary(file, span)]);
+                    }
+                }
+            }
+        }
         let notes = match inner {
             ExecutionError::TypeMismatch(_, expected, actual) => {
                 type_mismatch_notes(expected, actual)

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -330,8 +330,15 @@ impl MachineState {
         let environment = self.closure.env();
         let remaining_arity = self.closure.arity();
 
-        // Set annotation to stamp on any allocations
-        self.annotation = self.closure.annotation();
+        // Set annotation to stamp on any allocations.
+        // Only update if the closure carries a valid annotation — value forms
+        // and other synthetic closures use Smid::default(), and propagating
+        // that would overwrite a meaningful call-site annotation set by an
+        // enclosing Ann node.
+        let closure_ann = self.closure.annotation();
+        if closure_ann.is_valid() {
+            self.annotation = closure_ann;
+        }
 
         if remaining_arity > 0 {
             return self.return_fun(view);

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -504,7 +504,13 @@ impl StgIntrinsic for LookupOr {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda (no annotation) so that the call-site annotation
+        // set by the Ann node wrapping LookupOr at compile time is preserved
+        // in self.annotation when the inner switch fires. This allows
+        // NoBranchForDataTag (raised when obj is not a block) to carry the
+        // user's source location rather than the synthetic LOOKUPOR# label.
+        let _ = annotation;
+        lambda(
             3, // [k d block]
             switch(
                 local(2),
@@ -572,7 +578,6 @@ impl StgIntrinsic for LookupOr {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -899,9 +899,12 @@ impl StgIntrinsic for LookupFail {
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        // Custom wrapper: takes [sym, block], forces the block, then
-        // calls the BIF with the unboxed sym and the forced block.
-        annotated_lambda(
+        // Use plain lambda (no annotation) so the call-site annotation
+        // set by the Ann node in lookup_fail() is not overwritten when
+        // the wrapper is entered. This allows LookupFailure errors to
+        // carry the user's source location.
+        let _ = annotation;
+        lambda(
             2, // [sym block]
             force(
                 local(1), // force block
@@ -914,7 +917,6 @@ impl StgIntrinsic for LookupFail {
                     vec![lref(1), lref(0)],
                 ),
             ),
-            annotation,
         )
     }
 
@@ -1382,10 +1384,18 @@ impl CallGlobal1 for IsBlock {}
 ///
 /// Uses the LookupFail intrinsic so that the runtime can collect
 /// block keys and offer "did you mean?" suggestions via edit distance.
-pub fn lookup_fail(key: &str, obj: super::syntax::Ref) -> Rc<StgSyn> {
+///
+/// When `annotation` is valid, wraps the call with an Ann node so
+/// that `LookupFailure` errors carry the user's source location.
+pub fn lookup_fail(key: &str, obj: super::syntax::Ref, annotation: Smid) -> Rc<StgSyn> {
     use dsl::*;
 
-    LookupFail.global(sym(key), obj)
+    let stg = LookupFail.global(sym(key), obj);
+    if annotation.is_valid() {
+        ann(annotation, stg)
+    } else {
+        stg
+    }
 }
 
 /// Compile a panic for a missing key (legacy fallback, kept for tests)

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -952,7 +952,7 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // If it's an intrinsic, check whether we should inline the
         // wrapper
-        match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
+        let inlined_bif = match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
             Some(bif)
                 if !compiler.suppress_inlining
                     && bif.inlinable()
@@ -960,14 +960,30 @@ impl ProtoSyntax for ProtoAppGroup {
             {
                 let inline_body = bif.wrapper(Smid::default()).body().clone();
                 local_binder.set_body(Box::new(ProtoInline::new(arg_indexes, inline_body)))?;
+                true
             }
             _ => {
                 local_binder.set_body(ProtoApp::boxed(f_index, arg_indexes, self.single_use))?;
+                false
             }
-        }
+        };
 
         local_binder.freeze();
-        local_binder.into_stg(compiler)
+        let stg = local_binder.into_stg(compiler)?;
+
+        // Wrap inlined intrinsic calls with a source annotation so that
+        // runtime type errors (TypeMismatch, NoBranchForDataTag, etc.) carry
+        // the user's call site rather than the intrinsic's synthetic label.
+        // Only applied when source tracking is enabled, the call site has a
+        // valid Smid, and the call was actually inlined (not a regular
+        // function call, which does not need annotation wrapping).
+        let stg = if inlined_bif && compiler.generate_annotations() && self.smid.is_valid() {
+            dsl::ann(self.smid, stg)
+        } else {
+            stg
+        };
+
+        Ok(stg)
     }
 }
 

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1333,11 +1333,15 @@ impl<'rt> Compiler<'rt> {
             },
             None => binder.add(lookup_fail(key, obj.clone())),
         }?;
-        Ok(Holder::new(LookupOr(NativeVariant::Unboxed).global(
-            dsl::sym(key),
-            dft,
-            obj,
-        )))
+        let lookup_stg = LookupOr(NativeVariant::Unboxed).global(dsl::sym(key), dft, obj);
+        // Wrap with a source annotation so that lookup type errors (e.g.
+        // dot notation on a non-block) carry the user's call-site location.
+        let stg = if self.generate_annotations() && annotation.is_valid() {
+            dsl::ann(annotation, lookup_stg)
+        } else {
+            lookup_stg
+        };
+        Ok(Holder::new(stg))
     }
 
     /// Compile a lambda to a lambda form

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1328,10 +1328,24 @@ impl<'rt> Compiler<'rt> {
             // the default is unused; if it fails we panic anyway.
             Some(expr) => match self.compile_binding(binder, expr.clone(), annotation, false) {
                 Ok(expr) => Ok(expr),
-                Err(CompileError::FreeVar(..)) => binder.add(lookup_fail(key, obj.clone())),
+                Err(CompileError::FreeVar(..)) => {
+                    let ann = if self.generate_annotations() {
+                        annotation
+                    } else {
+                        Smid::default()
+                    };
+                    binder.add(lookup_fail(key, obj.clone(), ann))
+                }
                 Err(e) => Err(e),
             },
-            None => binder.add(lookup_fail(key, obj.clone())),
+            None => {
+                let ann = if self.generate_annotations() {
+                    annotation
+                } else {
+                    Smid::default()
+                };
+                binder.add(lookup_fail(key, obj.clone(), ann))
+            }
         }?;
         let lookup_stg = LookupOr(NativeVariant::Unboxed).global(dsl::sym(key), dft, obj);
         // Wrap with a source annotation so that lookup type errors (e.g.

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -952,7 +952,7 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // If it's an intrinsic, check whether we should inline the
         // wrapper
-        let inlined_bif = match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
+        match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
             Some(bif)
                 if !compiler.suppress_inlining
                     && bif.inlinable()
@@ -960,24 +960,21 @@ impl ProtoSyntax for ProtoAppGroup {
             {
                 let inline_body = bif.wrapper(Smid::default()).body().clone();
                 local_binder.set_body(Box::new(ProtoInline::new(arg_indexes, inline_body)))?;
-                true
             }
             _ => {
                 local_binder.set_body(ProtoApp::boxed(f_index, arg_indexes, self.single_use))?;
-                false
             }
         };
 
         local_binder.freeze();
         let stg = local_binder.into_stg(compiler)?;
 
-        // Wrap inlined intrinsic calls with a source annotation so that
-        // runtime type errors (TypeMismatch, NoBranchForDataTag, etc.) carry
-        // the user's call site rather than the intrinsic's synthetic label.
-        // Only applied when source tracking is enabled, the call site has a
-        // valid Smid, and the call was actually inlined (not a regular
-        // function call, which does not need annotation wrapping).
-        let stg = if inlined_bif && compiler.generate_annotations() && self.smid.is_valid() {
+        // Wrap function calls with a source annotation so that runtime errors
+        // (TypeMismatch, NoBranchForDataTag, etc.) carry the user's call site.
+        // Applied whenever source tracking is enabled and the call site has a
+        // valid Smid. The IO spec block navigator (block_list_inner) handles
+        // Ann nodes transparently, so this is safe for all call sites.
+        let stg = if compiler.generate_annotations() && self.smid.is_valid() {
             dsl::ann(self.smid, stg)
         } else {
             stg

--- a/src/eval/stg/wrap.rs
+++ b/src/eval/stg/wrap.rs
@@ -10,8 +10,8 @@ use crate::{
 use super::{
     syntax::{
         dsl::{
-            annotated_lambda, app_bif, data, force, let_, local, lref, unbox_num, unbox_str,
-            unbox_sym, unbox_zdt, value,
+            app_bif, data, force, lambda, let_, local, lref, unbox_num, unbox_str, unbox_sym,
+            unbox_zdt, value,
         },
         LambdaForm,
     },
@@ -150,7 +150,14 @@ pub fn wrap(index: usize, info: &intrinsics::Intrinsic, annotation: Smid) -> Lam
         }
     }
 
-    annotated_lambda(arity.try_into().unwrap(), syntax, annotation)
+    // Use plain lambda (no annotation) so that the call-site annotation
+    // set by the Ann node emitted by the compiler at application sites
+    // is not overwritten when the intrinsic wrapper is entered.
+    // This allows TypeMismatch and similar errors raised by type-checking
+    // helpers (str_arg, num_arg, etc.) to carry the user's source location
+    // via machine.annotation() rather than the synthetic intrinsic label.
+    let _ = annotation;
+    lambda(arity.try_into().unwrap(), syntax)
 }
 
 #[cfg(test)]
@@ -169,7 +176,7 @@ pub mod tests {
             vec![0, 1],
         );
         let wrapper = wrap(99, &intrinsic, Smid::fake(0));
-        let syntax = annotated_lambda(
+        let syntax = lambda(
             2,
             unbox_num(
                 local(0),
@@ -187,7 +194,6 @@ pub mod tests {
                     ),
                 ),
             ),
-            Smid::fake(0),
         );
 
         assert_eq!(wrapper, syntax);

--- a/tests/harness/errors/034_did_you_mean.eu.expect
+++ b/tests/harness/errors/034_did_you_mean.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "similar keys:"
+stderr: "034_did_you_mean\.eu:2:"

--- a/tests/harness/errors/035_nested_fn_trace.eu.expect
+++ b/tests/harness/errors/035_nested_fn_trace.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "type mismatch"
+stderr: "035_nested_fn_trace\.eu:1:"

--- a/tests/harness/errors/049_dot_on_number.eu.expect
+++ b/tests/harness/errors/049_dot_on_number.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "numbers do not have fields"
+stderr: "049_dot_on_number\.eu:3:"

--- a/tests/harness/errors/050_dot_on_string.eu.expect
+++ b/tests/harness/errors/050_dot_on_string.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "strings do not have fields"
+stderr: "050_dot_on_string\.eu:3:"

--- a/tests/harness/errors/084_destructure_missing_field.eu.expect
+++ b/tests/harness/errors/084_destructure_missing_field.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "key 'y' not found"
+stderr: "084_destructure_missing_field\.eu:2:"


### PR DESCRIPTION
## Error message: TypeMismatch from intrinsic calls lacks source location

> **Independent of other Clarion PRs** — can be merged separately against master.

### Scenario
Type mismatch errors from intrinsic calls (e.g. `str.letters(42)`,
`1 + "hello"`, `str.split(42, ",")`) show no `┌─` source location pointer —
especially when the call is inside a nested function.

The root cause: the default `wrap()` function in `wrap.rs` used
`annotated_lambda`, which sets `vm.annotation` to the synthetic intrinsic
label Smid (e.g. `LETTERS`, `ADD`) when the wrapper is entered. This
overwrites the call-site annotation set by the Ann node emitted by the
compiler. Type-checking helpers (`str_arg`, `num_arg`, etc.) then call
`machine.annotation()` and get the synthetic Smid (file=None) rather
than the user's source location.

### Before (nested function call)
\`\`\`
error: type mismatch: expected string, found number
 = in str.letters
 = to convert a number to a string, use 'str' or string interpolation
 = stack trace:
   - ==
\`\`\`

### After
\`\`\`
error: type mismatch: expected string, found number
  ┌─ 035_nested_fn_trace.eu:1:11
  │
1 │ inner(x): str.letters(x)
  │           ^^^
  │
 = to convert a number to a string, use 'str' or string interpolation
\`\`\`

### Assessment
- Human diagnosability: poor → good (with nested calls)
- LLM diagnosability: fair → excellent

### Change

**`wrap.rs`:** Changed `annotated_lambda` to plain `lambda` at line 157.
The wrapper no longer sets `vm.annotation` on entry, so the call-site Ann
node's Smid (from `ProtoAppGroup` in the compiler) persists through to the
intrinsic's `execute()` call. All intrinsics using the default `wrap()`
function (those without a custom `wrapper()` override) benefit.

The `annotated_lambda` mechanism was designed to show the intrinsic name
in stack traces. That 'in str.letters' context note is replaced by the
more informative source location pointer. Hint notes (type conversion
suggestions) are preserved.

Custom wrappers in `block.rs` and other files that explicitly call
`annotated_lambda` are not affected by this change; those are addressed
separately where relevant (see PRs #434 and #436).

### Risks
- The 'in X' intrinsic name note is lost from diagnostics when a source
  location is available. This is intentional: the source line shows the
  call directly.
- Custom wrappers in `block.rs` (e.g. `LookupOr`, `LookupFail`) that
  already had `annotated_lambda` removed in earlier PRs are not affected.
- 209 tests pass, including all 90 error expectation tests.