### PR TITLE
fix(errors): include actual operand types in comparison type mismatch error

### DIFF
--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -32,6 +32,19 @@ fn is_zero(n: &Number) -> bool {
     n.as_i64() == Some(0) || n.as_u64() == Some(0) || n.as_f64() == Some(0.0)
 }
 
+/// Return a human-readable type label for a native value, for use in error messages.
+fn native_type_label(n: &Native) -> &'static str {
+    match n {
+        Native::Num(_) => "number",
+        Native::Str(_) => "string",
+        Native::Sym(_) => "symbol",
+        Native::Zdt(_) => "datetime",
+        Native::Index(_) => "index",
+        Native::Set(_) => "set",
+        Native::NdArray(_) => "array",
+    }
+}
+
 /// Floor division for signed integers (rounds toward negative infinity).
 ///
 /// Differs from Rust's truncating `/` for negative dividends:
@@ -443,9 +456,12 @@ fn ordered_cmp(
             Ok(pred(ls.cmp(rs)))
         }
         (Native::Zdt(ref dx), Native::Zdt(ref dy)) => Ok(pred(dx.cmp(dy))),
-        _ => Err(ExecutionError::Panic(format!(
-            "cannot compare values with {name}: operands must be the same type \
-             (both numbers, strings, symbols, or datetimes)"
+        (ref lhs, ref rhs) => Err(ExecutionError::Panic(format!(
+            "cannot compare {} with {} using {name}: \
+             comparison requires both operands to have the same type \
+             (number, string, symbol, or datetime)",
+            native_type_label(lhs),
+            native_type_label(rhs),
         ))),
     }
 }


### PR DESCRIPTION
## Error message: Cross-type comparison with <, >, <=, >=

### Scenario
Comparing values of different types, which eucalypt does not support:

```eu
a: 42
b: "hello"
result: a < b
```

### Before
```
error: panic: cannot compare values with LT: operands must be the same type
  (both numbers, strings, symbols, or datetimes)
```

### After
```
error: panic: cannot compare number with string using LT: comparison requires
  both operands to have the same type (number, string, symbol, or datetime)
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: good → excellent

The old message told users what the requirement was, but not which operand
violated it. The new message names both actual types, making it immediately
obvious which value needs to change.

### Change
Added a private `native_type_label(n: &Native) -> &'static str` helper in
`arith.rs` and used it in the wildcard arm of `ordered_cmp` to include both
operand types in the panic message.

### Risks
Low. Only changes the panic string content, not the error type. No harness
test expectations reference this message.