### PR TITLE
fix(gc): evacuate HeapSyn backing arrays during immix GC

### DIFF
--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -694,8 +694,26 @@ fn evaluate_spec_block(
     //
     // For list-valued fields (e.g. `args` in io.exec) we walk the cons list and
     // render each element individually, then join with NUL as a separator.
+    //
+    // SAFETY: each call to evaluate_to_whnf_for_io runs machine.run() which
+    // ends with collect::collect.  If evacuation occurs, any SynClosure values
+    // held on the Rust stack (i.e. the remaining entries in raw_fields) become
+    // dangling — the GC does not know about them.  We convert raw_fields into
+    // an ordered Vec and stash ALL closures upfront so the GC can trace and
+    // update their heap pointers during each sub-evaluation.  Each closure is
+    // popped from the stash immediately before it is used.
+    let raw_fields_vec: Vec<(String, SynClosure)> = raw_fields.into_iter().collect();
+    // Push all closures onto the stash (bottom = index n-1, top = index 0).
+    // We iterate in reverse so that after all pushes the order matches the Vec
+    // (raw_fields_vec[0] is deepest, raw_fields_vec[last] is shallowest).
+    // We will pop them in forward order, so push in reverse.
+    for (_, c) in raw_fields_vec.iter().rev() {
+        machine.stash_push(c.clone());
+    }
     let mut eval_fields: HashMap<String, Option<String>> = HashMap::new();
-    for (key, raw_closure) in raw_fields {
+    for (key, _) in raw_fields_vec {
+        // Pop the GC-protected closure for this field (in original order).
+        let raw_closure = machine.stash_pop();
         let whnf = machine
             .evaluate_to_whnf_for_io(raw_closure)
             .map_err(IoRunError::from)?;
@@ -723,8 +741,17 @@ fn evaluate_spec_block(
             let elements = machine
                 .mutate(CollectListElements(whnf), Some(globals))
                 .map_err(IoRunError::from)?;
+            // Stash all element closures before the evaluation loop for the same
+            // reason as raw_fields above: evaluate_to_whnf_for_io triggers GC
+            // which can evacuate remaining elements, leaving their stack copies
+            // dangling.  Push in reverse so we pop in forward order.
+            for e in elements.iter().rev() {
+                machine.stash_push(e.clone());
+            }
+            let count = elements.len();
             let mut parts: Vec<String> = Vec::new();
-            for elem in elements {
+            for _ in 0..count {
+                let elem = machine.stash_pop();
                 let elem_whnf = machine
                     .evaluate_to_whnf_for_io(elem)
                     .map_err(IoRunError::from)?;

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -333,9 +333,17 @@ impl CollectorHeapView<'_> {
         let old_header = unsafe { &mut *self.heap.header_ptr_mut(obj) };
         old_header.set_forwarded(new_obj.cast());
 
-        // Mark the new copy as live
+        // Mark the new copy as live.
+        //
+        // Use `mark_lines_for_bytes` rather than `mark_line<T>` so that the
+        // actual payload length (stored in the AllocHeader) is used to mark all
+        // lines spanned by the evacuation copy.  `mark_line<T>` uses
+        // `size_of::<T>()` which is 0 for ZST types like `OpaqueHeapBytes`:
+        // that would leave lines 1..N of a large backing store unmarked, making
+        // them visible to `lazy_sweep_next()` as reclaimable holes — corrupting
+        // live data on the next allocation.
         self.heap.mark_object(new_obj);
-        self.heap.mark_line(new_obj);
+        self.heap.mark_lines_for_bytes(new_obj.cast::<u8>());
 
         Some(new_obj)
     }

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -386,6 +386,12 @@ impl GcScannable for HeapSyn {
                     out.push(ScanPtr::from_non_null(scope, *scrutinee));
                 }
                 if marker.mark_array(branch_table) {
+                    if let Some(backing_ptr) = branch_table.allocated_data() {
+                        out.push(ScanPtr::from_non_null(
+                            scope,
+                            backing_ptr.cast::<OpaqueHeapBytes>(),
+                        ));
+                    }
                     for b in branch_table.iter().flatten() {
                         if marker.mark(*b) {
                             out.push(ScanPtr::from_non_null(scope, *b));
@@ -399,16 +405,37 @@ impl GcScannable for HeapSyn {
                 }
             }
             HeapSyn::Cons { tag: _, args } => {
-                marker.mark_array(args);
+                if marker.mark_array(args) {
+                    if let Some(backing_ptr) = args.allocated_data() {
+                        out.push(ScanPtr::from_non_null(
+                            scope,
+                            backing_ptr.cast::<OpaqueHeapBytes>(),
+                        ));
+                    }
+                }
                 mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::App { callable, args } => {
                 mark_ref_heap_pointers(callable, scope, marker, out);
-                marker.mark_array(args);
+                if marker.mark_array(args) {
+                    if let Some(backing_ptr) = args.allocated_data() {
+                        out.push(ScanPtr::from_non_null(
+                            scope,
+                            backing_ptr.cast::<OpaqueHeapBytes>(),
+                        ));
+                    }
+                }
                 mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::Bif { intrinsic: _, args } => {
-                marker.mark_array(args);
+                if marker.mark_array(args) {
+                    if let Some(backing_ptr) = args.allocated_data() {
+                        out.push(ScanPtr::from_non_null(
+                            scope,
+                            backing_ptr.cast::<OpaqueHeapBytes>(),
+                        ));
+                    }
+                }
                 mark_ref_array_heap_pointers(args, scope, marker, out);
             }
             HeapSyn::Let { bindings, body } => {
@@ -493,6 +520,13 @@ impl GcScannable for HeapSyn {
                 if let Some(new) = heap.forwarded_to(*scrutinee) {
                     *scrutinee = new;
                 }
+                if let Some(old_ptr) = branch_table.allocated_data() {
+                    if let Some(new_ptr) = heap.forwarded_to(old_ptr) {
+                        // SAFETY: new_ptr is a valid evacuated copy of the same
+                        // backing allocation.
+                        unsafe { branch_table.set_backing_ptr(new_ptr.cast()) };
+                    }
+                }
                 for ptr in branch_table.iter_mut().flatten() {
                     if let Some(new) = heap.forwarded_to(*ptr) {
                         *ptr = new;
@@ -505,13 +539,34 @@ impl GcScannable for HeapSyn {
                 }
             }
             HeapSyn::Cons { args, .. } => {
+                if let Some(old_ptr) = args.allocated_data() {
+                    if let Some(new_ptr) = heap.forwarded_to(old_ptr) {
+                        // SAFETY: new_ptr is a valid evacuated copy of the same
+                        // backing allocation.
+                        unsafe { args.set_backing_ptr(new_ptr.cast()) };
+                    }
+                }
                 update_ref_array_heap_pointers(args, heap);
             }
             HeapSyn::App { callable, args } => {
                 update_ref_heap_pointers(callable, heap);
+                if let Some(old_ptr) = args.allocated_data() {
+                    if let Some(new_ptr) = heap.forwarded_to(old_ptr) {
+                        // SAFETY: new_ptr is a valid evacuated copy of the same
+                        // backing allocation.
+                        unsafe { args.set_backing_ptr(new_ptr.cast()) };
+                    }
+                }
                 update_ref_array_heap_pointers(args, heap);
             }
             HeapSyn::Bif { args, .. } => {
+                if let Some(old_ptr) = args.allocated_data() {
+                    if let Some(new_ptr) = heap.forwarded_to(old_ptr) {
+                        // SAFETY: new_ptr is a valid evacuated copy of the same
+                        // backing allocation.
+                        unsafe { args.set_backing_ptr(new_ptr.cast()) };
+                    }
+                }
                 update_ref_array_heap_pointers(args, heap);
             }
             HeapSyn::Let { bindings, body } | HeapSyn::LetRec { bindings, body } => {


### PR DESCRIPTION
## Summary

Fixes three GC correctness bugs causing a macOS aarch64 SIGSEGV in
sequential IO test runs:

### 1. GC backing-array evacuation (`syntax.rs`, `cont.rs`)

`HeapSyn::Cons`, `App`, `Bif`, and `Case::branch_table` were missing both
halves of the OpaqueHeapBytes evacuation protocol:

- `scan()`: push backing allocation as `OpaqueHeapBytes` so the evacuator
  calls `try_evacuate` on it.
- `scan_and_update()`: update `args.data.ptr` if `heap.forwarded_to()`
  returns a new location.

Without this, stale backing-store pointers were held after evacuation,
corrupting the heap on the next access.

### 2. IO spec-block closure stash (`io_run.rs`)

`evaluate_spec_block` calls `evaluate_to_whnf_for_io` in a loop to force
each spec-block field.  Without stashing all field closures in
`machine.stash` before the loop, a GC triggered inside `run()` could
evacuate the remaining field closures without updating their heap pointers,
leaving dangling references.

### 3. Evacuation line-marking for ZST types (`collect.rs`)

`evacuate<T>()` called `mark_line(new_obj)` to mark the new copy's lines,
using `size_of::<T>()` to determine the object size.  For ZST types such as
`OpaqueHeapBytes` (used as a sentinel for Array backing stores), this is 0:
only the single line at `new_obj` was marked.

Large backing stores (>128 bytes — e.g., the globals `EnvFrame` bindings
array, or LetRec bindings with >8 entries) span multiple lines. Lines 1..N
were left unmarked and appeared as reclaimable holes to `lazy_sweep_next()`.
New allocations placed in those holes overwrote live array data, causing
SIGSEGV when the parent object later accessed its backing store.

Fixed by replacing `mark_line(new_obj)` with `mark_lines_for_bytes(new_obj.cast::<u8>())`
which reads the actual payload size from the `AllocHeader` and marks all
spanned lines. Behaviour is identical for non-ZST types.

## Test plan

- [ ] CI: macOS aarch64 sequential test suite passes (all 120 harness tests)
- [ ] CI: macOS aarch64 isolate test 116 (io_shell_with) passes
- [ ] CI: Linux x86_64 tests pass
- [ ] `EU_GC_STRESS=1 cargo test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)