### PR TITLE
docs: add curl one-liner install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ target-zones:
 brew install curvelogic/homebrew-tap/eucalypt
 ```
 
+### Linux / macOS (install script)
+
+```sh
+curl -sSf https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+```
+
+Installs the latest release binary to `~/.local/bin`. Set `EUCALYPT_INSTALL_DIR` to override.
+
 ### From Source
 
 ```sh

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,7 +10,13 @@ On macOS, use Homebrew:
 brew install curvelogic/homebrew-tap/eucalypt
 ```
 
-On other platforms, download a binary from the
+On Linux or macOS without Homebrew, use the install script:
+
+```sh
+curl -sSf https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+```
+
+You can also download a binary from the
 [GitHub releases](https://github.com/curvelogic/eucalypt/releases)
 page, or build from source with `cargo install --path .`.
 

--- a/docs/welcome/quick-start.md
+++ b/docs/welcome/quick-start.md
@@ -10,6 +10,17 @@ If you use Homebrew, you can install using:
 brew install curvelogic/homebrew-tap/eucalypt
 ```
 
+### Linux / macOS (install script)
+
+Alternatively, install the latest release binary directly:
+
+```sh
+curl -sSf https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+```
+
+This installs to `~/.local/bin`. Set `EUCALYPT_INSTALL_DIR` to
+override the install location.
+
 Otherwise binaries for macOS are available on the [releases
 page](https://github.com/curvelogic/eucalypt/releases).
 


### PR DESCRIPTION
## Summary

- Add the `curl | sh` one-liner to README, quick-start guide, and FAQ
- The `install.sh` script existed but wasn't documented anywhere

## Test plan

- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)