### PR TITLE
fix(errors): structured error for mixed-type ordered comparisons

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -496,6 +496,8 @@ pub enum ExecutionError {
     BadNumberFormat(String),
     #[error("could not format {1} with {0}")]
     FormatError(String, Number),
+    #[error("cannot compare mixed types with '{1}': both operands must be the same type (numbers, strings, symbols, or datetimes)")]
+    ComparisonTypeMismatch(Smid, String),
     #[error("expected scalar value")]
     NotScalar(Smid),
     #[error("{}", format_unknown_format(.0))]
@@ -581,6 +583,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NotCallable(s, _) => *s,
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
+            ExecutionError::ComparisonTypeMismatch(s, _) => *s,
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
@@ -712,6 +715,16 @@ impl ExecutionError {
                 } else {
                     vec![]
                 }
+            }
+            ExecutionError::ComparisonTypeMismatch(_, _) => {
+                vec![
+                    "ordered comparisons (<, >, <=, >=) require both operands to be the same \
+                     type — you cannot compare a number to a string, for example"
+                        .to_string(),
+                    "use 'str' to convert a number to a string before comparing, or 'num' \
+                     to convert a string to a number"
+                        .to_string(),
+                ]
             }
             _ => vec![],
         };

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -443,10 +443,10 @@ fn ordered_cmp(
             Ok(pred(ls.cmp(rs)))
         }
         (Native::Zdt(ref dx), Native::Zdt(ref dy)) => Ok(pred(dx.cmp(dy))),
-        _ => Err(ExecutionError::Panic(format!(
-            "cannot compare values with {name}: operands must be the same type \
-             (both numbers, strings, symbols, or datetimes)"
-        ))),
+        _ => Err(ExecutionError::ComparisonTypeMismatch(
+            machine.annotation(),
+            name.to_string(),
+        )),
     }
 }
 
@@ -469,7 +469,7 @@ impl StgIntrinsic for Gt {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
-        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_gt, "GT")?;
+        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_gt, ">")?;
         machine_return_bool(machine, view, result)
     }
 }
@@ -495,7 +495,7 @@ impl StgIntrinsic for Gte {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
-        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_ge, "GTE")?;
+        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_ge, ">=")?;
         machine_return_bool(machine, view, result)
     }
 }
@@ -521,7 +521,7 @@ impl StgIntrinsic for Lt {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
-        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_lt, "LT")?;
+        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_lt, "<")?;
         machine_return_bool(machine, view, result)
     }
 }
@@ -547,7 +547,7 @@ impl StgIntrinsic for Lte {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
-        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_le, "LTE")?;
+        let result = ordered_cmp(machine, view, args, std::cmp::Ordering::is_le, "<=")?;
         machine_return_bool(machine, view, result)
     }
 }


### PR DESCRIPTION
## Error message: mixed-type comparison

### Scenario
Using an ordered comparison operator (`>`, `>=`, `<`, `<=`) with operands of different types, e.g. `1 > "hello"` or `"abc" < 42`.

### Before
```
error: panic: cannot compare values with GT: operands must be the same type (both numbers, strings, symbols, or datetimes)
  ┌─ test.eu:1:6
```

### After
```
error: cannot compare mixed types with '>': both operands must be the same type (numbers, strings, symbols, or datetimes)
  ┌─ test.eu:1:6
  │
1 │ x: 1 > "hello"
  │      ^
  │
  = ordered comparisons (<, >, <=, >=) require both operands to be the same type — you cannot compare a number to a string, for example
  = use 'str' to convert a number to a string before comparing, or 'num' to convert a string to a number
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

### Change
- Added `ComparisonTypeMismatch(Smid, String)` variant to `ExecutionError` — stores source location and the operator symbol
- Added source location extraction in `HasSmid` impl
- Added diagnostic notes explaining valid usage and conversion options
- Replaced `Panic(format!(...))` in `ordered_cmp()` in `src/eval/stg/arith.rs`
- Operator names now use symbols (`>`, `>=`, `<`, `<=`) rather than internal intrinsic names (`GT`, `GTE`, `LT`, `LTE`)

### Risks
None — the error was already returned for these inputs; only the message and location tracking changed.