### PR TITLE
fix(errors): improve datetime, array, and timezone error messages

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -443,6 +443,41 @@ fn format_bad_timezone(tz: &str) -> String {
     )
 }
 
+/// Format a bad datetime components error with a hint about valid ranges
+fn format_bad_datetime_components(
+    y: &Number,
+    m: &Number,
+    d: &Number,
+    h: &Number,
+    min: &Number,
+    s: &Number,
+    tz: &str,
+) -> String {
+    // Try to identify which component is out of range
+    let hint = if m.as_u64().is_some_and(|v| v == 0 || v > 12) {
+        format!("month {m} is out of range; months are numbered 1–12")
+    } else if d.as_u64().is_some_and(|v| v == 0 || v > 31) {
+        format!("day {d} is out of range; days are numbered 1–31 (depending on month)")
+    } else if h.as_u64().is_some_and(|v| v > 23) {
+        format!("hour {h} is out of range; valid hours are 0–23")
+    } else if min.as_u64().is_some_and(|v| v > 59) {
+        format!("minute {min} is out of range; valid minutes are 0–59")
+    } else if s.as_u64().is_some_and(|v| v > 59) {
+        format!("second {s} is out of range; valid seconds are 0–59")
+    } else {
+        format!(
+            "the combination ({y}, {m}, {d}) does not form a valid calendar date \
+             (e.g. February has at most 29 days)"
+        )
+    };
+    format!(
+        "invalid date/time components: {hint}\n  \
+         help: cal.zdt takes (year, month, day, hour, minute, second, timezone), \
+         e.g. cal.zdt(2023, 1, 15, 10, 30, 0, \"UTC\")\n  \
+         note: given components were ({y}, {m}, {d}, {h}, {min}, {s}, {tz})"
+    )
+}
+
 /// Convert a data tag number to a human-readable type name for error messages
 fn display_data_tag(tag: u8) -> String {
     match DataConstructor::try_from(tag) {
@@ -499,7 +534,7 @@ pub enum ExecutionError {
     NotValue(Smid, String),
     #[error("bad regex: {1}\n  help: the pattern '{0}' is not a valid regular expression")]
     BadRegex(String, String),
-    #[error("bad date / time components ({0}, {1}, {2}, {3}, {4}, {5}, {6})")]
+    #[error("{}", format_bad_datetime_components(.0, .1, .2, .3, .4, .5, .6))]
     BadDateTimeComponents(Number, Number, Number, Number, Number, Number, String),
     #[error("{}", format_bad_timezone(.0))]
     BadTimeZone(String),

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -424,6 +424,25 @@ fn format_bad_format_string(detail: &str) -> String {
     )
 }
 
+/// Format a bad datetime string error message with ISO 8601 examples
+fn format_bad_datetime_string(s: &str) -> String {
+    format!(
+        "cannot parse '{s}' as a date or datetime\n  \
+         help: cal.parse expects ISO 8601 format, \
+         e.g. '2023-01-15' (date), '2023-01-15T10:30:00Z' (UTC datetime), \
+         or '2023-01-15T10:30:00+01:00' (datetime with offset)"
+    )
+}
+
+/// Format a bad timezone string error message
+fn format_bad_timezone(tz: &str) -> String {
+    format!(
+        "unrecognised time zone '{tz}'\n  \
+         help: use an IANA timezone name (e.g. 'Europe/London', 'America/New_York') \
+         or a UTC offset string (e.g. '+0100', '-0530', 'UTC')"
+    )
+}
+
 /// Convert a data tag number to a human-readable type name for error messages
 fn display_data_tag(tag: u8) -> String {
     match DataConstructor::try_from(tag) {
@@ -482,11 +501,11 @@ pub enum ExecutionError {
     BadRegex(String, String),
     #[error("bad date / time components ({0}, {1}, {2}, {3}, {4}, {5}, {6})")]
     BadDateTimeComponents(Number, Number, Number, Number, Number, Number, String),
-    #[error("bad time zone ({0})")]
+    #[error("{}", format_bad_timezone(.0))]
     BadTimeZone(String),
     #[error("bad timestamp ({0})")]
     BadTimestamp(Number),
-    #[error("bad datetime format ({0})")]
+    #[error("{}", format_bad_datetime_string(.0))]
     BadDateTimeString(String),
     #[error("failed to apply format string")]
     FormatFailure,

--- a/src/eval/stg/array.rs
+++ b/src/eval/stg/array.rs
@@ -158,11 +158,21 @@ impl StgIntrinsic for ArrayFromFlat {
     ) -> Result<(), ExecutionError> {
         let shape = num_list_to_usize_vec(machine, view, &args[0])?;
         let values = num_list_to_f64_vec(machine, view, &args[1])?;
+        let expected_len: usize = shape.iter().product();
+        let actual_len = values.len();
         match HeapNdArray::from_flat(&shape, values) {
             Some(arr) => machine_return_ndarray(machine, view, arr),
-            None => Err(ExecutionError::Panic(
-                "array shape does not match data length".to_string(),
-            )),
+            None => {
+                let shape_str = shape
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(ExecutionError::Panic(format!(
+                    "arr.from-flat: shape [{shape_str}] requires {expected_len} element(s) \
+                     but {actual_len} value(s) were provided"
+                )))
+            }
         }
     }
 }
@@ -223,9 +233,22 @@ impl StgIntrinsic for ArrayGet {
                 view,
                 Number::from_f64(val).unwrap_or_else(|| Number::from(0)),
             ),
-            None => Err(ExecutionError::Panic(
-                "array index out of bounds".to_string(),
-            )),
+            None => {
+                let coords_str = coords
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let shape_str = arr
+                    .shape()
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(ExecutionError::Panic(format!(
+                    "arr.get: coordinates [{coords_str}] are out of bounds for array with shape [{shape_str}]"
+                )))
+            }
         }
     }
 }
@@ -284,9 +307,22 @@ impl StgIntrinsic for ArraySet {
         let arr = ndarray_arg(machine, view, &args[2])?;
         match arr.with_set(&coords, value) {
             Some(new_arr) => machine_return_ndarray(machine, view, new_arr),
-            None => Err(ExecutionError::Panic(
-                "array index out of bounds".to_string(),
-            )),
+            None => {
+                let coords_str = coords
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let shape_str = arr
+                    .shape()
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(ExecutionError::Panic(format!(
+                    "arr.set: coordinates [{coords_str}] are out of bounds for array with shape [{shape_str}]"
+                )))
+            }
         }
     }
 }

--- a/tests/harness/errors/080_array_oob.eu.expect
+++ b/tests/harness/errors/080_array_oob.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "array index out of bounds"
+stderr: "arr.get: coordinates .* are out of bounds for array with shape"

--- a/tests/harness/errors/081_array_shape_mismatch.eu.expect
+++ b/tests/harness/errors/081_array_shape_mismatch.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "array shape does not match data length"
+stderr: "arr.from-flat: shape .* requires .* element"


### PR DESCRIPTION
## Error messages: datetime, timezone, date components, and array operations

### Scenarios covered

1. `cal.parse("not-a-date")` — bad datetime string
2. `cal.zdt(2023, 1, 15, 10, 30, 0, "INVALID_TZ")` — bad timezone
3. `cal.zdt(2023, 13, 1, 0, 0, 0, "UTC")` — bad date components
4. `arr.get([5, 0])` on a 3×3 array — array index out of bounds
5. `arr.from-flat([2, 3], [1, 2, 3, 4])` — shape/data length mismatch

### Before
```
error: bad datetime format (not-a-date)
error: bad time zone (INVALID_TZ)
error: bad date / time components (2023, 13, 1, 0, 0, 0, UTC)
error: panic: array index out of bounds
error: panic: array shape does not match data length
```

### After
```
error: cannot parse 'not-a-date' as a date or datetime
  help: cal.parse expects ISO 8601 format, e.g. '2023-01-15' (date),
        '2023-01-15T10:30:00Z' (UTC datetime),
        or '2023-01-15T10:30:00+01:00' (datetime with offset)

error: unrecognised time zone 'INVALID_TZ'
  help: use an IANA timezone name (e.g. 'Europe/London', 'America/New_York')
        or a UTC offset string (e.g. '+0100', '-0530', 'UTC')

error: invalid date/time components: month 13 is out of range; months are numbered 1–12
  help: cal.zdt takes (year, month, day, hour, minute, second, timezone), ...
  note: given components were (2023, 13, 1, 0, 0, 0, UTC)

error: panic: arr.get: coordinates [5, 0] are out of bounds for array with shape [3, 3]

error: panic: arr.from-flat: shape [2, 3] requires 6 element(s) but 4 value(s) were provided
```

### Assessment
- Human diagnosability: poor → good/excellent
- LLM diagnosability: poor → excellent

### Changes
- `src/eval/error.rs`: Added helpers `format_bad_datetime_string`, `format_bad_timezone`, `format_bad_datetime_components`; updated `#[error]` attributes for `BadDateTimeString`, `BadTimeZone`, `BadDateTimeComponents`
- `src/eval/stg/array.rs`: Improved `ArrayGet`, `ArraySet`, and `ArrayFromFlat` panic messages to include actual coordinates and shape values
- `tests/harness/errors/080_array_oob.eu.expect`: Updated regex to match new message format
- `tests/harness/errors/081_array_shape_mismatch.eu.expect`: Updated regex to match new message format

### Risks
Low. All 90 error tests pass. Clippy clean.