### PR TITLE
fix(errors): propagate IoRunError as structured ExecutionError variants

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -35,10 +35,10 @@ use super::statistics::Statistics;
 /// for user-facing errors and `Panic` for internal machine errors.
 fn io_run_error_to_execution(e: IoRunError) -> ExecutionError {
     match e {
-        IoRunError::IoNotAllowed => ExecutionError::IoNotAllowed,
-        IoRunError::Fail(msg) => ExecutionError::IoFail(msg),
-        IoRunError::Timeout(secs) => ExecutionError::IoTimeout(secs),
-        IoRunError::CommandError(msg) => ExecutionError::IoCommandError(msg),
+        IoRunError::IoNotAllowed(smid) => ExecutionError::IoNotAllowed(smid),
+        IoRunError::Fail(msg) => ExecutionError::IoFail(Smid::default(), msg),
+        IoRunError::Timeout(smid, secs) => ExecutionError::IoTimeout(smid, secs),
+        IoRunError::CommandError(smid, msg) => ExecutionError::IoCommandError(smid, msg),
         IoRunError::MachineError(boxed) => *boxed,
         other => ExecutionError::Panic(other.to_string()),
     }

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -7,7 +7,7 @@ use crate::{
     core::expr::*,
     driver::{
         error::EucalyptError,
-        io_run::{inject_world_and_run, io_run_and_render},
+        io_run::{inject_world_and_run, io_run_and_render, IoRunError},
         options::{ErrorFormat, EucalyptOptions},
         source::SourceLoader,
     },
@@ -30,6 +30,19 @@ use codespan_reporting::{
 use std::{io::Write, time::Instant};
 
 use super::statistics::Statistics;
+
+/// Convert an `IoRunError` to an `ExecutionError`, using structured variants
+/// for user-facing errors and `Panic` for internal machine errors.
+fn io_run_error_to_execution(e: IoRunError) -> ExecutionError {
+    match e {
+        IoRunError::IoNotAllowed => ExecutionError::IoNotAllowed,
+        IoRunError::Fail(msg) => ExecutionError::IoFail(msg),
+        IoRunError::Timeout(secs) => ExecutionError::IoTimeout(secs),
+        IoRunError::CommandError(msg) => ExecutionError::IoCommandError(msg),
+        IoRunError::MachineError(boxed) => *boxed,
+        other => ExecutionError::Panic(other.to_string()),
+    }
+}
 
 /// Run the prepared core expression and output to selected emitter
 pub fn run(opt: &EucalyptOptions, loader: SourceLoader) -> Result<Statistics, EucalyptError> {
@@ -234,20 +247,20 @@ impl<'a> Executor<'a> {
                     if ret.is_ok() {
                         if machine.io_yielded() {
                             let io_result = io_run_and_render(&mut machine, opt.allow_io)
-                                .map_err(|e| ExecutionError::Panic(e.to_string()));
+                                .map_err(io_run_error_to_execution);
                             machine.take_emitter().stream_end();
                             return io_result;
                         }
                         // Machine terminated without yielding.  Try world
                         // injection to handle IO functions (case 2).
-                        let io_yielded = inject_world_and_run(&mut machine)
-                            .map_err(|e| ExecutionError::Panic(e.to_string()));
+                        let io_yielded =
+                            inject_world_and_run(&mut machine).map_err(io_run_error_to_execution);
                         match io_yielded {
                             Ok(true) => {
                                 // World injection triggered an IO yield;
                                 // proceed with the io-run loop.
                                 let io_result = io_run_and_render(&mut machine, opt.allow_io)
-                                    .map_err(|e| ExecutionError::Panic(e.to_string()));
+                                    .map_err(io_run_error_to_execution);
                                 machine.take_emitter().stream_end();
                                 return io_result;
                             }

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -42,18 +42,18 @@ use crate::export;
 /// Error from running the IO monad interpret loop
 #[derive(Debug, thiserror::Error)]
 pub enum IoRunError {
-    #[error("io monad failure: {0}")]
+    #[error("io.fail: {0}")]
     Fail(String),
-    #[error("IO operations require the --allow-io (-I) flag")]
-    IoNotAllowed,
+    #[error("IO operations are not permitted; use the --allow-io (-I) flag to enable")]
+    IoNotAllowed(Smid),
     #[error("unknown IO action tag: {0}")]
     UnknownActionTag(String),
     #[error("malformed IO action spec block")]
     MalformedSpec,
-    #[error("command timed out after {0} seconds")]
-    Timeout(u64),
-    #[error("command execution error: {0}")]
-    CommandError(String),
+    #[error("io.shell-with: command timed out after {0} seconds")]
+    Timeout(Smid, u64),
+    #[error("io.shell-with: command execution error: {0}")]
+    CommandError(Smid, String),
     /// Boxed to keep the error variant size small (ExecutionError is large).
     #[error("STG machine error: {0}")]
     MachineError(Box<ExecutionError>),
@@ -1109,12 +1109,12 @@ fn run_command(
 
     let mut child = command
         .spawn()
-        .map_err(|e| IoRunError::CommandError(e.to_string()))?;
+        .map_err(|e| IoRunError::CommandError(Smid::default(), e.to_string()))?;
 
     if let Some(input) = stdin_data {
         if let Some(mut pipe) = child.stdin.take() {
             pipe.write_all(input.as_bytes())
-                .map_err(|e| IoRunError::CommandError(e.to_string()))?;
+                .map_err(|e| IoRunError::CommandError(Smid::default(), e.to_string()))?;
             // Drop `pipe` to close stdin and signal EOF to the child
         }
     }
@@ -1137,8 +1137,8 @@ fn run_command(
                 exit_code,
             })
         }
-        Ok(Err(e)) => Err(IoRunError::CommandError(e.to_string())),
-        Err(_timeout) => Err(IoRunError::Timeout(timeout_secs)),
+        Ok(Err(e)) => Err(IoRunError::CommandError(Smid::default(), e.to_string())),
+        Err(_timeout) => Err(IoRunError::Timeout(Smid::default(), timeout_secs)),
     }
 }
 
@@ -1208,7 +1208,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
 
             Ok(DataConstructor::IoAction) => {
                 if !allow_io {
-                    return Err(IoRunError::IoNotAllowed);
+                    return Err(IoRunError::IoNotAllowed(machine.annotation()));
                 }
                 let world = args[0].clone();
                 let spec_block = args[1].clone();
@@ -1222,8 +1222,16 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                 // that contain unevaluated thunks (lookup-or calls, etc.).
                 let spec = evaluate_spec_block(machine, spec_block)?;
 
+                // Capture source annotation before the shell call so
+                // timeout / command errors carry a source location.
+                let ann = machine.annotation();
+
                 // Execute the shell action
-                let result = run_spec(&spec)?;
+                let result = run_spec(&spec).map_err(|e| match e {
+                    IoRunError::Timeout(_, secs) => IoRunError::Timeout(ann, secs),
+                    IoRunError::CommandError(_, msg) => IoRunError::CommandError(ann, msg),
+                    other => other,
+                })?;
 
                 // Pre-intern the result block key symbols into the machine's
                 // pool so that the IDs embedded by BuildResultBlock are already

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -641,6 +641,16 @@ pub enum ExecutionError {
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
     VersionRequirementFailed(Smid, String, String),
+    #[error(
+        "IO operations are not permitted; use the --allow-io (-I) flag or io.shell-with to enable"
+    )]
+    IoNotAllowed,
+    #[error("io.fail: {0}")]
+    IoFail(String),
+    #[error("io.shell-with: command timed out after {0} seconds")]
+    IoTimeout(u64),
+    #[error("io.shell-with: command execution error: {0}")]
+    IoCommandError(String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
     #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -641,16 +641,14 @@ pub enum ExecutionError {
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
     VersionRequirementFailed(Smid, String, String),
-    #[error(
-        "IO operations are not permitted; use the --allow-io (-I) flag or io.shell-with to enable"
-    )]
-    IoNotAllowed,
-    #[error("io.fail: {0}")]
-    IoFail(String),
-    #[error("io.shell-with: command timed out after {0} seconds")]
-    IoTimeout(u64),
-    #[error("io.shell-with: command execution error: {0}")]
-    IoCommandError(String),
+    #[error("IO operations are not permitted; use the --allow-io (-I) flag to enable")]
+    IoNotAllowed(Smid),
+    #[error("io.fail: {1}")]
+    IoFail(Smid, String),
+    #[error("io.shell-with: command timed out after {1} seconds")]
+    IoTimeout(Smid, u64),
+    #[error("io.shell-with: command execution error: {1}")]
+    IoCommandError(Smid, String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
     #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]
@@ -737,6 +735,10 @@ impl HasSmid for ExecutionError {
             ExecutionError::ArrayNdIndexOutOfBounds(s, _) => *s,
             ExecutionError::ArrayShapeMismatch(s, _) => *s,
             ExecutionError::ArrayNegativeIndex(s, _) => *s,
+            ExecutionError::IoNotAllowed(s) => *s,
+            ExecutionError::IoFail(s, _) => *s,
+            ExecutionError::IoTimeout(s, _) => *s,
+            ExecutionError::IoCommandError(s, _) => *s,
             _ => Smid::default(),
         }
     }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1183,6 +1183,11 @@ impl<'a> Machine<'a> {
         &self.clock
     }
 
+    /// Current source annotation for error reporting
+    pub fn annotation(&self) -> Smid {
+        self.state.annotation
+    }
+
     /// Create a mutator heap view for heap access
     fn view(&'a self) -> MutatorHeapView<'a> {
         MutatorHeapView::new(&self.heap)

--- a/tests/harness/errors/094_io_no_flag.eu.expect
+++ b/tests/harness/errors/094_io_no_flag.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "IO operations require the --allow-io"
+stderr: "IO operations are not permitted; use the --allow-io"


### PR DESCRIPTION
## Error message: IO operations — IoNotAllowed, IoFail, IoTimeout, IoCommandError

### Scenario
When IO actions are used without the `--allow-io` flag, or when IO operations fail, the errors were previously wrapped in `ExecutionError::Panic` losing all structure and source location.

### Before (IoNotAllowed example)
```
error: panic: IO operations require the --allow-io (-I) flag
```

### After (IoNotAllowed)
```
error: IO operations are not permitted; use the --allow-io (-I) flag to enable
  ┌── input.eu:3:9 ───
  │ result: io.shell("echo hello")
  │         ^^^^^^^^
```

### After (IoTimeout example)
```
error: io.shell-with: command timed out after 30 seconds
  ┌── input.eu:5:3 ───
  │ result: io.shell-with({timeout: 30, cmd: "sleep 60"})
  │         ^^^^^^^^^^^^^^
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

The "panic:" prefix is removed, error messages use user-facing function names (`io.shell-with`) rather than internal tags (`:io-shell`), and source locations are propagated via `Smid`.

### Changes
- `src/eval/error.rs`: Added `IoNotAllowed(Smid)`, `IoFail(Smid, String)`, `IoTimeout(Smid, u64)`, and `IoCommandError(Smid, String)` variants to `ExecutionError`, with `smid()` support for source location extraction
- `src/eval/machine/vm.rs`: Exposed `Machine::annotation()` so the io-run driver can capture the current source annotation
- `src/driver/io_run.rs`: `IoRunError` variants now carry `Smid` — `IoNotAllowed(Smid)`, `Timeout(Smid, u64)`, `CommandError(Smid, String)`. The annotation is captured from the machine at the `IoAction` call site and mapped onto errors from `run_spec()`
- `src/driver/eval.rs`: `io_run_error_to_execution()` propagates the `Smid` from each `IoRunError` variant into the corresponding `ExecutionError`
- `tests/harness/errors/094_io_no_flag.eu.expect`: Updated regex to match new message wording

### Test
- `cargo test test_error_094` — verifies `IoNotAllowed` error with exit code 1
- All 96 error harness tests pass

### Risks
Low. `UnknownActionTag` and `MalformedSpec` IoRunError variants still go through the `Panic` fallback since they represent internal states not typically seen by users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)