### PR TITLE
feat(errors): add block-operation hints for get, items, assoc, and dissoc

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -205,8 +205,14 @@ impl CompileError {
                     }
                     "index" | "get" | "at" => {
                         notes.push(
-                            "to index into a list, use 'nth', e.g. 'xs nth(0)' for \
+                            "to index into a list by position, use 'nth', e.g. 'xs nth(0)' for \
                              the first element, or the '!!' operator: 'xs !! 0'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to look up a key in a block (record), use dot notation: \
+                             'block.key', or 'lookup-or(:key, default, block)' for a \
+                             safe lookup with a fallback"
                                 .to_string(),
                         );
                     }
@@ -387,6 +393,37 @@ impl CompileError {
                             "eucalypt uses kebab-case: 'sort-by' (for general ordering) or \
                              'sort-by-num' (for numeric keys), e.g. \
                              'xs sort-by-num(.score)'"
+                                .to_string(),
+                        );
+                    }
+                    // Python dict.items() — list of [key, value] pairs from a block.
+                    // Eucalypt's equivalent is 'pairs'.
+                    "items" | "entries" => {
+                        notes.push(
+                            "to get a list of key-value pairs from a block, use 'pairs', \
+                             e.g. 'block pairs' returns [[k1, v1], [k2, v2], ...]"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to get just the keys use 'keys'; to get just the values use 'values'"
+                                .to_string(),
+                        );
+                    }
+                    // Clojure assoc / dissoc for updating blocks.
+                    // Eucalypt uses merge to add/update keys, and has no built-in dissoc.
+                    "assoc" | "assoc-in" => {
+                        notes.push(
+                            "eucalypt has no 'assoc'; to add or update a key in a block, \
+                             merge with a new block: 'original merge({key: new_value})'"
+                                .to_string(),
+                        );
+                    }
+                    "dissoc" | "delete" | "remove-key" | "without" => {
+                        notes.push(
+                            "eucalypt has no built-in 'dissoc'/'delete' for removing block keys; \
+                             rebuild the block selecting only the keys you want, \
+                             or use 'pairs' to filter: \
+                             'block pairs filter(.head != :key-to-remove) block-of-pairs'"
                                 .to_string(),
                         );
                     }


### PR DESCRIPTION
## Error message: block/dict operation idioms from other languages

### Scenario
Users coming from Python, Clojure, or JavaScript write block operations using idioms that don't exist in eucalypt, and get a bare "unresolved variable" error with no guidance.

Four patterns addressed:

1. `config get(:host)` — Python dict `.get()` style key lookup
2. `config items` — Python `dict.items()` for key-value pairs
3. `assoc(config, :key, val)` — Clojure-style block update
4. `dissoc(config, :key)` / `delete(config, :key)` — key removal

### Before

**`get`:**
```
error: unresolved variable 'get'
  = check that the variable is defined and in scope
  = to index into a list, use 'nth', e.g. 'xs nth(0)' for the first element, or the '!!' operator: 'xs !! 0'
```
(mentions list indexing only — user was trying to look up a block key)

**`items`:**
```
error: unresolved variable 'items'
  = check that the variable is defined and in scope
```
(no guidance at all)

**`assoc`:**
```
error: unresolved variable 'assoc'
  = check that the variable is defined and in scope
```
(no guidance at all)

### After

**`get`:**
```
error: unresolved variable 'get'
  = check that the variable is defined and in scope
  = to index into a list by position, use 'nth', e.g. 'xs nth(0)' for the first element, or the '!!' operator: 'xs !! 0'
  = to look up a key in a block (record), use dot notation: 'block.key', or 'lookup-or(:key, default, block)' for a safe lookup with a fallback
```

**`items`:**
```
error: unresolved variable 'items'
  = check that the variable is defined and in scope
  = to get a list of key-value pairs from a block, use 'pairs', e.g. 'block pairs' returns [[k1, v1], [k2, v2], ...]
  = to get just the keys use 'keys'; to get just the values use 'values'
```

**`assoc`:**
```
error: unresolved variable 'assoc'
  = check that the variable is defined and in scope
  = eucalypt has no 'assoc'; to add or update a key in a block, merge with a new block: 'original merge({key: new_value})'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Extended the `FreeVar` keyword-hint match in `src/eval/stg/compiler.rs`:
- `"index" | "get" | "at"`: added a second note about block key lookup
- Added `"items" | "entries"`: → `pairs`, `keys`, `values`
- Added `"assoc" | "assoc-in"`: → `merge({key: val})`
- Added `"dissoc" | "delete" | "remove-key" | "without"`: → pairs/filter pattern

### Risks
Low. Purely additive; only adds extra notes to existing free-variable errors. No new error conditions. All 90 error harness tests pass; clippy clean.