### PR TITLE
fix(errors): structured error for non-integer bitwise operation arguments

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -536,6 +536,8 @@ pub enum ExecutionError {
     ExpectedClosure,
     #[error("array bounds error: index {index} out of bounds for array of length {length}")]
     ArrayBoundsError { index: usize, length: usize },
+    #[error("bitwise operations require integer arguments ({0})")]
+    BitwiseIntegerRequired(String),
 }
 
 impl From<bump::AllocError> for ExecutionError {

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -816,19 +816,22 @@ fn require_i64(n: &Number) -> Result<i64, ExecutionError> {
     if let Some(i) = n.as_i64() {
         Ok(i)
     } else if let Some(u) = n.as_u64() {
-        i64::try_from(u)
-            .map_err(|_| ExecutionError::Panic(format!("bitwise: value {u} out of i64 range")))
+        i64::try_from(u).map_err(|_| {
+            ExecutionError::BitwiseIntegerRequired(format!(
+                "{u} is out of the i64 range for bitwise operations"
+            ))
+        })
     } else if let Some(f) = n.as_f64() {
         if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
             Ok(f as i64)
         } else {
-            Err(ExecutionError::Panic(
-                "bitwise operations require integer arguments (got non-integer float)".to_string(),
-            ))
+            Err(ExecutionError::BitwiseIntegerRequired(format!(
+                "got {f}, which is not a whole number"
+            )))
         }
     } else {
-        Err(ExecutionError::Panic(
-            "bitwise operations require integer arguments".to_string(),
+        Err(ExecutionError::BitwiseIntegerRequired(
+            "value cannot be represented as an integer".to_string(),
         ))
     }
 }


### PR DESCRIPTION
## Error message: non-integer arguments to bitwise operations

### Scenario
Using bitwise operations (left shift `≪`, right shift `≫`, `bitand`, `bitor`, `bitxor`, `bitnot`, `popcount`) with a non-integer float argument such as `1.5 ≪ 2`.

### Before
```
error: panic: bitwise operations require integer arguments (got non-integer float)
  ┌─ test.eu:1:8
```

### After
```
error: bitwise operations require integer arguments (got 1.5, which is not a whole number)
  ┌─ test.eu:1:8
  │
1 │ x: 1.5 ≪ 2
  │        ^
```

Also improved the out-of-i64-range case:
- Before: `error: panic: bitwise: value 18446744073709551615 out of i64 range`
- After: `error: bitwise operations require integer arguments (18446744073709551615 is out of the i64 range for bitwise operations)`

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change
- Added `BitwiseIntegerRequired(String)` variant to `ExecutionError` — carries a description of why the value was rejected
- Replaced all three `Panic(...)` paths in `require_i64()` in `src/eval/stg/arith.rs`

### Risks
None — these errors were already returned for these inputs; only the message changed.