### PR TITLE
fix(errors): improve note for list in string interpolation context

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -87,6 +87,19 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
              pipeline functions like 'head', 'nth'"
                 .to_string(),
         ]
+    } else if is_list && expects_number && expects_string {
+        // The STR intrinsic (used for string interpolation) expects a scalar type.
+        // A list was passed where a scalar was required — likely in string interpolation.
+        vec![
+            "lists cannot be used directly in string interpolation or string conversion"
+                .to_string(),
+            "to render a list as a string, use 'render-as', \
+             e.g. 'my_list render-as(:json)' or 'my_list render-as(:yaml)'"
+                .to_string(),
+            "to join a list of strings with a separator, use 'join-on', \
+             e.g. 'items join-on(\", \")'"
+                .to_string(),
+        ]
     } else if is_list && expects_number {
         vec![
             "arithmetic operators like '+' work on numbers, not lists".to_string(),


### PR DESCRIPTION
## Error message: list in string interpolation

### Scenario
A user interpolates a list value into a string, e.g.:

```eu
my_list: [1, 2, 3]
result: "items: {my_list}"
```

### Before
```
error: type mismatch: expected null, true, false, number, symbol or string, found list
  ┌─ test.eu:2:9
  │
2 │ result: "items: {my_list}"
  │         ^^^^^^^^^^^^^^^^^^
  │
  = arithmetic operators like '+' work on numbers, not lists
  = to concatenate two lists, use 'append(xs, ys)' or the '++' operator
```

The notes say "arithmetic operators like '+' work on numbers" — which is entirely wrong context. The user is doing string interpolation, not arithmetic.

### After
```
error: type mismatch: expected null, true, false, number, symbol or string, found list
  ┌─ test.eu:2:9
  │
2 │ result: "items: {my_list}"
  │         ^^^^^^^^^^^^^^^^^^
  │
  = lists cannot be used directly in string interpolation or string conversion
  = to render a list as a string, use 'render-as', e.g. 'my_list render-as(:json)' or 'my_list render-as(:yaml)'
  = to join a list of strings with a separator, use 'join-on', e.g. 'items join-on(", ")'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
`src/eval/error.rs`: Added a branch in `data_tag_mismatch_notes()` that fires when `is_list && expects_number && expects_string`. This combination of expected types is the signature of the `STR` intrinsic's switch statement, which is used for string interpolation and the `str.of` conversion function. The new branch correctly identifies the string-interpolation context and suggests `render-as` or `join-on` as actionable alternatives.

The existing `is_list && expects_number` branch still handles pure arithmetic contexts (e.g. `[1, 2, 3] + 5`) where only `BoxedNumber` is expected.

### Risks
Low. All 90 existing error harness tests pass. The arithmetic-context behaviour is unchanged (only `BoxedNumber` expected). The new branch only fires when both `BoxedNumber` and `BoxedString` are in the expected set, which is specific to the `STR` intrinsic switch.