### PR TITLE
fix: replace ptr::offset UB in heap get_header/get_object

### DIFF
--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -2172,11 +2172,21 @@ impl Allocator for Heap {
     fn get_header<T>(&self, object: NonNull<T>) -> NonNull<AllocHeader> {
         // SAFETY: Pointer arithmetic is valid because:
         // - All objects are allocated with an AllocHeader prefix
-        // - offset(-1) moves back exactly size_of::<AllocHeader>() bytes
+        // - The header is at `object_ptr - size_of::<AllocHeader>()` bytes
         // - The pointer came from alloc() which guarantees this layout
         // - NonNull input guarantees non-null result
-        let header_ptr =
-            unsafe { NonNull::new_unchecked(object.cast::<AllocHeader>().as_ptr().offset(-1)) };
+        //
+        // Uses byte_sub instead of offset(-1) to avoid UB when Rust's
+        // pointer provenance checks flag cross-object offset arithmetic.
+        let header_ptr = unsafe {
+            NonNull::new_unchecked(
+                object
+                    .as_ptr()
+                    .cast::<u8>()
+                    .sub(size_of::<AllocHeader>())
+                    .cast::<AllocHeader>(),
+            )
+        };
         debug_assert!(header_ptr.as_ptr() as usize > 0);
         header_ptr
     }
@@ -2185,9 +2195,17 @@ impl Allocator for Heap {
     fn get_object(&self, header: NonNull<AllocHeader>) -> NonNull<()> {
         // SAFETY: Pointer arithmetic is valid because:
         // - Headers are always followed by their object data
-        // - offset(1) moves forward exactly size_of::<AllocHeader>() bytes
+        // - The object is at `header_ptr + size_of::<AllocHeader>()` bytes
         // - The header came from an allocation with this layout
-        unsafe { NonNull::new_unchecked(header.as_ptr().offset(1)).cast::<()>() }
+        unsafe {
+            NonNull::new_unchecked(
+                header
+                    .as_ptr()
+                    .cast::<u8>()
+                    .add(size_of::<AllocHeader>())
+                    .cast::<()>(),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`get_header()` used `ptr::offset(-1)` on a `*mut AllocHeader` to navigate from an object back to its header. This crosses provenance boundaries (the header and object are different "objects" from Rust's perspective), which Rust 1.94's UB sanitiser flags in debug builds:

```
unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow
```

This caused `test_harness_105` (IO chain) to abort on ubuntu CI across all recent master merges.

**Fix:** Replace `offset(-1)` / `offset(1)` with byte-level arithmetic: `cast::<u8>().sub(size_of::<AllocHeader>())` / `.add(...)`. Same result, no provenance violation.

## Test plan

- [x] All 222 harness tests pass locally (including test 105)
- [x] Clippy clean
- [x] CI should now pass on ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)