### PR TITLE
fix(errors): improve base64 decode error messages

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -639,6 +639,8 @@ pub enum ExecutionError {
     Panic(String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
+    #[error("invalid base64 input: {1}")]
+    Base64DecodeError(Smid, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -705,6 +707,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
+            ExecutionError::Base64DecodeError(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/encoding.rs
+++ b/src/eval/stg/encoding.rs
@@ -1,7 +1,38 @@
 //! Encoding and hashing intrinsics (base64, SHA-256, etc.)
 
+use base64::DecodeError;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use sha2::{Digest, Sha256};
+
+/// Format a base64 `DecodeError` into a human-readable string.
+///
+/// `DecodeError::InvalidByte` carries a raw byte code (e.g. 33 for `!`);
+/// convert it to a printable character where possible so users can identify
+/// the offending character without consulting an ASCII table.
+fn format_base64_error(e: DecodeError) -> String {
+    match e {
+        DecodeError::InvalidByte(offset, byte) => {
+            let ch = char::from(byte);
+            if ch.is_ascii_graphic() || ch == ' ' {
+                format!("invalid character '{ch}' at offset {offset}")
+            } else {
+                format!("invalid byte 0x{byte:02X} at offset {offset}")
+            }
+        }
+        DecodeError::InvalidLength(len) => {
+            format!("invalid length {len} (base64 input length must be a multiple of 4 when padding is required)")
+        }
+        DecodeError::InvalidLastSymbol(offset, byte) => {
+            let ch = char::from(byte);
+            format!(
+                "non-zero padding bits in last symbol '{ch}' at offset {offset} — input may be truncated or corrupted"
+            )
+        }
+        DecodeError::InvalidPadding => {
+            "incorrect padding — base64 strings must be padded with '=' to a multiple of 4 characters".to_string()
+        }
+    }
+}
 
 use crate::eval::{
     emit::Emitter,
@@ -51,11 +82,14 @@ impl StgIntrinsic for Base64Decode {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let input = str_arg(machine, view, &args[0])?;
-        let bytes = STANDARD
-            .decode(&input)
-            .map_err(|e| ExecutionError::Panic(format!("invalid base64 input: {e}")))?;
+        let bytes = STANDARD.decode(&input).map_err(|e| {
+            ExecutionError::Base64DecodeError(machine.annotation(), format_base64_error(e))
+        })?;
         let decoded = String::from_utf8(bytes).map_err(|e| {
-            ExecutionError::Panic(format!("decoded base64 is not valid UTF-8: {e}"))
+            ExecutionError::Base64DecodeError(
+                machine.annotation(),
+                format!("decoded bytes are not valid UTF-8: {e}"),
+            )
         })?;
         machine_return_str(machine, view, decoded)
     }


### PR DESCRIPTION
## Error message: base64 decode failures

### Scenario
A user calls `str.base64-decode` (or the underlying `__BASE64_DECODE`
intrinsic) with a string that is not valid base64. The underlying `base64`
crate returns structured error information including the offending byte code,
but this was previously formatted using the default `Display` which shows
numeric ASCII codes.

### Before
```
error: panic: invalid base64 input: Invalid symbol 33, offset 3.
```

Two problems:
1. The `panic:` prefix is misleading.
2. "Invalid symbol 33" requires the user to look up ASCII code 33 to discover
   the offending character is `!`.

### After
```
error: invalid base64 input: invalid character '!' at offset 3
```

For other error cases:

```
error: invalid base64 input: incorrect padding — base64 strings must be
       padded with '=' to a multiple of 4 characters
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
- Added `ExecutionError::Base64DecodeError(Smid, String)` to the error enum.
- Added `format_base64_error()` helper in `encoding.rs` that:
  - Converts `DecodeError::InvalidByte(offset, byte)` to `"invalid character 'X' at offset N"` for printable bytes, or `"invalid byte 0xNN at offset N"` for non-printable.
  - Provides plain English descriptions for `InvalidPadding`, `InvalidLength`, and `InvalidLastSymbol`.
- Updated `Base64Decode::execute()` to use this helper.

### Risks
- All 90 error tests pass; `cargo clippy --all-targets -- -D warnings` is clean.