### PR TITLE
fix: c-string lexer handles escaped quotes

### DIFF
--- a/src/syntax/rowan/lex.rs
+++ b/src/syntax/rowan/lex.rs
@@ -330,12 +330,23 @@ where
         // Collect the string content to check for interpolation
         let mut content = String::new();
 
-        // Consume characters until closing quote or EOF
+        // Consume characters until closing quote or EOF.
+        // For c-strings, backslash-quote (\") is an escape — not a terminator.
+        let is_cstring = string_prefix == StringPrefix::CString;
         loop {
             match self.peek() {
                 Some(&'"') => {
                     self.bump(); // consume closing quote
                     break;
+                }
+                Some(&'\\') if is_cstring => {
+                    content.push('\\');
+                    self.bump();
+                    // Consume the escaped character (including \")
+                    if let Some(&c) = self.peek() {
+                        content.push(c);
+                        self.bump();
+                    }
                 }
                 Some(&c) => {
                     content.push(c);
@@ -956,6 +967,18 @@ d: {
     fn test_cstring_simple() {
         // c"hello" should be lexed as a C_STRING
         test_lex(r#"c"hello""#, vec![(C_STRING, Span::new(0, 8))]);
+    }
+
+    #[test]
+    fn test_cstring_escaped_quote() {
+        // c"say \"hi\"" should be lexed as a single C_STRING token
+        test_lex(r#"c"say \"hi\"""#, vec![(C_STRING, Span::new(0, 13))]);
+    }
+
+    #[test]
+    fn test_cstring_escaped_quote_only() {
+        // c"\"" should be a single C_STRING token (one escaped quote)
+        test_lex(r#"c"\"""#, vec![(C_STRING, Span::new(0, 5))]);
     }
 
     #[test]

--- a/tests/harness/124_cstring_escapes.eu
+++ b/tests/harness/124_cstring_escapes.eu
@@ -1,0 +1,67 @@
+"Comprehensive c-string escape tests"
+
+` { target: :test }
+test: {
+  # Basic escapes - verify by length
+  newline: c"a\nb" str.len //= 3
+  tab: c"a\tb" str.len //= 3
+  cr: c"a\rb" str.len //= 3
+  backslash: c"a\\b" str.len //= 3
+  null-char: c"a\0b" str.len //= 3
+
+  # Escaped quotes - the c-string contains a literal quote character
+  dquote-len: c"\"" str.len //= 1
+  dquote-start: c"\"hello" str.len //= 6
+  dquote-end: c"hello\"" str.len //= 6
+  dquote-both: c"\"hello\"" str.len //= 7
+  dquote-adjacent: c"\"\"" str.len //= 2
+  dquote-multi: c"say \"hello\" and \"bye\"" str.len //= 21
+
+  # Escaped braces produce literal brace characters
+  lbrace-len: c"\{" str.len //= 1
+  rbrace-len: c"\}" str.len //= 1
+  braces-len: c"\{\}" str.len //= 2
+  braces-content-len: c"\{hello\}" str.len //= 7
+
+  # Escaped quotes with braces
+  quoted-braces-len: c"\"\{\}\"" str.len //= 4
+
+  # Hex escapes
+  hex-a: c"\x41" //= "A"
+
+  # Unicode escapes
+  unicode-alpha: c"\u03B1" //= "α"
+
+  # Mixed escapes
+  mixed-len: c"say \"hi\"\nok" str.len //= 11
+
+  # c-string equals equivalent regular string
+  plain-match: c"hello" //= "hello"
+  newline-match: c"a\nb" //= "a
+b"
+
+  # Backslash before closing quote
+  backslash-end: c"path\\" str.len //= 5
+
+  # Multiple escapes in sequence
+  multi-escape: c"\\\"\\n" str.len //= 4
+
+  RESULT: [newline, tab, cr, backslash, null-char,
+           dquote-len, dquote-start, dquote-end, dquote-both,
+           dquote-adjacent, dquote-multi,
+           lbrace-len, rbrace-len, braces-len, braces-content-len,
+           quoted-braces-len,
+           hex-a, unicode-alpha, mixed-len,
+           plain-match, newline-match, backslash-end,
+           multi-escape] all-true? then(:PASS, :FAIL)
+}
+
+# c-string interpolation with escaped quotes around interpolated content
+` { target: :test-interpolation }
+test-interpolation: {
+  x: 42
+  interp: c"\"{x}\""
+  # Should be "42" (literal quotes around the interpolated value)
+  interp-len: interp str.len //= 4
+  RESULT: interp-len then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -629,6 +629,11 @@ pub fn test_harness_123() {
 }
 
 #[test]
+pub fn test_harness_124() {
+    run_test(&opts("124_cstring_escapes.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Fix lexer to skip over `\"` in c-strings instead of terminating the string
- The escape processor already handled `\"` correctly — the lexer was the gap
- Works for both plain c-strings and c-strings with interpolation

## Changes

- `src/syntax/rowan/lex.rs`: In `dquote()`, when lexing a c-string, consume backslash-escaped characters (including `\"`) without terminating
- Two new lexer unit tests for escaped quotes
- New harness test 124 with comprehensive c-string escape coverage: `\n`, `\t`, `\r`, `\\`, `\0`, `\"`, `\{`, `\}`, `\xHH`, `\uHHHH`, plus interpolation with escaped quotes

## Test plan

- [x] 224 harness tests passing (including new test 124)
- [x] Lexer unit tests for escaped quotes
- [x] Interpolation with escaped quotes: `c"\"{x}\""` produces `"42"`
- [x] Clippy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)