### PR TITLE
fix: reverse monad then() arg order for pipeline use

### DIFF
--- a/docs/guide/monads.md
+++ b/docs/guide/monads.md
@@ -124,7 +124,7 @@ The returned block provides:
 | `bind(action, f)` | Passed through from `m.bind` |
 | `return(v)` | Passed through from `m.return` |
 | `map(f, action)` | Apply pure function `f` to the result of an action (fmap) |
-| `then(a, b)` | Sequence two actions, discarding the result of the first |
+| `then(b, a)` | Sequence two actions, discarding the result of the first. Pipeline: `a m.then(b)` |
 | `join(mm)` | Flatten a nested monadic value |
 | `sequence(ms)` | Run a list of actions in order, collecting results |
 | `map-m(f, xs)` | Apply `f` to each element of `xs`, then sequence |

--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -62,7 +62,7 @@ Optional `{stdin: s}` pipes string `s` to the command's standard input.
 | `io.fail(msg)` | Fail the IO action with the given error message |
 | `io.map(f, action)` | Apply a pure function to the result of an IO action (fmap) |
 | `io.and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
-| `io.then(a, b)` | Sequence two actions, discarding the result of the first |
+| `io.then(b, a)` | Sequence two actions, discarding the result of the first. Pipeline: `a io.then(b)` |
 | `io.join(mm)` | Flatten a nested IO action |
 | `io.sequence(ms)` | Run a list of IO actions in order, collecting results into a list |
 | `io.map-m(f, xs)` | Apply `f` to each element of `xs` (producing IO actions), then sequence |
@@ -80,7 +80,7 @@ pattern and the [IO guide](../../guide/io.md) for practical usage.
 | `monad(m).return` | Passed through from `m.return` |
 | `monad(m).map(f, action)` | Apply pure function `f` to the result of a monadic action (fmap) |
 | `monad(m).and-then(f, action)` | Pass the result of `action` to `f` (bind with flipped args, for pipeline use) |
-| `monad(m).then(a, b)` | Sequence two monadic actions, discarding the result of the first |
+| `monad(m).then(b, a)` | Sequence two monadic actions, discarding the result of the first. Pipeline: `a m.then(b)` |
 | `monad(m).join(mm)` | Flatten a nested monadic value |
 | `monad(m).sequence(ms)` | Sequence a list of monadic actions, collecting results into a list |
 | `monad(m).map-m(f, xs)` | Apply `f` to each element of `xs` (producing actions), then sequence |

--- a/docs/reference/prelude/random.md
+++ b/docs/reference/prelude/random.md
@@ -58,7 +58,7 @@ infinite stream.
 | `random.shuffle(list)` | Action returning a shuffled copy of list |
 | `random.sample(n, list)` | Action returning n elements sampled without replacement |
 | `random.map(f, action)` | Apply pure function f to the result of an action (derived) |
-| `random.then(a, b)` | Sequence two actions, discard first result (derived) |
+| `random.then(b, a)` | Sequence two actions, discard first result (derived). Pipeline: `a random.then(b)` |
 | `random.join(mm)` | Flatten a nested action (derived) |
 | `random.sequence(ms)` | Sequence a list of actions, collect results (derived) |
 | `random.map-m(f, xs)` | Map f over list producing actions, then sequence (derived) |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -81,8 +81,8 @@ monad(m): {
   ` "map(f, action) - apply pure function f to the result of a monadic action (fmap)."
   map(f, action): m.bind(action, compose(m.return, f))
 
-  ` "then(a, b) - sequence two monadic actions, discarding the result of the first."
-  then(a, b): m.bind(a, -> b)
+  ` "then(b, a) - sequence two monadic actions, discarding the result of the first. Pipeline: `a io.then(b)`."
+  then(b, a): m.bind(a, -> b)
 
   ` "and-then(f, action) - pass the result of action to f (bind with flipped args, for pipeline use)."
   and-then(f, action): m.bind(action, f)

--- a/tests/harness/119_monad_utility.eu
+++ b/tests/harness/119_monad_utility.eu
@@ -24,10 +24,12 @@ test-map-pure:
 
 ##
 ## then: sequence two actions, discard the first result
+## then(b, a) — runs a, discards result, returns b
+## Pipeline: a id-monad.then(b)
 ##
 ` { target: :test-then-pure }
 test-then-pure:
-  if(id-monad.then(99, 42) = 42,
+  if(id-monad.then(42, 99) = 42,
     { RESULT: :PASS },
     { RESULT: :FAIL })
 
@@ -79,13 +81,25 @@ test-io-map:
 
 ##
 ## IO: derived monad then sequences two IO actions
+## then(b, a) — runs a first, discards, then returns b
+## So then(io.shell("echo second"), io.shell("echo first"))
+## runs "echo first", discards, runs "echo second", returns its result
 ##
 ` { target: :test-io-then requires-io: true }
 test-io-then:
-  { :io r: monad({bind: io.bind, return: io.return}).then(io.shell("echo first"), io.shell("echo second")) }.(
+  { :io r: monad({bind: io.bind, return: io.return}).then(io.shell("echo second"), io.shell("echo first")) }.(
     if(r.stdout str.matches?("second.*"),
       { RESULT: :PASS },
       { RESULT: :FAIL }))
+
+##
+## then: pipeline style — a id-monad.then(b) runs a, discards, returns b
+##
+` { target: :test-then-pipeline }
+test-then-pipeline:
+  if((99 id-monad.then(42)) = 42,
+    { RESULT: :PASS },
+    { RESULT: :FAIL })
 
 ##
 ## and-then: bind with flipped args for pipeline use (pure)


### PR DESCRIPTION
## Summary

- Change `then(a, b)` to `then(b, a)` in `monad()` so pipeline style works: `a io.then(b)`
- Previously `a io.then(b)` passed args backwards — `a` as the action to discard, `b` as the result
- Updated docs (monads guide, io.md, random.md) and tests
- Added pipeline-style test case: `99 id-monad.then(42) = 42`

Addresses the same pipeline convention used by `and-then(f, action)` and `map(f, action)`.

## Test plan

- [x] Existing `test-then-pure` updated and passing
- [x] Existing `test-io-then` updated and passing
- [x] New `test-then-pipeline` added and passing
- [x] Full test suite (223 tests) passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)