### PR TITLE
fix(errors): replace Panic with ParseError variant for parse-as failures

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -516,6 +516,8 @@ pub enum ExecutionError {
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
+    #[error("parse-as({1}): {2}")]
+    ParseError(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -579,6 +581,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -66,7 +66,13 @@ impl StgIntrinsic for ParseString {
 
         let core_expr =
             import::read_to_core_data_only(&format_name, &mut files, &mut source_map, file_id)
-                .map_err(|e| ExecutionError::Panic(format!("parse-as({format_name}): {e}")))?;
+                .map_err(|e| {
+                    ExecutionError::ParseError(
+                        machine.annotation(),
+                        format_name.clone(),
+                        e.to_string(),
+                    )
+                })?;
 
         // Compile the data-only RcExpr to STG.
         // We use an empty intrinsics list because data-only expressions


### PR DESCRIPTION
## Error message: parse-as failures — remove "panic:" prefix

### Scenario

Using `parse-as(:yaml, ...)` or `parse-as(:toml, ...)` with invalid input.

```
bad_yaml: ": invalid: yaml: content"
result: bad_yaml parse-as(:yaml)
```

### Before

```
error: panic: parse-as(yaml): invalid yaml or json syntax mapping values are not allowed in this context at line 1 column 16
    ┌─ [prelude]:893:21
    │
893 │ parse-as(fmt, str): __PARSE_STRING(fmt, str)
    │                     ^^^^^^^^^^^^^^
```

Human diagnosability: fair — "panic:" suggests an internal bug, not a user input error.

LLM diagnosability: fair — the "panic:" prefix is misleading, but the rest of the message is informative.

### After

```
error: parse-as(yaml): invalid yaml or json syntax mapping values are not allowed in this context at line 1 column 16
    ┌─ [prelude]:893:21
    │
893 │ parse-as(fmt, str): __PARSE_STRING(fmt, str)
    │                     ^^^^^^^^^^^^^^
```

Human diagnosability: fair → good — the error clearly names the operation (`parse-as(yaml)`) and the cause without implying an internal crash.

LLM diagnosability: fair → good — no spurious "panic:" noise, making the error classification unambiguous.

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change

- Added `ExecutionError::ParseError(Smid, String, String)` variant with format `"parse-as({1}): {2}"`
- The `Smid` is set from `machine.annotation()` at error time, enabling source location once PR #434 (Ann node emission) lands
- Updated `parse_string.rs` to use `ParseError` for the user-visible parse failure path
- The compile and load error paths retain `Panic` as these represent genuine internal failures that should not occur with well-formed intrinsic setup

### Risks

Minimal. This is an additive change to the error enum. All existing tests pass.

Note: the source location still points to the prelude's `__PARSE_STRING` rather than the user call site. This is a known limitation that depends on PR #434 (Ann node emission at application sites) to resolve — once that lands, the `Smid` stored in `ParseError` will contain the user's source position.