### PR TITLE
feat(errors): add hints for match/case/switch, isinstance, and block string-key access

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -32,6 +32,9 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
             "the '.' operator performs key lookup on blocks; \
              strings do not have fields"
                 .to_string(),
+            "if you passed a string as a key to a block (e.g. 'block(\"key\")', use \
+             dot notation instead: 'block.key', or a symbol: 'block(:key)'"
+                .to_string(),
             "to apply string functions, use pipeline catenation, \
              e.g. 'x str.to-upper' or 'str.to-lower(x)' instead of 'x.upper'"
                 .to_string(),
@@ -108,6 +111,9 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
         vec![
             "the '.' operator performs key lookup on blocks; \
              strings do not have fields"
+                .to_string(),
+            "if you passed a string as a key to a block (e.g. 'block(\"key\")'), use \
+             dot notation instead: 'block.key'"
                 .to_string(),
             "to apply string functions, use pipeline catenation, \
              e.g. 'x str.to-upper' or 'str.to-lower(x)' instead of 'x.upper'"

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -390,6 +390,37 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Pattern matching keywords from Haskell, Rust, OCaml, Elixir.
+                    // Eucalypt has no match expression; dispatch is done via 'if' or 'cond'.
+                    "match" | "case" | "switch" => {
+                        notes.push(
+                            "eucalypt has no 'match'/'case'/'switch' expression; \
+                             use 'if(condition, then-value, else-value)' for two-way branching"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "for multi-way dispatch use 'cond', e.g. \
+                             'cond([x = 1, \"one\"], [x = 2, \"two\"], [true, \"other\"])'"
+                                .to_string(),
+                        );
+                    }
+                    // Type-conversion keywords from various languages.
+                    "cast" | "coerce" | "convert" => {
+                        notes.push(
+                            "eucalypt has no explicit type-cast; use 'num' to convert strings \
+                             to numbers, 'str' for numbers to strings, or 'str.of(x)' for a \
+                             general string representation"
+                                .to_string(),
+                        );
+                    }
+                    // Type-test / isinstance from Python, Java, Kotlin.
+                    "isinstance" | "isA" | "is_a" | "instanceof" | "is-a" => {
+                        notes.push(
+                            "eucalypt has no runtime type-test operator; use 'num?', 'str?', \
+                             'nil?', 'bool?' or 'list?' predicates to test the type of a value"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)


### PR DESCRIPTION
## Error message: FreeVar hints and TypeMismatch improvement

### Scenario A — match/case/switch
Using pattern matching keywords from other languages (Haskell, Rust, Elixir):
```
result: match(x)
```

### Before (A)
```
error: unresolved variable 'match'
= check that the variable is defined and in scope
```

### After (A)
```
error: unresolved variable 'match'
= check that the variable is defined and in scope
= eucalypt has no 'match'/'case'/'switch' expression; use 'if(condition, then-value, else-value)' for two-way branching
= for multi-way dispatch use 'cond', e.g. 'cond([x = 1, "one"], [x = 2, "two"], [true, "other"])'
```

---

### Scenario B — block called with string key
Attempting Python-style dict access: `config("host")` where `config` is a block.

### Before (B)
```
error: type mismatch: expected block, found string
= the '.' operator performs key lookup on blocks; strings do not have fields
= to apply string functions, use pipeline catenation…
```

### After (B)
```
error: type mismatch: expected block, found string
= the '.' operator performs key lookup on blocks; strings do not have fields
= if you passed a string as a key to a block (e.g. 'block("key")'), use dot notation instead: 'block.key'
= to apply string functions, use pipeline catenation…
```

---

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
- `src/eval/stg/compiler.rs`: add FreeVar arms for `match`/`case`/`switch`, `isinstance`/`isA`/`instanceof`, `cast`/`coerce`/`convert`
- `src/eval/error.rs`: add "block string key" note to `(Record(_), String)` in `type_mismatch_notes` and corresponding `is_string && expects_block` in `data_tag_mismatch_notes`

### Risks
Low — additive changes only; no existing error messages changed.