### PR TITLE
feat(errors): add hints for Option/Maybe, unwrap, enumerate, and type constructors

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -390,6 +390,68 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Rust/Haskell Option type constructors.
+                    // Eucalypt has no Option/Maybe type; use null for absence.
+                    "Some" | "Just" => {
+                        notes.push(
+                            "eucalypt has no Option/Maybe type; use 'null' for absent values \
+                             and 'nil?' to test for null"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to provide a fallback for a nullable value, use \
+                             'if(x nil?, default, x)' or define a helper"
+                                .to_string(),
+                        );
+                    }
+                    "Nothing" => {
+                        notes.push(
+                            "eucalypt uses 'null' for the absent/nothing value, not 'Nothing'"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to test for null, use 'nil?', e.g. 'x nil?' returns true if x is null"
+                                .to_string(),
+                        );
+                    }
+                    // Rust Result unwrapping idioms.
+                    // Eucalypt has no Result type; errors are reported as execution errors.
+                    "unwrap" | "unwrap_or" | "expect" | "ok_or" => {
+                        notes.push(
+                            "eucalypt has no Result/Option type or 'unwrap'; values are \
+                             directly available or null"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to safely access a potentially null value with a fallback, \
+                             use 'if(x nil?, fallback, x)' or 'lookup-or(:key, default, block)'"
+                                .to_string(),
+                        );
+                    }
+                    // Python enumerate() — pair each element with its index.
+                    // Eucalypt equivalent: zip with iota.
+                    "enumerate" => {
+                        notes.push(
+                            "eucalypt has no 'enumerate'; to pair each element with its index, \
+                             use 'zip(range(0, xs count), xs)', which gives \
+                             [[0, x0], [1, x1], ...]"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "to process each pair, define a named function: \
+                             'process[i, x]: ...' and then 'zipped map(process)'"
+                                .to_string(),
+                        );
+                    }
+                    // Python/JS type constructors — not needed in eucalypt.
+                    "tuple" | "dict" | "HashMap" | "ArrayList" => {
+                        notes.push(
+                            "eucalypt has no type constructors like 'tuple()' or 'dict()'; \
+                             write literals directly: '[1, 2, 3]' for a list, \
+                             '{key: value}' for a block (dict/record)"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)


### PR DESCRIPTION
## Error message: Rust/Haskell/Python idioms with no eucalypt equivalent

### Scenario
Users coming from Rust, Haskell, or Python write code using idioms that don't exist in eucalypt and get a bare "unresolved variable" error with no guidance.

Five patterns addressed:

1. `Some(42)` / `Just(42)` — Rust/Haskell Option constructors
2. `Nothing` — Haskell Nothing (Note: `None` already handled by a prior commit)
3. `unwrap` / `unwrap_or` / `expect` / `ok_or` — Rust Result/Option unwrapping
4. `enumerate` — Python `enumerate()` for index-value pairs
5. `tuple(...)` / `dict(...)` / `HashMap` — Python/Java type constructors

### Before
```
error: unresolved variable 'Some'
  = check that the variable is defined and in scope

error: unresolved variable 'unwrap'
  = check that the variable is defined and in scope

error: unresolved variable 'enumerate'
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable 'Some'
  = check that the variable is defined and in scope
  = eucalypt has no Option/Maybe type; use 'null' for absent values and 'nil?' to test for null
  = to provide a fallback for a nullable value, use 'if(x nil?, default, x)' or define a helper

error: unresolved variable 'unwrap'
  = check that the variable is defined and in scope
  = eucalypt has no Result/Option type or 'unwrap'; values are directly available or null
  = to safely access a potentially null value with a fallback, use 'if(x nil?, fallback, x)' or 'lookup-or(:key, default, block)'

error: unresolved variable 'enumerate'
  = check that the variable is defined and in scope
  = eucalypt has no 'enumerate'; to pair each element with its index, use 'zip(range(0, xs count), xs)', which gives [[0, x0], [1, x1], ...]
  = to process each pair, define a named function: 'process[i, x]: ...' and then 'zipped map(process)'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added five new match arms to the `FreeVar` keyword-hint block in `src/eval/stg/compiler.rs`.

### Risks
Low. Purely additive; only adds extra notes to unresolved-variable errors. No new error conditions. `"Some"` and `"Just"` are CamelCase so they won't clash with typical eucalypt bindings. All 90 error harness tests pass; clippy clean.