### PR TITLE
fix(errors): add anaphora hint to NotValue 'function application' error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -809,6 +809,17 @@ impl ExecutionError {
                         .to_string(),
                 ]
             }
+            ExecutionError::NotValue(_, context) if context == "a function application" => {
+                vec![
+                    "if using '_' anaphora in a 'map' or similar higher-order function, note \
+                     that each '_' creates a separate parameter — 'map(_ + _)' passes a \
+                     two-argument function, not a one-argument function"
+                        .to_string(),
+                    "to reuse the same argument, use '_0': 'map(_0 + _0)' applies '+' to \
+                     the same element twice; 'map(_0 * _0)' squares each element"
+                        .to_string(),
+                ]
+            }
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
             ExecutionError::LookupFailure(_, key, suggestions, _) => {
                 lookup_failure_notes(key, suggestions)


### PR DESCRIPTION
## Error message: map with two-parameter anaphora

### Scenario
A user attempts to square list elements by writing:

```eu
result: [1, 2, 3] map(_ * _)
```

In eucalypt, each `_` introduces a new parameter, so `_ * _` is a two-argument function `_0 * _1`. `map` applies it to the single element but gets a partially-applied closure back; when it tries to collect the result as a list element, it fails.

### Before
```
error: expected a value but found a function application
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
  ┌─ test.eu:1:19
  │
1 │ result: [1, 2, 3] map(_ * _)
  │                   ^^^
  │
  = stack trace:
    - cons
    - ==
```

No indication of what went wrong or how to fix it.

### After
```
error: expected a value but found a function application
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
  ┌─ test.eu:1:19
  │
1 │ result: [1, 2, 3] map(_ * _)
  │                   ^^^
  │
  = if using '_' anaphora in a 'map' or similar higher-order function, note that each '_' creates a separate parameter — 'map(_ + _)' passes a two-argument function, not a one-argument function
  = to reuse the same argument, use '_0': 'map(_0 + _0)' applies '+' to the same element twice; 'map(_0 * _0)' squares each element
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: poor → excellent

### Change
`src/eval/error.rs`: Added a `NotValue(_, context) if context == "a function application"` arm in `to_diagnostic()`. The context string "a function application" comes from the VM's `native_ref()` function when it encounters an `App` node on the heap. This fires whenever a partially-applied function is found where a concrete value is expected — the most common user-facing trigger is `map` with a multi-`_` anaphora expression.

This is analogous to the existing `CannotReturnFunToCase` note that fires for `filter`/boolean predicates with the same anaphora mistake.

### Risks
Low. All 90 existing error harness tests pass. The note only fires when `context == "a function application"` — a specific string set by the VM, not something user-controlled. The general `NotValue` message and `help:` line are unchanged.