### PR TITLE
fix(errors): remove 'panic:' from invalid semver constraint error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -520,6 +520,8 @@ pub enum ExecutionError {
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
     VersionRequirementFailed(Smid, String, String),
+    #[error("invalid version constraint '{1}': {2}")]
+    InvalidVersionConstraint(Smid, String, String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
@@ -587,6 +589,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
+            ExecutionError::InvalidVersionConstraint(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
@@ -695,6 +698,11 @@ impl ExecutionError {
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
             ExecutionError::LookupFailure(_, key, suggestions) => {
                 lookup_failure_notes(key, suggestions)
+            }
+            ExecutionError::InvalidVersionConstraint(_, _, _) => {
+                vec![
+                    "semver constraints use operators like '^', '~', '>=', e.g. '^0.5' or '>=0.4, <0.6'".to_string(),
+                ]
             }
             ExecutionError::CannotReturnFunToCase(_, expected_tags) => {
                 let expects_bool = expected_tags.contains(&DataConstructor::BoolTrue.tag())

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -28,9 +28,11 @@ impl StgIntrinsic for Requires {
         let constraint_str = str_arg(machine, view, &args[0])?;
 
         let req = semver::VersionReq::parse(&constraint_str).map_err(|e| {
-            ExecutionError::Panic(format!(
-                "invalid version constraint \"{constraint_str}\": {e}"
-            ))
+            ExecutionError::InvalidVersionConstraint(
+                machine.annotation(),
+                constraint_str.clone(),
+                e.to_string(),
+            )
         })?;
 
         // Strip any ".dev" suffix from the Cargo package version


### PR DESCRIPTION
## Error message: invalid semver constraint in eu.requires()

### Scenario
A user writes `eu.requires("not-a-version")` using a string that is not a
valid semver constraint. The underlying `semver` crate's parse error was
previously wrapped in `ExecutionError::Panic`.

### Before
```
error: panic: invalid version constraint "not-a-semver-constraint": unexpected character 'n' while parsing major version number
```

### After
```
error: invalid version constraint 'not-a-semver-constraint': unexpected character 'n' while parsing major version number
  = semver constraints use operators like '^', '~', '>=', e.g. '^0.5' or '>=0.4, <0.6'
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

### Change
- Added `ExecutionError::InvalidVersionConstraint(Smid, String, String)` variant — (location, constraint, parse error message).
- Updated `Requires::execute()` to emit the structured variant instead of `Panic`.
- Added a diagnostic note with a semver syntax example to guide users towards valid constraint syntax.

### Risks
- No existing tests for this error path (the test for `eu.requires` covers the version-mismatch case, not the parse-error case).
- All 90 existing error tests pass; `cargo clippy --all-targets -- -D warnings` is clean.