### PR TITLE
fix(errors): show available keys on lookup failure when no close match

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -217,11 +217,28 @@ pub fn format_suggestions(suggestions: &[String]) -> Option<String> {
     Some(format!("similar keys: {}", quoted.join(", ")))
 }
 
-/// Format a lookup failure message, including suggestions if available
-fn format_lookup_failure(key: &str, suggestions: &[String]) -> String {
+/// Format a lookup failure message, including suggestions or available keys
+fn format_lookup_failure(key: &str, suggestions: &[String], available: &[String]) -> String {
     let mut msg = format!("key '{key}' not found in block");
     if let Some(hint) = format_suggestions(suggestions) {
         msg.push_str(&format!("\n  help: {hint}"));
+    } else if !available.is_empty() {
+        // No close matches — show the full set of available keys (capped at 8)
+        let shown: Vec<String> = available
+            .iter()
+            .take(8)
+            .map(|s| format!("'{s}'"))
+            .collect();
+        let suffix = if available.len() > 8 {
+            format!(" (and {} more)", available.len() - 8)
+        } else {
+            String::new()
+        };
+        msg.push_str(&format!(
+            "\n  help: available keys: {}{}",
+            shown.join(", "),
+            suffix
+        ));
     }
     msg
 }
@@ -468,8 +485,8 @@ pub enum ExecutionError {
     FreeVar(Smid, String),
     #[error("code not valid for execution")]
     InvalidCode(Smid),
-    #[error("{}", format_lookup_failure(.1, .2))]
-    LookupFailure(Smid, String, Vec<String>),
+    #[error("{}", format_lookup_failure(.1, .2, .3))]
+    LookupFailure(Smid, String, Vec<String>, Vec<String>),
     #[error("type mismatch: expected {1}, found {2}")]
     TypeMismatch(Smid, IntrinsicType, IntrinsicType),
     #[error("unknown intrinsic {1}")]
@@ -569,7 +586,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NotFound(s) => *s,
             ExecutionError::FreeVar(s, _) => *s,
             ExecutionError::InvalidCode(s) => *s,
-            ExecutionError::LookupFailure(s, _, _) => *s,
+            ExecutionError::LookupFailure(s, _, _, _) => *s,
             ExecutionError::TypeMismatch(s, _, _) => *s,
             ExecutionError::UnknownIntrinsic(s, _) => *s,
             ExecutionError::NotCallable(s, _) => *s,
@@ -684,7 +701,7 @@ impl ExecutionError {
                 ]
             }
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
-            ExecutionError::LookupFailure(_, key, suggestions) => {
+            ExecutionError::LookupFailure(_, key, suggestions, _) => {
                 lookup_failure_notes(key, suggestions)
             }
             ExecutionError::CannotReturnFunToCase(_, expected_tags) => {

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -224,11 +224,7 @@ fn format_lookup_failure(key: &str, suggestions: &[String], available: &[String]
         msg.push_str(&format!("\n  help: {hint}"));
     } else if !available.is_empty() {
         // No close matches — show the full set of available keys (capped at 8)
-        let shown: Vec<String> = available
-            .iter()
-            .take(8)
-            .map(|s| format!("'{s}'"))
-            .collect();
+        let shown: Vec<String> = available.iter().take(8).map(|s| format!("'{s}'")).collect();
         let suffix = if available.len() > 8 {
             format!(" (and {} more)", available.len() - 8)
         } else {

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -952,6 +952,7 @@ impl StgIntrinsic for LookupFail {
             machine.annotation(),
             key_name,
             suggestions,
+            available_keys,
         ))
     }
 }


### PR DESCRIPTION
## Error message: block key lookup failure — show available keys

### Scenario

Accessing a key that doesn't exist on a block and has no close matches. For example:

```
config: { host: "localhost" port: 8080 }
result: config.database
```

### Before

```
error: key 'database' not found in block
  ┌─ test.eu:2:9
  │
2 │ result: config.database
  │         ^^^^^^
  │
  = stack trace:
    - ==
    - ==
```

Human diagnosability: fair — you know the key doesn't exist, but you have to go back to the source to find what keys do exist.

LLM diagnosability: fair — the LLM can look up the block definition, but needs to read the whole file to find which keys are available.

### After

```
error: key 'database' not found in block
  help: available keys: 'host', 'port'
  ┌─ test.eu:2:9
  │
2 │ result: config.database
  │         ^^^^^^
  │
  = stack trace:
    - ==
    - ==
```

For large blocks (more than 8 keys), the output is capped: `available keys: 'a', 'b', 'c', ... (and N more)`.

The "similar keys" hint for near-misses (typos) is unchanged — it still shows `help: similar keys: 'host'` when the lookup was `hots`.

Human diagnosability: fair → good — the available keys are right there in the error.

LLM diagnosability: fair → excellent — the LLM can immediately see what keys exist without reading the full source.

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

### Change

- `LookupFailure` variant gains a 4th field: `Vec<String>` containing all available keys
- `format_lookup_failure` updated: when no suggestions exist but available keys do, display up to 8 keys with a count suffix
- `LookupFail.execute()` in `block.rs` passes `available_keys` (already computed for the suggestions query) to the error
- All pattern matches on `LookupFailure` updated for the new arity

### Risks

The `LookupFailure` variant is a public enum field change. No external consumers are expected (this is an internal eval error type). All existing tests pass; the sidecar regex for test 020 (`"key 'g' not found in block"`) still matches because the regex anchors to a substring, not the full message.