### PR TITLE
fix(prelude): eliminate __monad-return-of and __monad-map-m top-level helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,20 @@ All notable changes to eucalypt are documented here.
   - Supports `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jsonl`
   - Data-only mode: untrusted input (e.g. shell output) never executes embedded code
 
+- **`monad(m)`** — Derive standard monad combinators from a block with `bind` and `return` fields
+  - Returns a block with `map`, `then`, `join`, `sequence`, `map-m`, `filter-m`
+  - Compose with `{ ... }` to build monadic namespaces: `monad(m) { extra-field: ... }`
+
+- **Monadic `random:` namespace** — State-monad interface to the PRNG
+  - `random.stream(seed)` — create initial stream; each action is a function `stream -> {value, rest}`
+  - `random.float`, `random.int(n)`, `random.choice(xs)`, `random.shuffle(xs)`, `random.sample(n, xs)`
+  - `random.map`, `random.sequence`, `random.map-m`, `random.bind`, `random.return`
+  - Legacy `random-stream`, `random-int`, `random-choice`, `random-shuffle`, `random-sample` retained
+
 ### Fixed
 
 - **GC evacuation alignment** — 16-byte alignment padding for `evacuate()` allocation
+- **GC aarch64 segfault** — Diagnostic instrumentation and workaround for aarch64 evacuation crash
 - **Emacs mode** — Backtick auto-pairing, closing brace indentation, docstring indentation, smartparens compatibility
 - **Unicode input** — Check mark and other new Unicode chars in Quail and transient menu
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -87,9 +87,6 @@ __io-exec-spec(opts, c, as): {
 ##
 
 ` :suppress
-__monad-return-of(m, f, x): m.return(f(x))
-
-` :suppress
 __monad-sequence-put(m, hd, xs): m.return(cons(hd, xs))
 
 ` :suppress
@@ -110,14 +107,15 @@ __monad-filter-gate(m, p, elt, rest-ms, flag):
 __monad-filter-m(m, p, xs):
   if(xs nil?, m.return([]), m.bind(p(xs head), __monad-filter-gate(m, p, xs head, xs tail)))
 
+# Alias for the list map function, captured before monad() shadows the name 'map'
 ` :suppress
-__monad-map-m(m, f, xs): __monad-sequence(m, map(f, xs))
+list-map: map
 
 ` "monad(m) - derive standard monad combinators from a block m with bind and return fields.
 Returns a block with map, then, join, sequence, map-m, and filter-m."
 monad(m): {
   ` "map(f, action) - apply pure function f to the result of a monadic action (fmap)."
-  map(f, action): m.bind(action, __monad-return-of(m, f))
+  map(f, action): m.bind(action, compose(m.return, f))
 
   ` "then(a, b) - sequence two monadic actions, discarding the result of the first."
   then(a, b): m.bind(a, -> b)
@@ -129,7 +127,7 @@ monad(m): {
   sequence(ms): __monad-sequence(m, ms)
 
   ` "map-m(f, xs) - apply f to each element of xs (producing actions), then sequence."
-  map-m(f, xs): __monad-map-m(m, f, xs)
+  map-m(f, xs): list-map(f, xs) sequence
 
   ` "filter-m(p, xs) - monadic filter: apply predicate p (returning a monadic bool) to each element."
   filter-m(p, xs): __monad-filter-m(m, p, xs)


### PR DESCRIPTION
## Summary

- Removes `__monad-return-of(m, f, x)` top-level helper — replaced by `compose(m.return, f)` in `map`
- Removes `__monad-map-m(m, f, xs)` top-level helper — replaced by `list-map(f, xs) sequence` in `map-m`
- Adds `` ` :suppress `` `list-map: map` alias at the top-level prelude scope, capturing `map` before `monad()` shadows it with its own `map` field
- Updates `CHANGELOG.md` with `monad()`, monadic `random:`, and GC aarch64 entries

### Why these helpers were wrong

Both helpers leaked into the visible prelude namespace (suppressed, but still present as top-level bindings). The correct fix captures the shadowed name via a single alias (`list-map: map`) declared before the shadowing block.

### Why `compose(m.return, f)` for `map`

`m.return(f(_))` looks correct but has an anaphor scoping trap: `_` inside `f(_)` is in an opaque arg tuple, so it creates `λy. y` (identity) rather than a free variable. The expression evaluates as `m.return(f(identity))` — wrong. `compose(m.return, f)` = `λx. m.return(f(x))` — correct.

### Why `list-map(f, xs) sequence` for `map-m`

`map` is shadowed inside the `monad(m)` block by the derived `map` field. `list-map` is an alias for the prelude `map`, captured at the outer scope before shadowing occurs. The `{ list-map: map }.{ ... }` block-dot pattern does NOT work for function-valued outer fields (only data values).

## Test plan

- [x] `cargo test --test harness_test` — all 211 tests pass (210 existing + 119 + 120)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)