### PR TITLE
fix(errors): improve error for raising negative base to fractional power

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -502,6 +502,8 @@ pub enum ExecutionError {
     UnknownFormat(String),
     #[error("cannot combine numbers ({0}, {1}) into same numeric domain\n  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision")]
     NumericDomainError(Number, Number),
+    #[error("result of ({0})^({1}) is not a real number\n  help: raising a negative base to a fractional exponent yields a complex result; use a non-negative base or an integer exponent")]
+    ComplexResult(Number, Number),
     #[error("numeric overflow: result of operating on {0} and {1} is out of range\n  help: the result exceeds the representable range for this numeric type")]
     NumericRangeError(Number, Number),
     #[error("{}", format_division_by_zero(.0))]

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -654,8 +654,12 @@ impl StgIntrinsic for Pow {
 
         // Fall back to f64
         if let (Some(b), Some(e)) = (base.as_f64(), exp.as_f64()) {
-            if let Some(ret) = Number::from_f64(b.powf(e)) {
+            let result = b.powf(e);
+            if let Some(ret) = Number::from_f64(result) {
                 machine_return_num(machine, view, ret)
+            } else if result.is_nan() && b < 0.0 && e.fract() != 0.0 {
+                // Negative base raised to a fractional exponent produces a complex number.
+                Err(ExecutionError::ComplexResult(base, exp))
             } else {
                 Err(ExecutionError::NumericDomainError(base, exp))
             }

--- a/tests/harness/errors/089_numeric_domain.eu.expect
+++ b/tests/harness/errors/089_numeric_domain.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "cannot combine numbers"
+stderr: "is not a real number"


### PR DESCRIPTION
## Error message: power operation / complex result

### Scenario
A user writes `(-1.0) ^ 0.5` or `(-4) ^ 0.5`, expecting a numeric result. The
`^` operator falls back to `f64.powf()`, which returns `NaN` because the
mathematical result is complex (imaginary). The existing error was the generic
`NumericDomainError`, which is shared with type-incompatibility errors.

### Before
```
error: cannot combine numbers (-1.0, 0.5) into same numeric domain
  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision
```

The message is actively misleading. `-1.0` and `0.5` are both floats — there is
no type mismatch. The help text about "mixing integer and floating-point
arithmetic" does not describe what went wrong.

### After
```
error: result of (-1.0)^(0.5) is not a real number
  help: raising a negative base to a fractional exponent yields a complex result; use a non-negative base or an integer exponent
```

### Assessment
- Human diagnosability: fair → excellent
- LLM diagnosability: fair → excellent

### Change
- Added `ExecutionError::ComplexResult(Number, Number)` for this specific
  mathematical domain violation.
- In `Pow::execute`, after `b.powf(e)` returns NaN, check whether `b < 0.0`
  and `e.fract() != 0.0` and emit `ComplexResult` instead of the generic
  `NumericDomainError`.
- Updated `tests/harness/errors/089_numeric_domain.eu.expect` to match the
  new message (the test file uses `(-1.0)^0.5`).

### Risks
- `ComplexResult` is only reachable via the `Pow` intrinsic — no other call
  sites emit it. The new variant does not carry a `Smid`; the stack-trace
  fallback in `to_diagnostic` provides source location, matching the
  existing behaviour for `NumericDomainError`.
- All 90 error tests pass; `cargo clippy --all-targets -- -D warnings` is clean.