### PR TITLE
fix(errors): structured variant for invalid version constraint

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -516,6 +516,8 @@ pub enum ExecutionError {
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
+    #[error("invalid version constraint '{1}': {2}\n  help: version constraints use semver syntax, e.g. '>=0.2.0', '~0.5', '^1.2'")]
+    InvalidVersionConstraint(Smid, String, String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
@@ -585,6 +587,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::InvalidVersionConstraint(s, _, _) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -25,12 +25,11 @@ impl StgIntrinsic for Requires {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
+        let smid = machine.annotation();
         let constraint_str = str_arg(machine, view, &args[0])?;
 
         let req = semver::VersionReq::parse(&constraint_str).map_err(|e| {
-            ExecutionError::Panic(format!(
-                "invalid version constraint \"{constraint_str}\": {e}"
-            ))
+            ExecutionError::InvalidVersionConstraint(smid, constraint_str.clone(), e.to_string())
         })?;
 
         // Strip any ".dev" suffix from the Cargo package version


### PR DESCRIPTION
## Error message: version constraint — invalid semver syntax

### Scenario
A user calls `eu.requires("not a semver !!!@#")` with a string that is not valid semver syntax.

### Before
```
error: panic: invalid version constraint "not a semver !!!@#": unexpected character 'n' while parsing major version number
 = stack trace:
   - ==
```

### After
```
error: invalid version constraint 'not a semver !!!@#': unexpected character 'n' while parsing major version number
  help: version constraints use semver syntax, e.g. '>=0.2.0', '~0.5', '^1.2'
 = stack trace:
   - ==
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The "panic:" prefix was misleading — an invalid semver constraint is a user error, not an internal invariant violation. The new message removes the prefix and adds semver syntax examples to guide correction.

### Change
- `src/eval/error.rs`: Added `InvalidVersionConstraint(Smid, String, String)` variant; added to `HasSmid` match
- `src/eval/stg/version.rs`: `Requires::execute()` now uses `InvalidVersionConstraint` for parse errors; obtains `smid` before `str_arg` to capture source location

### Risks
Low. No existing harness tests cover invalid version constraint errors. The Cargo version parse failure (line 38–42 of `version.rs`) remains as `Panic` since it represents an internal invariant (our own version string should always be valid semver).