### PR TITLE
fix(gc): mark lines in evacuation target blocks to prevent heap corruption

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -68,6 +68,25 @@ jobs:
           python3 scripts/test-doc-examples.py --eu ./target/release/eu --timeout 30
 
 
+  test-aarch64-sequential:
+    name: Sequential harness (aarch64 release)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: aarch64-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            aarch64-cargo-registry-
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run sequential harness with release binary
+        run: target/release/eu test --allow-io tests/harness
+
   wasm:
     name: WASM Compilation Check
     runs-on: ubuntu-latest

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -84,8 +84,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Build release binary
         run: cargo build --release
-      - name: Run sequential harness with release binary
+      - name: Run sequential harness with release binary (GC stress)
         run: target/release/eu test --allow-io tests/harness
+        env:
+          EU_GC_STRESS: "1"
 
   wasm:
     name: WASM Compilation Check

--- a/.github/workflows/macos-diag.yaml
+++ b/.github/workflows/macos-diag.yaml
@@ -2,7 +2,9 @@ name: macOS SIGSEGV diagnostic
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - 'fix/furnace-*'
+      - 'test/verify-*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macos-diag.yaml
+++ b/.github/workflows/macos-diag.yaml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Experiment L: many repeats of full harness to catch low-probability crash.
-  # Previous 3-attempt runs all passed. Crash probability may be low per run.
-  # Run 10x in a single job to increase detection probability.
-  macos-repeat-10:
-    name: macOS harness x10 repeats
-    runs-on: macos-latest
+  # Sequential binary harness on aarch64 Linux — this is the exact
+  # invocation that was crashing before the evacuation line-mark fix.
+  # Run 3x to catch any low-probability recurrence.
+  aarch64-sequential-3x:
+    name: aarch64 sequential harness x3
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -19,47 +19,22 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: macos-diag-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: aarch64-diag-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            macos-diag-registry-
+            aarch64-diag-registry-
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --release --test harness_test
-      - name: Attempt 1
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 2
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 3
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 4
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 5
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 6
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 7
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 8
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 9
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 10
-        run: cargo test --release --test harness_test
-        continue-on-error: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run 1
+        run: target/release/eu test --allow-io tests/harness
+      - name: Run 2
+        run: target/release/eu test --allow-io tests/harness
+      - name: Run 3
+        run: target/release/eu test --allow-io tests/harness
 
-  # Experiment M: exact Release MacOS clone x10.
-  # The crash appears in the Release MacOS job; replicate that context.
-  macos-release-clone-repeat:
-    name: macOS Release MacOS clone x10
+  # macOS ARM sequential binary harness — also crashed before the fix.
+  macos-sequential:
+    name: macOS sequential harness
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,42 +47,7 @@ jobs:
           restore-keys: |
             macos-diag-registry-
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build and install temporary eu (as Release MacOS does)
-        run: cargo install --path .
-      - name: Regenerate build-meta.yaml (as Release MacOS does)
-        run: |
-          export OSTYPE=$(uname)
-          export HOSTTYPE=$(uname -m)
-          eu build.eu -t build-meta > build-meta.yaml.new
-          mv -f build-meta.yaml.new build-meta.yaml
-          echo "TAG_NAME=$(eu build.eu -t version)" >> $GITHUB_ENV
-      - name: Attempt 1
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 2
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 3
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 4
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 5
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 6
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 7
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 8
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 9
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 10
-        run: cargo test --release
-        continue-on-error: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run sequential harness
+        run: target/release/eu test --allow-io tests/harness

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -1288,4 +1288,122 @@ pub mod tests {
             evacuated_obj
         );
     }
+
+    /// Deterministic invariant test: after `collect_with_evacuation`, the block
+    /// that was used as the evacuation target must have at least one marked line.
+    ///
+    /// This test is designed to FAIL on the unfixed code and PASS on the fix.
+    ///
+    /// ## The invariant
+    ///
+    /// `mark_region_in_block` must search `evacuation_target` and
+    /// `filled_evacuation_blocks` so that lines containing evacuated objects
+    /// are marked.  Without this, the target block enters the block lifecycle
+    /// with zero marks and `lazy_sweep_next()` can recycle the entire block,
+    /// overwriting live evacuated data.
+    ///
+    /// ## Lifecycle of the evacuation target
+    ///
+    /// After `collect_with_evacuation` returns:
+    ///   1. `finalise_evacuation()` moves the target → `rest`
+    ///   2. `defer_sweep()` moves ALL of `rest` → `unswept`
+    ///
+    /// Therefore `rest` is always empty on return.  The former evacuation
+    /// target is in `unswept`.  The test captures `unswept` base addresses
+    /// before and after the evacuation GC pass to find the new block.
+    ///
+    /// ## Pass/fail criterion
+    ///
+    /// - **With the fix**: `mark_region_in_block` searched `evacuation_target`
+    ///   during marking, so the block's line map has >0 marked lines.
+    /// - **Without the fix**: `mark_region_in_block` silently skipped the
+    ///   evacuation target, so the block has 0 marked lines → the assertion
+    ///   fails.
+    #[test]
+    pub fn test_evacuation_target_block_has_marked_lines_after_collection() {
+        use std::collections::HashSet;
+
+        let mut heap = Heap::new();
+        let mut clock = Clock::default();
+        let mut pool = crate::eval::memory::symbol::SymbolPool::new();
+        clock.switch(ThreadOccupation::Mutator);
+
+        // Allocate enough objects to fill multiple blocks so we have rest
+        // candidates to evacuate.
+        let root_ptr = {
+            let view = MutatorHeapView::new(&heap);
+            let ids: Vec<LambdaForm> = repeat_with(|| -> LambdaForm {
+                LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default())
+            })
+            .take(512)
+            .collect();
+            let idarray = view.array(ids.as_slice());
+            view.let_(
+                idarray,
+                view.app(
+                    Ref::L(0),
+                    view.singleton(view.sym_ref(&mut pool, "root").unwrap()),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .as_ptr()
+        };
+
+        // Mark-in-place collection to settle live objects into rest blocks.
+        let mut roots = vec![root_ptr];
+        collect(&mut roots, &mut heap, &mut clock, false);
+        heap.flush_unswept();
+
+        let rest_count = heap.rest_block_count();
+        if rest_count == 0 {
+            // Nothing to evacuate — test is inconclusive, skip rather than fail.
+            return;
+        }
+
+        // Capture unswept addresses BEFORE the evacuation pass so we can
+        // identify the newly-added evacuation target block afterwards.
+        let unswept_before: HashSet<usize> = heap.unswept_block_base_addresses();
+
+        // Force evacuation of all rest blocks (indices 2..2+rest_count is a
+        // conventional way to include every block in the evacuation candidate
+        // set — the exact indices do not matter as long as all rest blocks
+        // are selected).
+        let candidates: Vec<usize> = (2..2 + rest_count).collect();
+        collect_with_evacuation(&mut roots, &mut heap, &mut clock, &candidates, false);
+
+        // After collect_with_evacuation:
+        //   finalise_evacuation() → target to rest
+        //   defer_sweep()         → rest (including target) to unswept
+        // So rest is empty and the former target is in unswept.
+        let unswept_after: HashSet<usize> = heap.unswept_block_base_addresses();
+        let new_blocks: Vec<usize> = unswept_after.difference(&unswept_before).copied().collect();
+
+        // If no new block appeared in unswept, the evacuation target was never
+        // allocated (nothing was actually evacuated).  Skip rather than fail.
+        if new_blocks.is_empty() {
+            return;
+        }
+
+        // Each new block that appeared in unswept after the evacuation pass is
+        // either the active evacuation target or one of the
+        // `filled_evacuation_blocks`.  ALL of them must have at least one
+        // marked line; a zero-marked block would be fully recycled by
+        // `lazy_sweep_next()`, overwriting live evacuated data.
+        for &target_base in &new_blocks {
+            let marked = heap
+                .unswept_block_marked_lines(target_base)
+                .expect("former evacuation target block must be in unswept");
+
+            assert!(
+                marked > 0,
+                "evacuation target block {:#x} has 0 marked lines after collection: \
+                 mark_region_in_block did not search evacuation_target / \
+                 filled_evacuation_blocks.  Without the fix in heap.rs, \
+                 lazy_sweep_next() will recycle this block and overwrite the \
+                 live evacuated data (test119 / monad_utility crash on aarch64).",
+                target_base
+            );
+        }
+    }
 }

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -1197,4 +1197,95 @@ pub mod tests {
             other => panic!("pinned object has wrong data: {:?}", other),
         }
     }
+
+    /// Test that evacuated objects' lines in the target block are correctly
+    /// marked, preventing the target block from being recycled by lazy sweep.
+    ///
+    /// Without the fix (evacuation_target not searched in mark_region_in_block),
+    /// the target block has zero line marks after finalise_evacuation(). When
+    /// flush_unswept() processes it, recycle() sees a large hole and moves the
+    /// block to `recycled`. Subsequent allocations overwrite the evacuated data.
+    ///
+    /// With the fix, all lines containing evacuated objects are marked, so
+    /// recycle() cannot find a hole spanning the occupied lines, and the data
+    /// is preserved.
+    #[test]
+    pub fn test_evacuation_target_lines_marked_after_collection() {
+        let mut heap = Heap::new();
+        let mut clock = Clock::default();
+        let mut pool = crate::eval::memory::symbol::SymbolPool::new();
+        clock.switch(ThreadOccupation::Mutator);
+
+        // Allocate enough objects to fill several blocks, producing at least
+        // one `rest` block which can be used as an evacuation candidate.
+        let root_ptr = {
+            let view = MutatorHeapView::new(&heap);
+            let ids: Vec<LambdaForm> = repeat_with(|| -> LambdaForm {
+                LambdaForm::new(1, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default())
+            })
+            .take(512)
+            .collect();
+            let idarray = view.array(ids.as_slice());
+            view.let_(
+                idarray,
+                view.app(
+                    Ref::L(0),
+                    view.singleton(view.sym_ref(&mut pool, "root-data").unwrap()),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .as_ptr()
+        };
+
+        // First mark-in-place collection to establish rest blocks.
+        // Use a named Vec so scan_and_update updates our pointer if needed.
+        let mut roots = vec![root_ptr];
+        collect(&mut roots, &mut heap, &mut clock, false);
+        heap.flush_unswept();
+
+        let rest_count = heap.rest_block_count();
+        if rest_count == 0 {
+            eprintln!(
+                "test_evacuation_target_lines_marked: no rest blocks after first GC, skipping"
+            );
+            return;
+        }
+
+        // Force evacuation of all rest blocks.  After this call, roots[0] is
+        // updated to the post-evacuation pointer by scan_and_update.
+        let candidates: Vec<usize> = (2..2 + rest_count).collect();
+        collect_with_evacuation(&mut roots, &mut heap, &mut clock, &candidates, false);
+        // roots[0] is now the pointer into the evacuation target block.
+        let evacuated_ptr = roots[0];
+
+        // Flush unswept forces lazy sweep of all blocks including the evacuation
+        // target (target → rest → unswept via finalise_evacuation + defer_sweep).
+        // Without the fix: target has zero line marks → recycle() finds a huge hole
+        // → block goes to `recycled` → subsequent allocations overwrite it.
+        heap.flush_unswept();
+
+        // Allocate aggressively to fill any recycled space.  If the evacuation
+        // target was recycled, these allocations will overwrite the evacuated objects.
+        clock.switch(ThreadOccupation::Mutator);
+        {
+            let view = MutatorHeapView::new(&heap);
+            let fillers: Vec<LambdaForm> = repeat_with(|| -> LambdaForm {
+                LambdaForm::new(1, view.atom(Ref::L(99)).unwrap().as_ptr(), Smid::default())
+            })
+            .take(1024)
+            .collect();
+            let _ = view.array(fillers.as_slice());
+        }
+
+        // Verify the evacuated object is still a valid LetRec node.
+        // If the evacuation target block was recycled and overwritten, reading
+        // evacuated_ptr gives garbage — a wrong HeapSyn variant or garbage fields.
+        let evacuated_obj: &HeapSyn = unsafe { &*evacuated_ptr.as_ptr() };
+        assert!(
+            matches!(evacuated_obj, HeapSyn::Let { .. }),
+            "evacuation target corruption: expected Let node, got {:?}",
+            evacuated_obj
+        );
+    }
 }

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -724,6 +724,23 @@ impl HeapState {
                 return;
             }
         }
+
+        // Evacuation target blocks: objects evacuated into the current target
+        // block must have their lines marked so that lazy sweep does not treat
+        // the live content as free holes.
+        if let Some(target) = &mut self.evacuation_target {
+            if target.base_address() == base {
+                target.mark_line(ptr);
+                return;
+            }
+        }
+
+        for block in &mut self.filled_evacuation_blocks {
+            if block.base_address() == base {
+                block.mark_line(ptr);
+                return;
+            }
+        }
     }
 
     /// Find the block containing `ptr` by its base address and mark
@@ -760,6 +777,23 @@ impl HeapState {
         }
 
         for block in &mut self.recycled {
+            if block.base_address() == base {
+                block.mark_region(ptr, bytes);
+                return;
+            }
+        }
+
+        // Evacuation target blocks: objects evacuated into the current target
+        // block must have their lines marked so that lazy sweep does not treat
+        // the live content as free holes.
+        if let Some(target) = &mut self.evacuation_target {
+            if target.base_address() == base {
+                target.mark_region(ptr, bytes);
+                return;
+            }
+        }
+
+        for block in &mut self.filled_evacuation_blocks {
             if block.base_address() == base {
                 block.mark_region(ptr, bytes);
                 return;

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -734,7 +734,6 @@ impl HeapState {
                 return;
             }
         }
-
         for block in &mut self.filled_evacuation_blocks {
             if block.base_address() == base {
                 block.mark_line(ptr);
@@ -792,7 +791,6 @@ impl HeapState {
                 return;
             }
         }
-
         for block in &mut self.filled_evacuation_blocks {
             if block.base_address() == base {
                 block.mark_region(ptr, bytes);
@@ -2610,6 +2608,107 @@ impl Heap {
         while !heap_state.unswept.is_empty() {
             heap_state.lazy_sweep_next();
         }
+    }
+
+    /// Return the number of marked lines in the current evacuation target block.
+    ///
+    /// Returns `None` if there is no active evacuation target (no evacuating
+    /// collection has started, or finalise_evacuation has already been called).
+    ///
+    /// Used by tests to verify that `mark_region_in_block` correctly marks
+    /// lines in the evacuation target, preventing lazy sweep from recycling it.
+    #[cfg(test)]
+    pub fn evacuation_target_marked_lines(&self) -> Option<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        heap_state.evacuation_target.as_ref().map(|block| {
+            let (_holes, _free, marked) = block.stats();
+            marked
+        })
+    }
+
+    /// Return the base address of the current evacuation target block, if any.
+    ///
+    /// Used by tests to identify which block is the evacuation target so we
+    /// can find it in `rest` after `finalise_evacuation()` and inspect its
+    /// line marks there.
+    #[cfg(test)]
+    pub fn evacuation_target_base_address(&self) -> Option<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        heap_state
+            .evacuation_target
+            .as_ref()
+            .map(|b| b.base_address())
+    }
+
+    /// Return the marked line count for the block with the given base address
+    /// in the `rest` list.
+    ///
+    /// Returns `None` if no block with that base address is found in `rest`.
+    ///
+    /// Used by tests to verify that the evacuation target block, after being
+    /// moved to `rest` by `finalise_evacuation()`, has its lines marked.
+    #[cfg(test)]
+    pub fn rest_block_marked_lines(&self, base_address: usize) -> Option<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        for block in &heap_state.rest {
+            if block.base_address() == base_address {
+                let (_holes, _free, marked) = block.stats();
+                return Some(marked);
+            }
+        }
+        None
+    }
+
+    /// Return the set of base addresses of all blocks currently in `rest`.
+    ///
+    /// Used by tests to find the evacuation target block after
+    /// `finalise_evacuation()` moves it into `rest`.
+    #[cfg(test)]
+    pub fn rest_block_base_addresses(&self) -> std::collections::HashSet<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        heap_state.rest.iter().map(|b| b.base_address()).collect()
+    }
+
+    /// Return the set of base addresses of all blocks currently in `unswept`.
+    ///
+    /// After `collect_with_evacuation`, `defer_sweep()` moves all `rest` blocks
+    /// (including the former evacuation target) into `unswept`.  This helper
+    /// lets tests inspect the former target block before `lazy_sweep_next()`
+    /// processes it.
+    #[cfg(test)]
+    pub fn unswept_block_base_addresses(&self) -> std::collections::HashSet<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        heap_state
+            .unswept
+            .iter()
+            .map(|b| b.base_address())
+            .collect()
+    }
+
+    /// Return the marked line count for the block with the given base address
+    /// in the `unswept` list.
+    ///
+    /// Returns `None` if no block with that base address is found in `unswept`.
+    ///
+    /// Used by tests to verify that the evacuation target block, after being
+    /// moved to `unswept` by `defer_sweep()`, has its lines marked so that
+    /// `lazy_sweep_next()` does not recycle the entire block.
+    #[cfg(test)]
+    pub fn unswept_block_marked_lines(&self, base_address: usize) -> Option<usize> {
+        // SAFETY: Read-only access during test, single-threaded.
+        let heap_state = unsafe { &*self.state.get() };
+        for block in &heap_state.unswept {
+            if block.base_address() == base_address {
+                let (_holes, _free, marked) = block.stats();
+                return Some(marked);
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a GC correctness bug: evacuation target blocks had zero line marks
after `finalise_evacuation()`, causing `lazy_sweep_next()` to recycle them
and overwrite live evacuated data.

### The bug

`mark_region_in_block()` and `mark_line_in_block()` in `HeapState` search
`head`, `overflow`, `rest`, `unswept`, and `recycled` — but NOT
`evacuation_target` or `filled_evacuation_blocks`.

During `collect_with_evacuation()`, `evacuate()` calls
`mark_lines_for_bytes(new_obj)` to mark the evacuated copy's lines. Since
`new_obj` is in `evacuation_target`, the call silently finds no matching
block and returns without writing any marks.

After `finalise_evacuation()` moves the target to `rest`, and
`defer_sweep()` moves `rest` to `unswept`, `lazy_sweep_next()` processes
the target block. Finding zero line marks, `recycle()` returns `true` and
moves the block to `recycled`. Subsequent allocations overwrite the
evacuated live data.

### The fix

Extended both `mark_line_in_block` and `mark_region_in_block` to also
search `evacuation_target` and `filled_evacuation_blocks`, so line marks
are correctly written for evacuated objects.

### Test added

Added `test_evacuation_target_lines_marked_after_collection` to
`collect.rs::tests`. The test forces evacuation, flushes unswept blocks,
allocates filler objects, and then asserts the evacuated object is still
intact. The test passes on the fixed code.

Note: the unit test does not reliably fail on the unfixed code in small
test scenarios (the corruption window doesn't open in time). The fix is
justified by code analysis: the missing block search is a clear correctness
bug that causes heap corruption under sufficient memory pressure.

### CI

Added `Sequential harness (aarch64 release)` job to `build-rust.yaml` so
this class of sequential-harness GC bugs is caught in PR CI (not just on
master push). The job runs with `EU_GC_STRESS=1` to force evacuation on
every GC cycle.

## Test plan

- [x] All existing lib tests pass (`cargo test --lib`: 600/600)
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [x] `test_evacuation_target_lines_marked_after_collection` passes
- [ ] CI: aarch64 sequential harness passes