### PR TITLE
fix: handle io.exec spawn failure and io-fail action tag

### DIFF
--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -839,6 +839,12 @@ fn evaluate_spec_block(
             stdin,
             timeout_secs,
         })
+    } else if tag_name == "io-fail" {
+        let message = eval_fields
+            .get("message")
+            .and_then(|opt| opt.clone())
+            .unwrap_or_else(|| "io.fail".to_string());
+        Err(IoRunError::Fail(message))
     } else {
         Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
             format!("unrecognised IO action tag: {tag_name}"),
@@ -1107,9 +1113,23 @@ fn run_command(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let mut child = command
-        .spawn()
-        .map_err(|e| IoRunError::CommandError(Smid::default(), e.to_string()))?;
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            // Spawn failure (e.g. binary not found) returns a result block
+            // rather than a hard error, matching shell conventions.
+            let exit_code = match e.kind() {
+                std::io::ErrorKind::NotFound => 127,
+                std::io::ErrorKind::PermissionDenied => 126,
+                _ => -1,
+            };
+            return Ok(CommandResult {
+                stdout: String::new(),
+                stderr: e.to_string(),
+                exit_code,
+            });
+        }
+    };
 
     if let Some(input) = stdin_data {
         if let Some(mut pipe) = child.stdin.take() {

--- a/tests/harness/121_io_exec_not_found.eu
+++ b/tests/harness/121_io_exec_not_found.eu
@@ -1,0 +1,8 @@
+"io.exec: nonexistent binary returns result block with exit-code 127 and error in stderr. Uses --allow-io."
+
+` { target: :test requires-io: true }
+test:
+  { :io r: io.exec(["nonexistent-binary-xyz"]) }.(
+    if(r.'exit-code' = 127,
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))

--- a/tests/harness/errors/106_io_check_fail.eu
+++ b/tests/harness/errors/106_io_check_fail.eu
@@ -1,0 +1,2 @@
+` { target: :main requires-io: true }
+main: io.bind("false" io.shell, io.check)

--- a/tests/harness/errors/106_io_check_fail.eu.expect
+++ b/tests/harness/errors/106_io_check_fail.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "io.fail"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -602,6 +602,11 @@ pub fn test_harness_120() {
 }
 
 #[test]
+pub fn test_harness_121() {
+    run_test(&io_opts("121_io_exec_not_found.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }
@@ -1188,4 +1193,20 @@ pub fn test_error_104() {
 #[test]
 pub fn test_error_105() {
     run_error_test(&error_opts("105_base64_decode_invalid.eu"));
+}
+
+#[test]
+pub fn test_error_106() {
+    use eucalypt::driver::options::EucalyptOptions;
+    let lib_path = vec![
+        std::path::PathBuf::from("tests/harness/errors"),
+        std::path::PathBuf::from("tests/harness"),
+    ];
+    let path = "tests/harness/errors/106_io_check_fail.eu".to_string();
+    let opt = EucalyptOptions::default()
+        .with_explicit_inputs(vec![Input::from_str(&path).unwrap()])
+        .with_lib_path(lib_path)
+        .with_allow_io()
+        .build();
+    run_error_test(&opt);
 }


### PR DESCRIPTION
## Summary

- `io.exec` with a nonexistent binary now returns a result block (`{stdout: "", stderr: "No such file or directory (os error 2)", exit-code: 127}`) instead of a hard error, matching shell conventions (127 = not found, 126 = permission denied)
- The `io-fail` spec block tag (used by `io.check` in the prelude) is now recognised by the IO action dispatcher, so `io.check` correctly raises `io.fail` with the stderr message when a command returns a non-zero exit code

Closes eu-ayiz.

## Test plan

- [x] Test 121: `io.exec` with nonexistent binary returns result block with exit-code 127
- [x] Error test 106: `io.check` on a failed command (`false`) raises `io.fail`
- [x] All 222 harness tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)