### PR TITLE
fix(errors): add block field-name shadowing hint to BlackHole error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -670,7 +670,12 @@ impl ExecutionError {
                 vec![
                     "a binding that references itself directly or indirectly creates an infinite loop"
                         .to_string(),
-                    "use a function parameter instead of self-reference, or break the cycle"
+                    "common cause: inside a block, a field name shadows any outer binding with \
+                     the same name — 'f(x): {x: x}' makes 'x' refer to itself, not the parameter; \
+                     rename the parameter: 'f(p): {x: p}'"
+                        .to_string(),
+                    "to break a self-referential cycle, use a function parameter or introduce \
+                     an intermediate binding"
                         .to_string(),
                 ]
             }


### PR DESCRIPTION
## Error message: BlackHole / infinite-loop self-reference

### Scenario
A function that destructures a value into a block where the field names
match the parameter names — the classic `f(x): {x: x}` pattern. The
block field shadows the parameter, creating a self-referential binding.

```eu
make-config(host, port): { host: host, port: port }
config: make-config("localhost", 8080)
result: config.timeout
```

### Before
```
error: infinite loop detected: binding refers to itself
  = a binding that references itself directly or indirectly creates an infinite loop
  = use a function parameter instead of self-reference, or break the cycle
```

### After
```
error: infinite loop detected: binding refers to itself
  = a binding that references itself directly or indirectly creates an infinite loop
  = common cause: inside a block, a field name shadows any outer binding with the same
    name — 'f(x): {x: x}' makes 'x' refer to itself, not the parameter; rename the
    parameter: 'f(p): {x: p}'
  = to break a self-referential cycle, use a function parameter or introduce an
    intermediate binding
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent

The old message told users to "use a function parameter" but gave no hint *why* their
code was wrong or what pattern to look for. The new message names the exact cause
(block field-name shadowing) with a concrete example matching the actual mistake.

### Change
Replaced the single vague note in the `BlackHole` arm of `to_diagnostic()` with two
notes: one identifying the specific block-shadowing cause with a before/after example,
and one giving the general remedy.

### Risks
Low. The change only affects the diagnostic notes appended to the human-readable error
output; the error variant itself and all test expectations are unchanged.