### PR TITLE
fix(errors): add source location to merge/catenation type errors

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -787,6 +787,12 @@ impl MachineState {
                         let mut args = Array::from_slice(&view, args.as_slice());
                         args.push(&view, self.closure.clone());
                         self.push(view, Continuation::ApplyTo { args, annotation })?;
+                        // Restore the application-site annotation so that any
+                        // type-mismatch errors raised inside the MERGE wrapper
+                        // (e.g. NoBranchForDataTag when a non-block is merged)
+                        // carry the user's source location rather than a
+                        // synthetic intrinsic label.
+                        self.annotation = annotation;
                         self.closure = SynClosure::new(
                             view.atom(Ref::G(
                                 intrinsics::index("MERGE")

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1118,7 +1118,11 @@ impl StgIntrinsic for Merge {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             2, // [l r]
             switch(
                 local(0),
@@ -1151,7 +1155,6 @@ impl StgIntrinsic for Merge {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 
@@ -1222,7 +1225,11 @@ impl StgIntrinsic for MergeWith {
             ),
         );
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             3, // [l r f]
             switch(
                 local(0),
@@ -1255,7 +1262,6 @@ impl StgIntrinsic for MergeWith {
                     ),
                 )],
             ),
-            annotation,
         )
     }
 
@@ -1322,7 +1328,11 @@ impl StgIntrinsic for DeepMerge {
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        annotated_lambda(
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
             2,
             case(
                 local(0),
@@ -1343,7 +1353,6 @@ impl StgIntrinsic for DeepMerge {
                 // [l] [l r]
                 local(2),
             ),
-            annotation,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Remove `annotated_lambda` from Merge/MergeWith/DeepMerge wrappers so call-site source locations propagate through to error messages

## Context
Originally PR #441, merged by wicket without authorisation during CI freeze. Reverted and re-created for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)