### PR TITLE
fix(errors): add str.len, replace, trim, starts/ends-with hints to unresolved variables

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -183,6 +183,11 @@ impl CompileError {
                             "to count the elements of a list, use 'count', e.g. 'xs count'"
                                 .to_string(),
                         );
+                        notes.push(
+                            "to get the number of characters in a string, use 'str.len', \
+                             e.g. 's str.len'"
+                                .to_string(),
+                        );
                     }
                     "contains" | "includes" => {
                         notes.push(
@@ -387,6 +392,44 @@ impl CompileError {
                             "eucalypt uses kebab-case: 'sort-by' (for general ordering) or \
                              'sort-by-num' (for numeric keys), e.g. \
                              'xs sort-by-num(.score)'"
+                                .to_string(),
+                        );
+                    }
+                    // String replace — no direct built-in; use regex split+join
+                    "replace" | "str.replace" | "gsub" | "sub" => {
+                        notes.push(
+                            "eucalypt has no str.replace; to replace text, split on the \
+                             pattern and rejoin: \
+                             's str.split-on(\"old\") join-on(\"new\")'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "note: str.split-on uses a regex pattern, so special characters \
+                             must be escaped, e.g. '\"[.]\"' to match a literal dot"
+                                .to_string(),
+                        );
+                    }
+                    // String trim — no direct built-in
+                    "trim" | "strip" | "lstrip" | "rstrip" | "chomp" => {
+                        notes.push(
+                            "eucalypt has no trim function; to remove leading/trailing \
+                             whitespace, use a regex: \
+                             's str.match(\"^\\\\s*(.*?)\\\\s*$\") !! 1'"
+                                .to_string(),
+                        );
+                    }
+                    // Common name for string starts-with / ends-with checks
+                    "startsWith" | "starts_with" | "starts-with" => {
+                        notes.push(
+                            "to test if a string starts with a prefix, use 'str.matches?', \
+                             e.g. 's str.matches?(\"^prefix\")'"
+                                .to_string(),
+                        );
+                    }
+                    "endsWith" | "ends_with" | "ends-with" => {
+                        notes.push(
+                            "to test if a string ends with a suffix, use 'str.matches?', \
+                             e.g. 's str.matches?(\"suffix$\")'"
                                 .to_string(),
                         );
                     }


### PR DESCRIPTION
## Error message: Unresolved variable — common string operation names

### Scenario
Several common string operation names from Python, JavaScript, Ruby, and
other languages have no direct equivalent in eucalypt or use different names.
When a user writes `s trim`, `s replace(...)`, or `s length`, the error gives
no guidance.

### Before

```
error: unresolved variable 'replace'
  = check that the variable is defined and in scope

error: unresolved variable 'trim'
  = check that the variable is defined and in scope

error: unresolved variable 'length'
  = check that the variable is defined and in scope
  = to count the elements of a list, use 'count', e.g. 'xs count'
```

### After

```
error: unresolved variable 'replace'
  = check that the variable is defined and in scope
  = eucalypt has no str.replace; to replace text, split on the pattern and
    rejoin: 's str.split-on("old") join-on("new")'
  = note: str.split-on uses a regex pattern, so special characters must be
    escaped, e.g. '"[.]"' to match a literal dot

error: unresolved variable 'trim'
  = check that the variable is defined and in scope
  = eucalypt has no trim function; to remove leading/trailing whitespace, use
    a regex: 's str.match("^\\s*(.*?)\\s*$") !! 1'

error: unresolved variable 'length'
  = check that the variable is defined and in scope
  = to count the elements of a list, use 'count', e.g. 'xs count'
  = to get the number of characters in a string, use 'str.len', e.g. 's str.len'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added five new match arms to the `FreeVar`-name pattern match in
`compiler.rs`:
- `replace`/`gsub`/`sub` → str.split-on + join-on pattern
- `trim`/`strip`/etc. → regex match approach
- `startsWith`/etc. → str.matches? with `^` anchor
- `endsWith`/etc. → str.matches? with `$` anchor
- Extended existing `length`/`len`/`size` arm with `str.len` hint

### Risks
Low. Only adds notes to compile-time unresolved variable errors. No
existing test expectations are affected.