### PR TITLE
fix(errors): add hint to BadNumericTypeForFormat error message

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -490,7 +490,11 @@ pub enum ExecutionError {
     BadDateTimeString(String),
     #[error("failed to apply format string")]
     FormatFailure,
-    #[error("failed to convert numeric type as required by format string")]
+    #[error(
+        "failed to convert numeric type as required by format string\n  \
+         help: integer specifiers like %d, %o, %x require an integer value; \
+         use %f or %g for floating-point numbers"
+    )]
     BadNumericTypeForFormat,
     #[error("bad number format: {0}")]
     BadNumberFormat(String),


### PR DESCRIPTION
## Error message: float with integer format specifier

### Scenario
A user tries to format a floating-point number with an integer format specifier:

```eu
result: str.fmt(3.14, "%o")
```

### Before
```
error: failed to convert numeric type as required by format string
 = stack trace:
   - ==
```

No indication of why the format failed or which specifiers require integers.

### After
```
error: failed to convert numeric type as required by format string
  help: integer specifiers like %d, %o, %x require an integer value; use %f or %g for floating-point numbers
 = stack trace:
   - ==
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change
`src/eval/error.rs`: Embedded a `\n  help:` line directly in the `#[error(...)]` attribute for `BadNumericTypeForFormat`. Since this variant carries no fields, the help text must be part of the error string itself rather than added via `to_diagnostic()` notes.

### Risks
Low. All 90 existing error harness tests pass. The error message is strictly additive — the existing message text is unchanged; a help line is appended.