### PR TITLE
fix(errors): replace Panic with VersionRequirementFailed for eu.requires

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -518,6 +518,8 @@ pub enum ExecutionError {
     Panic(String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
+    #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
+    VersionRequirementFailed(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -582,6 +584,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
+            ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -44,9 +44,11 @@ impl StgIntrinsic for Requires {
         if req.matches(&version) {
             machine_return_unit(machine, view)
         } else {
-            Err(ExecutionError::Panic(format!(
-                "eucalypt version {version} does not satisfy requirement {constraint_str}"
-            )))
+            Err(ExecutionError::VersionRequirementFailed(
+                machine.annotation(),
+                version.to_string(),
+                constraint_str,
+            ))
         }
     }
 }


### PR DESCRIPTION
## Error message: eu.requires version constraint failure

### Scenario

Using `eu.requires(">=X.Y.Z")` when the installed eucalypt version does not satisfy the constraint:

```
result: eu.requires(">=99.99.99")
```

### Before

```
error: panic: eucalypt version 0.5.0 does not satisfy requirement >=99.99.99
 = stack trace:
   - ==
```

Human diagnosability: fair — "panic:" implies a crash; the message text is informative but the framing is wrong.

LLM diagnosability: fair — the information is there but the "panic:" prefix creates noise.

### After

```
error: version requirement not satisfied: eucalypt 0.5.0 does not satisfy '>=99.99.99'
 = stack trace:
   - ==
```

Human diagnosability: fair → good — the error class is immediately clear: this is a version mismatch, not a bug.

LLM diagnosability: fair → good — clean signal with no spurious "panic:" noise.

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change

- Added `ExecutionError::VersionRequirementFailed(Smid, String, String)` variant with format `"version requirement not satisfied: eucalypt {1} does not satisfy '{2}'"`
- `version.rs`: changed the constraint-not-satisfied path from `Panic` to `VersionRequirementFailed`, storing the machine annotation as `Smid`
- The invalid-constraint and invalid-version-parse paths retain `Panic` as these represent genuine internal errors (malformed version in `Cargo.toml`, or a user-supplied unparseable constraint string)

### Risks

Minimal. Additive change to the error enum. All existing error tests pass. No sidecar files reference this error message.