### PR TITLE
feat(errors): add hints for scan, fold variants, pipe operator, and null-coalescing

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -390,6 +390,53 @@ impl CompileError {
                                 .to_string(),
                         );
                     }
+                    // Various names for scanl (running/prefix accumulation).
+                    // Python itertools.accumulate, Haskell scanl, Rust scan.
+                    "scan" | "accumulate" | "prefix-sum" | "prefix_sum" | "running-total"
+                    | "running_total" => {
+                        notes.push(
+                            "eucalypt uses 'scanl' for running accumulation, e.g. \
+                             'xs scanl(+, 0)' for a running sum"
+                                .to_string(),
+                        );
+                    }
+                    // Alternative names for foldl/foldr not already matched above.
+                    "foldl1" | "fold_left" | "fold_right" | "reduceLeft" | "reduceRight"
+                    | "inject" => {
+                        notes.push(
+                            "eucalypt has 'foldl(op, init, list)' (left fold) and \
+                             'foldr(op, init, list)' (right fold)"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "'reduce(op, list)' is also available and uses 'head' as the \
+                             initial value — equivalent to 'foldl1' in Haskell"
+                                .to_string(),
+                        );
+                    }
+                    // Pipe operator from Elixir, F#, Haskell (|>).
+                    // Eucalypt uses juxtaposition (catenation) for the same purpose.
+                    "|>" | "|>>" | ">>>" | "<<" => {
+                        notes.push(
+                            "eucalypt has no pipe operator '|>'; use juxtaposition instead: \
+                             'x double inc' is equivalent to 'x |> double |> inc' in Elixir"
+                                .to_string(),
+                        );
+                        notes.push(
+                            "catenation (juxtaposition) has low precedence (20) — \
+                             if combining with operators, use parentheses: '(x double) + 1'"
+                                .to_string(),
+                        );
+                    }
+                    // Null-coalescing operator from C#/JS (?? / ?:).
+                    // Eucalypt uses if(x nil?, default, x).
+                    "??" | "?:" => {
+                        notes.push(
+                            "eucalypt has no null-coalescing operator '??'; use \
+                             'if(x nil?, default, x)' or 'lookup-or(:key, default, block)'"
+                                .to_string(),
+                        );
+                    }
                     _ => {}
                 }
                 diag.with_notes(notes)


### PR DESCRIPTION
## Error message: scan/fold/pipe/null-coalescing idioms from other languages

### Scenario
Four more cross-language idiom patterns that produce bare "unresolved variable" errors without guidance.

### Before
```
error: unresolved variable 'scan'
  = check that the variable is defined and in scope

error: unresolved variable '|>'
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable 'scan'
  = check that the variable is defined and in scope
  = eucalypt uses 'scanl' for running accumulation, e.g. 'xs scanl(+, 0)' for a running sum

error: unresolved variable '|>'
  = check that the variable is defined and in scope
  = eucalypt has no pipe operator '|>'; use juxtaposition instead: 'x double inc' is equivalent to 'x |> double |> inc' in Elixir
  = catenation (juxtaposition) has low precedence (20) — if combining with operators, use parentheses: '(x double) + 1'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added four new match arms to the `FreeVar` keyword-hint block in `src/eval/stg/compiler.rs`:
- `"scan"` / `"accumulate"` / `"prefix-sum"` / ... → `'scanl'`
- `"foldl1"` / `"fold_left"` / `"reduceLeft"` / `"inject"` → `'foldl'` / `'reduce'`
- `"|>"` / `"|>>"` / `">>>"` → juxtaposition (with precedence warning)
- `"??"` / `"?:"` → `if(x nil?, default, x)`

Note: `"foldLeft"` and `"foldRight"` are already handled by an existing arm (line 147); this PR adds the remaining variants not already covered.

### Risks
Low. Purely additive. All 90 error harness tests pass; clippy clean.