### PR TITLE
fix(errors): add predicate-type mismatch notes for filter/all/any/if

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -63,6 +63,28 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
              symbols are written with a leading colon"
                 .to_string(),
         ],
+        (Bool, Number) => vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a number"
+                .to_string(),
+            "to make a predicate, compare the value: e.g. use '(_ > 0)' instead of \
+             '(_ * 2)' in a filter"
+                .to_string(),
+        ],
+        (Bool, String) => vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a string"
+                .to_string(),
+            "to make a predicate, compare or test the value: \
+             e.g. use '(str.len > 3)' or 'str.matches?(\"pattern\")' in a filter"
+                .to_string(),
+        ],
+        (Bool, List(_)) => vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a list"
+                .to_string(),
+            "to test list membership, use 'any', e.g. 'xs any(42 = _)'".to_string(),
+        ],
         _ => vec![],
     }
 }
@@ -79,6 +101,8 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
     let expects_number = expected.contains(&DataConstructor::BoxedNumber.tag());
     let expects_string = expected.contains(&DataConstructor::BoxedString.tag());
     let expects_symbol = expected.contains(&DataConstructor::BoxedSymbol.tag());
+    let expects_bool = expected.contains(&DataConstructor::BoolTrue.tag())
+        || expected.contains(&DataConstructor::BoolFalse.tag());
 
     if is_list && expects_block {
         vec![
@@ -144,6 +168,42 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
             "a symbol (`:name`) was found where a string was expected".to_string(),
             "to convert a symbol to a string, use 'str.of', e.g. `str.of(:name)` \
              gives the string `\"name\"`"
+                .to_string(),
+        ]
+    } else if is_number && expects_bool {
+        vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a number"
+                .to_string(),
+            "to make a predicate from a number, compare it: e.g. use '(_ > 0)' instead \
+             of '(_ * 2)' in a filter call"
+                .to_string(),
+        ]
+    } else if is_string && expects_bool {
+        vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a string"
+                .to_string(),
+            "to make a predicate from a string, test it: e.g. use 'str.matches?(\"pat\")' \
+             or '(str.len > 0)' in a filter call"
+                .to_string(),
+        ]
+    } else if is_list && expects_bool {
+        vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a list"
+                .to_string(),
+            "to check if a list is non-empty use 'non-nil?'; \
+             to check if a value is in a list use 'any', e.g. 'xs any(42 = _)'"
+                .to_string(),
+        ]
+    } else if is_block && expects_bool {
+        vec![
+            "functions like 'filter', 'all', 'any', and 'if' expect a predicate that \
+             returns true or false — the function you passed returns a block"
+                .to_string(),
+            "to test a block field, extract it first: e.g. 'filter(.active)' \
+             selects elements where the 'active' field is true"
                 .to_string(),
         ]
     } else {


### PR DESCRIPTION
## Error message: non-boolean predicate passed to filter/all/any/if

### Scenario
A common mistake is passing a transforming function (e.g. `(_ * 2)`) where a predicate (returning boolean) is needed.

```eu
xs: [1, 2, 3, 4, 5]
result: xs filter(_ * 2)   # mistake — returns number, not bool
```

Also covers:
- `xs filter(str.of)` — predicate returns string
- `if(42, "yes", "no")` — condition is a number
- `xs filter(some-fn-returning-a-list)`

### Before
```
error: type mismatch: expected true or false, found number
  = in if
```
(no guidance on how to fix)

### After
```
error: type mismatch: expected true or false, found number
  = in if
  = functions like 'filter', 'all', 'any', and 'if' expect a predicate that returns true or false — the function you passed returns a number
  = to make a predicate from a number, compare it: e.g. use '(_ > 0)' instead of '(_ * 2)' in a filter call
```

For string predicates:
```
error: type mismatch: expected true or false, found string
  = in if
  = functions like 'filter', 'all', 'any', and 'if' expect a predicate that returns true or false — the function you passed returns a string
  = to make a predicate from a string, test it: e.g. use 'str.matches?("pat")' or '(str.len > 0)' in a filter call
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added `expects_bool` flag to `data_tag_mismatch_notes()` and four new branches:
- `is_number && expects_bool` → compare the number
- `is_string && expects_bool` → test the string
- `is_list && expects_bool` → use `non-nil?` or `any`
- `is_block && expects_bool` → extract and test a field

Also added matching arms to `type_mismatch_notes()` for the `IntrinsicType` path (`Bool, Number`), (`Bool, String`), (`Bool, List(_)`).

### Risks
Low. The `expects_bool` flag only fires when `BoolTrue` or `BoolFalse` are in the expected tags — which is only for `if`/`cond`-style case discrimination. All 90 error harness tests pass; clippy clean.