### PR TITLE
fix(errors): structured error for out-of-range bitshift amounts

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -639,6 +639,8 @@ pub enum ExecutionError {
     Panic(String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
+    #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]
+    BitshiftRangeError(Smid, i64),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -705,6 +707,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
+            ExecutionError::BitshiftRangeError(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -971,9 +971,7 @@ impl StgIntrinsic for Shl {
         let n = require_i64(&x)?;
         let k = require_i64(&y)?;
         if !(0..64).contains(&k) {
-            return Err(ExecutionError::Panic(format!(
-                "SHL: shift amount {k} out of range 0..63"
-            )));
+            return Err(ExecutionError::BitshiftRangeError(machine.annotation(), k));
         }
         let result = n << k;
         machine_return_num(machine, view, Number::from(result))
@@ -1002,9 +1000,7 @@ impl StgIntrinsic for Shr {
         let n = require_i64(&x)?;
         let k = require_i64(&y)?;
         if !(0..64).contains(&k) {
-            return Err(ExecutionError::Panic(format!(
-                "SHR: shift amount {k} out of range 0..63"
-            )));
+            return Err(ExecutionError::BitshiftRangeError(machine.annotation(), k));
         }
         let result = n >> k;
         machine_return_num(machine, view, Number::from(result))


### PR DESCRIPTION
## Error message: bitshift range error

### Scenario
Using the left-shift operator `≪` or right-shift operator `≫` with a shift amount outside the valid range 0–63 (e.g. `1 ≪ 100`).

### Before
```
error: panic: SHL: shift amount 100 out of range 0..63
```

### After
```
error: shift amount 100 is out of range: must be between 0 and 63 for 64-bit integers
  ┌─ test.eu:1:6
  │
1 │ x: 1 ≪ 100
  │      ^
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

### Change
- Added `BitshiftRangeError(Smid, i64)` variant to `ExecutionError` with a self-explanatory message
- Added `Smid` extraction to `HasSmid` impl
- Replaced both `Panic(format!(...))` calls in `Shl::execute()` and `Shr::execute()` in `src/eval/stg/arith.rs`
- The `≪` and `≫` operators now point to the operator location in the source

### Risks
None — the error was already returned; only the formatting and location tracking changed.