### PR TITLE
feat(eu-8dh7): replace bracket content heuristic with proper bracket registry

### DIFF
--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -287,13 +287,20 @@ and `return` function names:
 ⟦{}⟧: { :monad namespace: my-monad }
 ```
 
-A bracket expression whose inner content contains top-level colons is parsed
-as a **bracket block** — a sequence of `name: monadic-action` declarations.
-The closing bracket must be followed by a dot and a return expression:
+A bracket pair declared with an empty block `{}` as its parameter (e.g.
+`⟦{}⟧: …`) is registered as **block-mode**.  When such a bracket pair is used,
+its content is parsed as a sequence of `name: monadic-action` declarations
+(a **bracket block**).  The closing bracket must be followed by a dot and a
+return expression:
 
 ```eu,notest
 result: ⟦ a: ma  b: mb ⟧.return_expr
 ```
+
+The parser determines the parse mode from a registry built by pre-scanning the
+source file for `⟦{}⟧:` declarations.  Only bracket pairs explicitly declared
+in this way are parsed as block-mode; other bracket pairs are always
+expression-mode regardless of their content.
 
 #### Block metadata forms
 

--- a/src/syntax/rowan/brackets.rs
+++ b/src/syntax/rowan/brackets.rs
@@ -11,8 +11,47 @@
 //! The ASCII bracket characters `(`, `)`, `[`, `]`, `{`, `}` are excluded as
 //! they are reserved by the eucalypt language.
 
+use std::collections::HashMap;
+
 use unicode_bidi_mirroring::get_mirrored;
 use unicode_general_category::{get_general_category, GeneralCategory};
+
+/// How the content of a bracket pair is parsed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BracketContentType {
+    /// Block-mode: content is parsed as declarations (like `{}`).
+    Block,
+    /// Expression-mode: content is parsed as a soup expression.
+    Expression,
+}
+
+/// Parser-level registry of bracket pairs and their expected content types.
+///
+/// Populated by pre-scanning the token stream for bracket pair declarations
+/// of the form `⟦{}⟧: …` (bare) or `(⟦{}⟧): …` (paren).  Consulted by the
+/// parser to decide whether a bracket expression should be parsed as a
+/// `BRACKET_BLOCK` or a `BRACKET_EXPR`.
+#[derive(Default, Clone, Debug)]
+pub struct BracketRegistry {
+    pairs: HashMap<char, BracketContentType>,
+}
+
+impl BracketRegistry {
+    /// Register `open` as having the given content type.
+    pub fn register(&mut self, open: char, content_type: BracketContentType) {
+        self.pairs.insert(open, content_type);
+    }
+
+    /// Return the content type for `open`, or `None` if not registered.
+    pub fn content_type(&self, open: char) -> Option<&BracketContentType> {
+        self.pairs.get(&open)
+    }
+
+    /// Return `true` if `open` is registered as block-mode.
+    pub fn is_block_mode(&self, open: char) -> bool {
+        matches!(self.content_type(open), Some(BracketContentType::Block))
+    }
+}
 
 /// Return true if `c` is a Unicode bracket open character eligible for use as
 /// an idiot bracket.

--- a/src/syntax/rowan/mod.rs
+++ b/src/syntax/rowan/mod.rs
@@ -214,6 +214,49 @@ mod tests {
     }
 
     #[test]
+    pub fn test_bracket_registry_block_mode() {
+        use crate::syntax::rowan::kind::{EucalyptLanguage, SyntaxKind};
+        use crate::syntax::rowan::parse_unit;
+
+        // Without a ⟦{}⟧: declaration, a bracket expression-style declaration
+        // parses cleanly (expression-mode).
+        let expr_no_decl = parse_unit("⟦ x ⟧: x");
+        assert!(
+            expr_no_decl.ok().is_ok(),
+            "expression-mode bracket pair declaration should parse"
+        );
+
+        // With a ⟦{}⟧: declaration, subsequent ⟦ … ⟧ uses are block-mode.
+        let src_with_decl = "⟦{}⟧: id\n⟦ r: 42 ⟧";
+        let parse = parse_unit(src_with_decl);
+        assert!(parse.errors().is_empty(), "should parse without errors");
+        let tree = parse.syntax_node();
+        let has_block = tree
+            .descendants()
+            .any(|n: rowan::SyntaxNode<EucalyptLanguage>| n.kind() == SyntaxKind::BRACKET_BLOCK);
+        assert!(
+            has_block,
+            "expected BRACKET_BLOCK node when pair declared as block-mode"
+        );
+
+        // The declaration template ⟦{}⟧ itself is always expression-mode.
+        let src_decl_only = "⟦{}⟧: id";
+        let parse_decl = parse_unit(src_decl_only);
+        assert!(
+            parse_decl.errors().is_empty(),
+            "declaration template should parse cleanly"
+        );
+        let tree_decl = parse_decl.syntax_node();
+        let has_expr = tree_decl
+            .descendants()
+            .any(|n: rowan::SyntaxNode<EucalyptLanguage>| n.kind() == SyntaxKind::BRACKET_EXPR);
+        assert!(
+            has_expr,
+            "declaration template should produce BRACKET_EXPR, not BRACKET_BLOCK"
+        );
+    }
+
+    #[test]
     pub fn test_string_patterns() {
         use super::ast::{Element, StringChunk};
 

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 use std::mem::swap;
 
-use super::brackets;
+use super::brackets::{self, BracketContentType, BracketRegistry};
 use super::kind::SyntaxKind::{self, *};
 
 use super::lex::Lexer;
@@ -27,24 +27,84 @@ pub struct Parser<'text> {
     tokens: Vec<(SyntaxKind, &'text str)>,
     /// index into tokens
     next_token: usize,
-    /// stack of event sinks to capture events into  
+    /// stack of event sinks to capture events into
     sink_stack: Vec<Box<dyn EventSink>>,
     /// accumulated errors
     errors: Vec<ParseError>,
+    /// Registry of bracket pairs and their content types, populated by a
+    /// pre-scan of the token stream before the main parse begins.
+    bracket_registry: BracketRegistry,
+}
+
+/// Pre-scan the token stream for bracket pair declarations of the form
+/// `⟦{}⟧: …` (bare) or `(⟦{}⟧): …` (paren).
+///
+/// For each such declaration found, the opening bracket character is
+/// registered as `BracketContentType::Block` in the returned registry.
+/// All other bracket pairs default to expression mode.
+fn prescan_bracket_declarations(tokens: &[(SyntaxKind, &str)]) -> BracketRegistry {
+    let mut registry = BracketRegistry::default();
+
+    // Work over significant (non-trivia) tokens only.
+    let sig: Vec<_> = tokens
+        .iter()
+        .filter(|(k, _)| !matches!(k, WHITESPACE | COMMENT))
+        .collect();
+
+    let n = sig.len();
+    for i in 0..n {
+        // Pattern 1 (bare): BRACKET_OPEN OPEN_BRACE CLOSE_BRACE BRACKET_CLOSE COLON
+        //   e.g.  ⟦ { } ⟧ :
+        if i + 4 < n
+            && sig[i].0 == BRACKET_OPEN
+            && sig[i + 1].0 == OPEN_BRACE
+            && sig[i + 2].0 == CLOSE_BRACE
+            && sig[i + 3].0 == BRACKET_CLOSE
+            && sig[i + 4].0 == COLON
+        {
+            if let Some(open_char) = sig[i].1.chars().next() {
+                registry.register(open_char, BracketContentType::Block);
+            }
+        }
+
+        // Pattern 2 (paren): (OPEN_PAREN|OPEN_PAREN_APPLY) BRACKET_OPEN OPEN_BRACE CLOSE_BRACE BRACKET_CLOSE CLOSE_PAREN COLON
+        //   e.g.  ( ⟦ { } ⟧ ) :
+        if i + 6 < n
+            && matches!(sig[i].0, OPEN_PAREN | OPEN_PAREN_APPLY)
+            && sig[i + 1].0 == BRACKET_OPEN
+            && sig[i + 2].0 == OPEN_BRACE
+            && sig[i + 3].0 == CLOSE_BRACE
+            && sig[i + 4].0 == BRACKET_CLOSE
+            && sig[i + 5].0 == CLOSE_PAREN
+            && sig[i + 6].0 == COLON
+        {
+            if let Some(open_char) = sig[i + 1].1.chars().next() {
+                registry.register(open_char, BracketContentType::Block);
+            }
+        }
+    }
+
+    registry
 }
 
 impl<'text> Parser<'text> {
-    /// Construct directly from text
+    /// Construct directly from text.
+    ///
+    /// A pre-scan of the token stream is performed to populate the bracket
+    /// registry before the main parse begins.
     pub fn new(text: &'text str) -> Self {
         let tokens: Vec<_> = Lexer::from_text(text)
             .map(|(tok, span)| (tok, &text[(span.start().into())..span.end().into()]))
             .collect();
+
+        let bracket_registry = prescan_bracket_declarations(&tokens);
 
         Parser {
             tokens,
             next_token: 0,
             sink_stack: vec![Box::new(SimpleEventSink::default())],
             errors: vec![],
+            bracket_registry,
         }
     }
 
@@ -387,17 +447,76 @@ impl<'text> Parser<'text> {
         self.sink().finish_node();
     }
 
+    /// Return `true` if the tokens immediately following the current position
+    /// form a bracket-pair declaration template: `BRACKET_OPEN OPEN_BRACE
+    /// CLOSE_BRACE BRACKET_CLOSE` (i.e. `⟦{}⟧`), optionally with whitespace
+    /// between the tokens.
+    ///
+    /// This pattern is always a declaration head and must be parsed in
+    /// expression mode, even when the bracket pair is otherwise registered as
+    /// block-mode.
+    fn is_bracket_declaration_template(&self) -> bool {
+        let mut idx = self.next_token;
+
+        // Must start with BRACKET_OPEN
+        if idx >= self.tokens.len() || self.tokens[idx].0 != BRACKET_OPEN {
+            return false;
+        }
+        idx += 1;
+
+        // Skip trivia
+        while idx < self.tokens.len() && self.tokens[idx].0.is_trivial() {
+            idx += 1;
+        }
+        // Expect OPEN_BRACE
+        if idx >= self.tokens.len() || self.tokens[idx].0 != OPEN_BRACE {
+            return false;
+        }
+        idx += 1;
+
+        // Skip trivia
+        while idx < self.tokens.len() && self.tokens[idx].0.is_trivial() {
+            idx += 1;
+        }
+        // Expect CLOSE_BRACE
+        if idx >= self.tokens.len() || self.tokens[idx].0 != CLOSE_BRACE {
+            return false;
+        }
+        idx += 1;
+
+        // Skip trivia
+        while idx < self.tokens.len() && self.tokens[idx].0.is_trivial() {
+            idx += 1;
+        }
+        // Expect BRACKET_CLOSE
+        idx < self.tokens.len() && self.tokens[idx].0 == BRACKET_CLOSE
+    }
+
     /// Parse a bracket expression using a Unicode idiot bracket pair.
     ///
     /// For example: `⟦ x ⟧` or `⌈ x ⌉`.
     ///
-    /// If the bracket content contains top-level colons (at depth 0), the
+    /// If the opening bracket character has been registered as block-mode in
+    /// the `bracket_registry` (via a pre-scanned `⟦{}⟧: …` declaration), the
     /// contents are parsed as block declarations and the node is emitted as
     /// `BRACKET_BLOCK`.  Otherwise the contents are parsed as a soup
     /// expression and the node is `BRACKET_EXPR`.
+    ///
+    /// Exception: the bracket-pair declaration template `⟦{}⟧` is always
+    /// parsed as expression mode, even for registered block-mode pairs.
     fn parse_bracket_expression(&mut self) {
-        // Peek ahead to detect block mode (top-level colons inside the brackets)
-        let is_block_mode = self.peek_for_top_level_colon_in_bracket();
+        let open_char = if let Some((BRACKET_OPEN, open_text)) = self.peek() {
+            open_text.chars().next()
+        } else {
+            None
+        };
+
+        // The declaration template `⟦{}⟧` must always be expression-mode,
+        // even when this bracket pair is registered as block-mode.
+        let is_block_mode = !self.is_bracket_declaration_template()
+            && open_char
+                .map(|c| self.bracket_registry.is_block_mode(c))
+                .unwrap_or(false);
 
         if is_block_mode {
             self.sink().start_node(BRACKET_BLOCK);
@@ -413,13 +532,8 @@ impl<'text> Parser<'text> {
             self.sink().finish_node();
         } else {
             self.sink().start_node(BRACKET_EXPR);
-            // Determine expected close char for validation
-            let expected_close = if let Some((BRACKET_OPEN, open_text)) = self.peek() {
-                let open_char = open_text.chars().next().unwrap_or('⟦');
-                brackets::close_for_open(open_char)
-            } else {
-                None
-            };
+            // Determine expected close char for validation (deferred to validate.rs)
+            let expected_close = open_char.and_then(brackets::close_for_open);
             self.expect(BRACKET_OPEN);
             self.add_trivia();
             self.parse_soup();
@@ -432,42 +546,6 @@ impl<'text> Parser<'text> {
             }
             self.sink().finish_node();
         }
-    }
-
-    /// Peek forward through the token stream to detect whether the bracket
-    /// content (at depth 0 relative to the opening bracket) contains a COLON.
-    ///
-    /// Returns `true` if a COLON is found at depth 0 before the matching
-    /// BRACKET_CLOSE, `false` otherwise.
-    fn peek_for_top_level_colon_in_bracket(&self) -> bool {
-        let mut depth: i32 = 0;
-        let mut idx = self.next_token;
-        // The current token should be BRACKET_OPEN; skip it
-        if idx < self.tokens.len() && self.tokens[idx].0 == BRACKET_OPEN {
-            idx += 1;
-        } else {
-            return false;
-        }
-        while idx < self.tokens.len() {
-            match self.tokens[idx].0 {
-                BRACKET_OPEN | OPEN_BRACE | OPEN_PAREN | OPEN_SQUARE | OPEN_BRACE_APPLY
-                | OPEN_PAREN_APPLY | OPEN_SQUARE_APPLY => {
-                    depth += 1;
-                }
-                BRACKET_CLOSE if depth == 0 => {
-                    return false;
-                }
-                BRACKET_CLOSE | CLOSE_BRACE | CLOSE_PAREN | CLOSE_SQUARE => {
-                    depth -= 1;
-                }
-                COLON if depth == 0 => {
-                    return true;
-                }
-                _ => {}
-            }
-            idx += 1;
-        }
-        false
     }
 
     /// Parse block content terminated by BRACKET_CLOSE instead of CLOSE_BRACE.


### PR DESCRIPTION
## Summary

- Adds `BracketRegistry` and `BracketContentType` to `src/syntax/rowan/brackets.rs`
- Replaces `peek_for_top_level_colon_in_bracket()` with a pre-scan (`prescan_bracket_declarations`) that detects `⟦{}⟧:` declaration patterns before the main parse
- `parse_bracket_expression()` now consults the registry; the declaration template `⟦{}⟧` is always forced to expression-mode to avoid circular issues
- Updates `docs/reference/syntax.md` to reflect the registry-based mechanism
- Adds `test_bracket_registry_block_mode` unit test

## Test plan

- [x] `cargo test` — all 223 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes
- [x] Harness tests 096 (monadic brackets) and 097 (idiot brackets) both pass
- [x] New unit test `test_bracket_registry_block_mode` verifies: block-mode pairs produce BRACKET_BLOCK, declaration templates produce BRACKET_EXPR, and expression-mode bracket declarations parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)