### PR TITLE
feat: add io.fail(msg)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7914,6 +7914,7 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 |----------|-------------|
 | `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
 | `io.checked` | Pipeline-friendly check: bind the preceding IO action through `io.check` |
+| `io.fail(msg)` | Fail the IO action with the given error message |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
 | `io.and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `io.then(a, b)` | Sequence two actions, discarding the result of the first |

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -59,6 +59,7 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 |----------|-------------|
 | `io.check(result)` | If `exit-code` is non-zero, fail with the stderr message; otherwise return the result |
 | `io.checked` | Pipeline-friendly check: bind the preceding IO action through `io.check` |
+| `io.fail(msg)` | Fail the IO action with the given error message |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
 | `io.and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
 | `io.then(a, b)` | Sequence two actions, discarding the result of the first |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -55,6 +55,9 @@ io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
 
   ` "Pipeline-friendly check: bind the preceding IO action through check."
   checked: io.and-then(io.check)
+
+  ` "Fail the IO action with the given error message."
+  fail(msg): __IO_ACTION({:io-fail message: msg})
 }
 
 

--- a/tests/harness/errors/072_io_fail.eu
+++ b/tests/harness/errors/072_io_fail.eu
@@ -1,0 +1,3 @@
+# io.fail should produce an error with the given message
+` { target: :main requires-io: true }
+main: io.fail("deliberate test failure")

--- a/tests/harness/errors/072_io_fail.eu.expect
+++ b/tests/harness/errors/072_io_fail.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "deliberate test failure"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -25,6 +25,18 @@ pub fn error_opts(filename: &str) -> EucalyptOptions {
         .build()
 }
 
+/// Options for IO error tests — enables shell execution via --allow-io
+pub fn io_error_opts(filename: &str) -> EucalyptOptions {
+    let lib_path = vec![PathBuf::from("tests/harness/errors")];
+    let path = format!("tests/harness/errors/{filename}");
+
+    EucalyptOptions::default()
+        .with_explicit_inputs(vec![Input::from_str(&path).unwrap()])
+        .with_lib_path(lib_path)
+        .with_allow_io()
+        .build()
+}
+
 /// Options for IO monad tests — enables shell execution via --allow-io
 pub fn io_opts(filename: &str) -> EucalyptOptions {
     let lib_path = vec![PathBuf::from("tests/harness")];
@@ -991,6 +1003,11 @@ pub fn test_error_070() {
 #[test]
 pub fn test_error_071() {
     run_error_test(&error_opts("071_def_keyword.eu"));
+}
+
+#[test]
+pub fn test_error_072() {
+    run_error_test(&io_error_opts("072_io_fail.eu"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `io.fail(msg)` — an IO action that immediately fails with the given error message
- Wraps the existing `IoFail` data constructor via `__IO_ACTION({:io-fail message: msg})`
- Error test verifies the message appears in stderr

## Test plan

- [x] All 223 tests pass (including new error test 072)
- [x] `io.fail("oops")` produces `io.fail: oops` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)