### PR TITLE
fix(errors): replace Panic with VersionRequirementFailed for eu.requires

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -639,6 +639,8 @@ pub enum ExecutionError {
     Panic(String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
+    #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
+    VersionRequirementFailed(Smid, String, String),
     #[error("assertion failed: expected {2}, got {1}")]
     AssertionFailed(Smid, String, String),
     #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]
@@ -709,6 +711,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
+            ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::BitshiftRangeError(s, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -44,9 +44,11 @@ impl StgIntrinsic for Requires {
         if req.matches(&version) {
             machine_return_unit(machine, view)
         } else {
-            Err(ExecutionError::Panic(format!(
-                "eucalypt version {version} does not satisfy requirement {constraint_str}"
-            )))
+            Err(ExecutionError::VersionRequirementFailed(
+                machine.annotation(),
+                version.to_string(),
+                constraint_str,
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `VersionRequirementFailed` variant to `ExecutionError` with source location tracking
- Use it in `Requires` intrinsic instead of generic `Panic`

## Context
Originally PR #446, merged by wicket without authorisation during CI freeze. Reverted and re-created for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)