### PR TITLE
feat(eu-32so): VS Code extension parity with emacs mode

### DIFF
--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -5,25 +5,45 @@
   "brackets": [
     ["{", "}"],
     ["[", "]"],
-    ["(", ")"]
+    ["(", ")"],
+    ["⟦", "⟧"],
+    ["⟨", "⟩"],
+    ["⟪", "⟫"],
+    ["⌈", "⌉"],
+    ["⌊", "⌋"],
+    ["«", "»"],
+    ["【", "】"],
+    ["〔", "〕"]
   ],
   "autoClosingPairs": [
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
-    { "open": "'", "close": "'", "notIn": ["string"] }
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "⟦", "close": "⟧" },
+    { "open": "⟨", "close": "⟩" },
+    { "open": "⟪", "close": "⟫" },
+    { "open": "⌈", "close": "⌉" },
+    { "open": "⌊", "close": "⌋" },
+    { "open": "«", "close": "»" },
+    { "open": "【", "close": "】" },
+    { "open": "〔", "close": "〕" }
   ],
   "surroundingPairs": [
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"" },
-    { "open": "'", "close": "'" }
+    { "open": "'", "close": "'" },
+    { "open": "⟦", "close": "⟧" },
+    { "open": "⟨", "close": "⟩" },
+    { "open": "⟪", "close": "⟫" },
+    { "open": "«", "close": "»" }
   ],
   "indentationRules": {
     "increaseIndentPattern": ".*[{\\[]\\s*$",
     "decreaseIndentPattern": "^\\s*[}\\]]"
   },
-  "wordPattern": "[a-zA-Z_][a-zA-Z0-9_\\-?!]*"
+  "wordPattern": "[•$?_a-zA-Z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02AF][•$?_!*\\-a-zA-Z0-9\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02AF]*"
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -28,7 +28,11 @@
           "eucalypt"
         ],
         "extensions": [
-          ".eu"
+          ".eu",
+          ".eucalypt"
+        ],
+        "filenames": [
+          "Eufile"
         ],
         "configuration": "./language-configuration.json"
       }
@@ -40,9 +44,63 @@
         "path": "./syntaxes/eucalypt.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "eucalypt",
+        "path": "./snippets/eucalypt.code-snippets"
+      }
+    ],
+    "commands": [
+      {
+        "command": "eucalypt.insertUnicodeOperator",
+        "title": "Insert Unicode Operator",
+        "category": "Eucalypt"
+      },
+      {
+        "command": "eucalypt.renderBuffer",
+        "title": "Render Buffer",
+        "category": "Eucalypt"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "eucalypt.insertUnicodeOperator",
+        "key": "ctrl+c ctrl+u",
+        "mac": "cmd+c cmd+u",
+        "when": "editorTextFocus && editorLangId == eucalypt"
+      },
+      {
+        "command": "eucalypt.renderBuffer",
+        "key": "ctrl+c ctrl+k",
+        "mac": "cmd+c cmd+k",
+        "when": "editorTextFocus && editorLangId == eucalypt"
+      }
+    ],
+    "configuration": {
+      "title": "Eucalypt",
+      "properties": {
+        "eucalypt.euCommand": {
+          "type": "string",
+          "default": "eu",
+          "description": "Path to the eucalypt `eu` binary. Defaults to `eu` on the PATH."
+        },
+        "eucalypt.globalOptions": {
+          "type": "string",
+          "default": "",
+          "description": "Default options to pass to `eu` for all invocations."
+        },
+        "eucalypt.lspEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the Eucalypt Language Server Protocol integration."
+        }
+      }
+    },
     "configurationDefaults": {
       "[eucalypt]": {
-        "editor.unicodeHighlight.ambiguousCharacters": false
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true
       }
     }
   },

--- a/editors/vscode/snippets/eucalypt.code-snippets
+++ b/editors/vscode/snippets/eucalypt.code-snippets
@@ -1,0 +1,100 @@
+{
+  "Function declaration": {
+    "prefix": "fn",
+    "body": ["${1:name}(${2:x}): ${3:x}"],
+    "description": "Function declaration"
+  },
+  "Property declaration": {
+    "prefix": "prop",
+    "body": ["${1:name}: ${2:value}"],
+    "description": "Property declaration"
+  },
+  "Block": {
+    "prefix": "blk",
+    "body": [
+      "{",
+      "\t${1:name}: ${2:value}",
+      "}"
+    ],
+    "description": "Block literal"
+  },
+  "Documented declaration": {
+    "prefix": "doc",
+    "body": [
+      "` \"${1:Documentation.}\"",
+      "${2:name}: ${3:value}"
+    ],
+    "description": "Declaration with documentation string"
+  },
+  "Block with documentation": {
+    "prefix": "docblk",
+    "body": [
+      "` {doc: \"${1:Documentation.}\"}",
+      "${2:name}: ${3:value}"
+    ],
+    "description": "Declaration with block-valued metadata documentation"
+  },
+  "If expression": {
+    "prefix": "if",
+    "body": ["if ${1:condition} then ${2:true-value} else ${3:false-value}"],
+    "description": "Conditional if expression"
+  },
+  "Cond expression": {
+    "prefix": "cond",
+    "body": [
+      "cond([",
+      "\t[${1:condition}, ${2:value}],",
+      "\t[true, ${3:default}]",
+      "])"
+    ],
+    "description": "Multi-branch conditional"
+  },
+  "Map": {
+    "prefix": "map",
+    "body": ["${1:list} map(${2:f})"],
+    "description": "Map over a list"
+  },
+  "Filter": {
+    "prefix": "filter",
+    "body": ["${1:list} filter(${2:pred})"],
+    "description": "Filter a list"
+  },
+  "Foldl": {
+    "prefix": "foldl",
+    "body": ["${1:list} foldl(${2:f}, ${3:initial})"],
+    "description": "Left fold over a list"
+  },
+  "Lambda (expression anaphor)": {
+    "prefix": "lam",
+    "body": ["(_ ${1:+ 1})"],
+    "description": "Anonymous function using expression anaphor"
+  },
+  "Merge blocks": {
+    "prefix": "merge",
+    "body": ["${1:a} merge(${2:b})"],
+    "description": "Merge two blocks"
+  },
+  "Import": {
+    "prefix": "import",
+    "body": ["${1:data}: import(\"${2:file.yaml}\")"],
+    "description": "Import external data file"
+  },
+  "Render target": {
+    "prefix": "target",
+    "body": [
+      "` :target",
+      "${1:name}: ${2:expression}"
+    ],
+    "description": "Declare a named render target"
+  },
+  "List comprehension (mapcat)": {
+    "prefix": "mapcat",
+    "body": ["${1:list} mapcat(${2:f})"],
+    "description": "Flat-map over a list"
+  },
+  "Pipeline": {
+    "prefix": "pipe",
+    "body": ["${1:value} ${2:f} ${3:g}"],
+    "description": "Value pipeline (catenation)"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -3,6 +3,7 @@ import * as cp from "child_process";
 import {
   commands,
   ExtensionContext,
+  OutputChannel,
   QuickPickItem,
   window,
   workspace,
@@ -61,7 +62,7 @@ async function insertUnicodeOperator(): Promise<void> {
   }
 }
 
-async function renderBuffer(): Promise<void> {
+async function renderBuffer(outputChannel: OutputChannel): Promise<void> {
   const editor = window.activeTextEditor;
   if (!editor) {
     return;
@@ -76,7 +77,6 @@ async function renderBuffer(): Promise<void> {
   const fmt = ext === "yaml" ? "yaml" : ext === "csv" ? "csv" : "eu";
   const args = [euCommand, ...globalOpts.split(" ").filter(Boolean), `${fmt}@-`];
 
-  const outputChannel = window.createOutputChannel("Eucalypt");
   outputChannel.clear();
   outputChannel.show(true);
 
@@ -105,6 +105,12 @@ async function renderBuffer(): Promise<void> {
 }
 
 export function activate(context: ExtensionContext) {
+  const config = workspace.getConfiguration("eucalypt");
+
+  // Create output channel once so it is reused across renderBuffer invocations
+  const outputChannel = window.createOutputChannel("Eucalypt");
+  context.subscriptions.push(outputChannel);
+
   // Register commands
   context.subscriptions.push(
     commands.registerCommand(
@@ -114,30 +120,34 @@ export function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    commands.registerCommand("eucalypt.renderBuffer", renderBuffer)
+    commands.registerCommand("eucalypt.renderBuffer", () =>
+      renderBuffer(outputChannel)
+    )
   );
 
-  // Start the LSP client
-  const config = workspace.getConfiguration("eucalypt");
-  const command = config.get<string>("euCommand", "eu");
+  // Start the LSP client only when enabled (default: true)
+  const lspEnabled = config.get<boolean>("lspEnabled", true);
+  if (lspEnabled) {
+    const command = config.get<string>("euCommand", "eu");
 
-  const serverOptions: ServerOptions = {
-    command,
-    args: ["lsp"],
-  };
+    const serverOptions: ServerOptions = {
+      command,
+      args: ["lsp"],
+    };
 
-  const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "eucalypt" }],
-  };
+    const clientOptions: LanguageClientOptions = {
+      documentSelector: [{ scheme: "file", language: "eucalypt" }],
+    };
 
-  client = new LanguageClient(
-    "eucalypt",
-    "Eucalypt Language Server",
-    serverOptions,
-    clientOptions
-  );
+    client = new LanguageClient(
+      "eucalypt",
+      "Eucalypt Language Server",
+      serverOptions,
+      clientOptions
+    );
 
-  client.start();
+    client.start();
+  }
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,6 +1,10 @@
 import * as path from "path";
+import * as cp from "child_process";
 import {
+  commands,
   ExtensionContext,
+  QuickPickItem,
+  window,
   workspace,
 } from "vscode";
 import {
@@ -11,11 +15,111 @@ import {
 
 let client: LanguageClient | undefined;
 
+// Unicode operator table — matches the Emacs quail/transient menu
+const UNICODE_OPERATORS: QuickPickItem[] = [
+  { label: "∧", description: "Logical and  (&&)" },
+  { label: "∨", description: "Logical or  (||)" },
+  { label: "¬", description: "Logical not  (~~)" },
+  { label: "≤", description: "Less-or-equal  (<=)" },
+  { label: "≥", description: "Greater-or-equal  (>=)" },
+  { label: "≠", description: "Not equal  (!=)" },
+  { label: "∸", description: "Unary minus / negate  (/-)" },
+  { label: "÷", description: "Exact division  (/%)" },
+  { label: "∘", description: "Compose  (..)" },
+  { label: "•", description: "Bullet / anaphor  (**)" },
+  { label: "‖", description: "Cons operator  (|||)" },
+  { label: "↑", description: "Head prefix  (|>)" },
+  { label: "✓", description: "Non-nil check  (!!)" },
+  { label: "⊕", description: "Bitwise XOR  (^^)" },
+  { label: "≪", description: "Left shift  (~<)" },
+  { label: "≫", description: "Right shift  (~>)" },
+  { label: "∅", description: "Empty set  ({})" },
+  { label: "ℕ", description: "Natural numbers  (0N)" },
+  { label: "⟨", description: "Mathematical angle bracket open  ((()" },
+  { label: "⟩", description: "Mathematical angle bracket close  ()))"},
+  { label: "⟦", description: "Double square bracket open  ([[)" },
+  { label: "⟧", description: "Double square bracket close  (]])" },
+  { label: "«", description: "Left angle bracket  (<<)" },
+  { label: "»", description: "Right angle bracket  (>>)" },
+];
+
+async function insertUnicodeOperator(): Promise<void> {
+  const editor = window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+  const picked = await window.showQuickPick(UNICODE_OPERATORS, {
+    placeHolder: "Select a Unicode operator to insert",
+    matchOnDescription: true,
+  });
+  if (picked) {
+    editor.edit((editBuilder) => {
+      for (const selection of editor.selections) {
+        editBuilder.replace(selection, picked.label);
+      }
+    });
+  }
+}
+
+async function renderBuffer(): Promise<void> {
+  const editor = window.activeTextEditor;
+  if (!editor) {
+    return;
+  }
+
+  const config = workspace.getConfiguration("eucalypt");
+  const euCommand = config.get<string>("euCommand", "eu");
+  const globalOpts = config.get<string>("globalOptions", "");
+
+  const filePath = editor.document.fileName;
+  const ext = path.extname(filePath).slice(1) || "eu";
+  const fmt = ext === "yaml" ? "yaml" : ext === "csv" ? "csv" : "eu";
+  const args = [euCommand, ...globalOpts.split(" ").filter(Boolean), `${fmt}@-`];
+
+  const outputChannel = window.createOutputChannel("Eucalypt");
+  outputChannel.clear();
+  outputChannel.show(true);
+
+  const text = editor.document.getText();
+  const proc = cp.spawn(args[0], args.slice(1), { shell: false });
+
+  let stdout = "";
+  let stderr = "";
+  proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+  proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+  proc.stdin.write(text);
+  proc.stdin.end();
+
+  proc.on("close", (code) => {
+    if (code === 0) {
+      outputChannel.append(stdout);
+    } else {
+      outputChannel.append(stderr || stdout);
+      window.showErrorMessage(`eu exited with code ${code}`);
+    }
+  });
+
+  proc.on("error", (err) => {
+    window.showErrorMessage(`Failed to start eu: ${err.message}`);
+  });
+}
+
 export function activate(context: ExtensionContext) {
-  // The server command — assumes `eu` is on the PATH
-  const command = workspace
-    .getConfiguration("eucalypt")
-    .get<string>("serverPath", "eu");
+  // Register commands
+  context.subscriptions.push(
+    commands.registerCommand(
+      "eucalypt.insertUnicodeOperator",
+      insertUnicodeOperator
+    )
+  );
+
+  context.subscriptions.push(
+    commands.registerCommand("eucalypt.renderBuffer", renderBuffer)
+  );
+
+  // Start the LSP client
+  const config = workspace.getConfiguration("eucalypt");
+  const command = config.get<string>("euCommand", "eu");
 
   const serverOptions: ServerOptions = {
     command,

--- a/editors/vscode/syntaxes/eucalypt.tmLanguage.json
+++ b/editors/vscode/syntaxes/eucalypt.tmLanguage.json
@@ -4,13 +4,21 @@
   "scopeName": "source.eucalypt",
   "patterns": [
     { "include": "#comment" },
-    { "include": "#string" },
+    { "include": "#docstring" },
     { "include": "#c-string" },
     { "include": "#raw-string" },
+    { "include": "#string" },
     { "include": "#symbol" },
     { "include": "#number" },
-    { "include": "#metadata" },
+    { "include": "#metadata-backtick" },
+    { "include": "#builtin-intrinsic" },
     { "include": "#keyword" },
+    { "include": "#prelude" },
+    { "include": "#anaphor" },
+    { "include": "#function-declaration" },
+    { "include": "#property-declaration" },
+    { "include": "#function-call" },
+    { "include": "#unicode-operator" },
     { "include": "#operator" },
     { "include": "#punctuation" },
     { "include": "#identifier" }
@@ -20,36 +28,77 @@
       "name": "comment.line.number-sign.eucalypt",
       "match": "#.*$"
     },
-    "string": {
-      "name": "string.quoted.double.eucalypt",
-      "begin": "(?<!c|r)\"",
+
+    "docstring": {
+      "comment": "Documentation string immediately following a backtick metadata marker",
+      "begin": "(`)(\\s*)(\")",
       "end": "\"",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.metadata.eucalypt keyword.other.metadata.eucalypt" },
+        "3": { "name": "punctuation.definition.string.begin.eucalypt" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.eucalypt" }
+      },
+      "contentName": "comment.documentation.eucalypt",
       "patterns": [
         { "include": "#interpolation" },
-        { "include": "#brace-escape" }
+        { "include": "#brace-escape" },
+        { "include": "#markdown-inline" }
       ]
     },
+
     "c-string": {
       "name": "string.quoted.double.c.eucalypt",
       "begin": "c\"",
       "end": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.eucalypt" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.eucalypt" }
+      },
       "patterns": [
         { "include": "#interpolation" },
         {
           "name": "constant.character.escape.eucalypt",
-          "match": "\\\\[nrtv0\\\\\"afbe]|\\\\x[0-9a-fA-F]{2}|\\\\u\\{[0-9a-fA-F]+\\}"
+          "match": "\\\\[nrt0\\\\\"{}]|\\\\x[0-9a-fA-F]{2}|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8}"
         }
       ]
     },
+
     "raw-string": {
       "name": "string.quoted.double.raw.eucalypt",
       "begin": "r\"",
       "end": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.eucalypt" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.eucalypt" }
+      },
       "patterns": [
         { "include": "#interpolation" },
         { "include": "#brace-escape" }
       ]
     },
+
+    "string": {
+      "name": "string.quoted.double.eucalypt",
+      "begin": "\"",
+      "end": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.eucalypt" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.eucalypt" }
+      },
+      "patterns": [
+        { "include": "#interpolation" },
+        { "include": "#brace-escape" }
+      ]
+    },
+
     "interpolation": {
       "name": "meta.interpolation.eucalypt",
       "begin": "(?<!\\{)\\{(?!\\{)",
@@ -71,10 +120,29 @@
         }
       ]
     },
+
     "brace-escape": {
       "name": "constant.character.escape.eucalypt",
       "match": "\\{\\{|\\}\\}"
     },
+
+    "markdown-inline": {
+      "patterns": [
+        {
+          "name": "markup.inline.raw.eucalypt",
+          "match": "`[^`]+`"
+        },
+        {
+          "name": "markup.bold.eucalypt",
+          "match": "\\*\\*[^*]+\\*\\*"
+        },
+        {
+          "name": "markup.italic.eucalypt",
+          "match": "(?<![*])\\*[^*]+\\*(?![*])"
+        }
+      ]
+    },
+
     "symbol": {
       "patterns": [
         {
@@ -87,22 +155,75 @@
         }
       ]
     },
+
     "number": {
       "name": "constant.numeric.eucalypt",
-      "match": "-?(?:0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[bB][01]+|[0-9]+(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?)"
+      "match": "-?[0-9]+(?:\\.[0-9]+)?"
     },
-    "metadata": {
-      "name": "keyword.other.metadata.eucalypt",
+
+    "metadata-backtick": {
+      "name": "keyword.other.metadata.eucalypt punctuation.definition.metadata.eucalypt",
       "match": "`"
     },
+
+    "builtin-intrinsic": {
+      "comment": "Built-in intrinsic functions — double underscore prefix",
+      "name": "support.function.builtin.eucalypt",
+      "match": "\\b__[A-Z][A-Z0-9_]*\\b"
+    },
+
     "keyword": {
-      "name": "keyword.other.eucalypt",
+      "name": "keyword.control.eucalypt",
       "match": "\\b(?:if|then|when|cond|true|false|null|nil)\\b"
     },
+
+    "prelude": {
+      "comment": "Standard prelude functions",
+      "name": "support.function.prelude.eucalypt",
+      "match": "(?<![\\p{L}\\p{N}_$?!\\-*])(?:cons|head|tail|first|second|head-or|tail-or|second-or|map|filter|foldl|foldr|scanl|scanr|and|or|not|merge|concat|append|prepend|identity|const|compose|apply|flip|take|drop|take-while|drop-while|all|any|all-true\\?|any-true\\?|keys|values|lookup|has|range|repeat|iterate|cycle|zip|zip-with|reverse|remove|mapcat|group-by|qsort|partition|negate|inc|dec|floor|ceiling|max|min|abs|num|panic|assert|deep-merge|merge-all|elements|block|lookup-in|lookup-or|lookup-or-in|lookup-alts|lookup-across|lookup-path|complement|curry|uncurry|juxt|fnil|with-meta|meta|merge-meta|assertions|split-at|take-until|drop-until|split-after|split-when|nth|count|last|map2|zip-apply|window|over-sliding-pairs|differences|discriminate|key|value|bimap|map-first|map-second|map-kv|map-as-block|pair|zip-kv|with-keys|map-values|map-keys|filter-items|by-key|by-key-name|by-key-match|by-value|match-filter-values|filter-values|alter-value|update-value|alter|update|update-value-or|set-value|tongue|merge-at|nil\\?|zero\\?|pos\\?|neg\\?|max-of|min-of|sym|ch|str|eu|io|cal|iosm)(?![\\p{L}\\p{N}_$?!\\-*])"
+    },
+
+    "anaphor": {
+      "comment": "Anaphoric variables: _, _0, _1, •, •0, •1",
+      "name": "variable.language.anaphor.eucalypt",
+      "match": "(?<![\\p{L}\\p{N}_$?!\\-*])(?:_[0-9]*|•[0-9]*)(?![\\p{L}\\p{N}_$?!\\-*])"
+    },
+
+    "function-declaration": {
+      "comment": "Function declaration head: name(params): or f{...}: or f[...]: ",
+      "match": "^\\s*([\\p{L}_$?][\\p{L}\\p{N}_$?!\\-*]*)\\s*(?=\\(|\\{|\\[)",
+      "captures": {
+        "1": { "name": "entity.name.function.eucalypt" }
+      }
+    },
+
+    "property-declaration": {
+      "comment": "Property declaration head: name:",
+      "match": "^\\s*([\\p{L}_$?][\\p{L}\\p{N}_$?!\\-*]*)\\s*(?=:)",
+      "captures": {
+        "1": { "name": "variable.declaration.eucalypt" }
+      }
+    },
+
+    "function-call": {
+      "comment": "Function call: identifier immediately followed by (",
+      "match": "([\\p{L}_$?][\\p{L}\\p{N}_$?!\\-*]*)(?=\\()",
+      "captures": {
+        "1": { "name": "entity.name.function.call.eucalypt" }
+      }
+    },
+
+    "unicode-operator": {
+      "comment": "Unicode operators used in eucalypt",
+      "name": "keyword.operator.unicode.eucalypt",
+      "match": "[∧∨¬≤≥≠∸÷∘‖↑✓⊕≪≫∅→←⊂⊃∈∉∀∃⊥⊤≈≡∩∪∼±×√∞∂∫∑∏∇△▽⊢⊣⊨⊩⊕⊗⊙⊡⊞⊟⋅⋆⋈⋉⋊⟵⟶⟷⟸⟹⟺]+"
+    },
+
     "operator": {
       "name": "keyword.operator.eucalypt",
-      "match": "(?<![\\p{L}\\p{N}_])[+\\-*/<>=!&|^~%@$?]+(?![\\p{L}\\p{N}_])|\\.\\.+"
+      "match": "[+\\-*/<>=!&|^~%@$?.\\\\]+"
     },
+
     "punctuation": {
       "patterns": [
         { "name": "punctuation.definition.block.begin.eucalypt", "match": "\\{" },
@@ -111,10 +232,13 @@
         { "name": "punctuation.definition.list.end.eucalypt", "match": "\\]" },
         { "name": "punctuation.definition.paren.begin.eucalypt", "match": "\\(" },
         { "name": "punctuation.definition.paren.end.eucalypt", "match": "\\)" },
+        { "name": "punctuation.definition.bracket.begin.eucalypt", "match": "[⟦⟨⟪⌈⌊⦃⦇⦉«【〔〖〘〚]" },
+        { "name": "punctuation.definition.bracket.end.eucalypt", "match": "[⟧⟩⟫⌉⌋⦄⦈⦊»】〕〗〙〛]" },
         { "name": "punctuation.separator.colon.eucalypt", "match": ":" },
         { "name": "punctuation.separator.comma.eucalypt", "match": "," }
       ]
     },
+
     "identifier": {
       "patterns": [
         {


### PR DESCRIPTION
## Summary

- **Syntax highlighting** (tmLanguage): docstrings (string after backtick, with markdown), anaphors (`_`/`•`), builtin intrinsics (`__XXX`), prelude function list, function vs property declaration distinction, function calls, Unicode operators (∧∨¬≤≥≠∸÷∘‖↑✓⊕≪≫ etc.)
- **Language configuration**: Unicode idiot bracket pairs (⟦⟧ ⟨⟩ ⟪⟫ ⌈⌉ ⌊⌋ «» 【】 〔〕) with auto-close/surround; improved word pattern; backtick intentionally not auto-paired (metadata marker)
- **File registration**: `.eucalypt` extension and `Eufile` filename
- **Snippets**: 15 common eucalypt patterns (fn, prop, blk, doc, if, cond, map, filter, foldl, merge, import, target, mapcat, pipeline)
- **Commands**: `eucalypt.insertUnicodeOperator` (C-c C-u — QuickPick menu matching Emacs transient/quail) and `eucalypt.renderBuffer` (C-c C-k)
- **Configuration**: `eucalypt.euCommand`, `eucalypt.globalOptions`, `eucalypt.lspEnabled`; default tabSize 2 for eucalypt files

## Test plan

- [x] `npx tsc --noEmit` — clean, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)