### PR TITLE
fix(errors): add source location to merge/catenation type errors

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -780,6 +780,12 @@ impl MachineState {
                         let mut args = Array::from_slice(&view, args.as_slice());
                         args.push(&view, self.closure.clone());
                         self.push(view, Continuation::ApplyTo { args, annotation })?;
+                        // Restore the application-site annotation so that any
+                        // type-mismatch errors raised inside the MERGE wrapper
+                        // (e.g. NoBranchForDataTag when a non-block is merged)
+                        // carry the user's source location rather than a
+                        // synthetic intrinsic label.
+                        self.annotation = annotation;
                         self.closure = SynClosure::new(
                             view.atom(Ref::G(
                                 intrinsics::index("MERGE")

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1111,7 +1111,11 @@ impl StgIntrinsic for Merge {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             2, // [l r]
             switch(
                 local(0),
@@ -1144,7 +1148,6 @@ impl StgIntrinsic for Merge {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 
@@ -1215,7 +1218,11 @@ impl StgIntrinsic for MergeWith {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             3, // [l r f]
             switch(
                 local(0),
@@ -1248,7 +1255,6 @@ impl StgIntrinsic for MergeWith {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 
@@ -1315,7 +1321,11 @@ impl StgIntrinsic for DeepMerge {
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             2,
             case(
                 local(0),
@@ -1336,7 +1346,6 @@ impl StgIntrinsic for DeepMerge {
                 // [l] [l r]
                 local(2),
             ),
-            annotation,
         )
     }
 }


### PR DESCRIPTION
## Error message: merge type mismatch — missing source location

### Scenario

Perturbation applied to realistic code: `x str` where `x = 42`. This is a common mistake where users from dynamically typed languages try to convert a number to a string by catenating with the `str` namespace block.

### Before

```
error: type mismatch: expected block, found number
 = in merge
 = the '.' operator performs key lookup on blocks; numbers do not have fields
 = to apply a function to a number, use pipeline catenation, e.g. 'x abs' or 'x negate' instead of 'x.abs'
 = note: 'str' is a namespace of string functions, not a type conversion function; to convert a number to a string use 'str.of(x)' or string interpolation
```

### After (once PR #434 is merged)

```
error: type mismatch: expected block, found number
  ┌─ example.eu:5:11
  │
5 │ result: x str
  │           ^^^
  │
 = the '.' operator performs key lookup on blocks; numbers do not have fields
 = to apply a function to a number, use pipeline catenation, e.g. 'x abs' or 'x negate' instead of 'x.abs'
 = note: 'str' is a namespace of string functions, not a type conversion function; to convert a number to a string use 'str.of(x)' or string interpolation
```

### Assessment

- Human diagnosability: fair → good (source location points exactly to the problematic `str`)
- LLM diagnosability: poor → good (with file:line:col, an LLM can find the exact expression)

### How block application merges work

When `x str` is evaluated (catenation of a number with a block), eucalypt compiles this as `App(str, x)`. At runtime, when `str` evaluates to a `Block`, the VM dynamically dispatches to the `MERGE` intrinsic. The `Merge::wrapper()` then performs `switch(l, [(Block, ...)])`, which raises `NoBranchForDataTag` when `l` (the number `x`) is not a block.

### Change

Three intrinsic wrappers in `src/eval/stg/block.rs` were changed from `annotated_lambda` to `lambda`:

- `Merge::wrapper()` — the shallow merge operator
- `MergeWith::wrapper()` — merge with a combining function
- `DeepMerge::wrapper()` — the `<<` deep-merge operator

Each wrapper used `annotated_lambda` with a synthetic Smid (file=None, annotation="MERGE"/"MERGEWITH"/"DEEPMERGE"), which overwrote `vm.annotation` when the wrapper was entered. This erased the call-site annotation set by the compiler's Ann node, so type errors inside the wrapper had no user source location.

Additionally, in `src/eval/machine/vm.rs`, the block-application MERGE dispatch now restores `self.annotation` from the `ApplyTo` continuation's annotation field before dispatching to MERGE. This ensures the call-site Smid is present when the MERGE wrapper is entered and pushes its Branch continuation.

### Dependency

This PR is a prerequisite fix for the source-location improvements in PR #434 (which emits Ann nodes at application sites). Without PR #434, the `ApplyTo` annotation is always `Smid::default()` on master, so this PR has no visible effect alone. Once PR #434 merges, these changes immediately enable source locations for merge/catenation type errors.

All 211 tests pass. Clippy and rustfmt clean.

### Risks

Low. Only changes how `vm.annotation` is set during MERGE wrapper execution — from a synthetic intrinsic Smid to the application-site Smid. Existing tests all pass, including the `054_num_merge_hint` test.