### PR TITLE
feat: str.replace, str.contains?, str.trim, shell escaping

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7492,6 +7492,13 @@ merged: ({a: 1} pb.from-block) pb.merge({a: 99, b: 2} pb.from-block)
 | `str.gt(a, b)` | True if string `a` is lexicographically greater than `b` |
 | `str.lte(a, b)` | True if string `a` is lexicographically less than or equal to `b` |
 | `str.gte(a, b)` | True if string `a` is lexicographically greater than or equal to `b` |
+| `str.replace(pattern, replacement, s)` | Replace all matches of regex `pattern` with `replacement` in `s` |
+| `str.contains?(pattern, s)` | True if `s` contains a match for regex `pattern` |
+| `str.trim` | Trim leading and trailing whitespace |
+| `str.starts-with?(re, s)` | True if `s` starts with a match for regex `re` |
+| `str.ends-with?(re, s)` | True if `s` ends with a match for regex `re` |
+| `str.shell-escape(s)` | Wrap in single quotes for safe shell use, escaping embedded `'` |
+| `str.dq-escape(s)` | Escape `$`, `` ` ``, `"`, `\` for use inside double quotes |
 | `str.base64-encode` | Encode string `s` as base64 |
 | `str.base64-decode` | Decode base64 string `s` back to its original string |
 | `str.sha256` | Return the SHA-256 hash of string `s` as lowercase hex |

--- a/docs/reference/prelude/strings.md
+++ b/docs/reference/prelude/strings.md
@@ -27,6 +27,13 @@
 | `str.gt(a, b)` | True if string `a` is lexicographically greater than `b` |
 | `str.lte(a, b)` | True if string `a` is lexicographically less than or equal to `b` |
 | `str.gte(a, b)` | True if string `a` is lexicographically greater than or equal to `b` |
+| `str.replace(pattern, replacement, s)` | Replace all matches of regex `pattern` with `replacement` in `s` |
+| `str.contains?(pattern, s)` | True if `s` contains a match for regex `pattern` |
+| `str.trim` | Trim leading and trailing whitespace |
+| `str.starts-with?(re, s)` | True if `s` starts with a match for regex `re` |
+| `str.ends-with?(re, s)` | True if `s` ends with a match for regex `re` |
+| `str.shell-escape(s)` | Wrap in single quotes for safe shell use, escaping embedded `'` |
+| `str.dq-escape(s)` | Escape `$`, `` ` ``, `"`, `\` for use inside double quotes |
 | `str.base64-encode` | Encode string `s` as base64 |
 | `str.base64-decode` | Decode base64 string `s` back to its original string |
 | `str.sha256` | Return the SHA-256 hash of string `s` as lowercase hex |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -772,6 +772,27 @@ str: {
 
   ` "`sha256(s)` - return the SHA-256 hash of string `s` as lowercase hex."
   sha256: __SHA256
+
+  ` "`replace(pattern, replacement, s)` - replace all occurrences of regex `pattern` with `replacement` in string `s`. Pipeline: s str.replace(pat, rep)."
+  replace(pattern, replacement, s): __STR_REPLACE(pattern, replacement, s)
+
+  ` "`contains?(pattern, s)` - true if string `s` contains a match for regex `pattern`. Pipeline: s str.contains?(pat)."
+  contains?(pattern, s): __STR_CONTAINS(pattern, s)
+
+  ` "`trim(s)` - trim leading and trailing whitespace from string `s`."
+  trim: __STR_TRIM
+
+  ` "`starts-with?(re, s)` - true if string `s` starts with a match for regex `re`."
+  starts-with?(re, s): __STR_CONTAINS(["^", re] join-on(""), s)
+
+  ` "`ends-with?(re, s)` - true if string `s` ends with a match for regex `re`."
+  ends-with?(re, s): __STR_CONTAINS([re, "$"] join-on(""), s)
+
+  ` "`shell-escape(s)` - wrap string in single quotes for safe shell use. Embedded single quotes are escaped."
+  shell-escape(s): [c"'", replace("'", c"'\\''", s), c"'"] join-on("")
+
+  ` "dq-escape(s) - escape string for use inside double quotes in shell commands. Escapes backslash, dollar, backtick, and double quote."
+  dq-escape(s): s replace(c"\\\\", c"\\\\\\\\") replace("[$]", c"\\$") replace("[`]", c"\\`") replace(ch.dq, [c"\\", ch.dq] join-on(""))
 }
 
 ##

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -839,6 +839,21 @@ lazy_static! {
             ty: function(vec![sym(), str_(), any()]).unwrap(),
             strict: vec![0, 1],
     },
+    Intrinsic { // 158
+            name: "STR_REPLACE",
+            ty: function(vec![str_(), str_(), str_(), str_()]).unwrap(),
+            strict: vec![0, 1, 2],
+    },
+    Intrinsic { // 159
+            name: "STR_CONTAINS",
+            ty: function(vec![str_(), str_(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
+    Intrinsic { // 160
+            name: "STR_TRIM",
+            ty: function(vec![str_(), str_()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -130,6 +130,9 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(string::Dq));
     rt.add(Box::new(string::Upper));
     rt.add(Box::new(string::Lower));
+    rt.add(Box::new(string::Replace));
+    rt.add(Box::new(string::Contains));
+    rt.add(Box::new(string::Trim));
     rt.add(Box::new(force::SeqStrList));
     rt.add(Box::new(meta::Meta));
     rt.add(Box::new(meta::RawMeta));

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -6,7 +6,7 @@ use crate::{
         emit::Emitter,
         error::ExecutionError,
         machine::intrinsic::{
-            CallGlobal0, CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic,
+            CallGlobal0, CallGlobal1, CallGlobal2, CallGlobal3, IntrinsicMachine, StgIntrinsic,
         },
         memory::{
             mutator::MutatorHeapView,
@@ -20,8 +20,8 @@ use super::{
     force::SeqStrList,
     printf::{self, PrintfError},
     support::{
-        machine_return_num, machine_return_str, machine_return_str_iter, machine_return_str_list,
-        machine_return_sym, str_arg, str_arg_ref, str_list_arg,
+        machine_return_bool, machine_return_num, machine_return_str, machine_return_str_iter,
+        machine_return_str_list, machine_return_sym, str_arg, str_arg_ref, str_list_arg,
     },
     syntax::{
         dsl::{
@@ -494,3 +494,78 @@ impl StgIntrinsic for Lower {
         machine_return_str(machine, view, string.to_lowercase())
     }
 }
+
+/// STR_REPLACE(pattern, replacement, string) — regex-based replace all
+pub struct Replace;
+
+impl StgIntrinsic for Replace {
+    fn name(&self) -> &str {
+        "STR_REPLACE"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let pattern = str_arg_ref(machine, view, &args[0])?;
+        let replacement = str_arg(machine, view, &args[1])?;
+        let string = str_arg_ref(machine, view, &args[2])?;
+
+        let re = cached_regex(machine, &pattern)?;
+        let result = re.replace_all(&string, replacement.as_str()).to_string();
+        machine_return_str(machine, view, result)
+    }
+}
+
+impl CallGlobal3 for Replace {}
+
+/// STR_CONTAINS(pattern, string) — regex-based containment check
+pub struct Contains;
+
+impl StgIntrinsic for Contains {
+    fn name(&self) -> &str {
+        "STR_CONTAINS"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let pattern = str_arg_ref(machine, view, &args[0])?;
+        let string = str_arg_ref(machine, view, &args[1])?;
+
+        let re = cached_regex(machine, &pattern)?;
+        let matched = re.is_match(&string);
+        machine_return_bool(machine, view, matched)
+    }
+}
+
+impl CallGlobal2 for Contains {}
+
+/// STR_TRIM(string) — trim leading and trailing whitespace
+pub struct Trim;
+
+impl StgIntrinsic for Trim {
+    fn name(&self) -> &str {
+        "STR_TRIM"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let string = str_arg(machine, view, &args[0])?;
+        machine_return_str(machine, view, string.trim().to_string())
+    }
+}
+
+impl CallGlobal1 for Trim {}

--- a/tests/harness/122_str_replace.eu
+++ b/tests/harness/122_str_replace.eu
@@ -1,0 +1,80 @@
+"String replacement, containment, trim, and escaping functions."
+
+tests: {
+
+  ` "str.replace: basic replacement"
+  replace-basic: {
+    result: "hello world" str.replace("o", "0")
+    pass: result = "hell0 w0rld"
+  }
+
+  ` "str.replace: regex replacement"
+  replace-regex: {
+    result: "foo123bar" str.replace("[0-9]+", "N")
+    pass: result = "fooNbar"
+  }
+
+  ` "str.replace: no match leaves string unchanged"
+  replace-no-match: {
+    result: "hello" str.replace("xyz", "!")
+    pass: result = "hello"
+  }
+
+  ` "str.contains?: positive"
+  contains-yes: {
+    pass: "hello world" str.contains?("world")
+  }
+
+  ` "str.contains?: negative"
+  contains-no: {
+    pass: not("hello" str.contains?("xyz"))
+  }
+
+  ` "str.contains?: regex"
+  contains-regex: {
+    pass: "foo123bar" str.contains?("[0-9]+")
+  }
+
+  ` "str.trim: whitespace"
+  trim-spaces: {
+    result: "  hello  " str.trim
+    pass: result = "hello"
+  }
+
+  ` "str.starts-with?: positive"
+  starts-yes: {
+    pass: "hello" str.starts-with?("hel")
+  }
+
+  ` "str.starts-with?: negative"
+  starts-no: {
+    pass: not("hello" str.starts-with?("llo"))
+  }
+
+  ` "str.ends-with?: positive"
+  ends-yes: {
+    pass: "hello" str.ends-with?("llo")
+  }
+
+  ` "str.ends-with?: negative"
+  ends-no: {
+    pass: not("hello" str.ends-with?("hel"))
+  }
+
+  ` "str.shell-escape: wraps in single quotes"
+  shell-simple: {
+    result: "hello" str.shell-escape
+    n: result str.len
+    pass: (result str.starts-with?("'")) ∧ (result str.ends-with?("'")) ∧ (n = 7)
+  }
+
+  ` "str.dq-escape: dollar sign is escaped (grows string)"
+  dq-dollar: {
+    result: "a$b" str.dq-escape
+    n: result str.len
+    pass: n = 4
+  }
+
+}
+
+RESULT: tests values map(_.pass) all-true? then(:PASS, :FAIL)

--- a/tests/harness/errors/062_str_contains_hint.eu
+++ b/tests/harness/errors/062_str_contains_hint.eu
@@ -1,3 +1,0 @@
-# Mistake: using str.contains? (Python/JavaScript style) — does not exist in eucalypt
-text: "hello world"
-check: text str.contains?("world")

--- a/tests/harness/errors/062_str_contains_hint.eu.expect
+++ b/tests/harness/errors/062_str_contains_hint.eu.expect
@@ -1,2 +1,0 @@
-exit: 1
-stderr: "str.matches?"

--- a/tests/harness/errors/063_str_trim_hint.eu
+++ b/tests/harness/errors/063_str_trim_hint.eu
@@ -1,3 +1,0 @@
-# Mistake: using str.trim (Python/JavaScript style) — does not exist in eucalypt
-text: "  hello  "
-trimmed: text str.trim

--- a/tests/harness/errors/063_str_trim_hint.eu.expect
+++ b/tests/harness/errors/063_str_trim_hint.eu.expect
@@ -1,2 +1,0 @@
-exit: 1
-stderr: "str.extract"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -607,6 +607,11 @@ pub fn test_harness_121() {
 }
 
 #[test]
+pub fn test_harness_122() {
+    run_test(&opts("122_str_replace.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }
@@ -941,16 +946,6 @@ pub fn test_error_060() {
 #[test]
 pub fn test_error_061() {
     run_error_test(&error_opts("061_lambda_keyword.eu"));
-}
-
-#[test]
-pub fn test_error_062() {
-    run_error_test(&error_opts("062_str_contains_hint.eu"));
-}
-
-#[test]
-pub fn test_error_063() {
-    run_error_test(&error_opts("063_str_trim_hint.eu"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **`str.replace(pattern, replacement, s)`** — regex-based replace all occurrences
- **`str.contains?(pattern, s)`** — regex containment predicate
- **`str.trim`** — trim leading/trailing whitespace
- **`str.starts-with?(re, s)`** / **`str.ends-with?(re, s)`** — anchored regex checks
- **`str.shell-escape(s)`** — wrap in single quotes for safe shell use
- **`str.dq-escape(s)`** — escape `$`, backtick, `"`, `\` for use inside double quotes

Three new Rust intrinsics: `STR_REPLACE`, `STR_CONTAINS`, `STR_TRIM`. Shell escaping built purely in the prelude on top of `str.replace`.

Removes error tests 062/063 which tested that `str.contains?` and `str.trim` did not exist.

## Test plan

- [x] All 221 harness tests pass (including new test 122)
- [x] Clippy clean
- [x] `"hello world" str.replace("o", "0")` → `hell0 w0rld`
- [x] `"hello" str.contains?("ell")` → `true`
- [x] `"  hello  " str.trim` → `hello`
- [x] `"hello" str.shell-escape` → `'hello'`
- [x] `"a$b" str.dq-escape` → `a\$b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)