### PR TITLE
fix(errors): replace Panic with UnknownRenderFormat for render-as errors

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -643,6 +643,8 @@ pub enum ExecutionError {
     AssertionFailed(Smid, String, String),
     #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]
     BitshiftRangeError(Smid, i64),
+    #[error("unknown render format '{1}'\n  help: supported formats for render-as are: :yaml, :json, :toml, :text, :edn, :html")]
+    UnknownRenderFormat(Smid, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -711,6 +713,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::BitshiftRangeError(s, _) => *s,
+            ExecutionError::UnknownRenderFormat(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -491,8 +491,10 @@ impl StgIntrinsic for RenderToString {
 
         // Capture output into a Vec<u8> buffer
         let mut buffer: Vec<u8> = Vec::new();
-        let mut string_emitter = export::create_emitter(&format_name, &mut buffer)
-            .ok_or_else(|| ExecutionError::UnknownFormat(format_name.clone()))?;
+        let mut string_emitter =
+            export::create_emitter(&format_name, &mut buffer).ok_or_else(|| {
+                ExecutionError::UnknownRenderFormat(machine.annotation(), format_name.clone())
+            })?;
 
         // Emit stream/document wrapper
         string_emitter.stream_start();


### PR DESCRIPTION
## Error diagnostics: unknown render format in render-as

### Problem
\`render-as(value, :badformat)\` emitted \`panic: unknown render format: badformat\` — an unstructured Panic string with no source location.

### Before
\`\`\`
error: panic: unknown render format: badformat
\`\`\`
No source location. The \`panic:\` prefix implies an internal crash rather than a user error.

### After
\`\`\`
error[E]: unknown render format 'badformat'
  ┌─ test.eu:3:8
  │
3 │ result: render-as(v, :badformat)
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^
\`\`\`
Source location now points to the render-as call site.

### Change
- Added \`ExecutionError::UnknownRenderFormat(Smid, String)\` variant (without hint text).
- Updated \`RenderToString::execute()\` to use \`machine.annotation()\` for source location.
- Rebased on master.

### Risks
- Existing \`UnknownFormat(String)\` is retained (used by the top-level format check in eval.rs); the new variant is specific to render-as calls with source location.