### PR TITLE
fix(errors): improve array and null-access error messages

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -63,6 +63,15 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
              symbols are written with a leading colon"
                 .to_string(),
         ],
+        (Record(_), Unit) => vec![
+            "cannot access a field on null — the value is null, not a block".to_string(),
+            "if this value may be null, check with 'null?' before accessing fields, \
+             e.g. 'if(x null?, default, x.field)'"
+                .to_string(),
+            "if this comes from a lookup that might fail, consider 'lookup-or' for a default, \
+             e.g. 'block lookup-or(:key, default)'"
+                .to_string(),
+        ],
         _ => vec![],
     }
 }
@@ -75,12 +84,36 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
     let is_number = actual == DataConstructor::BoxedNumber.tag();
     let is_block = actual == DataConstructor::Block.tag();
     let is_symbol = actual == DataConstructor::BoxedSymbol.tag();
+    let is_unit = actual == DataConstructor::Unit.tag();
     let expects_block = expected.contains(&DataConstructor::Block.tag());
     let expects_number = expected.contains(&DataConstructor::BoxedNumber.tag());
     let expects_string = expected.contains(&DataConstructor::BoxedString.tag());
     let expects_symbol = expected.contains(&DataConstructor::BoxedSymbol.tag());
 
-    if is_list && expects_block {
+    if is_unit && expects_block {
+        vec![
+            "cannot access a field on null — the value is null, not a block".to_string(),
+            "if this value may be null, check with 'null?' before accessing fields, \
+             e.g. 'if(x null?, default, x.field)'"
+                .to_string(),
+            "if this comes from a lookup that might fail, consider 'lookup-or' for a default, \
+             e.g. 'block lookup-or(:key, default)'"
+                .to_string(),
+        ]
+    } else if is_unit && expects_number {
+        vec![
+            "null cannot be used in arithmetic — it represents the absence of a value".to_string(),
+            "if the value may be null, use 'if(x null?, 0, x)' to provide a fallback \
+             before using it in arithmetic"
+                .to_string(),
+        ]
+    } else if is_unit && expects_string {
+        vec![
+            "null cannot be used in string operations or interpolation".to_string(),
+            "to handle a potentially null value, use 'if(x null?, \"\", x str)' as a fallback"
+                .to_string(),
+        ]
+    } else if is_list && expects_block {
         vec![
             "the '.' operator performs key lookup on blocks, not lists".to_string(),
             "for lists, use the index operator for indexing (e.g. xs index 0) or \

--- a/src/eval/stg/array.rs
+++ b/src/eval/stg/array.rs
@@ -475,11 +475,27 @@ impl StgIntrinsic for ArrayReshape {
     ) -> Result<(), ExecutionError> {
         let new_shape = num_list_to_usize_vec(machine, view, &args[0])?;
         let arr = ndarray_arg(machine, view, &args[1])?;
+        let old_len = arr.len();
+        let new_len: usize = new_shape.iter().product();
         match arr.reshape(&new_shape) {
             Some(reshaped) => machine_return_ndarray(machine, view, reshaped),
-            None => Err(ExecutionError::Panic(
-                "reshape: new shape does not match total element count".to_string(),
-            )),
+            None => {
+                let old_shape_str = arr
+                    .shape()
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let new_shape_str = new_shape
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(ExecutionError::Panic(format!(
+                    "arr.reshape: cannot reshape array of {old_len} element(s) (shape [{old_shape_str}]) \
+                     into shape [{new_shape_str}] which requires {new_len} element(s)"
+                )))
+            }
         }
     }
 }
@@ -506,9 +522,20 @@ impl StgIntrinsic for ArraySlice {
         let index = num_arg(machine, view, &args[2])?.as_f64().unwrap_or(0.0) as usize;
         match arr.slice_along(axis, index) {
             Some(sliced) => machine_return_ndarray(machine, view, sliced),
-            None => Err(ExecutionError::Panic(
-                "slice: axis or index out of bounds".to_string(),
-            )),
+            None => {
+                let shape_str = arr
+                    .shape()
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let rank = arr.rank();
+                Err(ExecutionError::Panic(format!(
+                    "arr.slice: axis {axis} or index {index} is out of bounds \
+                     for array with shape [{shape_str}] (rank {rank}); \
+                     axis must be 0..{rank} and index within the dimension size"
+                )))
+            }
         }
     }
 }
@@ -789,11 +816,25 @@ pub(crate) fn array_binop<F: Fn(f64, f64) -> f64>(
         (Native::NdArray(a_ptr), Native::NdArray(b_ptr)) => {
             let a = view.scoped(a_ptr);
             let b = view.scoped(b_ptr);
+            let a_shape_str = a
+                .shape()
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let b_shape_str = b
+                .shape()
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
             match a.zip_with(&b, f) {
                 Some(result) => machine_return_ndarray(machine, view, result),
-                None => Err(ExecutionError::Panic(
-                    "array shape mismatch in element-wise operation".to_string(),
-                )),
+                None => Err(ExecutionError::Panic(format!(
+                    "array shape mismatch: cannot apply element-wise operation \
+                     to arrays with shapes [{a_shape_str}] and [{b_shape_str}]; \
+                     shapes must be identical for element-wise operations"
+                ))),
             }
         }
         (Native::NdArray(a_ptr), Native::Num(n)) => {

--- a/tests/harness/errors/082_array_reshape_mismatch.eu.expect
+++ b/tests/harness/errors/082_array_reshape_mismatch.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "reshape: new shape does not match total element count"
+stderr: "arr.reshape: cannot reshape array of .* element"

--- a/tests/harness/errors/083_array_arith_mismatch.eu.expect
+++ b/tests/harness/errors/083_array_arith_mismatch.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "array shape mismatch in element-wise operation"
+stderr: "array shape mismatch: cannot apply element-wise operation"


### PR DESCRIPTION
## Error messages: array operations and null field access

### Scenarios covered

**Array operations:**
1. `arr.reshape([3, 4])` on a 2×3 array — cannot reshape 6 into 12 elements
2. `arr.slice(arr, 5, 0)` on a rank-2 array — axis out of bounds
3. `arr.add(a, b)` on arrays of different shapes — element-wise shape mismatch

**Null access:**
4. `x.field` where `x` is null — field access on null
5. `null + 5` — null in arithmetic
6. `"{null}"` — null in string interpolation

### Before
```
error: panic: reshape: new shape does not match total element count
error: panic: slice: axis or index out of bounds
error: panic: array shape mismatch in element-wise operation
error: type mismatch: expected block, found null
error: type mismatch: expected number, found null
```

### After
```
error: panic: arr.reshape: cannot reshape array of 6 element(s) (shape [2, 3]) into shape [3, 4] which requires 12 element(s)
error: panic: arr.slice: axis 5 or index 0 is out of bounds for array with shape [2, 3] (rank 2); axis must be 0..2 ...
error: panic: array shape mismatch: cannot apply element-wise operation to arrays with shapes [2, 3] and [2, 2]; ...
error: type mismatch: expected block, found null
  = cannot access a field on null — the value is null, not a block
  = if this value may be null, check with 'null?' before accessing fields, ...
  = if this comes from a lookup that might fail, consider 'lookup-or' for a default, ...
error: type mismatch: expected number, found null
  = null cannot be used in arithmetic — it represents the absence of a value
  = if the value may be null, use 'if(x null?, 0, x)' to provide a fallback ...
```

### Assessment
- Human diagnosability: poor → good/excellent
- LLM diagnosability: poor → excellent

### Changes
- `src/eval/stg/array.rs`: Improved `ArrayReshape`, `ArraySlice`, and `array_binop` panic messages to include actual shapes, counts, and axis/index values
- `src/eval/error.rs`: Added `(Record(_), Unit)` branch in `type_mismatch_notes` and `is_unit` branches in `data_tag_mismatch_notes` for null-access cases
- `tests/harness/errors/082_array_reshape_mismatch.eu.expect`: Updated regex to match new message format
- `tests/harness/errors/083_array_arith_mismatch.eu.expect`: Updated regex to match new message format

### Risks
Low. All 90 error tests pass. Clippy clean.