### PR TITLE
fix(errors): remove 'panic:' prefix from IO-not-allowed error

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -234,7 +234,7 @@ impl<'a> Executor<'a> {
                     if ret.is_ok() {
                         if machine.io_yielded() {
                             let io_result = io_run_and_render(&mut machine, opt.allow_io)
-                                .map_err(|e| ExecutionError::Panic(e.to_string()));
+                                .map_err(ExecutionError::from);
                             machine.take_emitter().stream_end();
                             return io_result;
                         }
@@ -247,7 +247,7 @@ impl<'a> Executor<'a> {
                                 // World injection triggered an IO yield;
                                 // proceed with the io-run loop.
                                 let io_result = io_run_and_render(&mut machine, opt.allow_io)
-                                    .map_err(|e| ExecutionError::Panic(e.to_string()));
+                                    .map_err(ExecutionError::from);
                                 machine.take_emitter().stream_end();
                                 return io_result;
                             }

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -65,6 +65,16 @@ impl From<ExecutionError> for IoRunError {
     }
 }
 
+impl From<IoRunError> for ExecutionError {
+    fn from(e: IoRunError) -> Self {
+        match e {
+            IoRunError::IoNotAllowed => ExecutionError::IoNotAllowed,
+            IoRunError::MachineError(e) => *e,
+            other => ExecutionError::Panic(other.to_string()),
+        }
+    }
+}
+
 // ─── Command result ───────────────────────────────────────────────────────────
 
 /// The outcome of a shell command execution

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -639,6 +639,8 @@ pub enum ExecutionError {
     Panic(String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
+    #[error("IO operations require the --allow-io (-I) flag\n  help: re-run with 'eu -I ...' to enable side effects")]
+    IoNotAllowed,
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]


### PR DESCRIPTION
## Error message: IO operations without --allow-io flag

### Scenario
A user writes code using `io.shell()` or any IO operation, but forgets to pass
the `--allow-io` (`-I`) flag to the `eu` command. Previously the error was:

### Before
```
error: panic: IO operations require the --allow-io (-I) flag
```

The `panic:` prefix is actively misleading — this is a user configuration issue,
not a programming error or runtime panic.

### After
```
error: IO operations require the --allow-io (-I) flag
  help: re-run with 'eu -I ...' to enable side effects
```

### Assessment
- Human diagnosability: fair → excellent
- LLM diagnosability: good → excellent

### Change
- Added `ExecutionError::IoNotAllowed` variant to the error enum with an
  appropriate message and help text.
- Added `From<IoRunError> for ExecutionError` in `io_run.rs` so that
  `IoRunError::IoNotAllowed` maps directly to `ExecutionError::IoNotAllowed`
  rather than being wrapped in `Panic`. Other `IoRunError` variants that are
  not internal invariant violations can be extended to use this pattern later.
- Updated the two `map_err` call sites in `eval.rs` that convert
  `IoRunError → ExecutionError` to use `.map_err(ExecutionError::from)`.

### Risks
- The `From<IoRunError>` implementation preserves the existing behaviour for all
  `IoRunError` variants other than `IoNotAllowed` and `MachineError` — they fall
  through to `Panic(other.to_string())`.
- All 90 error tests pass; `cargo clippy --all-targets -- -D warnings` is clean.