### PR TITLE
fix(errors): improve 'not a value' error for partial application context

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -313,17 +313,33 @@ fn lookup_failure_notes(key: &str, suggestions: &[String]) -> Vec<String> {
 /// Format a "not a value" error message when a non-value expression is found
 /// where a primitive value was expected.
 fn format_not_value(context: &str) -> String {
-    if context.is_empty() {
-        "expected a value but found an unevaluated expression\n  \
-         help: this can occur when a function or structured value appears \
-         where a primitive (number, string, etc.) was expected"
-            .to_string()
-    } else {
-        format!(
-            "expected a value but found {context}\n  \
-             help: this can occur when a function or structured value appears \
-             where a primitive (number, string, etc.) was expected"
-        )
+    match context {
+        "a function application" => {
+            "expected a primitive value but found an unevaluated function application\n  \
+             help: this often means a function received fewer arguments than it needs, \
+             producing a partial application instead of a result\n  \
+             help: check that all functions in the pipeline receive the correct number of \
+             arguments — e.g. 'add(x, y)' needs two args but 'xs map(add)' applies 'add' \
+             to each element with only one arg"
+                .to_string()
+        }
+        "a data constructor (e.g. block or list)" => {
+            "expected a primitive value but found a structured value (block or list)\n  \
+             help: to extract a field from a block, use '.field' notation; \
+             to extract an element from a list, use 'head' or 'nth(n, list)'"
+                .to_string()
+        }
+        c if !c.is_empty() => {
+            format!(
+                "expected a primitive value but found {c}\n  \
+                 help: this can occur when a function or structured value appears \
+                 where a primitive (number, string, etc.) was expected"
+            )
+        }
+        _ => "expected a value but found an unevaluated expression\n  \
+              help: this can occur when a function or structured value appears \
+              where a primitive (number, string, etc.) was expected"
+            .to_string(),
     }
 }
 


### PR DESCRIPTION
## Error message: NotValue / partial application from map/filter

### Scenario
Passing a multi-argument function directly to `map` without wrapping it in a
section or lambda, so each element gets partially applied rather than a
complete result:

```eu
add(x, y): x + y
result: [1, 2, 3] map(add)
```

`map(add)` applies `add` to each element with one argument — `add(1)`, `add(2)`, `add(3)` — producing partial applications (functions waiting for a second argument). When eucalypt tries to emit the result, it finds a function application where a value is expected.

### Before
```
error: expected a value but found a function application
help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
```

Generic and doesn't explain WHY the function application appeared.

### After
```
error: expected a primitive value but found an unevaluated function application
help: this often means a function received fewer arguments than it needs, producing a partial application instead of a result
help: check that all functions in the pipeline receive the correct number of arguments — e.g. 'add(x, y)' needs two args but 'xs map(add)' applies 'add' to each element with only one arg
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent (now names partial application explicitly)

### Change
- `src/eval/error.rs`: refactor `format_not_value()` from a generic formatter to a pattern-match on the `context` string, giving specific messages for "a function application" and "a data constructor" cases

### Risks
Low — no changes to error detection logic; only the formatting of the message. All 90 error tests pass.