### PR TITLE
feat(eu-92pk): unified test expectations with stderr diagnostics

### DIFF
--- a/docs/guide/advanced-topics.md
+++ b/docs/guide/advanced-topics.md
@@ -94,19 +94,28 @@ ref: !Ref my-resource
 This is useful for generating CloudFormation, Kubernetes, and other
 tagged YAML formats.
 
-### Assertions with `//=` and `//=>`
+### Test expectations and assertions
 
-The `//=` operator asserts equality at runtime:
+The `//=` operator tests equality and returns a boolean, emitting a
+diagnostic to stderr on failure:
 
 ```eu
-result: 2 + 2 //= 4  # panics if not equal
+result: 2 + 2 //= 4  # returns true; on failure, returns false and prints to stderr
 ```
 
-The `//=>` operator additionally stores the assertion as metadata:
+The `//=>` operator asserts equality and panics on failure, also storing the
+assertion as metadata:
 
 ```eu
 checked: 2 + 2 //=> 4
 m: meta(checked)  # contains the assertion
+```
+
+The `//!` operator tests that a value is `true`, returning a boolean and
+emitting a diagnostic to stderr on failure:
+
+```eu
+result: (2 > 1) //!  # returns true; on failure, returns false and prints to stderr
 ```
 
 ## Sets

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -859,19 +859,19 @@ All functions verified against `lib/prelude.eu`:
 
 All at precedence 5 (`:meta`).
 
-**Test expectations** (return booleans, for use in test harnesses):
+**Test expectations** (return booleans, emit stderr diagnostic on failure):
 
 | Operator | Description |
 |----------|-------------|
-| `e //= v` | Test `e` equals `v`, return boolean |
+| `e //= v` | Test `e` equals `v`; returns `true`/`false`, prints diagnostic on failure |
 | `e //=? f` | Test `f(e)` is `true`, return boolean |
+| `e //!` | Test `e` is `true`; returns `true`/`false`, prints diagnostic on failure |
 
 **Assertions** (panic on failure, return `e` on success):
 
 | Operator | Description |
 |----------|-------------|
 | `e //=> v` | Assert `e` equals `v`, panic with expected/actual on failure |
-| `e //!` | Assert `e` is `true`, panic on failure |
 
 **Deprecated** (use complement with positive forms instead):
 
@@ -886,3 +886,14 @@ All at precedence 5 (`:meta`).
 |----------|-------------|
 | `e // m` | Attach metadata block `m` to value `e` |
 | `e //<< m` | Merge `m` into existing metadata of `e` |
+
+**Debug intrinsics** (low-level BIFs for diagnostics and test infrastructure):
+
+| BIF | Signature | Description |
+|-----|-----------|-------------|
+| `__DBG_REPR(v)` | `unk → str` | Render any eucalypt value as a compact human-readable string (e.g. `42`, `"hello"`, `:foo`, `true`, `null`, `[]`) |
+| `__EXPECT(actual, expected_repr, pass)` | `unk × str × bool → bool` | Test infrastructure primitive: returns `pass` as a boolean; on failure prints `EXPECT FAILED: expected <expected_repr>, got <actual_repr>` to stderr |
+
+`__DBG_REPR` is used internally by `//=` and `//!` to format diagnostic
+messages. It can also be used directly in test harnesses when you need
+a string representation of a value for comparison or display.

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -944,20 +944,37 @@ expect: {
 }
 
 #
-# Test expectations (return booleans, for use in test harnesses)
+# Test expectations (return booleans for use in test harnesses)
+#
+# On success: return true.
+# On failure: emit a diagnostic to stderr, return false.
 #
 
-` { doc: "`e //= v` - test that expression `e` evaluates to `v`, return boolean"
+` { doc: "`e //= v` - test that expression `e` evaluates to `v`, return boolean.
+
+    On success: return true.
+    On failure: emit EXPECT FAILED diagnostic to stderr, return false."
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //= v): e with-meta({ assert: (= v)}) expect.check
+(e //= v): __EXPECT(e, __DBG_REPR(v), e = v)
 
-` { doc: "`e //=? f` - test that expression `e` satisfies predicate `f`, return boolean"
+` { doc: "`e //=? f` - test that expression `e` satisfies predicate `f`, return boolean.
+
+    On success: return true.
+    On failure: panic with assertion failure message."
     export: :suppress
     associates: :left
     precedence: :meta }
 (e //=? f): e with-meta({ assert: f}) expect.checked
+
+` { doc: "`e //!` - test that expression `e` is true, return boolean.
+
+    On success: return true.
+    On failure: emit EXPECT FAILED diagnostic to stderr, return false."
+    export: :suppress
+    precedence: :meta }
+(e //!): __EXPECT(e, "true", e = true)
 
 #
 # Assertions (panic on failure, return the value on success)
@@ -966,19 +983,11 @@ expect: {
 ` { doc: "`e //=> v` - assert expression `e` evaluates to `v` and return `e`.
 
     On failure, reports the expected and actual values:
-    `assertion failed: expected <v>, got <e>`"
+    assertion failed: expected v, got e"
     export: :suppress
     associates: :left
     precedence: :meta }
 (e //=> v): if(e = v, e, __ASSERT_FAIL(e, v))
-
-` { doc: "`e //!` - assert expression `e` is true and return `e`.
-
-    On failure, reports the actual value:
-    `assertion failed: expected true, got <e>`"
-    export: :suppress
-    precedence: :meta }
-(e //!): if(e = true, e, __ASSERT_FAIL(e, true))
 
 #
 # Deprecated operators (use complement with the positive forms instead)

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -854,6 +854,16 @@ lazy_static! {
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 161
+            name: "DBG_REPR",
+            ty: function(vec![unk(), str_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 162
+            name: "EXPECT",
+            ty: function(vec![unk(), str_(), bool_(), bool_()]).unwrap(),
+            strict: vec![1, 2],
+    },
     ];
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -1,0 +1,200 @@
+//! Debug representation intrinsic for eucalypt values.
+//!
+//! Provides `__DBG_REPR(value)` which renders any eucalypt value to a
+//! compact, human-readable string for use in diagnostic output, test
+//! failure messages, and debug tracing.
+
+use std::convert::TryInto;
+
+use crate::eval::{
+    emit::Emitter,
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        mutator::MutatorHeapView,
+        syntax::{HeapSyn, Native, Ref},
+    },
+    stg::support::machine_return_str,
+};
+
+use super::tags::DataConstructor;
+
+/// Render a eucalypt value to a compact, human-readable debug string.
+///
+/// Scalars are rendered in their literal form:
+/// - Numbers: `42`, `3.14`
+/// - Strings: `"hello"` (with surrounding quotes and escapes)
+/// - Symbols: `:foo`
+/// - Booleans: `true`, `false`
+/// - Null: `null`
+///
+/// Structured types produce a type label: `[list]`, `{block}`.
+/// Unevaluated thunks produce `<unevaluated>`.
+pub fn render_debug_repr(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    let closure = match machine.nav(view).resolve(r) {
+        Ok(c) => c,
+        Err(_) => return "<error>".to_string(),
+    };
+
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::BoolTrue) => "true".to_string(),
+                Ok(DataConstructor::BoolFalse) => "false".to_string(),
+                Ok(DataConstructor::Unit) => "null".to_string(),
+                Ok(DataConstructor::ListNil) => "[]".to_string(),
+                Ok(DataConstructor::ListCons) => "[list]".to_string(),
+                Ok(DataConstructor::Block)
+                | Ok(DataConstructor::BlockPair)
+                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
+                Ok(DataConstructor::BoxedNumber) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<number>".to_string()),
+                Ok(DataConstructor::BoxedString) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<string>".to_string()),
+                Ok(DataConstructor::BoxedSymbol) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_symbol(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<symbol>".to_string()),
+                Ok(DataConstructor::BoxedZdt) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
+                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
+                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
+                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
+                Err(_) => "<value>".to_string(),
+            }
+        }
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => render_native(n, view, machine),
+        _ => "<unevaluated>".to_string(),
+    }
+}
+
+/// Render a native value to a debug string.
+fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicMachine) -> String {
+    match n {
+        Native::Num(num) => num.to_string(),
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            format!("{:?}", (*scoped).as_str())
+        }
+        Native::Sym(id) => format!(":{}", machine.symbol_pool().resolve(*id)),
+        Native::Zdt(dt) => dt.to_rfc3339(),
+        Native::Index(_) => "<block-index>".to_string(),
+        Native::Set(_) => "<set>".to_string(),
+        Native::NdArray(ptr) => {
+            let arr = view.scoped(*ptr);
+            let shape = arr
+                .shape()
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("<array [{shape}]>")
+        }
+    }
+}
+
+/// Render an inner argument ref (from a boxed constructor) as a debug string.
+fn render_inner(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    Some(render_native(&native, view, machine))
+}
+
+/// Render an inner string arg with surrounding double quotes.
+fn render_inner_quoted(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    match &native {
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            Some(format!("{:?}", (*scoped).as_str()))
+        }
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Render an inner symbol arg with `:` prefix.
+fn render_inner_symbol(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    match &native {
+        Native::Sym(id) => Some(format!(":{}", machine.symbol_pool().resolve(*id))),
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Extract a native value from a ref, following local environment lookups.
+fn extract_native(
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<Native> {
+    match r {
+        Ref::V(n) => Some(n.clone()),
+        Ref::L(idx) => {
+            let closure = env.get(&view, *idx)?;
+            let code = view.scoped(closure.code());
+            match &*code {
+                HeapSyn::Atom {
+                    evaluand: Ref::V(n),
+                } => Some(n.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// `__DBG_REPR(value)` — render any value to a compact debug string.
+///
+/// Used as the shared foundation by both debug tracing functions and
+/// expectation failure messages. Returns a eucalypt string.
+pub struct DbgRepr;
+
+impl StgIntrinsic for DbgRepr {
+    fn name(&self) -> &str {
+        "DBG_REPR"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let repr = render_debug_repr(machine, view, &args[0]);
+        machine_return_str(machine, view, repr)
+    }
+}
+
+impl CallGlobal1 for DbgRepr {}

--- a/src/eval/stg/expect.rs
+++ b/src/eval/stg/expect.rs
@@ -1,0 +1,88 @@
+//! The `__EXPECT` intrinsic — unified test expectation with stderr diagnostics.
+//!
+//! `__EXPECT(actual, expected_repr, pass)` is the core of the unified
+//! expectation operators (`//=`, `//!`). On failure it emits a diagnostic
+//! to stderr and returns `false`; on success it returns `true`.
+
+use std::convert::TryInto;
+
+use crate::eval::{
+    emit::Emitter,
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal3, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        mutator::MutatorHeapView,
+        syntax::{HeapSyn, Ref},
+    },
+    stg::support::{machine_return_bool, str_arg},
+};
+
+use super::{debug::render_debug_repr, tags::DataConstructor};
+
+/// Resolve a strict bool argument to a Rust bool.
+///
+/// Since `pass` is declared strict in the intrinsic catalogue, it
+/// will have been evaluated to WHNF before `execute` runs, so we
+/// only need to check the data constructor tag.
+fn resolve_bool(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> bool {
+    let closure = match machine.nav(view).resolve(r) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let code = view.scoped(closure.code());
+    match &*code {
+        HeapSyn::Cons { tag, .. } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            matches!(dc, Ok(DataConstructor::BoolTrue))
+        }
+        _ => false,
+    }
+}
+
+/// `__EXPECT(actual, expected_repr, pass)` — unified expectation BIF.
+///
+/// Behaviour:
+/// - `pass` is `true` → return `true` (success, no output).
+/// - `pass` is `false` → emit a "EXPECT FAILED" diagnostic to stderr
+///   with the expected representation and the actual value rendered
+///   by `render_debug_repr`, then return `false`.
+///
+/// The `actual` argument is lazy (not forced by the wrapper) so that
+/// unforced thunks render as `<unevaluated>` in failure messages
+/// rather than triggering evaluation side-effects. The operator
+/// implementations (`//=`, `//!`) already force `actual` via the
+/// equality check passed as `pass`, so in practice `actual` is
+/// usually already at WHNF when `__EXPECT` runs.
+///
+/// `expected_repr` and `pass` are strict.
+pub struct Expect;
+
+impl StgIntrinsic for Expect {
+    fn name(&self) -> &str {
+        "EXPECT"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args[0] = actual value (lazy — rendered only on failure)
+        // args[1] = expected representation string (strict)
+        // args[2] = pass boolean (strict)
+        let pass = resolve_bool(machine, view, &args[2]);
+
+        if pass {
+            machine_return_bool(machine, view, true)
+        } else {
+            let expected_repr = str_arg(machine, view, &args[1])?;
+            let actual_repr = render_debug_repr(machine, view, &args[0]);
+            eprintln!("EXPECT FAILED: expected {expected_repr}, got {actual_repr}");
+            machine_return_bool(machine, view, false)
+        }
+    }
+}
+
+impl CallGlobal3 for Expect {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -8,10 +8,12 @@ pub mod block;
 pub mod boolean;
 pub mod compiler;
 pub mod constant;
+pub mod debug;
 pub mod embed;
 pub mod emit;
 pub mod encoding;
 pub mod eq;
+pub mod expect;
 pub mod force;
 pub mod graph;
 pub mod io;
@@ -209,6 +211,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(io::IoAction));
     rt.add(Box::new(render_to_string::RenderToString));
     rt.add(Box::new(parse_string::ParseString));
+    rt.add(Box::new(debug::DbgRepr));
+    rt.add(Box::new(expect::Expect));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/tests/harness/124_debug.eu
+++ b/tests/harness/124_debug.eu
@@ -1,0 +1,27 @@
+"124 debug representation"
+
+` { target: :test }
+test: {
+  ` "DBG_REPR renders a number"
+  num-repr: __DBG_REPR(42) //= "42"
+
+  ` "DBG_REPR renders a string with surrounding quotes"
+  str-repr: __DBG_REPR("hello") //= "{ch.dq}hello{ch.dq}"
+
+  ` "DBG_REPR renders a symbol with colon prefix"
+  sym-repr: __DBG_REPR(:foo) //= ":foo"
+
+  ` "DBG_REPR renders true"
+  bool-true-repr: __DBG_REPR(true) //= "true"
+
+  ` "DBG_REPR renders false"
+  bool-false-repr: __DBG_REPR(false) //= "false"
+
+  ` "DBG_REPR renders null"
+  null-repr: __DBG_REPR(null) //= "null"
+
+  ` "DBG_REPR renders empty list"
+  empty-list-repr: __DBG_REPR([]) //= "[]"
+
+  RESULT: [num-repr, str-repr, sym-repr, bool-true-repr, bool-false-repr, null-repr, empty-list-repr] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness/125_expectations.eu
+++ b/tests/harness/125_expectations.eu
@@ -1,0 +1,24 @@
+"125 unified expectations"
+
+` { target: :test }
+test: {
+  ` "//= returns true on success"
+  eq-pass: (2 + 3 //= 5) //= true
+
+  ` "//= returns false on failure"
+  eq-fail: (2 + 3 //= 6) //= false
+
+  ` "//= works with strings"
+  str-pass: ("hello" //= "hello") //= true
+
+  ` "//= works with booleans"
+  bool-pass: (true //= true) //= true
+
+  ` "//! returns true when value is true"
+  true-pass: (true //!) //= true
+
+  ` "//! returns false when value is false"
+  true-fail: (false //!) //= false
+
+  RESULT: [eq-pass, eq-fail, str-pass, bool-pass, true-pass, true-fail] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -629,6 +629,16 @@ pub fn test_harness_123() {
 }
 
 #[test]
+pub fn test_harness_124() {
+    run_test(&opts("124_debug.eu"));
+}
+
+#[test]
+pub fn test_harness_125() {
+    run_test(&opts("125_expectations.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Add `__DBG_REPR` BIF: renders any eucalypt value as a compact human-readable string for diagnostic output
- Add `__EXPECT` BIF: test infrastructure primitive returning bool with stderr diagnostic on failure
- Rewrite `//=` and `//!` to use `__EXPECT` — soft-fail semantics with informative failure messages
- Add harness tests 124 (`__DBG_REPR`) and 125 (unified expectations)
- Update documentation: `docs/guide/advanced-topics.md`, `docs/reference/agent-reference.md`

## Before / After

**Before** — `//=` failure was silent (returned `false` with no output):
```
$ eu -e '2 + 2 //= 5'
false
```

**After** — `//=` failure emits a diagnostic to stderr:
```
$ eu -e '2 + 2 //= 5'
EXPECT FAILED: expected 5, got 4
false
```

## Test plan

- [x] `cargo test test_harness_124` — DBG_REPR tests pass
- [x] `cargo test test_harness_125` — unified expectations tests pass
- [x] `cargo test test_error_011` — assert_pred error test unchanged (exit 1, "Assertion failed")
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Full test suite: 225 tests pass

## Notes

`//=?` is intentionally left unchanged (still panics via `expect.checked`). Changing its semantics requires resolving the stderr capture architecture in `InProcessTester` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)