### PR TITLE
chore(ci): fix test cache poisoning and upgrade action-gh-release to v2

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -316,7 +316,7 @@ jobs:
           echo "RELEASE_VERSION=$(./eu_amd64 -e eu.build.version -x text)" >> $GITHUB_ENV
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           draft: true

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -54,10 +54,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-registry-
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo test


### PR DESCRIPTION
## Summary

- **Fix SIGSEGV in PR builds**: Remove `target/` from the test job cache. Master builds run `cargo build --release` for doc examples, saving release artefacts into `target/`. PR builds restore this cache then run `cargo test` (debug), producing a mixed debug/release binary that crashes with SIGSEGV after test 116. Fix: drop `target/` and use a `-registry-` key prefix matching the release jobs.
- **Upgrade `softprops/action-gh-release` to v2**: v1 uses deprecated Node 16; v2 uses Node 20.

## Test plan

- [ ] PR builds stop crashing with SIGSEGV after test 116
- [ ] CI passes on ubuntu-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)