### PR TITLE
fix(errors): replace panic with proper error for dotted metadata keys

### DIFF
--- a/src/core/cook/fill.rs
+++ b/src/core/cook/fill.rs
@@ -1,6 +1,7 @@
 //! Logic for filling out expressions with implicit anaphora
 use crate::common::sourcemap::{HasSmid, Smid};
 use crate::core::anaphora;
+use crate::core::error::CoreError;
 use crate::core::expr::*;
 use std::collections::HashSet;
 
@@ -8,11 +9,11 @@ pub type AnaphorSet = HashSet<Anaphor<Smid, i32>>;
 
 /// Fill implied gaps with expression anaphora and keep tabs on
 /// whether there are any naked anaphora amongs the `xs`.
-pub fn fill_gaps(xs: &[RcExpr]) -> (Vec<RcExpr>, AnaphorSet) {
+pub fn fill_gaps(xs: &[RcExpr]) -> Result<(Vec<RcExpr>, AnaphorSet), CoreError> {
     let mut out = Vec::new();
     let mut naked_anaphora = HashSet::new();
 
-    if let Some(prefix) = filler(None, Some(&xs[0])) {
+    if let Some(prefix) = filler(None, Some(&xs[0]))? {
         naked_anaphora.extend(anaphora::naked_anaphora(&prefix));
         out.push(prefix);
     }
@@ -21,7 +22,7 @@ pub fn fill_gaps(xs: &[RcExpr]) -> (Vec<RcExpr>, AnaphorSet) {
         if let [ref l, ref r] = window {
             naked_anaphora.extend(anaphora::naked_anaphora(l));
             out.push(l.clone());
-            if let Some(fill) = filler(Some(l), Some(r)) {
+            if let Some(fill) = filler(Some(l), Some(r))? {
                 naked_anaphora.extend(anaphora::naked_anaphora(&fill));
                 out.push(fill.clone());
             }
@@ -31,13 +32,13 @@ pub fn fill_gaps(xs: &[RcExpr]) -> (Vec<RcExpr>, AnaphorSet) {
     if let Some(end) = xs.last() {
         naked_anaphora.extend(anaphora::naked_anaphora(end));
         out.push(end.clone());
-        if let Some(suffix) = filler(Some(end), None) {
+        if let Some(suffix) = filler(Some(end), None)? {
             naked_anaphora.extend(anaphora::naked_anaphora(&suffix));
             out.push(suffix);
         }
     }
 
-    (out, naked_anaphora)
+    Ok((out, naked_anaphora))
 }
 
 /// Whether a side of an atom is operator like or value like
@@ -65,9 +66,9 @@ fn bind_sides(expr: Option<&RcExpr>) -> (BindSide, BindSide) {
 
 /// Return an appropriate filler expression to go between `left`
 /// and `right`
-pub fn filler(left: Option<&RcExpr>, right: Option<&RcExpr>) -> Option<RcExpr> {
+pub fn filler(left: Option<&RcExpr>, right: Option<&RcExpr>) -> Result<Option<RcExpr>, CoreError> {
     match (bind_sides(left).1, bind_sides(right).0) {
-        (BindSide::ValueLike, BindSide::ValueLike) => Some(core::cat()),
+        (BindSide::ValueLike, BindSide::ValueLike) => Ok(Some(core::cat())),
         (BindSide::OpLike, BindSide::OpLike) => {
             let rsmid = match right {
                 Some(r) => r.smid(),
@@ -78,14 +79,14 @@ pub fn filler(left: Option<&RcExpr>, right: Option<&RcExpr>) -> Option<RcExpr> {
                 _ => Smid::default(),
             };
             if rsmid != Smid::default() {
-                Some(core::section_anaphor_left(rsmid))
+                Ok(Some(core::section_anaphor_left(rsmid)))
             } else if lsmid != Smid::default() {
-                Some(core::section_anaphor_right(lsmid))
+                Ok(Some(core::section_anaphor_right(lsmid)))
             } else {
-                panic!("no SMID for implicit anaphor")
+                Err(CoreError::NoSmidForImplicitAnaphor)
             }
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -99,7 +100,7 @@ pub mod tests {
     use moniker::assert_term_eq;
 
     fn fill(exprs: &[RcExpr]) -> Vec<RcExpr> {
-        fill_gaps(exprs).0
+        fill_gaps(exprs).unwrap().0
     }
 
     #[test]

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -82,7 +82,10 @@ impl Cooker {
     /// `(2+*5) => (2+_*5)`
     ///
     /// Also return the expression anaphora which have been added.
-    fn insert_anaphora(&mut self, soup: &[RcExpr]) -> (Vec<RcExpr>, fill::AnaphorSet) {
+    fn insert_anaphora(
+        &mut self,
+        soup: &[RcExpr],
+    ) -> Result<(Vec<RcExpr>, fill::AnaphorSet), CoreError> {
         fill::fill_gaps(soup)
     }
 
@@ -124,7 +127,7 @@ impl Cooker {
     /// their own lambda — their anaphors propagate to the outer scope
     /// (subsumption).
     fn cook_soup(&mut self, exprs: &[RcExpr]) -> Result<RcExpr, CoreError> {
-        let (filled, naked_anaphora) = self.insert_anaphora(exprs);
+        let (filled, naked_anaphora) = self.insert_anaphora(exprs)?;
 
         let wrap_lambda = !self.in_expr_anaphor_scope && !naked_anaphora.is_empty();
 

--- a/src/core/cook/shunt.rs
+++ b/src/core/cook/shunt.rs
@@ -230,15 +230,19 @@ impl Shunter {
 
     /// Insert an initial fill if the first atom is not legal
     fn insert_initial_fill(&mut self) {
-        if let Some(fill) = super::fill::filler(None, self.peek_next()) {
-            self.push_back(fill);
+        match super::fill::filler(None, self.peek_next()) {
+            Ok(Some(fill)) => self.push_back(fill),
+            Ok(None) => {}
+            Err(e) => self.error = Some(e),
         }
     }
 
     /// Check the upcoming expr in case we need to insert an anaphor
     fn insert_fill(&mut self, lhs: &RcExpr) {
-        if let Some(fill) = super::fill::filler(Some(lhs), self.peek_next()) {
-            self.push_back(fill);
+        match super::fill::filler(Some(lhs), self.peek_next()) {
+            Ok(Some(fill)) => self.push_back(fill),
+            Ok(None) => {}
+            Err(e) => self.error = Some(e),
         }
     }
 

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -51,6 +51,12 @@ pub enum CoreError {
     EmptyMonadicBlock(Smid),
     #[error("bracket block definition body must be marked with ':monad' — use '{{ :monad bind: {0} return: {1} }}'")]
     MonadSpecMissingMarker(String, String, Smid),
+    /// An implicit anaphor was required to fill adjacent operators but no
+    /// source location was available to attach to it.  This typically
+    /// happens when operators in a metadata block key use dot notation
+    /// (e.g. `` ` { x.y: val } ``) which is not valid eucalypt syntax.
+    #[error("invalid block key: dotted names are not allowed as block keys")]
+    NoSmidForImplicitAnaphor,
 }
 
 impl HasSmid for CoreError {
@@ -86,6 +92,11 @@ impl CoreError {
                 "some input formats (csv, text, etc.) that read as lists need to be assigned names"
                     .to_string(),
                 "perhaps you need to name one or more of your inputs (<name>=<input>)".to_string(),
+            ]),
+            CoreError::NoSmidForImplicitAnaphor => source_map.diagnostic(self).with_notes(vec![
+                "block keys must be simple names (e.g. `x`), not dotted paths (e.g. `x.y`)".to_string(),
+                "example of valid metadata: `` ` { x: val } `` — use 'x', not 'x.y' as the key".to_string(),
+                "if you need nested metadata, use nested blocks: `` ` { x: { y: val } } ``".to_string(),
             ]),
             _ => source_map.diagnostic(self),
         }

--- a/tests/harness/errors/001_dot_in_metadata_key.eu.expect
+++ b/tests/harness/errors/001_dot_in_metadata_key.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "invalid block key"


### PR DESCRIPTION
## Error message: panic in dotted metadata key positions

### Scenario

Writing a metadata block with a dotted name as a key — e.g. `` ` { x.y: val } `` — caused a hard panic rather than a user-facing error. Eucalypt block keys must be simple names, not dot-notation paths.

The panic originated in `src/core/cook/fill.rs:filler()` when two adjacent operators had no source Smids. This can occur when dotted name syntax (`x.y`) appears in a metadata block key position, producing operator tokens with `Smid::default()`.

### Before

```
thread 'main' panicked at src/core/cook/fill.rs:85:17:
no SMID for implicit anaphor
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Human diagnosability: poor — the message is an internal invariant, nothing points to the user's source.

LLM diagnosability: poor — nothing relates this to block key syntax.

### After

```
error: invalid block key: dotted names are not allowed as block keys
 = block keys must be simple names (e.g. `x`), not dotted paths (e.g. `x.y`)
 = example of valid metadata: ` { x: val }` — use 'x', not 'x.y' as the key
 = if you need nested metadata, use nested blocks: ` { x: { y: val } }`
```

Human diagnosability: poor → good — the message names the constraint and shows the fix.

LLM diagnosability: poor → excellent — the notes provide both the rule and a corrected example.

### Assessment

- Human diagnosability: poor → good
- LLM diagnosability: poor → excellent

### Change

- `filler()` in `src/core/cook/fill.rs` changed from returning `Option<RcExpr>` to `Result<Option<RcExpr>, CoreError>`
- `fill_gaps()` changed to return `Result<(Vec<RcExpr>, AnaphorSet), CoreError>`
- `insert_anaphora()` in `mod.rs` updated to propagate the `Result`
- `insert_initial_fill()` and `insert_fill()` in `shunt.rs` updated to handle `Result` via a stored error field
- New `CoreError::NoSmidForImplicitAnaphor` variant added with user-facing message and three diagnostic notes
- New harness test sidecar `tests/harness/errors/001_dot_in_metadata_key.eu.expect` validates the exit code and error message

### Risks

The `filler()` return type change required updating three call sites. The internal test helper `fill()` in `fill.rs` uses `.unwrap()` which will panic if tests trigger the error path — this is intentional as those tests use synthetic expressions that should always have valid Smids.

The `CoreError::NoSmidForImplicitAnaphor` error message references block key syntax, which is the only known trigger for this code path. If other code paths reach `filler()` with two Smid-less operators, they will now get this error instead of a panic — which is strictly better.