### PR TITLE
fix(errors): add missing-colon hint when operator appears as free variable

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -103,6 +103,30 @@ impl CompileError {
                             .to_string(),
                     );
                 }
+                // If the free variable name is a bare operator symbol (*, /, +, -,
+                // %, ^, <, >, !, |, &), it probably means a colon was omitted
+                // from the preceding declaration.  For example:
+                //   double(n) n * 2   ← missing ':' after double(n)
+                // The parser then sees 'n' as the declaration value and '* 2'
+                // as a subsequent expression, making '*' a free variable.
+                if name.chars().all(|c| {
+                    matches!(
+                        c,
+                        '*' | '/' | '+' | '-' | '%' | '^' | '<' | '>' | '!' | '|' | '&'
+                    )
+                }) && !name.starts_with("//")
+                {
+                    notes.push(
+                        "note: an operator appearing as a free variable often means a \
+                         ':' is missing from the preceding declaration"
+                            .to_string(),
+                    );
+                    notes.push(
+                        "hint: function declarations require a colon before the body: \
+                         'f(x): x * 2' not 'f(x) x * 2'"
+                            .to_string(),
+                    );
+                }
                 // Suggest eucalypt equivalents for common operators from other
                 // languages.
                 if name == "==" {


### PR DESCRIPTION
## Error message: operator as free variable — missing declaration colon

### Scenario
A common mistake when writing eucalypt function declarations is omitting
the `:` between the parameter list and the body:

```
double(n) n * 2   ← should be: double(n): n * 2
```

The parser treats `n` as the declaration value and `* 2` as a subsequent
bare expression, making `*` a free variable.

### Before
```
error: unresolved variable '*'
  ┌─ test.eu:2:13
  │
2 │ double(n) n * 2
  │             ^
  │
  = check that the variable is defined and in scope
```

### After
```
error: unresolved variable '*'
  ┌─ test.eu:2:13
  │
2 │ double(n) n * 2
  │             ^
  │
  = check that the variable is defined and in scope
  = note: an operator appearing as a free variable often means a ':' is missing from the preceding declaration
  = hint: function declarations require a colon before the body: 'f(x): x * 2' not 'f(x) x * 2'
```

### Assessment
- Human diagnosability: poor → good
- LLM diagnosability: fair → excellent

### Change
Added a check in `compiler.rs FreeVar::to_diagnostic()`: when the free
variable name consists entirely of operator characters
(`* / + - % ^ < > ! | &`), add a note about the missing colon and a
hint showing the correct syntax. The guard `!name.starts_with("//")` avoids
false positives for the assertion operator `//=`.

### Risks
The operator-character check could theoretically match user-defined
operators with those characters, but eucalypt does not allow user-defined
operators — so any such name genuinely is unexpected and the hint is
appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)