### PR TITLE
fix(errors): structured variants for base64 decode errors

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -395,6 +395,21 @@ fn format_cannot_return_fun(expected_tags: &[u8]) -> String {
     msg
 }
 
+/// Format an invalid base64 error message, truncating long input strings
+fn format_invalid_base64(input: &str, detail: &str) -> String {
+    const PREVIEW_LEN: usize = 40;
+    let preview = if input.len() > PREVIEW_LEN {
+        format!("{}…", &input[..PREVIEW_LEN])
+    } else {
+        input.to_string()
+    };
+    format!(
+        "invalid base64 input: {detail}\n  \
+         help: '{preview}' is not valid standard base64 (RFC 4648); \
+         ensure the input uses the standard alphabet (A\u{2013}Z, a\u{2013}z, 0\u{2013}9, +, /) with '=' padding"
+    )
+}
+
 /// Format a division by zero error message with the operation context
 fn format_division_by_zero(operation: &str) -> String {
     if operation.is_empty() {
@@ -516,6 +531,10 @@ pub enum ExecutionError {
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
+    #[error("{}", format_invalid_base64(.1, .2))]
+    InvalidBase64(Smid, String, String),
+    #[error("base64 decoded bytes are not valid UTF-8: {1}\n  help: the base64 string decoded successfully but the resulting bytes do not form valid UTF-8 text")]
+    InvalidBase64Utf8(Smid, String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
@@ -585,6 +604,8 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::InvalidBase64(s, _, _) => *s,
+            ExecutionError::InvalidBase64Utf8(s, _) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,

--- a/src/eval/stg/encoding.rs
+++ b/src/eval/stg/encoding.rs
@@ -50,13 +50,13 @@ impl StgIntrinsic for Base64Decode {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
+        let smid = machine.annotation();
         let input = str_arg(machine, view, &args[0])?;
         let bytes = STANDARD
             .decode(&input)
-            .map_err(|e| ExecutionError::Panic(format!("invalid base64 input: {e}")))?;
-        let decoded = String::from_utf8(bytes).map_err(|e| {
-            ExecutionError::Panic(format!("decoded base64 is not valid UTF-8: {e}"))
-        })?;
+            .map_err(|e| ExecutionError::InvalidBase64(smid, input.clone(), e.to_string()))?;
+        let decoded = String::from_utf8(bytes)
+            .map_err(|e| ExecutionError::InvalidBase64Utf8(smid, e.to_string()))?;
         machine_return_str(machine, view, decoded)
     }
 }


### PR DESCRIPTION
## Error message: base64 decode — invalid input / non-UTF-8 result

### Scenario
A user calls `str.base64-decode` on a string that is not valid standard base64 (e.g. contains URL-safe `-` characters or other invalid symbols).

### Before
```
error: panic: invalid base64 input: Invalid symbol 45, offset 3.
  ┌─ /tmp/test-base64-decode.eu:1:10
  │
1 │ decoded: str.base64-decode("not-valid-base64!!!")
  │          ^^^
  │
  = stack trace:
    - ==
```

### After
```
error: invalid base64 input: Invalid symbol 45, offset 3.
  help: 'not-valid-base64!!!' is not valid standard base64 (RFC 4648); ensure the input uses the standard alphabet (A–Z, a–z, 0–9, +, /) with '=' padding
  ┌─ /tmp/test-base64-decode.eu:1:10
  │
1 │ decoded: str.base64-decode("not-valid-base64!!!")
  │          ^^^
  │
  = stack trace:
    - ==
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The "panic:" prefix was misleading — invalid base64 input is a user error, not an internal invariant violation. The new message removes the prefix and adds a hint explaining the standard base64 alphabet and padding requirements. Long input strings are truncated in the preview (at 40 characters) to avoid flooding the terminal.

Two new structured variants added:
- `InvalidBase64(Smid, String, String)` — invalid base64 encoding
- `InvalidBase64Utf8(Smid, String)` — decoded bytes not valid UTF-8

Both carry a `Smid` for source location propagation.

### Change
- `src/eval/error.rs`: Added `InvalidBase64` and `InvalidBase64Utf8` variants; added `format_invalid_base64()` helper; added both to `HasSmid` match
- `src/eval/stg/encoding.rs`: `Base64Decode::execute()` now uses structured variants; `machine.annotation()` obtained before `str_arg` to capture source location

### Risks
Low. No existing harness tests cover base64 decode errors, so no `.expect` sidecars to update. The change only affects error output format, not behaviour.