### PR TITLE
feat(eu-x6ry): add __DBG_REPR/__DBG BIFs and dbg/▶ debug operators

### DIFF
--- a/docs/guide/advanced-topics.md
+++ b/docs/guide/advanced-topics.md
@@ -109,6 +109,28 @@ checked: 2 + 2 //=> 4
 m: meta(checked)  # contains the assertion
 ```
 
+## Debug Tracing
+
+Use `▶` (U+25B6) to print any value to stderr and return it transparently:
+
+```eu,notest
+x + ▶y                    # debug y inline, return y unchanged
+data map(f) ▶head         # debug head in a pipeline
+```
+
+For labelled output or pipeline use, prefer `dbg`:
+
+```eu,notest
+value dbg{}                   # prints: ▶ <repr>
+value dbg{label: "here"}      # prints: ▶ here: <repr>
+```
+
+Both `▶` and `dbg` return the value unchanged, so they can be inserted
+anywhere without affecting the result.
+
+`▶` is intentionally prominent — the Unicode triangle is hard to overlook
+in a code review.
+
 ## Sets
 
 Sets are unordered collections of unique values, provided by the

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -886,3 +886,26 @@ All at precedence 5 (`:meta`).
 |----------|-------------|
 | `e // m` | Attach metadata block `m` to value `e` |
 | `e //<< m` | Merge `m` into existing metadata of `e` |
+
+---
+
+## 9. Debug Tracing
+
+**Operators and functions for inspecting values at runtime.**
+
+| Form | Description |
+|------|-------------|
+| `▶ v` | Print `v` to stderr and return it transparently. Prefix operator, precedence 85. |
+| `v dbg{}` | Print `v` to stderr and return it transparently. |
+| `v dbg{label: "x"}` | Print `x: <repr>` to stderr and return `v` transparently. |
+
+Output format: `▶ <repr>` or `▶ label: <repr>`.
+
+**Debug BIFs:**
+
+| BIF | Signature | Description |
+|-----|-----------|-------------|
+| `__DBG_REPR(v)` | `unk → str` | Render any value as a compact string (`42`, `"hello"`, `:foo`, `true`, `null`, `[]`, `{block}`) |
+| `__DBG(label, v)` | `str × unk → unk` | Print debug output to stderr; return `v` transparently |
+
+`▶` is intentionally large and visible — it does not get left in production code by accident.

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -998,6 +998,17 @@ expect: {
 (e //!!): if(e = false, e, __ASSERT_FAIL(e, false))
 
 #
+# Debug tracing
+#
+
+` { doc: "`dbg(opts, v)` - print value `v` to stderr and return `v` unchanged. opts keys: label (string)." }
+dbg(opts, v): __DBG(lookup-or(:label, "", opts), v)
+
+` { doc: "`▶v` - debug-print value `v` to stderr and return it. Tight-binding prefix operator."
+    precedence: 85 }
+(▶ v): __DBG("", v)
+
+#
 # List library functions, maps and folds
 #
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -854,6 +854,16 @@ lazy_static! {
             ty: function(vec![str_(), str_()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 161
+            name: "DBG_REPR",
+            ty: function(vec![unk(), str_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 162
+            name: "DBG",
+            ty: function(vec![str_(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
     ];
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -1,0 +1,244 @@
+//! Debug representation and tracing intrinsics.
+//!
+//! Provides:
+//! - `__DBG_REPR(value)` — render any eucalypt value to a compact, human-readable string
+//! - `__DBG(label, value)` — print value to stderr and return it transparently
+
+use std::convert::TryInto;
+
+use crate::eval::{
+    emit::Emitter,
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        mutator::MutatorHeapView,
+        syntax::{HeapSyn, Native, Ref},
+    },
+    stg::support::{machine_return_str, str_arg},
+};
+
+use super::tags::DataConstructor;
+
+/// Render a eucalypt value to a compact, human-readable debug string.
+///
+/// Scalars are rendered in their literal form:
+/// - Numbers: `42`, `3.14`
+/// - Strings: `"hello"` (with surrounding quotes)
+/// - Symbols: `:foo`
+/// - Booleans: `true`, `false`
+/// - Null: `null`
+///
+/// Structured types produce a type label: `[list]`, `{block}`.
+/// Unevaluated thunks produce `<unevaluated>`.
+pub fn render_debug_repr(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    let closure = match machine.nav(view).resolve(r) {
+        Ok(c) => c,
+        Err(_) => return "<error>".to_string(),
+    };
+
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::BoolTrue) => "true".to_string(),
+                Ok(DataConstructor::BoolFalse) => "false".to_string(),
+                Ok(DataConstructor::Unit) => "null".to_string(),
+                Ok(DataConstructor::ListNil) => "[]".to_string(),
+                Ok(DataConstructor::ListCons) => "[list]".to_string(),
+                Ok(DataConstructor::Block)
+                | Ok(DataConstructor::BlockPair)
+                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
+                Ok(DataConstructor::BoxedNumber) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<number>".to_string()),
+                Ok(DataConstructor::BoxedString) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<string>".to_string()),
+                Ok(DataConstructor::BoxedSymbol) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_symbol(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<symbol>".to_string()),
+                Ok(DataConstructor::BoxedZdt) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
+                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
+                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
+                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
+                Err(_) => "<value>".to_string(),
+            }
+        }
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => render_native(n, view, machine),
+        _ => "<unevaluated>".to_string(),
+    }
+}
+
+/// Render a native value to a debug string.
+fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicMachine) -> String {
+    match n {
+        Native::Num(num) => num.to_string(),
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            format!("{:?}", (*scoped).as_str())
+        }
+        Native::Sym(id) => format!(":{}", machine.symbol_pool().resolve(*id)),
+        Native::Zdt(dt) => dt.to_rfc3339(),
+        Native::Index(_) => "<block-index>".to_string(),
+        Native::Set(_) => "<set>".to_string(),
+        Native::NdArray(ptr) => {
+            let arr = view.scoped(*ptr);
+            let shape = arr
+                .shape()
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("<array [{shape}]>")
+        }
+    }
+}
+
+/// Render an inner argument ref (from a boxed constructor) as a debug string.
+fn render_inner(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    Some(render_native(&native, view, machine))
+}
+
+/// Render an inner string arg with surrounding double quotes.
+fn render_inner_quoted(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    match &native {
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            Some(format!("{:?}", (*scoped).as_str()))
+        }
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Render an inner symbol arg with `:` prefix.
+fn render_inner_symbol(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native(view, env, r)?;
+    match &native {
+        Native::Sym(id) => Some(format!(":{}", machine.symbol_pool().resolve(*id))),
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Extract a native value from a ref, following local environment lookups.
+fn extract_native(
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<Native> {
+    match r {
+        Ref::V(n) => Some(n.clone()),
+        Ref::L(idx) => {
+            let closure = env.get(&view, *idx)?;
+            let code = view.scoped(closure.code());
+            match &*code {
+                HeapSyn::Atom {
+                    evaluand: Ref::V(n),
+                } => Some(n.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// `__DBG_REPR(value)` — render any value to a compact debug string.
+///
+/// Used as the shared foundation by both debug tracing functions and
+/// expectation failure messages. Returns a eucalypt string.
+pub struct DbgRepr;
+
+impl StgIntrinsic for DbgRepr {
+    fn name(&self) -> &str {
+        "DBG_REPR"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let repr = render_debug_repr(machine, view, &args[0]);
+        machine_return_str(machine, view, repr)
+    }
+}
+
+impl CallGlobal1 for DbgRepr {}
+
+/// `__DBG(label, value)` — print debug output to stderr and return `value` transparently.
+///
+/// - `label`: a string label prepended to the output (may be empty).
+/// - `value`: the value to inspect; returned unchanged.
+///
+/// Output format:
+/// - With empty label: `▶ <repr>`
+/// - With label: `▶ label: <repr>`
+///
+/// This is the underlying BIF for both the `dbg` prelude function and the
+/// `▶` prefix operator.
+pub struct Dbg;
+
+impl StgIntrinsic for Dbg {
+    fn name(&self) -> &str {
+        "DBG"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args[0] = label (strict string)
+        // args[1] = value to debug (strict — we want the evaluated result)
+        let label = str_arg(machine, view, &args[0])?;
+        let repr = render_debug_repr(machine, view, &args[1]);
+
+        if label.is_empty() {
+            eprintln!("▶ {repr}");
+        } else {
+            eprintln!("▶ {label}: {repr}");
+        }
+
+        // Return args[1] transparently
+        let closure = machine.nav(view).resolve(&args[1])?;
+        machine.set_closure(closure)
+    }
+}
+
+impl CallGlobal2 for Dbg {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -8,6 +8,7 @@ pub mod block;
 pub mod boolean;
 pub mod compiler;
 pub mod constant;
+pub mod debug;
 pub mod embed;
 pub mod emit;
 pub mod encoding;
@@ -209,6 +210,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(io::IoAction));
     rt.add(Box::new(render_to_string::RenderToString));
     rt.add(Box::new(parse_string::ParseString));
+    rt.add(Box::new(debug::DbgRepr));
+    rt.add(Box::new(debug::Dbg));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/tests/harness/124_debug.eu
+++ b/tests/harness/124_debug.eu
@@ -1,0 +1,36 @@
+"124 debug representation and tracing"
+
+` { target: :test }
+test: {
+  ` "DBG_REPR renders a number"
+  num-repr: __DBG_REPR(42) //= "42"
+
+  ` "DBG_REPR renders a string with surrounding quotes"
+  str-repr: __DBG_REPR("hello") //= "{ch.dq}hello{ch.dq}"
+
+  ` "DBG_REPR renders a symbol with colon prefix"
+  sym-repr: __DBG_REPR(:foo) //= ":foo"
+
+  ` "DBG_REPR renders true"
+  bool-true-repr: __DBG_REPR(true) //= "true"
+
+  ` "DBG_REPR renders false"
+  bool-false-repr: __DBG_REPR(false) //= "false"
+
+  ` "DBG_REPR renders null"
+  null-repr: __DBG_REPR(null) //= "null"
+
+  ` "DBG_REPR renders empty list"
+  empty-list-repr: __DBG_REPR([]) //= "[]"
+
+  ` "dbg returns value transparently"
+  dbg-transparent: 42 dbg{} //= 42
+
+  ` "dbg with label returns value transparently"
+  dbg-labelled: "hello" dbg{label: "greeting"} //= "hello"
+
+  ` "▶ returns value transparently"
+  tri-transparent: (▶ 42) //= 42
+
+  RESULT: [num-repr, str-repr, sym-repr, bool-true-repr, bool-false-repr, null-repr, empty-list-repr, dbg-transparent, dbg-labelled, tri-transparent] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -629,6 +629,11 @@ pub fn test_harness_123() {
 }
 
 #[test]
+pub fn test_harness_124() {
+    run_test(&opts("124_debug.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Add `__DBG_REPR` BIF: renders any eucalypt value as a compact human-readable string
- Add `__DBG(label, value)` BIF: prints to stderr, returns value transparently
- Add `dbg(opts, v)` prelude function: pipeline-friendly debug wrapper with optional label
- Add `▶` prefix operator (precedence 85): inline debug-print shorthand
- Harness test 124 extended with transparent pass-through tests
- Docs: new section 9 in `agent-reference.md`, debug tracing in `advanced-topics.md`

## Before / After

**Before** — no debug tracing available without modifying the program structure:
```eu
# No way to inspect intermediate values inline
result: data map(f) filter(g)
```

**After** — inline debug tracing:
```eu
result: data map(f) ▶filter(g)   # prints ▶ [list] to stderr, returns filtered list
result: data dbg{label: "input"} map(f) filter(g)   # prints ▶ input: [list]
```

Output format:
```
▶ [list]
▶ input: [list]
```

## Test plan

- [x] `cargo test test_harness_124` — all 10 assertions pass (DBG_REPR + dbg/▶ transparent)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] No regressions in existing tests

## Notes

`__DBG_REPR` is duplicated here from eu-92pk (PR #545) since that branch is not yet merged. Once both PRs target `planning/0.5.1` and are merged, the implementation will unify. Wicket can rebase/deduplicate as needed.

`▶` is intentionally prominent — hard to leave in production code by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)