### PR TITLE
fix(errors): add diagnostic note for boolean value used in arithmetic

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -75,6 +75,8 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
     let is_number = actual == DataConstructor::BoxedNumber.tag();
     let is_block = actual == DataConstructor::Block.tag();
     let is_symbol = actual == DataConstructor::BoxedSymbol.tag();
+    let is_bool =
+        actual == DataConstructor::BoolTrue.tag() || actual == DataConstructor::BoolFalse.tag();
     let expects_block = expected.contains(&DataConstructor::Block.tag());
     let expects_number = expected.contains(&DataConstructor::BoxedNumber.tag());
     let expects_string = expected.contains(&DataConstructor::BoxedString.tag());
@@ -145,6 +147,14 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
             "to convert a symbol to a string, use 'str.of', e.g. `str.of(:name)` \
              gives the string `\"name\"`"
                 .to_string(),
+        ]
+    } else if is_bool && expects_number {
+        vec![
+            "boolean values (true/false) cannot be used directly in arithmetic".to_string(),
+            "to branch on a boolean, use 'if(cond, then_val, else_val)' or \
+             'cond then(then_val, else_val)'"
+                .to_string(),
+            "to convert a boolean to a number, use 'cond then(1, 0)'".to_string(),
         ]
     } else {
         vec![]


### PR DESCRIPTION
## Error message: boolean used in arithmetic

### Scenario
A user writes arithmetic with a boolean result:

```eu
x: 5 > 3
result: x + 1
```

Or directly:

```eu
result: true + 1
```

### Before
```
error: type mismatch: expected number, found true
  ┌─ test.eu:1:14
  │
1 │ result: true + 1
  │              ^
  │
  = stack trace:
    - ==
```

No hint about what booleans can/cannot do, or how to fix.

### After
```
error: type mismatch: expected number, found true
  ┌─ test.eu:1:14
  │
1 │ result: true + 1
  │              ^
  │
  = boolean values (true/false) cannot be used directly in arithmetic
  = to branch on a boolean, use 'if(cond, then_val, else_val)' or 'cond then(then_val, else_val)'
  = to convert a boolean to a number, use 'cond then(1, 0)'
  = stack trace:
    - ==
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

### Change
`src/eval/error.rs`: Added `is_bool` detection in `data_tag_mismatch_notes()`, tracking whether `actual` matches `BoolTrue` or `BoolFalse` tags. Added an `is_bool && expects_number` branch with three notes: (1) booleans cannot be used in arithmetic, (2) how to branch using `if`/`then`, and (3) how to convert to 0/1 with `then(1, 0)`.

Booleans are data constructors (`BoolTrue` tag = 1, `BoolFalse` tag = 2), not native values, so they reach `data_tag_mismatch_notes` via `NoBranchForDataTag`, not `TypeMismatch`.

### Risks
Low. All 90 existing error harness tests pass. The new branch condition is specific to boolean tags and only fires when a number is expected.