### PR TITLE
fix(errors): add missing-list-comma hint to string-not-callable error

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -345,7 +345,19 @@ fn not_callable_notes(actual_type: &str) -> Vec<String> {
              use '&&' and '||' for logical conjunction and disjunction"
                 .to_string(),
         ],
-        "number" | "string" | "symbol" | "datetime" | "empty list" => vec![
+        "string" => vec![
+            "a string value is not a function; check for a missing operator or \
+             extra argument"
+                .to_string(),
+            "note: catenation (juxtaposition) has low precedence — 'f(a) + 1' binds as \
+             'f(a + 1)'; add parentheses to disambiguate"
+                .to_string(),
+            "if this is inside a list literal '[...]', you may be missing commas between \
+             items — eucalypt lists require commas: '[\"a\", \"b\", \"c\"]' not \
+             '[\"a\" \"b\" \"c\"]'"
+                .to_string(),
+        ],
+        "number" | "symbol" | "datetime" | "empty list" => vec![
             format!(
                 "a {actual_type} value is not a function; check for a missing operator or \
                  extra argument"


### PR DESCRIPTION
## Error message: string called as function (missing list commas)

### Scenario
User writes a list literal with elements on separate lines but forgets commas —
a common mistake from Python/Ruby multi-line arrays:

```eu
items: [
  "apple"
  "banana"
  "cherry"
]
```

### Before
```
= a string value is not a function; check for a missing operator or extra argument
= note: catenation (juxtaposition) has low precedence — 'f(a) + 1' binds as 'f(a + 1)'; add parentheses to disambiguate
```

### After
```
= a string value is not a function; check for a missing operator or extra argument
= note: catenation (juxtaposition) has low precedence — 'f(a) + 1' binds as 'f(a + 1)'; add parentheses to disambiguate
= if this is inside a list literal '[...]', you may be missing commas between items — eucalypt lists require commas: '["a", "b", "c"]' not '["a" "b" "c"]'
```

### Assessment
- Human diagnosability: fair → good (the new note gives the likely fix immediately)
- LLM diagnosability: fair → excellent (direct pointer to the missing-comma idiom)

### Change
Split the `"number" | "string" | ...` arm in `not_callable_notes()` into a
separate `"string"` arm that appends the list-comma hint, keeping the existing
notes for the other scalar types unchanged.

### Risks
Low. The hint fires for all string-not-callable errors, including legitimate
catenation-precedence bugs. The note is clearly phrased as conditional
("if this is inside a list literal") so it is not misleading when the root
cause is something else. All 90 error tests pass; no clippy warnings.