### PR TITLE
chore(ci): remove RUST_MIN_STACK workaround

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -59,8 +59,6 @@ jobs:
             ${{ runner.os }}-cargo-registry-
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
-        env:
-          RUST_MIN_STACK: "67108864"
         run: cargo test
       - name: Test doc examples
         if: runner.os == 'Linux'
@@ -213,8 +211,6 @@ jobs:
           strip target/release/eu
           mv target/release/eu target/release/eu_darwin
       - name: Run final test with release binary
-        env:
-          RUST_MIN_STACK: "67108864"
         run: |
           target/release/eu_darwin version
           target/release/eu_darwin test --allow-io tests/harness


### PR DESCRIPTION
## Summary

- Removes `RUST_MIN_STACK=67108864` (64 MiB) from both CI test steps
- This was a workaround masking the GC line marking bug fixed in PR #525
- The sequential harness job with `EU_GC_STRESS=1` is retained as a useful ongoing GC stress test

## Test plan

- [ ] CI passes without RUST_MIN_STACK (this PR's CI run is the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)