### PR TITLE
test: verify aarch64 sequential harness CI catches the crash (no fix)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -68,6 +68,25 @@ jobs:
           python3 scripts/test-doc-examples.py --eu ./target/release/eu --timeout 30
 
 
+  test-aarch64-sequential:
+    name: Sequential harness (aarch64 release)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: aarch64-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            aarch64-cargo-registry-
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run sequential harness with release binary
+        run: target/release/eu test --allow-io tests/harness
+
   wasm:
     name: WASM Compilation Check
     runs-on: ubuntu-latest

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -84,8 +84,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Build release binary
         run: cargo build --release
-      - name: Run sequential harness with release binary
+      - name: Run sequential harness with release binary (GC stress)
         run: target/release/eu test --allow-io tests/harness
+        env:
+          EU_GC_STRESS: "1"
 
   wasm:
     name: WASM Compilation Check

--- a/.github/workflows/macos-diag.yaml
+++ b/.github/workflows/macos-diag.yaml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Experiment L: many repeats of full harness to catch low-probability crash.
-  # Previous 3-attempt runs all passed. Crash probability may be low per run.
-  # Run 10x in a single job to increase detection probability.
-  macos-repeat-10:
-    name: macOS harness x10 repeats
-    runs-on: macos-latest
+  # Sequential binary harness on aarch64 Linux — this is the exact
+  # invocation that was crashing before the evacuation line-mark fix.
+  # Run 3x to catch any low-probability recurrence.
+  aarch64-sequential-3x:
+    name: aarch64 sequential harness x3
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -19,47 +19,22 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: macos-diag-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: aarch64-diag-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            macos-diag-registry-
+            aarch64-diag-registry-
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --release --test harness_test
-      - name: Attempt 1
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 2
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 3
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 4
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 5
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 6
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 7
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 8
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 9
-        run: cargo test --release --test harness_test
-        continue-on-error: true
-      - name: Attempt 10
-        run: cargo test --release --test harness_test
-        continue-on-error: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run 1
+        run: target/release/eu test --allow-io tests/harness
+      - name: Run 2
+        run: target/release/eu test --allow-io tests/harness
+      - name: Run 3
+        run: target/release/eu test --allow-io tests/harness
 
-  # Experiment M: exact Release MacOS clone x10.
-  # The crash appears in the Release MacOS job; replicate that context.
-  macos-release-clone-repeat:
-    name: macOS Release MacOS clone x10
+  # macOS ARM sequential binary harness — also crashed before the fix.
+  macos-sequential:
+    name: macOS sequential harness
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,42 +47,7 @@ jobs:
           restore-keys: |
             macos-diag-registry-
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build and install temporary eu (as Release MacOS does)
-        run: cargo install --path .
-      - name: Regenerate build-meta.yaml (as Release MacOS does)
-        run: |
-          export OSTYPE=$(uname)
-          export HOSTTYPE=$(uname -m)
-          eu build.eu -t build-meta > build-meta.yaml.new
-          mv -f build-meta.yaml.new build-meta.yaml
-          echo "TAG_NAME=$(eu build.eu -t version)" >> $GITHUB_ENV
-      - name: Attempt 1
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 2
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 3
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 4
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 5
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 6
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 7
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 8
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 9
-        run: cargo test --release
-        continue-on-error: true
-      - name: Attempt 10
-        run: cargo test --release
-        continue-on-error: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run sequential harness
+        run: target/release/eu test --allow-io tests/harness


### PR DESCRIPTION
## Verification attempt: does the sequential CI job catch the crash?

This PR tests whether the `Sequential harness (aarch64 release)` CI job
added in PR #514 reliably catches the evacuation target line-marking bug
**without** the heap.rs fix applied.

### Result: No — the crash is not reliably reproduced

Even with `EU_GC_STRESS=1` (which forces evacuation on every GC cycle),
the sequential harness passes on the unfixed code. 

### Root cause analysis

The bug requires a specific timing window within a single test evaluation:
1. Evacuation occurs, objects copied to target block (with zero line marks)
2. `flush_unswept()` / lazy sweep recycles the target block
3. New allocations overwrite the evacuated data
4. The evacuated object is accessed AFTER step 3

In the test harness, each test creates a fresh heap. Individual tests are
too short-lived for the allocation pattern to trigger visible corruption
within one test's lifetime. The original crash on master may have been
caused by a specific accumulated heap state in test 119.

### Conclusion

PR #514's fix is correct based on code analysis, but we cannot produce a
deterministic CI proof. The fix is justified on correctness grounds:
`mark_region_in_block` not searching `evacuation_target` is a real bug
that WILL cause heap corruption under sufficient memory pressure.

This PR (515) can be closed — it served its diagnostic purpose.