### PR TITLE
fix(errors): replace Panic with AssertionFailed for assertion failures

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -520,6 +520,8 @@ pub enum ExecutionError {
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
     VersionRequirementFailed(Smid, String, String),
+    #[error("assertion failed: expected {2}, got {1}")]
+    AssertionFailed(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -585,6 +587,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
+            ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -156,9 +156,11 @@ impl StgIntrinsic for AssertFail {
     ) -> Result<(), ExecutionError> {
         let actual_str = format_ref(machine, view, &args[0]);
         let expected_str = format_ref(machine, view, &args[1]);
-        Err(ExecutionError::Panic(format!(
-            "assertion failed: expected {expected_str}, got {actual_str}"
-        )))
+        Err(ExecutionError::AssertionFailed(
+            machine.annotation(),
+            actual_str,
+            expected_str,
+        ))
     }
 }
 


### PR DESCRIPTION
## Error message: //=> assertion failure — remove "panic:" prefix

### Scenario

Using the assertion operator `//=>` when the assertion fails:

```
x: 5
result: (x //=> 10)
```

### Before

```
error: panic: assertion failed: expected 10, got 5
     ┌─ [prelude]:1034:26
     │
1034 │ (e //=> v): if(e = v, e, __ASSERT_FAIL(e, v))
     │                          ^^^^^^^^^^^^^
     │
     = stack trace:
       - ==
```

Human diagnosability: fair — "panic:" implies a crash; the assertion message itself is informative.

LLM diagnosability: fair — the "panic:" prefix is misleading noise.

### After

```
error: assertion failed: expected 10, got 5
     ┌─ [prelude]:1034:26
     │
1034 │ (e //=> v): if(e = v, e, __ASSERT_FAIL(e, v))
     │                          ^^^^^^^^^^^^^
     │
     = stack trace:
       - ==
```

Human diagnosability: fair → good — immediately clear this is a test/assertion failure, not a crash.

LLM diagnosability: fair → good — no spurious "panic:" noise.

### Assessment

- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change

- Added `ExecutionError::AssertionFailed(Smid, String, String)` variant with format `"assertion failed: expected {2}, got {1}"`
- `assert.rs`: changed `AssertFail.execute()` to use `AssertionFailed` with `machine.annotation()` as the source location
- The `Smid` stores the annotation at call time, enabling user source location once PR #434 lands

### Risks

Minimal. The existing sidecar test `errors/010_assert.eu.expect` matches `"assertion failed: expected false, got true"` which is a substring of the new message (unchanged except "panic:" removed). Test passes.