### PR TITLE
fix: render-as arg order and nested block null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to eucalypt are documented here.
 
-## [0.5.1] - Unreleased
-
 ## [0.5.0] - 2026-03-13
 
 ### Added
@@ -17,7 +15,7 @@ All notable changes to eucalypt are documented here.
   - Results as `{stdout, stderr, exit-code}` blocks
   - Spawn failures return result blocks (exit-code 127) rather than hard errors
 
-- **`render-as(value, fmt)`** — Serialise any eucalypt value to a string at runtime
+- **`render-as(fmt, value)`** — Serialise any eucalypt value to a string at runtime
   - Supports `:json`, `:yaml`, `:toml`, `:text`, `:edn`, `:html`
 
 - **`parse-as(fmt, str)`** — Pure inverse of `render-as`; converts strings to eucalypt data structures
@@ -37,6 +35,12 @@ All notable changes to eucalypt are documented here.
 
 ### Fixed
 
+- **`render-as` argument order** — Changed from `render-as(value, fmt)` to
+  `render-as(fmt, value)` for pipeline-friendly partial application
+  (e.g. `data render-as(:json)`)
+- **`render` / `render-as` nested block null** — Nested block values inside
+  `render` or `render-as` were serialised as null; now correctly traverses
+  unevaluated Let/LetRec thunks in the heap walk
 - **GC correctness** — Multiple garbage collector fixes addressing crashes on aarch64-linux and macOS ARM:
   - 16-byte alignment for evacuation allocations
   - Per-heap mark state (global `MARK_STATE` moved into `Heap` struct), fixing parallel test crashes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.5.1"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eucalypt"
-version = "0.5.1"
+version = "0.5.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -331,7 +331,7 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | Function | Description |
 |----------|-------------|
 | `render(value)` | Serialise to YAML string |
-| `render-as(value, fmt)` | Serialise to string in named format |
+| `render-as(fmt, value)` | Serialise to string in named format |
 | `parse-as(fmt, str)` | Parse string as structured data (inverse of `render-as`) |
 
 Formats for `render-as`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.

--- a/docs/guide/io.md
+++ b/docs/guide/io.md
@@ -240,7 +240,7 @@ data: "curl -s https://api.example.com/data"
 ```eu,notest
 ` :main
 text: { :io
-  r: "jq '.name'" io.shell-with({stdin: render-as(data, :json)})
+  r: "jq '.name'" io.shell-with({stdin: render-as(:json, data)})
 }.(r.stdout)
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5506,7 +5506,7 @@ data: "curl -s https://api.example.com/data"
 ```eu,notest
 ` :main
 text: { :io
-  r: "jq '.name'" io.shell-with({stdin: render-as(data, :json)})
+  r: "jq '.name'" io.shell-with({stdin: render-as(:json, data)})
 }.(r.stdout)
 ```
 
@@ -7519,7 +7519,7 @@ are pure functions — no IO is required.
 | Function | Description |
 |----------|-------------|
 | `render(value)` | Serialise `value` to a YAML string |
-| `render-as(value, fmt)` | Serialise `value` to a string in format `fmt` |
+| `render-as(fmt, value)` | Serialise `value` to a string in format `fmt` |
 
 Supported formats for `fmt`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.
 
@@ -7527,7 +7527,7 @@ Supported formats for `fmt`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`
 
 ```eu,notest
 yaml-str: render({a: 1, b: 2})           # "a: 1\nb: 2\n"
-json-str: render-as({a: 1, b: 2}, :json) # "{\"a\":1,\"b\":2}"
+json-str: render-as(:json, {a: 1, b: 2}) # "{\"a\":1,\"b\":2}"
 ```
 
 These functions are backed by the `RENDER_TO_STRING` intrinsic, which
@@ -7562,7 +7562,7 @@ data.x  # 1
 
 # Round-trip
 original: {x: 1, y: 2}
-recovered: render-as(original, :json) parse-as(:json)
+recovered: render-as(:json, original) parse-as(:json)
 recovered.x  # 1
 
 # Pipeline style (parse-as with first arg partially applied)
@@ -11571,7 +11571,7 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | Function | Description |
 |----------|-------------|
 | `render(value)` | Serialise to YAML string |
-| `render-as(value, fmt)` | Serialise to string in named format |
+| `render-as(fmt, value)` | Serialise to string in named format |
 | `parse-as(fmt, str)` | Parse string as structured data (inverse of `render-as`) |
 
 Formats for `render-as`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.

--- a/docs/reference/prelude/strings.md
+++ b/docs/reference/prelude/strings.md
@@ -55,7 +55,7 @@ are pure functions — no IO is required.
 | Function | Description |
 |----------|-------------|
 | `render(value)` | Serialise `value` to a YAML string |
-| `render-as(value, fmt)` | Serialise `value` to a string in format `fmt` |
+| `render-as(fmt, value)` | Serialise `value` to a string in format `fmt` |
 
 Supported formats for `fmt`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.
 
@@ -63,7 +63,7 @@ Supported formats for `fmt`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`
 
 ```eu,notest
 yaml-str: render({a: 1, b: 2})           # "a: 1\nb: 2\n"
-json-str: render-as({a: 1, b: 2}, :json) # "{\"a\":1,\"b\":2}"
+json-str: render-as(:json, {a: 1, b: 2}) # "{\"a\":1,\"b\":2}"
 ```
 
 These functions are backed by the `RENDER_TO_STRING` intrinsic, which
@@ -98,7 +98,7 @@ data.x  # 1
 
 # Round-trip
 original: {x: 1, y: 2}
-recovered: render-as(original, :json) parse-as(:json)
+recovered: render-as(:json, original) parse-as(:json)
 recovered.x  # 1
 
 # Pipeline style (parse-as with first arg partially applied)

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -778,8 +778,8 @@ str: {
 ` "render(value) - serialise value to a YAML string."
 render(value): __RENDER_TO_STRING(value, :yaml)
 
-` "render-as(value, fmt) - serialise value to a string in the named format. Supported formats: :yaml, :json, :toml, :text, :edn, :html."
-render-as(value, fmt): __RENDER_TO_STRING(value, fmt)
+` "render-as(fmt, value) - serialise value to a string in the named format. Pipeline-friendly: data render-as(:json). Supported formats: :yaml, :json, :toml, :text, :edn, :html."
+render-as(fmt, value): __RENDER_TO_STRING(value, fmt)
 
 ` "parse-as(fmt, str) - parse a string of structured data in the named format and return eucalypt data. The inverse of render-as. Supported formats: :json, :yaml, :toml, :csv, :xml, :edn, :jsonl. Content is parsed as inert data; embedded eucalypt expressions (e.g. YAML !eu tags) are never evaluated."
 parse-as(fmt, str): __PARSE_STRING(fmt, str)

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -15,11 +15,13 @@
 use std::convert::TryInto;
 
 use crate::{
+    common::sourcemap::Smid,
     eval::{
         emit::{Emitter, RenderMetadata},
         error::ExecutionError,
         machine::{
             env::{EnvFrame, SynClosure},
+            env_builder::EnvBuilder,
             intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
         },
         memory::{
@@ -273,9 +275,28 @@ pub(crate) fn render_closure_to_emitter(
                 }
             }
         }
+        HeapSyn::Let { bindings, body } => {
+            // Interpret Let by allocating the env frame and continuing
+            // with the body — this handles nested block literals that
+            // haven't been forced to WHNF.
+            let new_env = view.from_let(bindings.as_slice(), closure.env(), Smid::default())?;
+            let new_closure = SynClosure::new(*body, new_env);
+            render_closure_to_emitter(new_closure, pool, root_env, view, emitter)
+        }
+        HeapSyn::LetRec { bindings, body } => {
+            // Same as Let but with recursive bindings.
+            let new_env = view.from_letrec(bindings.as_slice(), closure.env(), Smid::default())?;
+            let new_closure = SynClosure::new(*body, new_env);
+            render_closure_to_emitter(new_closure, pool, root_env, view, emitter)
+        }
+        HeapSyn::Ann { body, .. } => {
+            // Skip through source annotations.
+            let new_closure = SynClosure::new(*body, closure.env());
+            render_closure_to_emitter(new_closure, pool, root_env, view, emitter)
+        }
         _ => {
-            // Other HeapSyn nodes (Let, App, etc.) — value was not fully
-            // evaluated.  Emit null and continue.
+            // Other HeapSyn nodes (App, Case, etc.) — value was not fully
+            // evaluated and cannot be interpreted here.  Emit null.
             emitter.scalar(&RenderMetadata::empty(), &Primitive::Null);
             Ok(())
         }

--- a/tests/harness/103_io_render.eu
+++ b/tests/harness/103_io_render.eu
@@ -10,13 +10,13 @@ tests: {
 
   ` "render-as with :yaml produces YAML string"
   render-as-yaml: {
-    result: render-as({a: 1}, :yaml)
+    result: render-as(:yaml, {a: 1})
     pass: result str.matches?("a:.*1.*")
   }
 
   ` "render-as with :json produces JSON string"
   render-as-json: {
-    result: render-as({x: 42}, :json)
+    result: render-as(:json, {x: 42})
     pass: result str.matches?(".*x.*42.*")
   }
 
@@ -28,7 +28,7 @@ tests: {
 
   ` "render-as a number to text"
   render-number: {
-    result: render-as(99, :text)
+    result: render-as(:text, 99)
     pass: result str.matches?("99")
   }
 

--- a/tests/harness/103_io_render.eu
+++ b/tests/harness/103_io_render.eu
@@ -32,6 +32,24 @@ tests: {
     pass: result str.matches?("99")
   }
 
+  ` "render nested block produces correct output (not null)"
+  render-nested: {
+    result: render({a: {b: 2}})
+    pass: result str.matches?("b:.*2.*")
+  }
+
+  ` "render-as nested block to JSON"
+  render-as-nested-json: {
+    result: render-as(:json, {a: {b: 2}})
+    pass: result str.matches?(".*b.*2.*")
+  }
+
+  ` "render-as in pipeline style"
+  render-as-pipeline: {
+    result: {x: 1} render-as(:json)
+    pass: result str.matches?(".*x.*1.*")
+  }
+
 }
 
 RESULT: tests values map(_.pass) all-true? then(:PASS, :FAIL)

--- a/tests/harness/107_parse_as_json.eu
+++ b/tests/harness/107_parse_as_json.eu
@@ -1,7 +1,7 @@
 "parse-as: parse a JSON string into eucalypt data."
 
 # Use a variable to avoid eucalypt treating braces in string literals as interpolation
-json-str: render-as({x: 1, y: 2}, :json)
+json-str: render-as(:json, {x: 1, y: 2})
 data: json-str parse-as(:json)
 
 tests: {

--- a/tests/harness/108_parse_as_yaml.eu
+++ b/tests/harness/108_parse_as_yaml.eu
@@ -1,7 +1,7 @@
 "parse-as: parse a YAML string into eucalypt data."
 
 # Use render-as to produce a valid YAML string, then parse it back
-yaml-str: render-as({x: 10, y: 20}, :yaml)
+yaml-str: render-as(:yaml, {x: 10, y: 20})
 data: yaml-str parse-as(:yaml)
 
 tests: {

--- a/tests/harness/109_parse_as_toml.eu
+++ b/tests/harness/109_parse_as_toml.eu
@@ -1,7 +1,7 @@
 "parse-as: parse a TOML string into eucalypt data."
 
 # Use render-as to produce a valid TOML string, then parse it back
-toml-str: render-as({x: 7, y: 8}, :toml)
+toml-str: render-as(:toml, {x: 7, y: 8})
 data: toml-str parse-as(:toml)
 
 tests: {

--- a/tests/harness/114_parse_as_roundtrip.eu
+++ b/tests/harness/114_parse_as_roundtrip.eu
@@ -3,11 +3,11 @@
 original: {x: 1, y: 2}
 
 # Round-trip via JSON
-json-str: render-as(original, :json)
+json-str: render-as(:json, original)
 recovered: json-str parse-as(:json)
 
 # Round-trip via YAML
-yaml-str: render-as(original, :yaml)
+yaml-str: render-as(:yaml, original)
 recovered-yaml: yaml-str parse-as(:yaml)
 
 tests: {


### PR DESCRIPTION
## Summary

- **`render-as` arg order**: Changed from `render-as(value, fmt)` to `render-as(fmt, value)` for pipeline-friendly partial application (e.g. `data render-as(:json)`), matching `parse-as(fmt, str)` convention
- **Nested block null in render**: `render({a: {b: 2}})` produced `a: ~` because `RENDER_TO_STRING`'s heap walk couldn't handle unevaluated `Let`/`LetRec` thunks — added interpretation of these nodes in `render_closure_to_emitter` by allocating env frames and recursing
- **Version reverted to 0.5.0** for patch release

## Test plan

- [x] All 222 harness tests pass
- [x] Clippy clean (`--all-targets -D warnings`)
- [x] `render({a: {b: 2}})` now produces `a: b: 2` (was `a: ~`)
- [x] `{data: :x} {data: •} render` now produces correct output
- [x] `{a: 1} render-as(:json)` works in pipeline style
- [x] Updated all test files, docs, and CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)