### PR TITLE
fix(errors): add string-characters hint to list-operation-on-string error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -657,6 +657,13 @@ impl ExecutionError {
                          or 'join-on' on a list of strings; '++' is for list append"
                             .to_string(),
                     );
+                    notes.push(
+                        "note: to work with individual characters of a string, use \
+                         'str.letters' to get a list of characters, then apply list \
+                         operations; e.g. 'text str.letters take(5) str.join-on(\"\")' \
+                         for the first 5 characters"
+                            .to_string(),
+                    );
                 } else {
                     notes.push(
                         "check that the value is a list before applying list operations; \


### PR DESCRIPTION
## Error message: list operation applied to a string

### Scenario
Users coming from Python expect `s.take(5)` or `s[:5]` style string slicing; they write `s take(5)` or similar and get a confusing error.

```eu
s: "hello world"
first5: s take(5)   # mistake — take works on lists, not strings
```

### Before
```
error: type mismatch: received a string where a structured value (block or list) was expected
  = in head
  = list operations such as 'head', 'tail', '++', 'map', 'filter' require list arguments
  = if you called 'head' or 'tail' on an empty list...
  = guard against empty lists with 'nil?'...
  = note: to concatenate strings, use string interpolation or 'join-on'...
```
(no hint about how to actually work with string characters)

### After
(same as before, plus:)
```
  = note: to work with individual characters of a string, use 'str.letters' to get a list of characters, then apply list operations; e.g. 'text str.letters take(5) str.join-on("")' for the first 5 characters
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → excellent (concrete correct approach shown)

### Change
Added a fifth note to the `NoBranchForNative("string")` handler in `to_diagnostic()` in `src/eval/error.rs`, explaining `str.letters` + list ops + `str.join-on`.

### Risks
Low. Purely additive note. All 90 error harness tests pass; clippy clean.