### PR TITLE
fix(errors): add interpolation-context notes for blocks and datetimes in scalar position

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -75,6 +75,7 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
     let is_number = actual == DataConstructor::BoxedNumber.tag();
     let is_block = actual == DataConstructor::Block.tag();
     let is_symbol = actual == DataConstructor::BoxedSymbol.tag();
+    let is_datetime = actual == DataConstructor::BoxedZdt.tag();
     let expects_block = expected.contains(&DataConstructor::Block.tag());
     let expects_number = expected.contains(&DataConstructor::BoxedNumber.tag());
     let expects_string = expected.contains(&DataConstructor::BoxedString.tag());
@@ -114,6 +115,26 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
                 .to_string(),
             "note: 'str' is a namespace of string functions, not a type conversion function; \
              use 'str.of(x)' or string interpolation to convert values to strings"
+                .to_string(),
+        ]
+    } else if is_block && expects_number && expects_string {
+        // String interpolation context — block where scalar is needed.
+        vec![
+            "blocks (structured values) cannot be used directly in string interpolation"
+                .to_string(),
+            "to serialise a block as a string, use 'render-as', \
+             e.g. 'my_block render-as(:yaml)' or 'my_block render-as(:json)'"
+                .to_string(),
+            "to interpolate a specific field, use 'block.field', \
+             e.g. '{config.host}' instead of '{config}'"
+                .to_string(),
+        ]
+    } else if is_datetime && expects_number && expects_string {
+        // String interpolation context — datetime where scalar is needed.
+        vec![
+            "datetime values cannot be used directly in string interpolation".to_string(),
+            "to format a datetime as an ISO 8601 string, use 'cal.format', \
+             e.g. 'd cal.format' or 'str' e.g. 'd str'"
                 .to_string(),
         ]
     } else if is_block && expects_number {


### PR DESCRIPTION
## Error message: Block or datetime used in string interpolation

### Scenario
A user tries to interpolate a structured value directly into a string:

```eu
config: { host: "localhost" }
result: "using {config}"

d: cal.zdt(2024, 1, 1, 0, 0, 0, "UTC")
result: "date: {d}"
```

### Before (block)
```
error: type mismatch: expected null, true, false, number, symbol or string, found block
  = blocks (structured values) cannot be used in arithmetic
  = did you mean to access a specific field? use 'block.field' to extract
    a value before applying arithmetic
```
(Notes about arithmetic are misleading — the user is doing string interpolation, not maths.)

### Before (datetime)
```
error: type mismatch: expected null, true, false, number, symbol or string, found datetime
```
(No notes at all.)

### After (block)
```
error: type mismatch: expected null, true, false, number, symbol or string, found block
  = blocks (structured values) cannot be used directly in string interpolation
  = to serialise a block as a string, use 'render-as',
    e.g. 'my_block render-as(:yaml)' or 'my_block render-as(:json)'
  = to interpolate a specific field, use 'block.field',
    e.g. '{config.host}' instead of '{config}'
```

### After (datetime)
```
error: type mismatch: expected null, true, false, number, symbol or string, found datetime
  = datetime values cannot be used directly in string interpolation
  = to format a datetime as an ISO 8601 string, use 'cal.format',
    e.g. 'd cal.format' or 'str' e.g. 'd str'
```

### Assessment
- Human diagnosability: poor → good (block), poor → fair (datetime)
- LLM diagnosability: fair → excellent (both)

The old block message mentioned arithmetic which is completely wrong context.
Both messages now point to the correct remedies.

### Change
Added `is_datetime` detection variable and two new higher-priority branches
in `data_tag_mismatch_notes()`:
- `is_block && expects_number && expects_string`: string interpolation context
- `is_datetime && expects_number && expects_string`: string interpolation context

Both are inserted before the existing `is_block && expects_number` arm to take
priority when the full scalar type set is expected.

### Risks
Low. Only adds notes. No harness test expectations are affected.