### PR TITLE
fix(errors): add map(.field) hint when dot notation used on list of blocks

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -19,6 +19,9 @@ fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<
             "for lists, use the index operator for indexing (e.g. xs index 0) or \
              pipeline functions like 'head', 'nth'"
                 .to_string(),
+            "to extract a field from every item in a list of blocks, \
+             use 'map', e.g. 'records map(.name)' or 'map(.name, records)'"
+                .to_string(),
         ],
         (Record(_), Number) => vec![
             "the '.' operator performs key lookup on blocks; \
@@ -85,6 +88,9 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
             "the '.' operator performs key lookup on blocks, not lists".to_string(),
             "for lists, use the index operator for indexing (e.g. xs index 0) or \
              pipeline functions like 'head', 'nth'"
+                .to_string(),
+            "to extract a field from every item in a list of blocks, \
+             use 'map', e.g. 'records map(.name)' or 'map(.name, records)'"
                 .to_string(),
         ]
     } else if is_list && expects_number {


### PR DESCRIPTION
## Error message: dot notation on list of blocks

### Scenario
When a user writes \`records.name\` where \`records\` is a list of blocks,
they likely intend to extract the \`name\` field from every block — a
natural expectation coming from languages like JavaScript (\`records.map(r => r.name)\`).
The previous error gave no hint of the \`map\` approach.

### Before
\`\`\`
error: type mismatch: expected block, found list
  ┌─ test.eu:6:9
  │
6 │ result: records.name
  │         ^^^^^^^
  │
  = the '.' operator performs key lookup on blocks, not lists
  = for lists, use the index operator for indexing (e.g. xs index 0) or pipeline functions like 'head', 'nth'
\`\`\`

### After
\`\`\`
error: type mismatch: expected block, found list
  ┌─ test.eu:6:9
  │
6 │ result: records.name
  │         ^^^^^^^
  │
  = the '.' operator performs key lookup on blocks, not lists
  = for lists, use the index operator for indexing (e.g. xs index 0) or pipeline functions like 'head', 'nth'
  = to extract a field from every item in a list of blocks, use 'map', e.g. 'records map(.name)' or 'map(.name, records)'
\`\`\`

### Assessment
- Human diagnosability: fair → good
- LLM diagnosability: good → excellent

### Change
Added the map hint to both code paths that fire for this scenario:
- `data_tag_mismatch_notes` (is_list && expects_block) — NoBranchForDataTag path
- `type_mismatch_notes` ((Record(_), List(_))) — TypeMismatch path

### Risks
None — purely additive note on an existing error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)