### PR TITLE
fix(errors): replace Panic with ParseError variant for parse-as failures

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -637,6 +637,8 @@ pub enum ExecutionError {
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
+    #[error("parse-as({1}): {2}")]
+    ParseError(Smid, String, String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
@@ -704,6 +706,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -66,7 +66,13 @@ impl StgIntrinsic for ParseString {
 
         let core_expr =
             import::read_to_core_data_only(&format_name, &mut files, &mut source_map, file_id)
-                .map_err(|e| ExecutionError::Panic(format!("parse-as({format_name}): {e}")))?;
+                .map_err(|e| {
+                    ExecutionError::ParseError(
+                        machine.annotation(),
+                        format_name.clone(),
+                        e.to_string(),
+                    )
+                })?;
 
         // Compile the data-only RcExpr to STG.
         // We use an empty intrinsics list because data-only expressions


### PR DESCRIPTION
## Summary
- Add `ParseError` variant to `ExecutionError` for parse-as failures instead of using generic `Panic`

## Context
Originally PR #445, merged by wicket without authorisation during CI freeze. Reverted and re-created for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)