### PR TITLE
ci: set RUST_MIN_STACK=64MiB for parallel test job to prevent SIGSEGV

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -59,6 +59,8 @@ jobs:
             ${{ runner.os }}-cargo-registry-
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
+        env:
+          RUST_MIN_STACK: "67108864"
         run: cargo test
       - name: Test doc examples
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Root cause

All PR branches (including docs-only changes with no code modifications) were failing with SIGSEGV after the IO harness tests (116-120) ran in parallel. Investigation confirmed:

- Master and PR runs produce an **identical harness_test binary** (same hash: `harness_test-05fb663bb6bf9045`)
- Therefore the crash is **not a code regression** — it is environmental
- Tests 116-120 all use `--allow-io` and run eucalypt VMs **in-process** on separate test threads
- When 4-8 threads run deep-recursing VMs simultaneously, thread stacks can overflow on certain GHA runner VMs
- `RUST_MIN_STACK=67108864` was already applied to the macOS release binary test step and is known to fix that crash
- Master consistently passes because master's ubuntu-latest runner happens to have a memory layout that avoids the overflow; PR builds land on different runner VMs that trigger it

## Fix

Set `RUST_MIN_STACK: "67108864"` (64 MiB) as an env var on the `Run tests` step of the test matrix job, matching the existing fix applied to the macOS release job.

## Evidence

- PR #520 (pure docs change, zero code modifications) crashed with the same SIGSEGV — ruling out any specific code change as the cause
- Binary hash is identical between passing master run and failing PR run
- `RUST_MIN_STACK` workaround already proven effective for the equivalent crash on macOS release binary
- All Clarion PR branches crash despite containing the same GC fixes as master

🤖 Generated with [Claude Code](https://claude.com/claude-code)