### PR TITLE
fix(errors): add source locations to all ExecutionError variants (eu-gwse)

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -40,7 +40,7 @@ fn io_run_error_to_execution(e: IoRunError) -> ExecutionError {
         IoRunError::Timeout(smid, secs) => ExecutionError::IoTimeout(smid, secs),
         IoRunError::CommandError(smid, msg) => ExecutionError::IoCommandError(smid, msg),
         IoRunError::MachineError(boxed) => *boxed,
-        other => ExecutionError::Panic(other.to_string()),
+        other => ExecutionError::Panic(Smid::default(), other.to_string()),
     }
 }
 

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -135,9 +135,10 @@ fn resolve_ref_with_globals(
                 genv.get(view, i)
                     .ok_or(ExecutionError::BadEnvironmentIndex(i))
             } else {
-                Err(ExecutionError::Panic(format!(
-                    "unexpected global ref G({i}) in io spec block"
-                )))
+                Err(ExecutionError::Panic(
+                    Smid::default(),
+                    format!("unexpected global ref G({i}) in io spec block"),
+                ))
             }
         }
     }
@@ -554,12 +555,12 @@ impl Mutator for CollectListElements {
             match &*code {
                 HeapSyn::Cons { tag, .. } if *tag == DataConstructor::ListNil.tag() => break,
                 HeapSyn::Cons { tag, args } if *tag == DataConstructor::ListCons.tag() => {
-                    let head_ref = args
-                        .get(0)
-                        .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
-                    let tail_ref = args
-                        .get(1)
-                        .ok_or_else(|| ExecutionError::Panic("malformed list cons".to_string()))?;
+                    let head_ref = args.get(0).ok_or_else(|| {
+                        ExecutionError::Panic(Smid::default(), "malformed list cons".to_string())
+                    })?;
+                    let tail_ref = args.get(1).ok_or_else(|| {
+                        ExecutionError::Panic(Smid::default(), "malformed list cons".to_string())
+                    })?;
                     let head = resolve_ref_with_globals(view, &current, head_ref, globals_env)?;
                     result.push(deref(view, head));
                     current = deref(
@@ -648,6 +649,7 @@ fn evaluate_spec_block(
         ) -> Result<HashMap<String, SynClosure>, ExecutionError> {
             let list_closure = block_list(view, self.0.clone()).ok_or_else(|| {
                 ExecutionError::Panic(
+                    Smid::default(),
                     "IoAction spec block did not evaluate to a Block constructor".to_string(),
                 )
             })?;
@@ -780,6 +782,7 @@ fn evaluate_spec_block(
             .and_then(|opt| opt.clone())
             .ok_or_else(|| {
                 IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                    Smid::default(),
                     "io-shell spec missing 'cmd'".to_string(),
                 )))
             })?;
@@ -794,6 +797,7 @@ fn evaluate_spec_block(
             .and_then(|opt| opt.clone())
             .ok_or_else(|| {
                 IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                    Smid::default(),
                     "io-exec spec missing 'cmd'".to_string(),
                 )))
             })?;
@@ -822,6 +826,7 @@ fn evaluate_spec_block(
         Err(IoRunError::Fail(message))
     } else {
         Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
+            Smid::default(),
             format!("unrecognised IO action tag: {tag_name}"),
         ))))
     }
@@ -1032,7 +1037,10 @@ impl Mutator for BuildRenderDoc {
 
     fn run(&self, view: &MutatorHeapView, _: ()) -> Result<SynClosure, ExecutionError> {
         let render_doc_idx = intrinsics::index("RENDER_DOC").ok_or_else(|| {
-            ExecutionError::Panic("RENDER_DOC intrinsic not found in registry".to_string())
+            ExecutionError::Panic(
+                Smid::default(),
+                "RENDER_DOC intrinsic not found in registry".to_string(),
+            )
         })?;
 
         // Frame: [value=0]
@@ -1174,6 +1182,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
     loop {
         if !machine.io_yielded() {
             return Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                Smid::default(),
                 "io_run called on non-yielded machine".to_string(),
             ))));
         }
@@ -1186,6 +1195,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                 // IoReturn(world=0, value=1)
                 return args.into_iter().nth(1).ok_or_else(|| {
                     IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                        Smid::default(),
                         "IoReturn missing value argument".to_string(),
                     )))
                 });
@@ -1194,6 +1204,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
             Ok(DataConstructor::IoFail) => {
                 let error_closure = args.into_iter().nth(1).ok_or_else(|| {
                     IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                        Smid::default(),
                         "IoFail missing error argument".to_string(),
                     )))
                 })?;
@@ -1331,6 +1342,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
                     machine.stash_pop();
                     machine.stash_pop();
                     return Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                        Smid::default(),
                         "IoBind action did not yield an IO constructor".to_string(),
                     ))));
                 }
@@ -1386,6 +1398,7 @@ pub fn io_run(machine: &mut Machine<'_>, allow_io: bool) -> Result<SynClosure, I
 
             _ => {
                 return Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
+                    Smid::default(),
                     format!("unexpected IO constructor tag: {tag}"),
                 ))));
             }

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -567,8 +567,8 @@ pub enum ExecutionError {
     BadEnvironmentIndex(usize),
     #[error("bad index {0} into globals")]
     BadGlobalIndex(usize),
-    #[error("{}", format_bad_format_string(.0))]
-    BadFormatString(String),
+    #[error("{}", format_bad_format_string(.1))]
+    BadFormatString(Smid, String),
     #[error("found free var {1}")]
     FreeVar(Smid, String),
     #[error("code not valid for execution")]
@@ -585,38 +585,38 @@ pub enum ExecutionError {
     NotValue(Smid, String),
     #[error("bad regex: {2}\n  help: the pattern '{1}' is not a valid regular expression")]
     BadRegex(Smid, String, String),
-    #[error("{}", format_bad_datetime_components(.0, .1, .2, .3, .4, .5, .6))]
-    BadDateTimeComponents(Number, Number, Number, Number, Number, Number, String),
-    #[error("{}", format_bad_timezone(.0))]
-    BadTimeZone(String),
-    #[error("bad timestamp ({0})")]
-    BadTimestamp(Number),
+    #[error("{}", format_bad_datetime_components(.1, .2, .3, .4, .5, .6, .7))]
+    BadDateTimeComponents(Smid, Number, Number, Number, Number, Number, Number, String),
+    #[error("{}", format_bad_timezone(.1))]
+    BadTimeZone(Smid, String),
+    #[error("bad timestamp ({1})")]
+    BadTimestamp(Smid, Number),
     #[error("bad datetime format '{1}': not a recognised ISO 8601 datetime string\n  help: expected a format like '2024-01-15T09:30:00+00:00' or '2024-01-15'")]
     BadDateTimeString(Smid, String),
     #[error("failed to apply format string")]
-    FormatFailure,
+    FormatFailure(Smid),
     #[error(
         "failed to convert numeric type as required by format string\n  \
          help: integer specifiers like %d, %o, %x require an integer value; \
          use %f or %g for floating-point numbers"
     )]
-    BadNumericTypeForFormat,
-    #[error("bad number format: {0}")]
-    BadNumberFormat(String),
-    #[error("could not format {1} with {0}")]
-    FormatError(String, Number),
+    BadNumericTypeForFormat(Smid),
+    #[error("bad number format: {1}")]
+    BadNumberFormat(Smid, String),
+    #[error("could not format {2} with {1}")]
+    FormatError(Smid, String, Number),
     #[error("expected scalar value")]
     NotScalar(Smid),
     #[error("{}", format_unknown_format(.0))]
     UnknownFormat(String),
-    #[error("cannot combine numbers ({0}, {1}) into same numeric domain\n  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision")]
-    NumericDomainError(Number, Number),
-    #[error("result of ({0})^({1}) is not a real number\n  help: raising a negative base to a fractional exponent yields a complex result; use a non-negative base or an integer exponent")]
-    ComplexResult(Number, Number),
-    #[error("numeric overflow: result of operating on {0} and {1} is out of range\n  help: the result exceeds the representable range for this numeric type")]
-    NumericRangeError(Number, Number),
-    #[error("{}", format_division_by_zero(.0))]
-    DivisionByZero(String),
+    #[error("cannot combine numbers ({1}, {2}) into same numeric domain\n  help: this can happen when mixing integer and floating-point arithmetic in ways that lose precision")]
+    NumericDomainError(Smid, Number, Number),
+    #[error("result of ({1})^({2}) is not a real number\n  help: raising a negative base to a fractional exponent yields a complex result; use a non-negative base or an integer exponent")]
+    ComplexResult(Smid, Number, Number),
+    #[error("numeric overflow: result of operating on {1} and {2} is out of range\n  help: the result exceeds the representable range for this numeric type")]
+    NumericRangeError(Smid, Number, Number),
+    #[error("{}", format_division_by_zero(.1))]
+    DivisionByZero(Smid, String),
     #[error("expected branch continuation")]
     ExpectedBranchContinuation,
     #[error("type mismatch: expected {}, found {}", display_expected_tags(.2), display_data_tag(*.1))]
@@ -625,8 +625,8 @@ pub enum ExecutionError {
     NoBranchForNative(Smid, String),
     #[error("{}", format_cannot_return_fun(.1))]
     CannotReturnFunToCase(Smid, Vec<u8>),
-    #[error("panic: {0}")]
-    Panic(String),
+    #[error("panic: {1}")]
+    Panic(Smid, String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
@@ -724,6 +724,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NoBranchForNative(s, _) => *s,
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
+            ExecutionError::Panic(s, _) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::InvalidBase64(s, _) => *s,
@@ -743,6 +744,18 @@ impl HasSmid for ExecutionError {
             ExecutionError::ListIndexOutOfBounds(s, _) => *s,
             ExecutionError::BadDateTimeString(s, _) => *s,
             ExecutionError::BadRegex(s, _, _) => *s,
+            ExecutionError::BadFormatString(s, _) => *s,
+            ExecutionError::BadTimeZone(s, _) => *s,
+            ExecutionError::BadTimestamp(s, _) => *s,
+            ExecutionError::FormatFailure(s) => *s,
+            ExecutionError::BadNumericTypeForFormat(s) => *s,
+            ExecutionError::BadNumberFormat(s, _) => *s,
+            ExecutionError::FormatError(s, _, _) => *s,
+            ExecutionError::NumericDomainError(s, _, _) => *s,
+            ExecutionError::ComplexResult(s, _, _) => *s,
+            ExecutionError::NumericRangeError(s, _, _) => *s,
+            ExecutionError::DivisionByZero(s, _) => *s,
+            ExecutionError::BadDateTimeComponents(s, _, _, _, _, _, _, _) => *s,
             _ => Smid::default(),
         }
     }
@@ -883,7 +896,7 @@ impl ExecutionError {
                         .to_string(),
                 ]
             }
-            ExecutionError::BadNumberFormat(_) => {
+            ExecutionError::BadNumberFormat(_, _) => {
                 vec![
                     "valid number formats are: integers (e.g. 42), decimals (e.g. 3.14), and \
                      scientific notation (e.g. 1.5e10)"
@@ -922,14 +935,14 @@ impl ExecutionError {
                         .to_string(),
                 ]
             }
-            ExecutionError::BadDateTimeComponents(_, _, _, _, _, _, _) => {
+            ExecutionError::BadDateTimeComponents(_, _, _, _, _, _, _, _) => {
                 vec![
                     "valid ranges: year (any integer), month (1–12), day (1–28/29/30/31 \
                      depending on month), hour (0–23), minute (0–59), second (0–59)"
                         .to_string(),
                 ]
             }
-            ExecutionError::BadTimeZone(_) => {
+            ExecutionError::BadTimeZone(_, _) => {
                 vec![
                     "timezone must be a UTC offset string like '+0100', '-0530', or 'UTC'"
                         .to_string(),

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1055,9 +1055,9 @@ impl IntrinsicMachine for MachineState {
     }
 
     fn take_capture_result(&mut self) -> Result<String, ExecutionError> {
-        self.capture_results
-            .pop()
-            .ok_or_else(|| ExecutionError::Panic("no capture result available".to_string()))
+        self.capture_results.pop().ok_or_else(|| {
+            ExecutionError::Panic(Smid::default(), "no capture result available".to_string())
+        })
     }
 }
 
@@ -1355,10 +1355,9 @@ impl<'a> Machine<'a> {
         // as the machine's closure.
         if self.state.capture_end_pending {
             self.state.capture_end_pending = false;
-            let mut capture = self
-                .capture_emitters
-                .pop()
-                .ok_or_else(|| ExecutionError::Panic("no active capture emitter".to_string()))?;
+            let mut capture = self.capture_emitters.pop().ok_or_else(|| {
+                ExecutionError::Panic(Smid::default(), "no active capture emitter".to_string())
+            })?;
             capture.stream_end();
             let result_str = capture.into_string()?;
             let view = MutatorHeapView::new(&self.heap);
@@ -1702,6 +1701,7 @@ impl<'a> Machine<'a> {
 
         if sub_yielded {
             return Err(ExecutionError::Panic(
+                Smid::default(),
                 "spec block field evaluation unexpectedly yielded an IO constructor".to_string(),
             ));
         }

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -21,7 +21,7 @@ use super::{
     array::array_binop,
     support::{machine_return_bool, machine_return_boxed_num, machine_return_num, num_arg},
     syntax::{
-        dsl::{annotated_lambda, app_bif, case, force, local, lref},
+        dsl::{app_bif, case, force, lambda, local, lref},
         LambdaForm, StgSyn,
     },
     tags::DataConstructor,
@@ -81,8 +81,8 @@ impl StgIntrinsic for Add {
         "ADD"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        arithmetic_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index())
     }
 
     fn execute(
@@ -105,23 +105,35 @@ impl StgIntrinsic for Add {
         let y = num_arg(machine, view, &args[1])?;
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let total = l
-                .checked_add(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let total = l.checked_add(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let total = l
-                .checked_add(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let total = l.checked_add(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l + r) {
                 machine_return_boxed_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -136,8 +148,8 @@ impl StgIntrinsic for Sub {
         "SUB"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        arithmetic_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index())
     }
 
     fn execute(
@@ -160,23 +172,35 @@ impl StgIntrinsic for Sub {
         let y = num_arg(machine, view, &args[1])?;
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let result = l
-                .checked_sub(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_sub(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let result = l
-                .checked_sub(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_sub(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l - r) {
                 machine_return_boxed_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -191,8 +215,8 @@ impl StgIntrinsic for Mul {
         "MUL"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        arithmetic_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index())
     }
 
     fn execute(
@@ -215,23 +239,35 @@ impl StgIntrinsic for Mul {
         let y = num_arg(machine, view, &args[1])?;
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let product = l
-                .checked_mul(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let product = l.checked_mul(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let product = l
-                .checked_mul(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let product = l.checked_mul(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l * r) {
                 machine_return_boxed_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -246,8 +282,8 @@ impl StgIntrinsic for Div {
         "DIV"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        arithmetic_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        arithmetic_wrapper(self.index())
     }
 
     fn execute(
@@ -271,27 +307,42 @@ impl StgIntrinsic for Div {
 
         if is_zero(&y) {
             return Err(ExecutionError::DivisionByZero(
+                machine.annotation(),
                 "floor division (/)".to_string(),
             ));
         }
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let result = floor_div_i64(l, r).ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = floor_div_i64(l, r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let result = l
-                .checked_div(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_div(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_boxed_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             let result = (l / r).floor();
             if let Some(n) = num_from_floored(result) {
                 machine_return_boxed_num(machine, view, n)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -317,16 +368,25 @@ impl StgIntrinsic for Mod {
         let y = num_arg(machine, view, &args[1])?;
 
         if is_zero(&y) {
-            return Err(ExecutionError::DivisionByZero("modulo (%)".to_string()));
+            return Err(ExecutionError::DivisionByZero(
+                machine.annotation(),
+                "modulo (%)".to_string(),
+            ));
         }
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let result = floor_mod_i64(l, r).ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = floor_mod_i64(l, r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let result = l
-                .checked_rem(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_rem(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             let q = (l / r).floor();
@@ -334,10 +394,18 @@ impl StgIntrinsic for Mod {
             if let Some(ret) = Number::from_f64(result) {
                 machine_return_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -365,7 +433,7 @@ fn unbox_any(scrutinee: Rc<StgSyn>, then: Rc<StgSyn>) -> Rc<StgSyn> {
 ///
 /// Unboxes and forces both arguments for any boxed native type, then
 /// calls the BIF with the raw native values.
-fn comparison_wrapper(index: usize, annotation: Smid) -> LambdaForm {
+fn comparison_wrapper(index: usize) -> LambdaForm {
     // Environment evolution (matching the default wrapper pattern):
     //
     //   lambda args:                                          [x, y]
@@ -382,7 +450,7 @@ fn comparison_wrapper(index: usize, annotation: Smid) -> LambdaForm {
     let unbox_y = unbox_any(local(3), force_y);
     let force_x = force(local(0), unbox_y);
     let unbox_x = unbox_any(local(0), force_x);
-    annotated_lambda(2, unbox_x, annotation)
+    lambda(2, unbox_x)
 }
 
 /// Build a wrapper for a polymorphic two-argument arithmetic intrinsic.
@@ -392,14 +460,14 @@ fn comparison_wrapper(index: usize, annotation: Smid) -> LambdaForm {
 /// `execute` methods are responsible for returning the correct result type:
 /// `machine_return_boxed_num` for scalar results, `machine_return_ndarray`
 /// for array results.
-fn arithmetic_wrapper(index: usize, annotation: Smid) -> LambdaForm {
+fn arithmetic_wrapper(index: usize) -> LambdaForm {
     // Environment layout matches comparison_wrapper — see its comment.
     let bif_call = app_bif(index as u8, vec![lref(2), lref(0)]);
     let force_y = force(local(0), bif_call);
     let unbox_y = unbox_any(local(3), force_y);
     let force_x = force(local(0), unbox_y);
     let unbox_x = unbox_any(local(0), force_x);
-    annotated_lambda(2, unbox_x, annotation)
+    lambda(2, unbox_x)
 }
 
 /// Ordering comparison between two numbers, trying i64, u64, then f64
@@ -411,10 +479,15 @@ fn num_ord(x: &Number, y: &Number) -> Result<std::cmp::Ordering, ExecutionError>
     } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
         Ok(l.cmp(&r))
     } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
-        l.partial_cmp(&r)
-            .ok_or_else(|| ExecutionError::NumericDomainError(x.clone(), y.clone()))
+        l.partial_cmp(&r).ok_or_else(|| {
+            ExecutionError::NumericDomainError(Smid::default(), x.clone(), y.clone())
+        })
     } else {
-        Err(ExecutionError::NumericDomainError(x.clone(), y.clone()))
+        Err(ExecutionError::NumericDomainError(
+            Smid::default(),
+            x.clone(),
+            y.clone(),
+        ))
     }
 }
 
@@ -458,8 +531,8 @@ impl StgIntrinsic for Gt {
         "GT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        comparison_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        comparison_wrapper(self.index())
     }
 
     fn execute(
@@ -484,8 +557,8 @@ impl StgIntrinsic for Gte {
         "GTE"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        comparison_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        comparison_wrapper(self.index())
     }
 
     fn execute(
@@ -510,8 +583,8 @@ impl StgIntrinsic for Lt {
         "LT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        comparison_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        comparison_wrapper(self.index())
     }
 
     fn execute(
@@ -536,8 +609,8 @@ impl StgIntrinsic for Lte {
         "LTE"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        comparison_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        comparison_wrapper(self.index())
     }
 
     fn execute(
@@ -577,7 +650,11 @@ impl StgIntrinsic for Ceil {
             if let Some(ret) = Number::from_f64(val.ceil()) {
                 machine_return_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, Number::from(0)))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    Number::from(0),
+                ))
             }
         } else {
             unreachable!();
@@ -610,7 +687,11 @@ impl StgIntrinsic for Floor {
             if let Some(ret) = Number::from_f64(val.floor()) {
                 machine_return_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, Number::from(0)))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    Number::from(0),
+                ))
             }
         } else {
             unreachable!();
@@ -659,12 +740,24 @@ impl StgIntrinsic for Pow {
                 machine_return_num(machine, view, ret)
             } else if result.is_nan() && b < 0.0 && e.fract() != 0.0 {
                 // Negative base raised to a fractional exponent produces a complex number.
-                Err(ExecutionError::ComplexResult(base, exp))
+                Err(ExecutionError::ComplexResult(
+                    machine.annotation(),
+                    base,
+                    exp,
+                ))
             } else {
-                Err(ExecutionError::NumericDomainError(base, exp))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    base,
+                    exp,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(base, exp))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                base,
+                exp,
+            ))
         }
     }
 }
@@ -699,6 +792,7 @@ impl StgIntrinsic for PreciseDiv {
 
         if is_zero(&y) {
             return Err(ExecutionError::DivisionByZero(
+                machine.annotation(),
                 "precise division (\u{00f7})".to_string(),
             ));
         }
@@ -707,10 +801,18 @@ impl StgIntrinsic for PreciseDiv {
             if let Some(ret) = Number::from_f64(l / r) {
                 machine_return_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -737,29 +839,42 @@ impl StgIntrinsic for Quot {
 
         if is_zero(&y) {
             return Err(ExecutionError::DivisionByZero(
+                machine.annotation(),
                 "truncation division (quot)".to_string(),
             ));
         }
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let result = l
-                .checked_div(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_div(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let result = l
-                .checked_div(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_div(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             let result = (l / r).trunc();
             if let Some(n) = num_from_floored(result) {
                 machine_return_num(machine, view, n)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }
@@ -786,28 +901,41 @@ impl StgIntrinsic for Rem {
 
         if is_zero(&y) {
             return Err(ExecutionError::DivisionByZero(
+                machine.annotation(),
                 "remainder (rem)".to_string(),
             ));
         }
 
         if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
-            let result = l
-                .checked_rem(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_rem(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
-            let result = l
-                .checked_rem(r)
-                .ok_or(ExecutionError::NumericRangeError(x, y))?;
+            let result = l.checked_rem(r).ok_or(ExecutionError::NumericRangeError(
+                machine.annotation(),
+                x,
+                y,
+            ))?;
             machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l % r) {
                 machine_return_num(machine, view, ret)
             } else {
-                Err(ExecutionError::NumericDomainError(x, y))
+                Err(ExecutionError::NumericDomainError(
+                    machine.annotation(),
+                    x,
+                    y,
+                ))
             }
         } else {
-            Err(ExecutionError::NumericDomainError(x, y))
+            Err(ExecutionError::NumericDomainError(
+                machine.annotation(),
+                x,
+                y,
+            ))
         }
     }
 }

--- a/src/eval/stg/array.rs
+++ b/src/eval/stg/array.rs
@@ -30,7 +30,7 @@ use super::{
         machine_return_num_list_of_lists, ndarray_arg, num_arg,
     },
     syntax::{
-        dsl::{annotated_lambda, app_bif, data, force, let_, local, lref, unbox_num, value},
+        dsl::{app_bif, data, force, lambda, let_, local, lref, unbox_num, value},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -48,17 +48,16 @@ impl StgIntrinsic for ArrayZeros {
         "ARRAY.ZEROS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Force SeqNumList on the shape arg before calling execute
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             1, // [shape]
             force(
                 SeqNumList.global(lref(0)),
                 // [concrete_shape] [shape]
                 app_bif(bif_index, vec![lref(0)]),
             ),
-            annotation,
         )
     }
 
@@ -84,7 +83,7 @@ impl StgIntrinsic for ArrayFill {
         "ARRAY.FILL"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Force SeqNumList on shape arg, then unbox+force value arg.
         //
         // Env trace (force uses from_closure, unbox uses env_from_data_args):
@@ -95,7 +94,7 @@ impl StgIntrinsic for ArrayFill {
         //
         // execute args: (shape=lref(2), val=lref(0))
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [shape, val]
             force(
                 SeqNumList.global(lref(0)),
@@ -104,7 +103,6 @@ impl StgIntrinsic for ArrayFill {
                     force(local(0), app_bif(bif_index, vec![lref(2), lref(0)])),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -131,12 +129,12 @@ impl StgIntrinsic for ArrayFromFlat {
         "ARRAY.FROM_FLAT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Force SeqNumList on both shape and values args.
         // After first force: lref(0)=concrete_shape, lref(1)=shape, lref(2)=vals
         // After second force: lref(0)=concrete_vals, lref(1)=concrete_shape, lref(2)=shape, lref(3)=vals
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [shape, vals]
             force(
                 SeqNumList.global(lref(0)),
@@ -145,7 +143,6 @@ impl StgIntrinsic for ArrayFromFlat {
                     app_bif(bif_index, vec![lref(1), lref(0)]),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -192,7 +189,7 @@ impl StgIntrinsic for ArrayGet {
         "ARRAY.GET"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // SeqNumList on coords (lref(0)), force array (lref(1)).
         // After SeqNumList force: lref(0)=concrete_coords, lref(1)=coords, lref(2)=array
         // After force(array):     lref(0)=forced_array, lref(1)=concrete_coords, lref(2)=coords, lref(3)=array
@@ -200,7 +197,7 @@ impl StgIntrinsic for ArrayGet {
         // execute args: (coords=lref(1), array=lref(0))
         // Result is boxed as BoxedNumber to match the default wrapper convention.
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [coords, array]
             force(
                 SeqNumList.global(lref(0)),
@@ -212,7 +209,6 @@ impl StgIntrinsic for ArrayGet {
                     ),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -247,7 +243,7 @@ impl StgIntrinsic for ArraySet {
         "ARRAY.SET"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Arg order: (coords, val, array) for pipeline use.
         // SeqNumList on coords (lref(0)), unbox+force val (lref(1)), force array (lref(2)).
         //
@@ -260,7 +256,7 @@ impl StgIntrinsic for ArraySet {
         //
         // execute args: (coords=lref(3), val=lref(1), array=lref(0))
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             3, // [coords, val, array]
             force(
                 SeqNumList.global(lref(0)),
@@ -275,7 +271,6 @@ impl StgIntrinsic for ArraySet {
                     ),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -451,7 +446,7 @@ impl StgIntrinsic for ArrayReshape {
         "ARRAY.RESHAPE"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Arg order: (new_shape, array) for pipeline use.
         // SeqNumList on new_shape (lref(0)), force array (lref(1)).
         //
@@ -462,13 +457,12 @@ impl StgIntrinsic for ArrayReshape {
         //
         // execute args: (new_shape=lref(1), array=lref(0))
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [new_shape, array]
             force(
                 SeqNumList.global(lref(0)),
                 force(local(2), app_bif(bif_index, vec![lref(1), lref(0)])),
             ),
-            annotation,
         )
     }
 
@@ -671,7 +665,7 @@ impl StgIntrinsic for ArrayNeighbours {
         "ARRAY_NEIGHBOURS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Args: (coords, offsets_flat, rank, array)
         //
         // Env trace:
@@ -684,7 +678,7 @@ impl StgIntrinsic for ArrayNeighbours {
         //
         // execute args: (coords=lref(4), offsets=lref(3), rank=lref(1), array=lref(0))
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             4, // [coords, offsets_flat, rank, array]
             force(
                 SeqNumList.global(lref(0)),
@@ -702,7 +696,6 @@ impl StgIntrinsic for ArrayNeighbours {
                     ),
                 ),
             ),
-            annotation,
         )
     }
 

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -51,7 +51,7 @@ impl StgIntrinsic for Block {
         "BLOCK"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         let kv_items = lambda(
@@ -76,7 +76,7 @@ impl StgIntrinsic for Block {
             ),
         );
 
-        annotated_lambda(
+        lambda(
             1,
             letrec_(
                 vec![
@@ -86,7 +86,6 @@ impl StgIntrinsic for Block {
                 ],
                 data(DataConstructor::Block.tag(), vec![lref(1), no_index()]),
             ),
-            annotation,
         )
     }
 }
@@ -104,10 +103,10 @@ impl StgIntrinsic for Kv {
         "KV"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        annotated_lambda(
+        lambda(
             1,
             case(
                 local(0),
@@ -127,7 +126,6 @@ impl StgIntrinsic for Kv {
                 ],
                 call::bif::panic(str("invalid key-value element in block")),
             ),
-            annotation,
         )
     }
 }
@@ -144,10 +142,10 @@ impl StgIntrinsic for Dekv {
         "DEKV"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        annotated_lambda(
+        lambda(
             1, // [pair]
             case(
                 local(0),
@@ -174,7 +172,6 @@ impl StgIntrinsic for Dekv {
                 ],
                 call::bif::panic(str("invalid key-value element in block")),
             ),
-            annotation,
         )
     }
 }
@@ -191,7 +188,7 @@ impl StgIntrinsic for Elements {
         "ELEMENTS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         let map_list = lambda(
@@ -216,7 +213,7 @@ impl StgIntrinsic for Elements {
             ),
         );
 
-        annotated_lambda(
+        lambda(
             1, // [block]
             letrec_(
                 vec![map_list], // [map_list] [block]
@@ -229,7 +226,6 @@ impl StgIntrinsic for Elements {
                     call::bif::panic(str("elements called on non-block")),
                 ),
             ),
-            annotation,
         )
     }
 }
@@ -246,9 +242,9 @@ impl StgIntrinsic for MatchesKey {
         "MATCHES_KEY"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
-        annotated_lambda(
+        lambda(
             2, // [pair unboxsym]
             case(
                 local(0),
@@ -274,7 +270,6 @@ impl StgIntrinsic for MatchesKey {
                 ],
                 call::bif::panic(str("bad key-value pair in MATCHES_KEY")),
             ),
-            annotation,
         )
     }
 }
@@ -291,9 +286,9 @@ impl StgIntrinsic for ExtractValue {
         "EXTRACT_VALUE"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
-        annotated_lambda(
+        lambda(
             1, // [pair]
             case(
                 local(0),
@@ -321,7 +316,6 @@ impl StgIntrinsic for ExtractValue {
                 ],
                 call::bif::panic(str("bad key-value pair in EXTRACT_VALUE")),
             ),
-            annotation,
         )
     }
 }
@@ -338,9 +332,9 @@ impl StgIntrinsic for ExtractKey {
         "EXTRACT_KEY"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
-        annotated_lambda(
+        lambda(
             1, // [pair]
             case(
                 local(0),
@@ -362,7 +356,6 @@ impl StgIntrinsic for ExtractKey {
                 ],
                 call::bif::panic(str("bad key-value pair in EXTRACT_KEY")),
             ),
-            annotation,
         )
     }
 }
@@ -380,15 +373,14 @@ impl StgIntrinsic for PackPair {
         "PACK_PAIR"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
-        annotated_lambda(
+        lambda(
             1, // [kv]
             force(
                 ExtractKey.global(lref(0)), // [sym] [kv]
                 data(DataConstructor::BlockPair.tag(), vec![lref(0), lref(1)]),
             ),
-            annotation,
         )
     }
 }
@@ -405,9 +397,9 @@ impl StgIntrinsic for BlockPair {
         "BLOCK_PAIR"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
-        annotated_lambda(
+        lambda(
             1, // [kv]
             switch(
                 local(0),
@@ -438,7 +430,6 @@ impl StgIntrinsic for BlockPair {
                     ),
                 ],
             ),
-            annotation,
         )
     }
 }
@@ -465,7 +456,7 @@ impl StgIntrinsic for LookupOr {
         }
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         let bif_index: u8 = intrinsics::index(self.name())
@@ -509,7 +500,7 @@ impl StgIntrinsic for LookupOr {
         // in self.annotation when the inner switch fires. This allows
         // NoBranchForDataTag (raised when obj is not a block) to carry the
         // user's source location rather than the synthetic LOOKUPOR# label.
-        let _ = annotation;
+
         lambda(
             3, // [k d block]
             switch(
@@ -864,10 +855,10 @@ impl StgIntrinsic for Lookup {
         "LOOKUP"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
-        annotated_lambda(
+        lambda(
             2, // [k block]
             unbox_sym(
                 local(0),
@@ -878,7 +869,6 @@ impl StgIntrinsic for Lookup {
                     LookupOr(NativeVariant::Unboxed).global(lref(1), lref(0), lref(3)),
                 ),
             ),
-            annotation,
         )
     }
 }
@@ -896,14 +886,14 @@ impl StgIntrinsic for LookupFail {
         "LOOKUP_FAIL"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         // Use plain lambda (no annotation) so the call-site annotation
         // set by the Ann node in lookup_fail() is not overwritten when
         // the wrapper is entered. This allows LookupFailure errors to
         // carry the user's source location.
-        let _ = annotation;
+
         lambda(
             2, // [sym block]
             force(
@@ -1044,18 +1034,23 @@ fn resolve_pair_key_symbol(
         // Boxed symbol (from dynamically-constructed blocks)
         syntax::HeapSyn::Cons { tag, args } if *tag == DataConstructor::BoxedSymbol.tag() => {
             let inner = args.get(0).ok_or_else(|| {
-                ExecutionError::Panic("empty boxed symbol in block pair key".to_string())
+                ExecutionError::Panic(
+                    Smid::default(),
+                    "empty boxed symbol in block pair key".to_string(),
+                )
             })?;
             let native = key_closure.navigate_local_native(&view, inner);
             if let syntax::Native::Sym(id) = native {
                 Ok(pool.resolve(id).to_string())
             } else {
                 Err(ExecutionError::Panic(
+                    Smid::default(),
                     "boxed symbol contained non-symbol native".to_string(),
                 ))
             }
         }
         _ => Err(ExecutionError::Panic(
+            Smid::default(),
             "bad block_pair passed to merge intrinsic: non-symbolic key".to_string(),
         )),
     }
@@ -1083,6 +1078,7 @@ fn deconstruct(
             Ok((sym, kv_closure))
         }
         _ => Err(ExecutionError::Panic(
+            Smid::default(),
             "bad block_pair passed to merge intrinsic: non-data type".to_string(),
         )),
     }
@@ -1099,7 +1095,7 @@ impl StgIntrinsic for Merge {
     /// pattern-matching blocks, then re-attaches the correct metadata
     /// to the merged result. For shallow merge, RHS metadata wins when
     /// both operands carry metadata.
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         let pack_items = lambda(
@@ -1166,7 +1162,6 @@ impl StgIntrinsic for Merge {
         // Use plain lambda so the call-site annotation set by the Ann node
         // emitted by the compiler at application sites is not overwritten
         // when the intrinsic wrapper is entered.
-        let _ = annotation;
         lambda(
             2, // [l, r]
             let_(
@@ -1250,7 +1245,7 @@ impl StgIntrinsic for MergeWith {
     }
 
     /// Expose the two lists to the intrinsic
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         let pair_items = lambda(
@@ -1278,7 +1273,7 @@ impl StgIntrinsic for MergeWith {
         // Use plain lambda so the call-site annotation set by the Ann node
         // emitted by the compiler at application sites is not overwritten
         // when the intrinsic wrapper is entered.
-        let _ = annotation;
+
         lambda(
             3, // [l r f]
             switch(
@@ -1379,7 +1374,7 @@ impl StgIntrinsic for DeepMerge {
     /// Uses `demeta` to capture metadata from both operands before
     /// pattern-matching blocks. RHS metadata wins when both carry metadata.
     /// Sub-block values are still recursively deep-merged (via MergeWith).
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         use dsl::*;
 
         // merge_deep_core: lambda(2, [l_blk, r_blk]) — deep-merges two bare
@@ -1408,7 +1403,7 @@ impl StgIntrinsic for DeepMerge {
         // Use plain lambda so the call-site annotation set by the Ann node
         // emitted by the compiler at application sites is not overwritten
         // when the intrinsic wrapper is entered.
-        let _ = annotation;
+
         lambda(
             2, // [l, r]
             let_(

--- a/src/eval/stg/boolean.rs
+++ b/src/eval/stg/boolean.rs
@@ -48,8 +48,8 @@ impl StgIntrinsic for Not {
         "NOT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             switch(
                 local(0),
@@ -58,7 +58,6 @@ impl StgIntrinsic for Not {
                     (DataConstructor::BoolTrue.tag(), f()),
                 ],
             ),
-            annotation,
         )
     }
 }
@@ -73,8 +72,8 @@ impl StgIntrinsic for And {
         "AND"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2,
             switch(
                 local(0),
@@ -92,7 +91,6 @@ impl StgIntrinsic for And {
                     (DataConstructor::BoolFalse.tag(), f()),
                 ],
             ),
-            annotation,
         )
     }
 }
@@ -107,8 +105,8 @@ impl StgIntrinsic for Or {
         "OR"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2,
             switch(
                 local(0),
@@ -126,7 +124,6 @@ impl StgIntrinsic for Or {
                     (DataConstructor::BoolTrue.tag(), t()),
                 ],
             ),
-            annotation,
         )
     }
 }
@@ -147,8 +144,8 @@ impl StgIntrinsic for If {
         &[1, 2]
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             3,
             dsl::switch_suppress(
                 local(0),
@@ -157,7 +154,6 @@ impl StgIntrinsic for If {
                     (DataConstructor::BoolFalse.tag(), local(2)),
                 ],
             ),
-            annotation,
         )
     }
 }

--- a/src/eval/stg/eq.rs
+++ b/src/eval/stg/eq.rs
@@ -99,8 +99,8 @@ impl StgIntrinsic for Eq {
 
     /// Switch on data type and recur or fallback to intrinsic for
     /// natives.
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2,
             case(
                 local(0), // [x y]
@@ -197,7 +197,6 @@ impl StgIntrinsic for Eq {
                     app_bif(self.index() as u8, vec![lref(0), lref(1)]), // [y-eval] [x-eval] [x y]
                 ),
             ),
-            annotation,
         )
     }
 

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     syntax::{
-        dsl::{annotated_lambda, data, force, local, lref, switch, unbox_num, unbox_str},
+        dsl::{data, force, lambda, local, lref, switch, unbox_num, unbox_str},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -21,8 +21,8 @@ impl StgIntrinsic for SeqStrList {
         "seqStrList"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             switch(
                 local(0),
@@ -46,7 +46,6 @@ impl StgIntrinsic for SeqStrList {
                     ),
                 ],
             ),
-            annotation,
         )
     }
 }
@@ -61,8 +60,8 @@ impl StgIntrinsic for SeqNumList {
         "seqNumList"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             switch(
                 local(0),
@@ -86,7 +85,6 @@ impl StgIntrinsic for SeqNumList {
                     ),
                 ],
             ),
-            annotation,
         )
     }
 }

--- a/src/eval/stg/graph.rs
+++ b/src/eval/stg/graph.rs
@@ -20,7 +20,7 @@ use super::{
     force::SeqNumList,
     support::{collect_num_list, machine_return_num_list},
     syntax::{
-        dsl::{annotated_lambda, app_bif, force, lref},
+        dsl::{app_bif, force, lambda, lref},
         LambdaForm,
     },
 };
@@ -35,9 +35,9 @@ impl StgIntrinsic for GraphUnionFind {
         "GRAPH_UNION_FIND"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [flat_edges, n_list]
             force(
                 SeqNumList.global(lref(0)),
@@ -48,7 +48,6 @@ impl StgIntrinsic for GraphUnionFind {
                     app_bif(bif_index, vec![lref(1), lref(0)]),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -61,10 +60,12 @@ impl StgIntrinsic for GraphUnionFind {
     ) -> Result<(), ExecutionError> {
         let edges = collect_num_list(machine, view, args[0].clone())?;
         let n_list = collect_num_list(machine, view, args[1].clone())?;
-        let n =
-            n_list.first().copied().ok_or_else(|| {
-                ExecutionError::Panic("graph.union-find: n list empty".to_string())
-            })? as usize;
+        let n = n_list.first().copied().ok_or_else(|| {
+            ExecutionError::Panic(
+                Smid::default(),
+                "graph.union-find: n list empty".to_string(),
+            )
+        })? as usize;
 
         // Union-Find with path compression and union by rank
         let mut parent: Vec<usize> = (0..n).collect();
@@ -123,9 +124,9 @@ impl StgIntrinsic for GraphTopoSort {
         "GRAPH_TOPO_SORT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [flat_edges, n_list]
             force(
                 SeqNumList.global(lref(0)),
@@ -136,7 +137,6 @@ impl StgIntrinsic for GraphTopoSort {
                     app_bif(bif_index, vec![lref(1), lref(0)]),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -149,11 +149,9 @@ impl StgIntrinsic for GraphTopoSort {
     ) -> Result<(), ExecutionError> {
         let edges = collect_num_list(machine, view, args[0].clone())?;
         let n_list = collect_num_list(machine, view, args[1].clone())?;
-        let n = n_list
-            .first()
-            .copied()
-            .ok_or_else(|| ExecutionError::Panic("graph.topo-sort: n list empty".to_string()))?
-            as usize;
+        let n = n_list.first().copied().ok_or_else(|| {
+            ExecutionError::Panic(Smid::default(), "graph.topo-sort: n list empty".to_string())
+        })? as usize;
 
         // Build adjacency list and in-degree counts
         let mut adj: Vec<Vec<usize>> = vec![vec![]; n];
@@ -207,9 +205,9 @@ impl StgIntrinsic for GraphKruskalEdges {
         "GRAPH_KRUSKAL_EDGES"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             2, // [flat_edges, n_list]
             force(
                 SeqNumList.global(lref(0)),
@@ -220,7 +218,6 @@ impl StgIntrinsic for GraphKruskalEdges {
                     app_bif(bif_index, vec![lref(1), lref(0)]),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -233,10 +230,12 @@ impl StgIntrinsic for GraphKruskalEdges {
     ) -> Result<(), ExecutionError> {
         let edges = collect_num_list(machine, view, args[0].clone())?;
         let n_list = collect_num_list(machine, view, args[1].clone())?;
-        let n =
-            n_list.first().copied().ok_or_else(|| {
-                ExecutionError::Panic("graph.kruskal-edges: n list empty".to_string())
-            })? as usize;
+        let n = n_list.first().copied().ok_or_else(|| {
+            ExecutionError::Panic(
+                Smid::default(),
+                "graph.kruskal-edges: n list empty".to_string(),
+            )
+        })? as usize;
 
         let mut parent: Vec<usize> = (0..n).collect();
         let mut rank: Vec<usize> = vec![0; n];

--- a/src/eval/stg/io.rs
+++ b/src/eval/stg/io.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     syntax::{
-        dsl::{annotated_lambda, data, lref},
+        dsl::{data, lambda, lref},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -29,11 +29,10 @@ impl StgIntrinsic for IoReturn {
         "IO_RETURN"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2, // [world value]
             data(DataConstructor::IoReturn.tag(), vec![lref(1), lref(0)]),
-            annotation,
         )
     }
 }
@@ -52,14 +51,13 @@ impl StgIntrinsic for IoBind {
         "IO_BIND"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             3, // [world action continuation]
             data(
                 DataConstructor::IoBind.tag(),
                 vec![lref(2), lref(1), lref(0)],
             ),
-            annotation,
         )
     }
 }
@@ -78,17 +76,16 @@ impl StgIntrinsic for IoAction {
         "IO_ACTION"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         // Parameters: [spec_block=lref(0), world=lref(1)]
         //
         // The spec_block arrives as an unevaluated thunk (LetRec closure)
         // when called from the io.shell / io.exec prelude functions.
         // ReadSpecBlock navigates the thunk structure directly on the heap
         // to extract the action spec without requiring machine evaluation.
-        annotated_lambda(
+        lambda(
             2, // [spec_block=lref(0), world=lref(1)]
             data(DataConstructor::IoAction.tag(), vec![lref(1), lref(0)]),
-            annotation,
         )
     }
 }

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -22,7 +22,7 @@ use super::{
         collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
     },
     syntax::{
-        dsl::{annotated_lambda, app_bif, case, data, force, local, lref, str, value},
+        dsl::{app_bif, case, data, force, lambda, local, lref, str, value},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -38,11 +38,10 @@ impl StgIntrinsic for Cons {
         "CONS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2, // [h t]
             data(DataConstructor::ListCons.tag(), vec![lref(0), lref(1)]),
-            annotation,
         )
     }
 }
@@ -72,15 +71,14 @@ impl StgIntrinsic for Tail {
         "TAIL"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             case(
                 local(0),
                 vec![(DataConstructor::ListCons.tag(), local(1))],
                 Panic.global(str("TAIL on empty list")),
             ),
-            annotation,
         )
     }
 }
@@ -95,15 +93,14 @@ impl StgIntrinsic for Head {
         "HEAD"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             case(
                 local(0),
                 vec![(DataConstructor::ListCons.tag(), local(0))],
                 Panic.global(str("HEAD on empty list")),
             ),
-            annotation,
         )
     }
 }
@@ -154,16 +151,15 @@ impl StgIntrinsic for SortNumList {
         "SORT_NUM_LIST"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let bif_index: u8 = self.index().try_into().unwrap();
-        annotated_lambda(
+        lambda(
             1, // [xs]
             force(
                 SeqNumList.global(lref(0)),
                 // [concrete_list] [xs]
                 app_bif(bif_index, vec![lref(0)]),
             ),
-            annotation,
         )
     }
 
@@ -212,10 +208,10 @@ impl StgIntrinsic for ListNth {
         }
         match current {
             Some(closure) => machine.set_closure(closure),
-            None => Err(ExecutionError::Panic(format!(
-                "LIST.NTH: index {} out of bounds",
-                n
-            ))),
+            None => Err(ExecutionError::Panic(
+                Smid::default(),
+                format!("LIST.NTH: index {} out of bounds", n),
+            )),
         }
     }
 }
@@ -260,7 +256,10 @@ impl StgIntrinsic for ListDrop {
                     match (*tag).try_into() {
                         Ok(DataConstructor::ListCons) => {
                             let tail_ref = cons_args.get(1).ok_or_else(|| {
-                                ExecutionError::Panic("malformed cons cell".to_string())
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    "malformed cons cell".to_string(),
+                                )
                             })?;
                             closure = closure.navigate_local(&view, tail_ref);
                         }
@@ -270,6 +269,7 @@ impl StgIntrinsic for ListDrop {
                         }
                         _ => {
                             return Err(ExecutionError::Panic(
+                                Smid::default(),
                                 "LIST.DROP: expected list".to_string(),
                             ));
                         }
@@ -277,6 +277,7 @@ impl StgIntrinsic for ListDrop {
                 }
                 _ => {
                     return Err(ExecutionError::Panic(
+                        Smid::default(),
                         "LIST.DROP: expected list".to_string(),
                     ));
                 }

--- a/src/eval/stg/meta.rs
+++ b/src/eval/stg/meta.rs
@@ -9,7 +9,7 @@ use super::{
     block::Merge,
     constant::KEmptyBlock,
     syntax::{
-        dsl::{annotated_lambda, demeta, let_, local, lref, value, with_meta},
+        dsl::{demeta, lambda, let_, local, lref, value, with_meta},
         LambdaForm,
     },
 };
@@ -22,8 +22,8 @@ impl StgIntrinsic for Meta {
         "META"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             demeta(
                 local(0),
@@ -36,7 +36,6 @@ impl StgIntrinsic for Meta {
                 ),
                 KEmptyBlock.global(),
             ),
-            annotation,
         )
     }
 }
@@ -55,8 +54,8 @@ impl StgIntrinsic for RawMeta {
         "RAWMETA"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             demeta(
                 local(0),
@@ -65,7 +64,6 @@ impl StgIntrinsic for RawMeta {
                 local(0),
                 KEmptyBlock.global(),
             ),
-            annotation,
         )
     }
 }
@@ -80,8 +78,8 @@ impl StgIntrinsic for WithMeta {
         "WITHMETA"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(2, with_meta(lref(0), lref(1)), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(2, with_meta(lref(0), lref(1)))
     }
 }
 

--- a/src/eval/stg/panic.rs
+++ b/src/eval/stg/panic.rs
@@ -24,7 +24,7 @@ impl StgIntrinsic for Panic {
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
         let message = str_arg(machine, view, &args[0])?;
-        Err(ExecutionError::Panic(message))
+        Err(ExecutionError::Panic(machine.annotation(), message))
     }
 }
 

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -56,6 +56,7 @@ impl StgIntrinsic for ParseString {
     ) -> Result<(), ExecutionError> {
         // args[0] = format symbol (strict)
         // args[1] = string to parse (strict)
+        let smid = machine.annotation();
         let format_name = sym_arg(machine, view, &args[0])?;
         let input = str_arg(machine, view, &args[1])?;
 
@@ -89,12 +90,12 @@ impl StgIntrinsic for ParseString {
         );
         let syntax: Rc<_> = compiler
             .compile(core_expr)
-            .map_err(|e| ExecutionError::Panic(format!("parse-as compile error: {e}")))?;
+            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as compile error: {e}")))?;
 
         // Load the compiled STG onto the machine heap and set as closure.
         let pool = RefCell::new(machine.symbol_pool_mut().clone());
         let heap_ptr = load(&view, &mut pool.borrow_mut(), syntax)
-            .map_err(|e| ExecutionError::Panic(format!("parse-as load error: {e}")))?;
+            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as load error: {e}")))?;
 
         // Update the machine's symbol pool with any new symbols interned during load
         *machine.symbol_pool_mut() = pool.into_inner();

--- a/src/eval/stg/prng.rs
+++ b/src/eval/stg/prng.rs
@@ -2,11 +2,14 @@
 
 use serde_json::Number;
 
-use crate::eval::{
-    emit::Emitter,
-    error::ExecutionError,
-    machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
-    memory::{mutator::MutatorHeapView, syntax::Ref},
+use crate::{
+    common::sourcemap::Smid,
+    eval::{
+        emit::Emitter,
+        error::ExecutionError,
+        machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+        memory::{mutator::MutatorHeapView, syntax::Ref},
+    },
 };
 
 use super::support::{machine_return_num, num_arg};
@@ -87,8 +90,9 @@ impl StgIntrinsic for PrngFloat {
         let seed = seed_to_u64(&seed_num);
         let (_, z) = splitmix64(seed);
         let float_val = (z >> 11) as f64 / ((1u64 << 53) as f64);
-        let result = Number::from_f64(float_val)
-            .ok_or_else(|| ExecutionError::Panic("PRNG produced invalid float".to_string()))?;
+        let result = Number::from_f64(float_val).ok_or_else(|| {
+            ExecutionError::Panic(Smid::default(), "PRNG produced invalid float".to_string())
+        })?;
         machine_return_num(machine, view, result)
     }
 }

--- a/src/eval/stg/render.rs
+++ b/src/eval/stg/render.rs
@@ -34,7 +34,7 @@ impl StgIntrinsic for Render {
     }
 
     /// Evaluate inspect and recur
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let suppressed = lambda(
             1,
             demeta(
@@ -163,7 +163,7 @@ impl StgIntrinsic for Render {
             ),
         );
 
-        annotated_lambda(
+        lambda(
             1,
             let_(
                 vec![suppressed, render], // [s r] [arg]
@@ -178,7 +178,6 @@ impl StgIntrinsic for Render {
                     ],
                 ),
             ),
-            annotation,
         )
     }
 }
@@ -193,14 +192,13 @@ impl StgIntrinsic for RenderDoc {
         "RENDER_DOC"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1, // [renderee]
             force(
                 call::bif::emit_doc_start(), // [()] [renderee]
                 force(Render.global(lref(1)), call::bif::emit_doc_end()),
             ),
-            annotation,
         )
     }
 }
@@ -215,8 +213,8 @@ impl StgIntrinsic for RenderItems {
         "RENDER_ITEMS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1, // [cons]
             case(
                 local(0),
@@ -238,7 +236,6 @@ impl StgIntrinsic for RenderItems {
                      check that '++' is used to concatenate two lists, not a list and a string",
                 )),
             ),
-            annotation,
         )
     }
 }
@@ -253,8 +250,8 @@ impl StgIntrinsic for RenderBlockItems {
         "RENDER_BLOCK_ITEMS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1, // [cons]
             case(
                 local(0),
@@ -276,7 +273,6 @@ impl StgIntrinsic for RenderBlockItems {
                      check that '++' is used to concatenate two lists, not a list and a string",
                 )),
             ),
-            annotation,
         )
     }
 }
@@ -320,8 +316,8 @@ impl StgIntrinsic for Suppresses {
         "SUPPRESSES"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             let_(
                 vec![value(box_sym("normal"))],
@@ -343,7 +339,6 @@ impl StgIntrinsic for Suppresses {
                     f(),
                 ),
             ),
-            annotation,
         )
     }
 }
@@ -358,8 +353,8 @@ impl StgIntrinsic for Tag {
         "TAG"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             let_(
                 vec![value(box_sym(""))],
@@ -374,7 +369,6 @@ impl StgIntrinsic for Tag {
                     local(1),
                 ),
             ),
-            annotation,
         )
     }
 }
@@ -391,7 +385,7 @@ impl StgIntrinsic for RenderKv {
         "RENDER_KV"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         let value_renderable = lambda(
             1,
             letrec_(
@@ -405,7 +399,7 @@ impl StgIntrinsic for RenderKv {
             ),
         );
 
-        annotated_lambda(
+        lambda(
             1, // [kv]
             case(
                 local(0),
@@ -437,7 +431,6 @@ impl StgIntrinsic for RenderKv {
                 ],
                 unit(),
             ),
-            annotation,
         )
     }
 }

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -9,6 +9,7 @@
 //! This avoids any heap-walk code or recursive machine re-entry.
 
 use crate::{
+    common::sourcemap::Smid,
     eval::{
         emit::{Emitter, Event},
         error::ExecutionError,
@@ -74,8 +75,10 @@ impl OwnedCaptureEmitter {
         // before the buffer (field declaration order), so the borrow is
         // valid for the emitter's entire lifetime.
         let buf_ptr: *mut StableBuffer = &mut *buffer;
-        let emitter = export::create_emitter(format, unsafe { &mut *buf_ptr })
-            .ok_or_else(|| ExecutionError::Panic(format!("unknown render format: {format}")))?;
+        let emitter =
+            export::create_emitter(format, unsafe { &mut *buf_ptr }).ok_or_else(|| {
+                ExecutionError::Panic(Smid::default(), format!("unknown render format: {format}"))
+            })?;
         // SAFETY: Erase the lifetime to 'static.  The buffer outlives
         // the emitter because the emitter is dropped first (field order).
         let emitter: Box<dyn Emitter + 'static> = unsafe { std::mem::transmute(emitter) };
@@ -90,8 +93,9 @@ impl OwnedCaptureEmitter {
     pub fn into_string(mut self) -> Result<String, ExecutionError> {
         // Drop the emitter first to end its borrow on the buffer.
         drop(self.emitter.take());
-        String::from_utf8(self.buffer.0)
-            .map_err(|e| ExecutionError::Panic(format!("capture not valid UTF-8: {e}")))
+        String::from_utf8(self.buffer.0).map_err(|e| {
+            ExecutionError::Panic(Smid::default(), format!("capture not valid UTF-8: {e}"))
+        })
     }
 }
 
@@ -136,8 +140,9 @@ impl StgIntrinsic for RenderToString {
         machine.push_capture_end(view)?;
 
         // Set closure to RENDER_DOC(value).
-        let render_doc_idx = intrinsics::index("RENDER_DOC")
-            .ok_or_else(|| ExecutionError::Panic("RENDER_DOC not found".to_string()))?;
+        let render_doc_idx = intrinsics::index("RENDER_DOC").ok_or_else(|| {
+            ExecutionError::Panic(machine.annotation(), "RENDER_DOC not found".to_string())
+        })?;
         let app = view
             .alloc(HeapSyn::App {
                 callable: Ref::G(render_doc_idx),

--- a/src/eval/stg/running.rs
+++ b/src/eval/stg/running.rs
@@ -16,23 +16,22 @@ use super::{
     force::SeqNumList,
     support::{collect_num_list, machine_return_num_list},
     syntax::{
-        dsl::{annotated_lambda, app_bif, force, lref},
+        dsl::{app_bif, force, lambda, lref},
         LambdaForm,
     },
 };
 
 /// Shared wrapper for single-list intrinsics: force via SeqNumList
 /// then call the intrinsic.
-fn num_list_wrapper(intrinsic: &dyn StgIntrinsic, annotation: Smid) -> LambdaForm {
+fn num_list_wrapper(intrinsic: &dyn StgIntrinsic) -> LambdaForm {
     let bif_index: u8 = intrinsic.index().try_into().unwrap();
-    annotated_lambda(
+    lambda(
         1, // [nums]
         force(
             SeqNumList.global(lref(0)),
             // [concrete_nums] [nums]
             app_bif(bif_index, vec![lref(0)]),
         ),
-        annotation,
     )
 }
 
@@ -45,8 +44,8 @@ impl StgIntrinsic for RunningMax {
         "RUNNING_MAX"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        num_list_wrapper(self, annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        num_list_wrapper(self)
     }
 
     fn execute(
@@ -78,8 +77,8 @@ impl StgIntrinsic for RunningMin {
         "RUNNING_MIN"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        num_list_wrapper(self, annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        num_list_wrapper(self)
     }
 
     fn execute(
@@ -111,8 +110,8 @@ impl StgIntrinsic for RunningSum {
         "RUNNING_SUM"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        num_list_wrapper(self, annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        num_list_wrapper(self)
     }
 
     fn execute(

--- a/src/eval/stg/set.rs
+++ b/src/eval/stg/set.rs
@@ -28,7 +28,7 @@ use super::{
         native_to_set_primitive, resolve_native_unboxing, set_arg, set_primitive_to_native,
     },
     syntax::{
-        dsl::{annotated_lambda, app_bif, case, force, local, lref},
+        dsl::{app_bif, case, force, lambda, local, lref},
         LambdaForm,
     },
 };
@@ -40,7 +40,7 @@ use super::{
 /// number leaves `BoxedNumber(thunk)` — the inner thunk is not
 /// evaluated. This wrapper adds case branches for all box types to
 /// force the inner value before calling the intrinsic.
-fn element_set_wrapper(index: usize, annotation: Smid) -> LambdaForm {
+fn element_set_wrapper(index: usize) -> LambdaForm {
     let bif_index: u8 = index.try_into().unwrap();
 
     // After force(set) + case(element) + force(inner):
@@ -54,7 +54,7 @@ fn element_set_wrapper(index: usize, annotation: Smid) -> LambdaForm {
     //   element at lref(0), set at lref(1)
     let bif_fallback = app_bif(bif_index, vec![lref(0), lref(1)]);
 
-    annotated_lambda(
+    lambda(
         2, // [element, set]
         force(
             local(1), // force set
@@ -69,7 +69,6 @@ fn element_set_wrapper(index: usize, annotation: Smid) -> LambdaForm {
                 bif_fallback,
             ),
         ),
-        annotation,
     )
 }
 
@@ -125,13 +124,17 @@ impl StgIntrinsic for SetFromList {
                 } => {
                     // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol)
                     let inner_ref = cargs.get(0).ok_or_else(|| {
-                        ExecutionError::Panic("empty boxed value in set".to_string())
+                        ExecutionError::Panic(
+                            Smid::default(),
+                            "empty boxed value in set".to_string(),
+                        )
                     })?;
                     let native = item_closure.navigate_local_native(&view, inner_ref.clone());
                     primitives.push(native_to_set_primitive(view, &native)?);
                 }
                 _ => {
                     return Err(ExecutionError::Panic(
+                        Smid::default(),
                         "non-primitive value in set construction".to_string(),
                     ))
                 }
@@ -187,6 +190,7 @@ impl StgIntrinsic for SetToList {
                 Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
                 _ => {
                     return Err(ExecutionError::Panic(
+                        Smid::default(),
                         "unexpected native type in set".to_string(),
                     ))
                 }
@@ -234,8 +238,8 @@ impl StgIntrinsic for SetAdd {
         "SET.ADD"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        element_set_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        element_set_wrapper(self.index())
     }
 
     fn execute(
@@ -262,8 +266,8 @@ impl StgIntrinsic for SetRemove {
         "SET.REMOVE"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        element_set_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        element_set_wrapper(self.index())
     }
 
     fn execute(
@@ -290,8 +294,8 @@ impl StgIntrinsic for SetContains {
         "SET.CONTAINS"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        element_set_wrapper(self.index(), annotation)
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        element_set_wrapper(self.index())
     }
 
     fn execute(

--- a/src/eval/stg/stream_intrinsic.rs
+++ b/src/eval/stg/stream_intrinsic.rs
@@ -4,18 +4,21 @@
 //! STG machine's Update mechanism to memoise the result of each
 //! tail thunk.
 
-use crate::eval::{
-    emit::Emitter,
-    error::ExecutionError,
-    machine::{
-        env::SynClosure,
-        intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
-    },
-    memory::{
-        array::Array,
-        loader::load,
-        mutator::MutatorHeapView,
-        syntax::{LambdaForm, Ref, StgBuilder},
+use crate::{
+    common::sourcemap::Smid,
+    eval::{
+        emit::Emitter,
+        error::ExecutionError,
+        machine::{
+            env::SynClosure,
+            intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+        },
+        memory::{
+            array::Array,
+            loader::load,
+            mutator::MutatorHeapView,
+            syntax::{LambdaForm, Ref, StgBuilder},
+        },
     },
 };
 
@@ -55,7 +58,10 @@ impl StgIntrinsic for StreamNext {
     ) -> Result<(), ExecutionError> {
         let handle_num = num_arg(machine, view, &args[0])?;
         let handle = handle_num.as_u64().ok_or_else(|| {
-            ExecutionError::Panic("stream handle must be a positive integer".to_string())
+            ExecutionError::Panic(
+                Smid::default(),
+                "stream handle must be a positive integer".to_string(),
+            )
         })? as u32;
 
         // Advance the stream by one element

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -25,8 +25,7 @@ use super::{
     },
     syntax::{
         dsl::{
-            annotated_lambda, atom, box_str, data, force, let_, local, lref, str, switch,
-            unbox_str, value,
+            atom, box_str, data, force, lambda, let_, local, lref, str, switch, unbox_str, value,
         },
         LambdaForm,
     },
@@ -86,8 +85,8 @@ impl StgIntrinsic for Str {
         "STR"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             1,
             let_(
                 vec![value(switch(
@@ -109,7 +108,6 @@ impl StgIntrinsic for Str {
                 ))],
                 data(DataConstructor::BoxedString.tag(), vec![lref(0)]),
             ),
-            annotation,
         )
     }
 
@@ -144,8 +142,8 @@ impl StgIntrinsic for Join {
         "JOIN"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2, // [list sep]
             force(
                 SeqStrList.global(lref(0)),
@@ -159,7 +157,6 @@ impl StgIntrinsic for Join {
                     ),
                 ),
             ),
-            annotation,
         )
     }
 
@@ -302,7 +299,10 @@ impl StgIntrinsic for NumParse {
         if let Ok(num) = str::parse::<Number>(&string) {
             machine_return_num(machine, view, num)
         } else {
-            Err(ExecutionError::BadNumberFormat(string))
+            Err(ExecutionError::BadNumberFormat(
+                machine.annotation(),
+                string,
+            ))
         }
     }
 }
@@ -318,8 +318,8 @@ impl StgIntrinsic for Fmt {
         "FMT"
     }
 
-    fn wrapper(&self, annotation: Smid) -> LambdaForm {
-        annotated_lambda(
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
             2, // [x fmtstring]
             let_(
                 vec![value(switch(
@@ -392,7 +392,6 @@ impl StgIntrinsic for Fmt {
                 ))],
                 data(DataConstructor::BoxedString.tag(), vec![lref(0)]),
             ),
-            annotation,
         )
     }
 
@@ -408,9 +407,15 @@ impl StgIntrinsic for Fmt {
 
         match printf::fmt(view, machine.symbol_pool(), &fmt_string, &nat) {
             Ok(text) => machine_return_str(machine, view, text),
-            Err(PrintfError::InvalidFormatString(s)) => Err(ExecutionError::BadFormatString(s)),
-            Err(PrintfError::FmtError(_)) => Err(ExecutionError::FormatFailure),
-            Err(PrintfError::ConversionError) => Err(ExecutionError::BadNumericTypeForFormat),
+            Err(PrintfError::InvalidFormatString(s)) => {
+                Err(ExecutionError::BadFormatString(machine.annotation(), s))
+            }
+            Err(PrintfError::FmtError(_)) => {
+                Err(ExecutionError::FormatFailure(machine.annotation()))
+            }
+            Err(PrintfError::ConversionError) => Err(ExecutionError::BadNumericTypeForFormat(
+                machine.annotation(),
+            )),
         }
     }
 }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -211,15 +211,26 @@ impl Iterator for DataIterator<'_> {
             HeapSyn::Cons { tag, args } => match (*tag).try_into() {
                 Ok(DataConstructor::ListCons) => (args.get(0), args.get(1)),
                 Ok(DataConstructor::ListNil) => return None,
-                _ => return Some(Err(ExecutionError::Panic("expected list data".to_string()))),
+                _ => {
+                    return Some(Err(ExecutionError::Panic(
+                        Smid::default(),
+                        "expected list data".to_string(),
+                    )))
+                }
             },
-            _ => return Some(Err(ExecutionError::Panic("expected list data".to_string()))),
+            _ => {
+                return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "expected list data".to_string(),
+                )))
+            }
         };
 
         let head = match h_ref {
             Some(h) => self.closure.navigate_local(&self.view, h),
             None => {
                 return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -231,6 +242,7 @@ impl Iterator for DataIterator<'_> {
             }
             None => {
                 return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -271,12 +283,14 @@ impl Iterator for StrListIterator<'_> {
                 Ok(DataConstructor::ListNil) => return None,
                 _ => {
                     return Some(Err(ExecutionError::Panic(
+                        Smid::default(),
                         "expected string list data".to_string(),
                     )))
                 }
             },
             _ => {
                 return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
                     "expected string list data".to_string(),
                 )))
             }
@@ -286,6 +300,7 @@ impl Iterator for StrListIterator<'_> {
             Some(h) => self.closure.navigate_local_native(&self.view, h),
             None => {
                 return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -297,6 +312,7 @@ impl Iterator for StrListIterator<'_> {
             }
             None => {
                 return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -441,9 +457,9 @@ pub fn resolve_native_unboxing(
                 | Ok(DataConstructor::BoxedString)
                 | Ok(DataConstructor::BoxedSymbol)
                 | Ok(DataConstructor::BoxedZdt) => {
-                    let inner_ref = args
-                        .get(0)
-                        .ok_or_else(|| ExecutionError::Panic("empty boxed value".to_string()))?;
+                    let inner_ref = args.get(0).ok_or_else(|| {
+                        ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())
+                    })?;
                     let native = closure.navigate_local_native(&view, inner_ref);
                     Ok(native)
                 }
@@ -471,6 +487,7 @@ pub fn native_to_set_primitive(
         Native::Str(s) => Ok(SetPrim::Str(view.scoped(*s).as_str().to_string())),
         Native::Sym(id) => Ok(SetPrim::Sym(*id)),
         _ => Err(ExecutionError::Panic(
+            Smid::default(),
             "only numbers, strings, and symbols can be set elements".to_string(),
         )),
     }
@@ -507,7 +524,10 @@ pub fn set_arg<'guard>(
     if let Native::Set(ptr) = native {
         Ok(view.scoped(ptr))
     } else {
-        Err(ExecutionError::Panic("expected set argument".to_string()))
+        Err(ExecutionError::Panic(
+            Smid::default(),
+            "expected set argument".to_string(),
+        ))
     }
 }
 
@@ -604,6 +624,7 @@ pub fn collect_num_list(
                     Native::Num(n) => numbers.push(n.as_f64().unwrap_or(0.0)),
                     _ => {
                         return Err(ExecutionError::Panic(
+                            Smid::default(),
                             "non-numeric value in number list".to_string(),
                         ))
                     }
@@ -614,13 +635,17 @@ pub fn collect_num_list(
                 args: cargs,
             } => {
                 let inner_ref = cargs.get(0).ok_or_else(|| {
-                    ExecutionError::Panic("empty boxed value in number list".to_string())
+                    ExecutionError::Panic(
+                        Smid::default(),
+                        "empty boxed value in number list".to_string(),
+                    )
                 })?;
                 let native = item_closure.navigate_local_native(&view, inner_ref.clone());
                 match native {
                     Native::Num(n) => numbers.push(n.as_f64().unwrap_or(0.0)),
                     _ => {
                         return Err(ExecutionError::Panic(
+                            Smid::default(),
                             "non-numeric value in number list".to_string(),
                         ))
                     }
@@ -628,6 +653,7 @@ pub fn collect_num_list(
             }
             _ => {
                 return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "unexpected value in number list".to_string(),
                 ))
             }

--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -43,7 +43,7 @@ fn offset_from_tz_str(tz_str: &str) -> Result<FixedOffset, ExecutionError> {
     // Try "Z" for UTC
     if tz_str == "Z" {
         return FixedOffset::east_opt(0)
-            .ok_or_else(|| ExecutionError::BadTimeZone(tz_str.to_string()));
+            .ok_or_else(|| ExecutionError::BadTimeZone(Smid::default(), tz_str.to_string()));
     }
 
     // Try parsing as a numeric offset by constructing a dummy datetime
@@ -76,7 +76,10 @@ fn offset_from_tz_str(tz_str: &str) -> Result<FixedOffset, ExecutionError> {
             .fix());
     }
 
-    Err(ExecutionError::BadTimeZone(tz_str.to_string()))
+    Err(ExecutionError::BadTimeZone(
+        Smid::default(),
+        tz_str.to_string(),
+    ))
 }
 
 /// ZDT(y, m, d, h, M, s, Z) - create a zoned date time
@@ -102,8 +105,10 @@ impl StgIntrinsic for Zdt {
         let sec = num_arg(machine, view, &args[5])?;
         let tz = str_arg(machine, view, &args[6])?;
 
+        let smid = machine.annotation();
         let err = || {
             ExecutionError::BadDateTimeComponents(
+                smid,
                 y.clone(),
                 m.clone(),
                 d.clone(),
@@ -293,7 +298,7 @@ impl StgIntrinsic for ZdtFromEpoch {
             );
             machine_return_zdt(machine, view, zdt)
         } else {
-            Err(ExecutionError::BadTimestamp(unix))
+            Err(ExecutionError::BadTimestamp(machine.annotation(), unix))
         }
     }
 }
@@ -309,12 +314,11 @@ impl StgIntrinsic for ZdtIFields {
     }
 
     /// The STG wrapper for calling the intrinsic
-    fn wrapper(&self, annotation: Smid) -> super::syntax::LambdaForm {
+    fn wrapper(&self, _annotation: Smid) -> super::syntax::LambdaForm {
         use super::syntax::dsl::*;
-        annotated_lambda(
+        lambda(
             1,
             force(ZdtFromEpoch.global(lref(0)), ZdtFields.global(lref(0))),
-            annotation,
         )
     }
 }

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -25,20 +25,23 @@ impl StgIntrinsic for Requires {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
+        let smid = machine.annotation();
         let constraint_str = str_arg(machine, view, &args[0])?;
 
         let req = semver::VersionReq::parse(&constraint_str).map_err(|e| {
-            ExecutionError::Panic(format!(
-                "invalid version constraint \"{constraint_str}\": {e}"
-            ))
+            ExecutionError::Panic(
+                smid,
+                format!("invalid version constraint \"{constraint_str}\": {e}"),
+            )
         })?;
 
         // Strip any ".dev" suffix from the Cargo package version
         let version_str = env!("CARGO_PKG_VERSION").replace(".dev", "");
         let version = semver::Version::parse(&version_str).map_err(|e| {
-            ExecutionError::Panic(format!(
-                "failed to parse eucalypt version \"{version_str}\": {e}"
-            ))
+            ExecutionError::Panic(
+                smid,
+                format!("failed to parse eucalypt version \"{version_str}\": {e}"),
+            )
         })?;
 
         if req.matches(&version) {

--- a/tests/harness/errors/107_source_location_in_error.eu
+++ b/tests/harness/errors/107_source_location_in_error.eu
@@ -1,0 +1,2 @@
+# Test that errors carry source locations
+bomb: 1 / 0

--- a/tests/harness/errors/107_source_location_in_error.eu.expect
+++ b/tests/harness/errors/107_source_location_in_error.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "107_source_location_in_error.eu:2"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1242,3 +1242,8 @@ pub fn test_error_106() {
         .build();
     run_error_test(&opt);
 }
+
+#[test]
+pub fn test_error_107() {
+    run_error_test(&error_opts("107_source_location_in_error.eu"));
+}


### PR DESCRIPTION
## Summary

Implements eu-gwse: systematic audit ensuring all `ExecutionError` variants carry source locations via `Smid`.

### Changes

**Error variant updates** (`src/eval/error.rs`):
- Added `Smid` as first parameter to 13 variants: `Panic`, `DivisionByZero`, `NumericDomainError`, `NumericRangeError`, `ComplexResult`, `BadFormatString`, `FormatFailure`, `BadNumericTypeForFormat`, `FormatError`, `BadNumberFormat`, `BadDateTimeComponents`, `BadTimeZone`, `BadTimestamp`
- Updated `HasSmid::smid()` match arms and `#[error(...)]` format strings (shifted field indices)

**Construction site fixes** (26 files):
- BIF `execute()` methods: use `machine.annotation()` for current call-site Smid
- Driver/helper code without machine access: use `Smid::default()`
- Pre-captured `smid = machine.annotation()` before closures in `parse_string.rs`, `time.rs`, `version.rs`
- Added `Smid` import to `prng.rs` and `stream_intrinsic.rs`

**Wrapper annotation removal** (15 files in `src/eval/stg/`):
- Replaced `annotated_lambda(N, body, annotation)` with `lambda(N, body)` in all BIF `wrapper()` methods
- Renamed parameter to `_annotation: Smid` to silence unused variable warnings
- Removed `annotated_lambda` from explicit imports where present
- Removed helper function `annotation: Smid` parameters in `comparison_wrapper`, `arithmetic_wrapper`, `element_set_wrapper`, `num_list_wrapper`

This preserves the call-site Ann annotation through the wrapper lambda, so errors raised inside intrinsics now carry the user's source location rather than the synthetic intrinsic label.

### Before/After

**Before** (division by zero in `bomb.eu`):
```
error[E0001]: panic: division by zero
  --> <unknown>:0:0
```

**After**:
```
error[E0001]: division by zero in floor division (/)
  --> bomb.eu:2:8
  |
2 | bomb: 1 / 0
  |       ^^^^^
```

### Test

- Added `tests/harness/errors/107_source_location_in_error.eu` — verifies the source filename appears in division-by-zero diagnostics
- All 226 existing tests pass

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — applied
- [x] `cargo test` — 226 passed, 0 failed
- [x] `cargo test test_error_107` — new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)