### PR TITLE
fix(errors): use UnknownFormat variant for render-as with invalid format

### DIFF
--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -491,10 +491,8 @@ impl StgIntrinsic for RenderToString {
 
         // Capture output into a Vec<u8> buffer
         let mut buffer: Vec<u8> = Vec::new();
-        let mut string_emitter =
-            export::create_emitter(&format_name, &mut buffer).ok_or_else(|| {
-                ExecutionError::Panic(format!("unknown render format: {format_name}"))
-            })?;
+        let mut string_emitter = export::create_emitter(&format_name, &mut buffer)
+            .ok_or_else(|| ExecutionError::UnknownFormat(format_name.clone()))?;
 
         // Emit stream/document wrapper
         string_emitter.stream_start();


### PR DESCRIPTION
## Error message: render-as — unknown format name

### Scenario
A user calls `render-as({ x: 1 }, :xml2)` with an unrecognised format symbol.

### Before
```
error: panic: unknown render format: xml2
    ┌─ [prelude]:890:24
    │
890 │ render-as(value, fmt): __RENDER_TO_STRING(value, fmt)
    │                        ^^^^^^^^^^^^^^^^^^
    │
    = stack trace:
      - ==
```

### After
```
error: unknown export format 'xml2'
  help: supported formats are: yaml, json, toml, text, edn, html
    ┌─ [prelude]:890:24
    │
890 │ render-as(value, fmt): __RENDER_TO_STRING(value, fmt)
    │                        ^^^^^^^^^^^^^^^^^^
    │
    = stack trace:
      - ==
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The "panic:" prefix was misleading — an unrecognised format name is a user error. The `UnknownFormat` variant already existed and had the correct format with a list of supported formats; the intrinsic just wasn't using it.

### Change
`src/eval/stg/render_to_string.rs`: `RenderToString::execute()` now uses `ExecutionError::UnknownFormat(format_name.clone())` instead of `ExecutionError::Panic(format!("unknown render format: {format_name}"))`.

### Risks
Low. No harness tests cover this error path. The `UnknownFormat` variant was already in use for the driver-level format selection in `eval.rs`.