### PR TITLE
ci: set RUST_MIN_STACK=64MiB for Release MacOS test step

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -212,6 +212,8 @@ jobs:
           strip target/release/eu
           mv target/release/eu target/release/eu_darwin
       - name: Run final test with release binary
+        env:
+          RUST_MIN_STACK: "67108864"
         run: |
           target/release/eu_darwin version
           target/release/eu_darwin test --allow-io tests/harness


### PR DESCRIPTION
## Summary

- Master CI has been red with SIGSEGV after test 115 on macOS release binaries
- Diagnostic CI (run [22974207687](https://github.com/curvelogic/eucalypt/actions/runs/22974207687)) confirmed `RUST_MIN_STACK=67108864` is a reliable fix: 5/5 pass vs 3/5 crash without it
- This PR sets `RUST_MIN_STACK` as an env var on the Release MacOS test step — minimal CI fix to get master green

## Diagnostic evidence

| Configuration | Result |
|---|---|
| Baseline (no env vars) | 2/5 pass, 3/5 SIGSEGV |
| `RUST_MIN_STACK=67108864` | 5/5 pass |

The crash is caused by thread stack exhaustion. The IO timeout worker in `execute_command()` is spawned with `thread::spawn` (default 8 MiB stack on macOS). After 115+ tests the accumulated state pushes it over the limit. `RUST_MIN_STACK` sets the default stack size for all spawned threads.

## Note

A proper source-level fix (using `thread::Builder::new().stack_size()` in `io_run.rs`) is under investigation on `fix/furnace-macos-stack-fix`. This PR is the minimal change to unblock master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)