### PR TITLE
fix(errors): add index-out-of-bounds hint to list-tail-as-string error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -769,6 +769,11 @@ impl ExecutionError {
                     //    represents the empty-list sentinel internally as a string native,
                     //    so the error message mentions "string" even though the user wrote [].
                     notes.push(
+                        "if you used 'l !! n' or 'nth' with an index beyond the end of the \
+                         list, that is the likely cause — the index is out of bounds"
+                            .to_string(),
+                    );
+                    notes.push(
                         "if you called 'head' or 'tail' on an empty list '[]', that is the \
                          likely cause — 'head' and 'tail' are only defined on non-empty lists"
                             .to_string(),


### PR DESCRIPTION
## Error message: list index out of bounds via !! or nth

### Scenario
A user indexes beyond the end of a list:

```eu
result: [1, 2, 3] !! 10
```

### Before
```
error: type mismatch: received a string where a structured value (block or list) was expected
     ┌─ [prelude]:1069:32
     │
1069 │ drop(n, l): __IF((n zero?), l, drop(n dec, l tail))
     │                                ^^^^
     │
     = in tail
     = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
     = if you called 'head' or 'tail' on an empty list '[]', that is the likely cause ...
     = guard against empty lists with 'nil?' ...
     = note: to concatenate strings, use string interpolation ...
```

The error points to the prelude's `drop` implementation, and the notes mention head/tail on empty lists but say nothing about index operators.

### After
```
error: type mismatch: received a string where a structured value (block or list) was expected
     ┌─ [prelude]:1069:32
     │
1069 │ drop(n, l): __IF((n zero?), l, drop(n dec, l tail))
     │                                ^^^^
     │
     = in tail
     = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
     = if you used 'l !! n' or 'nth' with an index beyond the end of the list, that is the likely cause — the index is out of bounds
     = if you called 'head' or 'tail' on an empty list '[]', that is the likely cause ...
     = guard against empty lists with 'nil?' ...
```

The `!!` / `nth` out-of-bounds case is now the first note listed.

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change
`src/eval/error.rs`: Added a note at the top of the `NoBranchForNative("string")` note block, placed before the existing "head/tail on empty list" note. `NoBranchForNative("string")` fires in two main user-visible scenarios: (1) index out of bounds via `!!`/`nth`, and (2) `head`/`tail` on `[]`. Both causes are now listed.

### Risks
Low. All 90 existing error harness tests pass. The existing notes are unchanged; the new note is prepended to the list.