### PR TITLE
feat: add monad and-then combinator and io.checked

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7905,7 +7905,9 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 | Function | Description |
 |----------|-------------|
 | `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
+| `io.checked` | Pipeline-friendly check: bind the preceding IO action through `io.check` |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
+| `io.and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `io.then(a, b)` | Sequence two actions, discarding the result of the first |
 | `io.join(mm)` | Flatten a nested IO action |
 | `io.sequence(ms)` | Run a list of IO actions in order, collecting results into a list |
@@ -7923,6 +7925,7 @@ pattern and the [IO guide](../../guide/io.md) for practical usage.
 | `monad(m).bind` | Passed through from `m.bind` |
 | `monad(m).return` | Passed through from `m.return` |
 | `monad(m).map(f, action)` | Apply pure function `f` to the result of a monadic action (fmap) |
+| `monad(m).and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `monad(m).then(a, b)` | Sequence two monadic actions, discarding the result of the first |
 | `monad(m).join(mm)` | Flatten a nested monadic value |
 | `monad(m).sequence(ms)` | Sequence a list of monadic actions, collecting results into a list |

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -58,7 +58,9 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 | Function | Description |
 |----------|-------------|
 | `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
+| `io.checked` | Pipeline-friendly check: bind the preceding IO action through `io.check` |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
+| `io.and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `io.then(a, b)` | Sequence two actions, discarding the result of the first |
 | `io.join(mm)` | Flatten a nested IO action |
 | `io.sequence(ms)` | Run a list of IO actions in order, collecting results into a list |
@@ -76,6 +78,7 @@ pattern and the [IO guide](../../guide/io.md) for practical usage.
 | `monad(m).bind` | Passed through from `m.bind` |
 | `monad(m).return` | Passed through from `m.return` |
 | `monad(m).map(f, action)` | Apply pure function `f` to the result of a monadic action (fmap) |
+| `monad(m).and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `monad(m).then(a, b)` | Sequence two monadic actions, discarding the result of the first |
 | `monad(m).join(mm)` | Flatten a nested monadic value |
 | `monad(m).sequence(ms)` | Sequence a list of monadic actions, collecting results into a list |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -52,6 +52,9 @@ io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
   check(result): if(result.'exit-code' = 0,
     io.return(result),
     __IO_ACTION({:io-fail message: result.stderr}))
+
+  ` "Pipeline-friendly check: bind the preceding IO action through check."
+  checked: io.and-then(io.check)
 }
 
 
@@ -77,6 +80,9 @@ monad(m): {
 
   ` "then(a, b) - sequence two monadic actions, discarding the result of the first."
   then(a, b): m.bind(a, -> b)
+
+  ` "and-then(f, action) - pass the result of action to f (bind with flipped args, for pipeline use)."
+  and-then(f, action): m.bind(action, f)
 
   ` "join(mm) - flatten a nested monadic value."
   join(mm): m.bind(mm, identity)

--- a/tests/harness/119_monad_utility.eu
+++ b/tests/harness/119_monad_utility.eu
@@ -86,3 +86,32 @@ test-io-then:
     if(r.stdout str.matches?("second.*"),
       { RESULT: :PASS },
       { RESULT: :FAIL }))
+
+##
+## and-then: bind with flipped args for pipeline use (pure)
+##
+` { target: :test-and-then-pure }
+test-and-then-pure:
+  if(id-monad.and-then(inc, 41) = 42,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
+
+##
+## IO: and-then in pipeline style
+##
+` { target: :test-io-and-then requires-io: true }
+test-io-and-then:
+  { :io r: "echo hello" io.shell io.and-then((.stdout) ; io.return) }.(
+    if(r = c"hello\n",
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))
+
+##
+## IO: io.checked pipeline (success case)
+##
+` { target: :test-io-checked-success requires-io: true }
+test-io-checked-success:
+  { :io r: "echo hello" io.shell io.checked io.map(.stdout) }.(
+    if(r = c"hello\n",
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))


### PR DESCRIPTION
## Summary
- Add `and-then(f, action)` to `monad()` — bind with flipped args for pipeline use
- Add `io.checked` convenience — `io.and-then(io.check)` for pipeline-style error checking
- e.g. `"ls" io.shell io.checked io.map(.stdout)` instead of `io.bind(io.shell("ls"), io.check)`

## Test plan
- [x] Pure `and-then` test with identity monad
- [x] IO `and-then` test with shell + forward composition
- [x] IO `checked` test (success case)
- [x] Full test suite passes (222 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)