### PR TITLE
fix(gc): mark all lines spanned by allocation to prevent use-after-free

### DIFF
--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -2539,24 +2539,47 @@ impl Heap {
         // SAFETY: Mutable access to heap state during GC mark phase.
         let heap_state = unsafe { &mut *self.state.get() };
 
-        let bytes = header.length() as usize;
-        heap_state.mark_region_in_block(ptr, bytes);
+        let header_size = size_of::<AllocHeader>();
+        let payload_bytes = header.length() as usize;
+        let total_size = header_size + payload_bytes;
+
+        // Mark from the header start, covering header + payload, so that
+        // all lines spanned by the full allocation are protected from
+        // lazy sweep.
+        // SAFETY: header is at ptr - size_of::<AllocHeader>(), always
+        // within the same block as ptr.
+        let header_ptr = unsafe { NonNull::new_unchecked(ptr.as_ptr().sub(header_size)) };
+        heap_state.mark_region_in_block(header_ptr, total_size);
     }
 
-    /// Mark the line in the appropriate block map.
+    /// Mark all lines covering the full allocation (header + object).
     ///
-    /// Looks up the block by base address for O(1) dispatch.
+    /// An allocation consists of an AllocHeader prefix followed by the object.
+    /// Both parts must be protected from lazy sweep. If the allocation
+    /// straddles a 128-byte line boundary, we must mark all lines it
+    /// touches — otherwise lazy sweep can reclaim the unmarked portion,
+    /// corrupting live object fields (use-after-free).
+    ///
+    /// Previous implementation only marked the single line containing the
+    /// object pointer, relying on Immix "conservative marking" to protect
+    /// straddling objects. But conservative marking only protects the upper
+    /// boundary of holes (objects extending down from a marked line above);
+    /// it does NOT protect the lower boundary (objects extending up from a
+    /// marked line below into the first line of a hole).
     pub fn mark_line<T>(&mut self, ptr: NonNull<T>) {
         // SAFETY: Mutable access to heap state during GC mark phase.
         // Single-threaded, stop-the-world collection ensures exclusive access.
         let heap_state = unsafe { &mut *self.state.get() };
 
-        let size = size_of::<T>();
-        if SizeClass::for_size(size) == SizeClass::Medium {
-            heap_state.mark_region_in_block(ptr.cast(), size);
-        } else {
-            heap_state.mark_line_in_block(ptr);
-        }
+        let header_size = size_of::<AllocHeader>();
+        let total_size = header_size + size_of::<T>();
+
+        // SAFETY: header_ptr is always within the same block as ptr
+        // because allocations never span blocks. The header is written
+        // at ptr - size_of::<AllocHeader>() during allocation.
+        let header_ptr =
+            unsafe { NonNull::new_unchecked((ptr.as_ptr() as *mut u8).sub(header_size)) };
+        heap_state.mark_region_in_block(header_ptr, total_size);
     }
 
     /// Unmark the line in the appropriate block map


### PR DESCRIPTION
## Summary

- **Root cause**: `mark_line<T>` marked only the single 128-byte Immix line containing the object pointer. When an allocation (header + object) straddled a line boundary, the portion in the adjacent line remained unmarked. Lazy sweep reclaimed that line; new allocations overwrote live object fields — a use-after-free.
- **Fix**: Both `mark_line<T>` and `mark_lines_for_bytes` now use `mark_region_in_block` covering the full allocation (AllocHeader + payload), ensuring all spanned lines are protected from sweep.
- **Impact**: Fixes the intermittent SIGSEGV on macOS ARM64 CI (corrupt `EnvFrame.next` pointers during GC scan, manifesting in test 119).

## Detail

The Immix GC uses 128-byte lines within 32KB blocks. During the mark phase, each live object's line is marked so lazy sweep knows not to reclaim it. The old code marked only ONE line per object — the line containing the object pointer (after the 16-byte AllocHeader).

Example failure scenario:
- EnvFrame (48 bytes) + AllocHeader (16 bytes) = 64 bytes total
- Header starts at offset 96 in a line → object at offset 112
- Object bytes 112-127 are in line N (marked), bytes 128-159 are in line N+1 (**unmarked**)
- `EnvFrame.next` at object+40 = byte 152 → in the **unmarked** line N+1
- Lazy sweep reclaims line N+1 → new allocation overwrites `next` → SIGSEGV

The Immix paper describes "conservative line marking" where the line following a marked line is implicitly protected. The code had a comment stating this intent but the implementation only applied conservative marking to the **upper** boundary of holes (protecting objects extending down from above), not the **lower** boundary (objects extending up from below).

The fix is simpler and more robust: mark the actual region from header start through object end, covering all lines the allocation touches.

## Test plan

- [x] All 601 library tests pass
- [x] All 217 harness tests pass (including test 119 which always crashed)
- [x] 10/10 consecutive runs of test 119 pass locally
- [x] 5/5 consecutive full test suite runs pass locally
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI passes on macOS ARM64 (the platform where the crash manifested)

## Note

Once CI confirms this fix, the `RUST_MIN_STACK=64MiB` workaround in CI can likely be removed (it was masking this bug by changing allocation patterns). I'd suggest verifying that separately.

Also found: `alloc_size_of` has a double-header bug (callers pass `header_size + object_size` but the function internally adds `HEADER_SIZE` again, wasting 16 bytes per allocation). Not fixed here to keep this PR focused on the SIGSEGV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)