### PR TITLE
fix(errors): improve list-not-callable notes with !! operator and slice guidance

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -332,9 +332,11 @@ fn not_callable_notes(actual_type: &str) -> Vec<String> {
     match actual_type {
         "list" => vec![
             "lists are not callable; to access elements by index use 'nth(index, list)' \
-             or pipeline form 'list nth(index)'"
+             or the shorthand '!!' operator: 'xs !! 0' for the first element"
                 .to_string(),
-            "for the first element use 'list head'; for the rest use 'list tail'".to_string(),
+            "for the first element use 'xs head'; for the last use 'xs reverse head'; \
+             for a slice use 'xs drop(n) take(m)'"
+                .to_string(),
         ],
         "true" | "false" => vec![
             format!(


### PR DESCRIPTION
## Error message: list used as function (index access)

### Scenario
User writes `xs(0)` attempting to index into a list `xs: [10, 20, 30]`, treating it like a function call. This is a common idiom from Python/JavaScript.

### Before
```
= lists are not callable; to access elements by index use 'nth(index, list)' or pipeline form 'list nth(index)'
= for the first element use 'list head'; for the rest use 'list tail'
```

### After
```
= lists are not callable; to access elements by index use 'nth(index, list)' or the shorthand '!!' operator: 'xs !! 0' for the first element
= for the first element use 'xs head'; for the last use 'xs reverse head'; for a slice use 'xs drop(n) take(m)'
```

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: fair → good

### Change
Updated the `"list"` arm in `not_callable_notes()` in `src/eval/error.rs`:
- Added the `!!` infix operator as the primary shorthand (it is idiomatic eucalypt, whereas `nth` is more verbose)
- Replaced "for the rest use 'list tail'" with "for the last use 'xs reverse head'; for a slice use 'xs drop(n) take(m)'"

### Risks
Low. Only changes hint text for an existing error variant. All 90 error tests pass; no clippy warnings.