### PR TITLE
fix(errors): improve 'improper list' panic message for ++ type mismatch

### DIFF
--- a/src/eval/stg/render.rs
+++ b/src/eval/stg/render.rs
@@ -233,7 +233,10 @@ impl StgIntrinsic for RenderItems {
                         unit(),
                     ),
                 ],
-                call::bif::panic(str("improper list")),
+                call::bif::panic(str(
+                    "improper list: a list must end with [] (nil), not a non-list value; \
+                     check that '++' is used to concatenate two lists, not a list and a string",
+                )),
             ),
             annotation,
         )
@@ -268,7 +271,10 @@ impl StgIntrinsic for RenderBlockItems {
                         unit(),
                     ),
                 ],
-                Panic.global(str("improper list")),
+                Panic.global(str(
+                    "improper list: a list must end with [] (nil), not a non-list value; \
+                     check that '++' is used to concatenate two lists, not a list and a string",
+                )),
             ),
             annotation,
         )


### PR DESCRIPTION
## Error message: improper list from ++ with non-list right-hand side

### Scenario
A user accidentally concatenates a list with a string using '++':

```eu
result: [1, 2] ++ "not-a-list"
```

The '++' operator calls `append(l1, l2)` which is `foldr(cons, l2, l1)`. When `l2` is a string rather than a proper list, `cons` produces an improper cons structure whose tail ends in a string rather than `[]`. When the renderer traverses this structure, the 'improper list' case is hit.

### Before
```
error: panic: improper list
 = stack trace:
   - cons
   - ==
```

This tells the user nothing about what caused the problem or how to fix it.

### After
```
error: panic: improper list: a list must end with [] (nil), not a non-list value; check that '++' is used to concatenate two lists, not a list and a string
 = stack trace:
   - cons
   - ==
```

### Assessment
- Human diagnosability: poor → fair
- LLM diagnosability: poor → good

The message still carries the "panic:" prefix (inherent to the `Panic` variant and the STG PANIC intrinsic mechanism), but now explains what an improper list is and identifies '++' with a non-list as the most common cause.

### Change
`src/eval/stg/render.rs`: Expanded the panic string in the default fallthrough branch of both `RenderItems.wrapper()` and `RenderBlockItems.wrapper()`. Both wrappers iterate over cons-lists and panic when the list tail is neither `ListCons` nor `ListNil`.

### Risks
Low. The render path panics were already terminal failures. The message change is content-only; no logic or variant changes. All 90 error harness tests pass.