### PR TITLE
fix(errors): add string interpolation context note for lists in scalar position

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -87,6 +87,20 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
              pipeline functions like 'head', 'nth'"
                 .to_string(),
         ]
+    } else if is_list && expects_number && expects_string {
+        // The string interpolation STG wrapper matches on scalar types (number, string,
+        // symbol, bool, null). A list in this position means the user tried to interpolate
+        // a list directly into a string template.
+        vec![
+            "lists cannot be used directly in string interpolation or string conversion"
+                .to_string(),
+            "to render a list as a string, use 'render-as', \
+             e.g. 'my_list render-as(:json)' or 'my_list render-as(:yaml)'"
+                .to_string(),
+            "to join a list of strings with a separator, use 'join-on', \
+             e.g. 'items join-on(\", \")'"
+                .to_string(),
+        ]
     } else if is_list && expects_number {
         vec![
             "arithmetic operators like '+' work on numbers, not lists".to_string(),


### PR DESCRIPTION
## Error message: List used in string interpolation

### Scenario
A user tries to interpolate a list directly into a string template:

```eu
items: [1, 2, 3]
result: "count: {items}"
```

### Before
```
error: type mismatch: expected null, true, false, number, symbol or string, found list
  = arithmetic operators like '+' work on numbers, not lists
  = to concatenate two lists, use 'append(xs, ys)' or the '++' operator
```
(Notes about arithmetic and list concatenation are completely wrong for this context.)

### After
```
error: type mismatch: expected null, true, false, number, symbol or string, found list
  = lists cannot be used directly in string interpolation or string conversion
  = to render a list as a string, use 'render-as',
    e.g. 'my_list render-as(:json)' or 'my_list render-as(:yaml)'
  = to join a list of strings with a separator, use 'join-on',
    e.g. 'items join-on(", ")'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

The old notes were actively misleading. The new notes identify the correct
context (string interpolation) and offer two practical remedies.

### Change
Added a `is_list && expects_number && expects_string` check before the
existing `is_list && expects_number` arm in `data_tag_mismatch_notes()`.
The string-interpolation STG wrapper expects all scalar types (number, string,
symbol, bool, null), so both `expects_number` and `expects_string` are true
in that context, allowing us to distinguish it from pure arithmetic.

A comment explains why this combination reliably identifies the string
interpolation/scalar-conversion context.

### Risks
Low. Only adds a note branch; does not change error types or exit codes.
All 90 harness error tests pass.