### PR TITLE
fix(errors): replace Panic with AssertionFailed for assertion failures

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -516,6 +516,8 @@ pub enum ExecutionError {
     CannotReturnFunToCase(Smid, Vec<u8>),
     #[error("panic: {0}")]
     Panic(String),
+    #[error("assertion failed: expected {2}, got {1}")]
+    AssertionFailed(Smid, String, String),
     #[error("machine did not terminate after {0} steps")]
     DidntTerminate(usize),
     #[error("infinite loop detected: binding refers to itself")]
@@ -579,6 +581,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::AssertionFailed(s, _, _) => *s,
             ExecutionError::Compile(compile_error) => compile_error.smid(),
             _ => Smid::default(),
         }

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -156,9 +156,11 @@ impl StgIntrinsic for AssertFail {
     ) -> Result<(), ExecutionError> {
         let actual_str = format_ref(machine, view, &args[0]);
         let expected_str = format_ref(machine, view, &args[1]);
-        Err(ExecutionError::Panic(format!(
-            "assertion failed: expected {expected_str}, got {actual_str}"
-        )))
+        Err(ExecutionError::AssertionFailed(
+            machine.annotation(),
+            actual_str,
+            expected_str,
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `AssertionFailed` variant to `ExecutionError` with source location tracking
- Use it in `AssertFail` intrinsic instead of generic `Panic`

## Context
Originally PR #447, merged by wicket without authorisation during CI freeze. Reverted and re-created for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)