### PR TITLE
fix: min-of-by/max-of-by return element, add max-map/min-map

### DIFF
--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -38,7 +38,7 @@ best-from(ps): ps tail map(area(ps head)) max-of
 best-area(pts):
   tails(pts)
     filter(count ; (> 1))
-    max-of-by(best-from)
+    max-map(best-from)
 
 parse(data): data filter(!= "") map(parse-coord)
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -658,8 +658,18 @@ max-of(l): cond( [[l nil?,      panic("max of empty list")]
                , [count(l) = 1, l head]]
 	       , max(l head, max-of(l tail)))
 
-` "`max-of-by(f, l)` - return maximum value of `f(x)` across elements of `l`."
-max-of-by(f, l): l map(f) max-of
+` "`max-of-by(f, l)` - return the element of `l` that maximises `f`. Error if empty."
+max-of-by(f, l): {
+  step(acc, x): {
+    v: x f
+    better: v > (acc second)
+  }.(if(better, [x, v], acc))
+  init: [l head, l head f]
+}.( foldl(step, init, l tail) head )
+
+
+` "`max-map(f, l)` - return maximum value of `f(x)` across elements of `l`."
+max-map(f, l): l map(f) max-of
 
 ` "`max-of-or(d, l)` - return max element in list `l`, or default `d` if empty."
 max-of-or(d, l): l nil? then(d, max-of(l))
@@ -672,8 +682,18 @@ min-of(l): cond( [[l nil?,      panic("min of empty list")]
                , [count(l) = 1, l head]]
 	       , min(l head, min-of(l tail)))
 
-` "`min-of-by(f, l)` - return minimum value of `f(x)` across elements of `l`."
-min-of-by(f, l): l map(f) min-of
+` "`min-of-by(f, l)` - return the element of `l` that minimises `f`. Error if empty."
+min-of-by(f, l): {
+  step(acc, x): {
+    v: x f
+    better: v < (acc second)
+  }.(if(better, [x, v], acc))
+  init: [l head, l head f]
+}.( foldl(step, init, l tail) head )
+
+
+` "`min-map(f, l)` - return minimum value of `f(x)` across elements of `l`."
+min-map(f, l): l map(f) min-of
 
 ` "`min-of-or(d, l)` - return min element in list `l`, or default `d` if empty."
 min-of-or(d, l): l nil? then(d, min-of(l))


### PR DESCRIPTION
## Summary

- **`max-of-by(f, l)` / `min-of-by(f, l)`** now return the element of `l` that maximises/minimises `f` (was incorrectly returning the derived value `f(x)`)
- **`max-map(f, l)` / `min-map(f, l)`** added for the old behaviour (return max/min of `f(x)` across elements)
- Updated `aoc25/day09.eu` to use `max-map` (it wanted the derived value)

## Examples

```
[3, 1, 4, 1, 5] max-of-by(negate)      # → 1 (element with largest negation)
[3, 1, 4, 1, 5] max-map(negate)         # → -1 (the largest negated value)
[[1,2], [3], [1,2,3,4]] max-of-by(count) # → [1,2,3,4] (longest list)
```

## Test plan

- [x] All 222 harness tests pass
- [x] `max-of-by(negate)` on `[3,1,4,1,5]` → `1`
- [x] `min-of-by(count)` on `[[1,2],[3],[1,2,3,4]]` → `[3]`
- [x] `max-map`/`min-map` preserve old behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)