### PR TITLE
fix: restore lost prelude renames from 8f301b8

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -213,7 +213,7 @@ From highest to lowest binding:
 | 95 | -- | prefix | `↑` | Tight prefix (head) |
 | 90 | lookup | left | `.` | Field access / lookup |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
-| 88 | bool-unary | postfix | `✓` | Non-nil check (true if non-nil) |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
 | 85 | exp | right | `^`, `∘`, `;` | Power, composition |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7206,11 +7206,12 @@ in the prelude).
 | Function | Description |
 |----------|-------------|
 | `cons` | Construct new list by prepending item `h` to list `t` |
+| `snoc(x, l)` | Append element `x` to the end of list `l` |
 | `head` | Return the head item of list `xs`, panic if empty |
 | `(↑ xs)` | Return first element of list `xs`. Tight-binding prefix operator |
 | `nil?` | `true` if list `xs` is empty, `false` otherwise |
 | `non-nil?` | `true` if list `xs` is non-empty, `false` otherwise |
-| `(x ✓)` | `true` if `x` is non-nil, `false` otherwise. Postfix non-nil check (precedence 88) |
+| `(x ✓)` | `true` if `x` is not null, `false` otherwise. Postfix not-null check (precedence 88) |
 | `head-or(d, xs)` | Return the head item of list `xs` or default `d` if empty |
 | `tail` | Return list `xs` without the head item. [] causes error |
 | `tail-or(d, xs)` | Return list `xs` without the head item or `d` for empty list |
@@ -9240,7 +9241,7 @@ From highest (tightest) to lowest binding:
 | 90 | lookup | left | `.` (built-in) | Property lookup |
 | 90 | call | left | (built-in) | Function call |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
-| 88 | bool-unary | postfix | `✓` | Non-nil check (true if non-nil) |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
 | 88 | -- | -- | `∘`, `;` | Composition (actual prec 88 from prelude) |
 | 85 | exp | right | `^` | Power |
 | 85 | exp | -- | `!!` (nth) | Indexing |
@@ -11453,7 +11454,7 @@ From highest to lowest binding:
 | 95 | -- | prefix | `↑` | Tight prefix (head) |
 | 90 | lookup | left | `.` | Field access / lookup |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
-| 88 | bool-unary | postfix | `✓` | Non-nil check (true if non-nil) |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
 | 85 | exp | right | `^`, `∘`, `;` | Power, composition |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -242,7 +242,7 @@ From highest (tightest) to lowest binding:
 | 90 | lookup | left | `.` (built-in) | Property lookup |
 | 90 | call | left | (built-in) | Function call |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
-| 88 | bool-unary | postfix | `✓` | Non-nil check (true if non-nil) |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
 | 88 | -- | -- | `∘`, `;` | Composition (actual prec 88 from prelude) |
 | 85 | exp | right | `^` | Power |
 | 85 | exp | -- | `!!` (nth) | Indexing |

--- a/docs/reference/prelude/lists.md
+++ b/docs/reference/prelude/lists.md
@@ -5,11 +5,12 @@
 | Function | Description |
 |----------|-------------|
 | `cons` | Construct new list by prepending item `h` to list `t` |
+| `snoc(x, l)` | Append element `x` to the end of list `l` |
 | `head` | Return the head item of list `xs`, panic if empty |
 | `(↑ xs)` | Return first element of list `xs`. Tight-binding prefix operator |
 | `nil?` | `true` if list `xs` is empty, `false` otherwise |
 | `non-nil?` | `true` if list `xs` is non-empty, `false` otherwise |
-| `(x ✓)` | `true` if `x` is non-nil, `false` otherwise. Postfix non-nil check (precedence 88) |
+| `(x ✓)` | `true` if `x` is not null, `false` otherwise. Postfix not-null check (precedence 88) |
 | `head-or(d, xs)` | Return the head item of list `xs` or default `d` if empty |
 | `tail` | Return list `xs` without the head item. [] causes error |
 | `tail-or(d, xs)` | Return list `xs` without the head item or `d` for empty list |

--- a/editors/emacs/eucalypt-mode.el
+++ b/editors/emacs/eucalypt-mode.el
@@ -474,7 +474,7 @@ Key sequences:
   ** → •  (bullet / anaphor)
   || → ‖  (cons operator — use |||| for ‖ after ∨)
   |> → ↑  (head prefix)
-  !! → ‼  (non-nil postfix)
+  !! → ✓  (non-nil check)
   ^^ → ⊕  (bitwise XOR)
   ~< → ≪  (left shift)
   ~> → ≫  (right shift)
@@ -508,7 +508,7 @@ Key sequences:
  ;; List operators
  ("|||" ?‖)
  ("|>"  ?↑)
- ("!!"  ?‼)
+ ("!!"  ?✓)
  ;; Sets
  ("{}"  ?∅)
  ;; Natural numbers
@@ -544,7 +544,7 @@ Key sequences:
    ("b" "• bullet"     (lambda () (interactive) (insert "•")))
    ("C" "‖ cons"       (lambda () (interactive) (insert "‖")))
    ("h" "↑ head"       (lambda () (interactive) (insert "↑")))
-   ("?" "‼ non-nil?"   (lambda () (interactive) (insert "‼")))]
+   ("?" "✓ non-nil?"   (lambda () (interactive) (insert "✓")))]
   ["Other"
    ("c" "∘ compose"    (lambda () (interactive) (insert "∘")))
    ("e" "∅ empty-set"  (lambda () (interactive) (insert "∅")))

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -223,9 +223,9 @@ nil?: = []
 ` "`non-nil?(xs)` - `true` if list `xs` is non-empty, `false` otherwise."
 non-nil?: nil? complement
 
-` { doc: "`x✓` - `true` if `x` is non-nil, `false` otherwise. Postfix non-nil check operator."
+` { doc: "`x✓` - `true` if `x` is not null, `false` otherwise. Postfix not-null check operator."
     precedence: :bool-unary }
-(x ✓): x non-nil?
+(x ✓): not(x = null)
 
 ` "`head-or(xs, d)` - return the head item of list `xs` or default `d` if empty."
 head-or(d, xs): xs nil? then(d, xs head)

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -202,6 +202,9 @@ when(p?, f, x): if(x p?, x f, x)
 ` "`cons(h, t)` - construct new list by prepending item `h` to list `t`."
 cons: __CONS
 
+` "`snoc(x, l)` - append element `x` to the end of list `l`."
+snoc(x, l): l ++ [x]
+
 ` { doc: "`x ‖ xs` - prepend element `x` to list `xs`. Right-associative cons operator."
     associates: :right
     precedence: 55 }
@@ -220,9 +223,9 @@ nil?: = []
 ` "`non-nil?(xs)` - `true` if list `xs` is non-empty, `false` otherwise."
 non-nil?: nil? complement
 
-` { doc: "`x‼` - `true` if `x` is non-nil, `false` otherwise. Postfix non-nil predicate operator."
+` { doc: "`x✓` - `true` if `x` is non-nil, `false` otherwise. Postfix non-nil check operator."
     precedence: :bool-unary }
-(x ‼): x non-nil?
+(x ✓): x non-nil?
 
 ` "`head-or(xs, d)` - return the head item of list `xs` or default `d` if empty."
 head-or(d, xs): xs nil? then(d, xs head)
@@ -881,10 +884,10 @@ merge-meta(m, e): e // (meta(e) m)
 ` "`assert(p?, s, v)` - if `v p?` is true then return `v` otherwise error with message `s`."
 assert(p?, s, v): if(v p?, v, panic(s))
 
-assertions: {
+expect: {
   # In debug mode maybe the machine checks every return value against
   # metadata, but for performance reasons we only check for explicit
-  # assertions.
+  # expectations.
 
   ` "`validator(v)` - find the validator for a value `v` in its metadata"
   validator(v): lookup-or(:assert, const(true), meta(v))
@@ -904,13 +907,13 @@ assertions: {
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //= v): e with-meta({ assert: (= v)}) assertions.check
+(e //= v): e with-meta({ assert: (= v)}) expect.check
 
 ` { doc: "`e //=? f` - test that expression `e` satisfies predicate `f`, return boolean"
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //=? f): e with-meta({ assert: f}) assertions.checked
+(e //=? f): e with-meta({ assert: f}) expect.checked
 
 #
 # Assertions (panic on failure, return the value on success)
@@ -942,7 +945,7 @@ assertions: {
     deprecated: true
     associates: :left
     precedence: :meta }
-(e //!? f): e with-meta({ assert: complement(f)}) assertions.checked
+(e //!? f): e with-meta({ assert: complement(f)}) expect.checked
 
 ` { doc: "DEPRECATED: use `if(e, __ASSERT_FAIL(e, false), e)` instead."
     export: :suppress

--- a/tests/harness/101_non_nil_postfix.eu
+++ b/tests/harness/101_non_nil_postfix.eu
@@ -1,14 +1,14 @@
 #!/usr/bin/env eu
 
-# Tests for the ‼ postfix non-nil predicate operator (U+203C DOUBLE EXCLAMATION MARK)
+# Tests for the ✓ postfix non-nil predicate operator (U+203C DOUBLE EXCLAMATION MARK)
 
-t1: []‼ = false
-t2: [1]‼ = true
-t3: [1, 2, 3]‼ = true
-t4: 42‼ = true
-t5: "hello"‼ = true
-t6: :sym‼ = true
-t7: {}‼ = true
-t8: not([]‼)
+t1: []✓ = false
+t2: [1]✓ = true
+t3: [1, 2, 3]✓ = true
+t4: 42✓ = true
+t5: "hello"✓ = true
+t6: :sym✓ = true
+t7: {}✓ = true
+t8: not([]✓)
 
 RESULT: [t1, t2, t3, t4, t5, t6, t7, t8] all-true? then(:PASS, :FAIL)

--- a/tests/harness/101_non_nil_postfix.eu
+++ b/tests/harness/101_non_nil_postfix.eu
@@ -1,14 +1,16 @@
 #!/usr/bin/env eu
 
-# Tests for the ✓ postfix non-nil predicate operator (U+203C DOUBLE EXCLAMATION MARK)
+# Tests for the ✓ postfix not-null check operator (U+2713 CHECK MARK)
 
-t1: []✓ = false
-t2: [1]✓ = true
-t3: [1, 2, 3]✓ = true
-t4: 42✓ = true
-t5: "hello"✓ = true
-t6: :sym✓ = true
-t7: {}✓ = true
-t8: not([]✓)
+t1: null✓ = false
+t2: 42✓ = true
+t3: "hello"✓ = true
+t4: :sym✓ = true
+t5: {}✓ = true
+t6: []✓ = true
+t7: [1, 2, 3]✓ = true
+t8: not(null✓)
+t9: 0✓ = true
+t10: false✓ = true
 
-RESULT: [t1, t2, t3, t4, t5, t6, t7, t8] all-true? then(:PASS, :FAIL)
+RESULT: [t1, t2, t3, t4, t5, t6, t7, t8, t9, t10] all-true? then(:PASS, :FAIL)


### PR DESCRIPTION
## Summary

Commit `21a433f` (monad marker enforcement) rewrote the entire prelude from a pre-rename base, clobbering three changes from `8f301b8`:

- **`‼` → `✓`** (U+2713 CHECK MARK) for postfix not-null operator — avoids GitHub emoji rendering of `‼` (U+203C)
- **`snoc(x, l)`** — append element to end of list (was removed entirely)
- **`assertions` → `expect`** namespace rename

Also fixed the `✓` operator semantics: was `non-nil?` (empty list check), now correctly checks **not null**.

## Test plan

- [x] All 222 harness tests pass
- [x] `null✓` → `false`, `42✓` → `true`, `[]✓` → `true`
- [x] `snoc(3, [1, 2])` → `[1, 2, 3]`
- [x] `5 //= 5` → `true` (expect.check path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)