### PR TITLE
fix(errors): add contextual notes when list or block used in comparison

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -687,6 +687,23 @@ impl ExecutionError {
             ExecutionError::LookupFailure(_, key, suggestions) => {
                 lookup_failure_notes(key, suggestions)
             }
+            ExecutionError::NotValue(_, context) => {
+                if context == "a data constructor (e.g. block or list)" {
+                    vec![
+                        "comparison operators (<, >, <=, >=) and arithmetic work on scalar \
+                         values (numbers, strings, symbols), not on lists or blocks"
+                            .to_string(),
+                        "to compare lists element-wise, compare specific elements: \
+                         'xs head < ys head'"
+                            .to_string(),
+                        "to check if all elements of a list satisfy a condition, use 'all', \
+                         e.g. 'xs all(_ > 0)'"
+                            .to_string(),
+                    ]
+                } else {
+                    vec![]
+                }
+            }
             ExecutionError::CannotReturnFunToCase(_, expected_tags) => {
                 let expects_bool = expected_tags.contains(&DataConstructor::BoolTrue.tag())
                     || expected_tags.contains(&DataConstructor::BoolFalse.tag());


### PR DESCRIPTION
## Error message: list or block used in comparison operator

### Scenario
Users with a background in Python or Haskell (where list comparison is defined element-wise) try to write `xs < ys` or `block_a < block_b`, or accidentally pass a list where a scalar is expected in a comparison.

```eu
xs: [1, 2, 3]
ys: [1, 2, 4]
result: xs < ys   # fails — < is not defined on lists
```

### Before
```
error: expected a value but found a data constructor (e.g. block or list)
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
```
(no guidance on what to do instead)

### After
```
error: expected a value but found a data constructor (e.g. block or list)
  help: this can occur when a function or structured value appears where a primitive (number, string, etc.) was expected
  note: comparison operators (<, >, <=, >=) and arithmetic work on scalar values (numbers, strings, symbols), not on lists or blocks
  note: to compare lists element-wise, compare specific elements: 'xs head < ys head'
  note: to check if all elements of a list satisfy a condition, use 'all', e.g. 'xs all(_ > 0)'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added a `NotValue` case in `to_diagnostic()` in `src/eval/error.rs`. When the context is `"a data constructor (e.g. block or list)"`, three notes are appended explaining:
1. That comparison and arithmetic require scalars
2. How to compare list elements individually
3. How to test list elements with `all`

### Risks
Low. The `"a data constructor (e.g. block or list)"` context string is generated at a fixed point in `vm.rs` and is very specific. Notes only fire for this exact context; other `NotValue` contexts (function application, let binding, etc.) are unaffected. All 90 error harness tests pass; clippy clean.