### PR TITLE
fix(errors): improve symbol-vs-string mismatch note to cover non-key contexts

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -58,9 +58,12 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
             "to concatenate two lists, use 'append(xs, ys)' or the '++' operator".to_string(),
         ],
         (Symbol, String) => vec![
-            "eucalypt uses symbol literals (`:name`) not strings for key names".to_string(),
-            "for example, use `has(:x)` instead of `has(\"x\")`; \
-             symbols are written with a leading colon"
+            "a symbol was expected but a string was passed; \
+             add a colon prefix to make it a symbol: ':yaml' not \"yaml\", \
+             ':key' not \"key\""
+                .to_string(),
+            "symbols (`:name`) and strings (`\"name\"`) are distinct in eucalypt; \
+             functions like 'render-as', 'has', 'lookup-or' take symbol arguments"
                 .to_string(),
         ],
         _ => vec![],
@@ -134,9 +137,11 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
         vec!["to convert a number to a string, use 'str' or string interpolation".to_string()]
     } else if is_string && expects_symbol {
         vec![
-            "eucalypt uses symbol literals (`:name`) not strings for key names".to_string(),
-            "for example, use `has(:x)` instead of `has(\"x\")`; \
-             symbols are written with a leading colon"
+            "a symbol was expected but a string was passed; \
+             add a colon prefix: ':yaml' not \"yaml\", ':key' not \"key\""
+                .to_string(),
+            "symbols (`:name`) and strings (`\"name\"`) are distinct in eucalypt; \
+             functions like 'render-as', 'has', 'lookup-or' take symbol arguments"
                 .to_string(),
         ]
     } else if is_symbol && expects_string {

--- a/tests/harness/errors/064_has_string_not_sym.eu.expect
+++ b/tests/harness/errors/064_has_string_not_sym.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "symbol literals"
+stderr: "symbol"


### PR DESCRIPTION
## Error message: string passed where symbol expected (render-as, has, lookup-or)

### Scenario
Users write `render-as(x, "yaml")` or `has("key")` and get a type mismatch with a note that says "eucalypt uses symbol literals for **key names**". But `render-as` has nothing to do with key names — the user just needs a colon prefix.

```eu
x: {name: "Alice"}
result: render-as(x, "yaml")  # should be render-as(x, :yaml)
```

### Before
```
error: type mismatch: expected symbol, found string
  = in render-as
  = eucalypt uses symbol literals (`:name`) not strings for key names
  = for example, use `has(:x)` instead of `has("x")`; symbols are written with a leading colon
```
(note is confusing — says "key names" but this is a format specifier)

### After
```
error: type mismatch: expected symbol, found string
  = in render-as
  = a symbol was expected but a string was passed; add a colon prefix: ':yaml' not "yaml", ':key' not "key"
  = symbols (`:name`) and strings (`"name"`) are distinct in eucalypt; functions like 'render-as', 'has', 'lookup-or' take symbol arguments
```

The new note is accurate for ALL (Symbol, String) mismatches — whether from `has("key")`, `render-as(x, "yaml")`, `parse-as(x, "json")`, or similar.

### Assessment
- Human diagnosability: fair → good (less misleading context)
- LLM diagnosability: good → excellent (concrete fix: add colon prefix)

### Change
- Updated `type_mismatch_notes(Symbol, String)` in `src/eval/error.rs`
- Updated `data_tag_mismatch_notes` `is_string && expects_symbol` arm
- Updated test 064 expect sidecar: regex narrowed from `"symbol literals"` to `"symbol"`

### Risks
Low. The change is to error message wording only. One test sidecar updated intentionally (regex `"symbol literals"` → `"symbol"`). All 90 error harness tests pass; clippy clean.