### PR TITLE
fix(eval): preserve block metadata through merge and deep merge (eu-s10s)

### DIFF
--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1093,7 +1093,12 @@ impl StgIntrinsic for Merge {
         "MERGE"
     }
 
-    /// Expose the two lists to the intrinsic
+    /// Expose the two lists to the intrinsic, preserving metadata.
+    ///
+    /// Uses `demeta` to capture metadata from both operands before
+    /// pattern-matching blocks, then re-attaches the correct metadata
+    /// to the merged result. For shallow merge, RHS metadata wins when
+    /// both operands carry metadata.
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         use dsl::*;
 
@@ -1119,20 +1124,20 @@ impl StgIntrinsic for Merge {
             ),
         );
 
-        // Use plain lambda so the call-site annotation set by the Ann node
-        // emitted by the compiler at application sites is not overwritten
-        // when the intrinsic wrapper is entered.
-        let _ = annotation;
-        lambda(
-            2, // [l r]
+        // merge_core: lambda(2, [l_blk, r_blk]) — merges two bare blocks
+        // (no metadata), returning a bare Block. Indices within are identical
+        // to the original Merge wrapper since it has the same arity and
+        // structure.
+        let merge_core = lambda(
+            2, // [l_blk, r_blk]
             switch(
                 local(0),
                 vec![(
-                    DataConstructor::Block.tag(), // [lcons lindex] [l r]
+                    DataConstructor::Block.tag(), // [lcons lindex] [l_blk r_blk]
                     switch(
                         local(3),
                         vec![(
-                            DataConstructor::Block.tag(), // [rcons rindex] [lcons lindex] [l r]
+                            DataConstructor::Block.tag(), // [rcons rindex] [lcons lindex] [l_blk r_blk]
                             let_(
                                 vec![pack_items],
                                 // [pack] [rcons rindex] [lcons lindex]
@@ -1155,6 +1160,50 @@ impl StgIntrinsic for Merge {
                         )],
                     ),
                 )],
+            ),
+        );
+
+        // Use plain lambda so the call-site annotation set by the Ann node
+        // emitted by the compiler at application sites is not overwritten
+        // when the intrinsic wrapper is entered.
+        let _ = annotation;
+        lambda(
+            2, // [l, r]
+            let_(
+                vec![merge_core],
+                // [merge_core, l, r]
+                demeta(
+                    local(1), // examine l
+                    // l has meta → [l_meta, l_body, merge_core, l, r]
+                    demeta(
+                        local(4), // examine r
+                        // both have meta → [r_meta, r_body, l_meta, l_body, merge_core, l, r]
+                        // shallow merge: RHS metadata wins
+                        force(
+                            app(lref(4), vec![lref(3), lref(1)]), // merge_core(l_body, r_body)
+                            // [merged, r_meta, r_body, l_meta, l_body, merge_core, l, r]
+                            with_meta(lref(1), lref(0)), // r_meta wins
+                        ),
+                        // only l has meta → [r_whnf, l_meta, l_body, merge_core, l, r]
+                        force(
+                            app(lref(3), vec![lref(2), lref(0)]), // merge_core(l_body, r_whnf)
+                            // [merged, r_whnf, l_meta, l_body, merge_core, l, r]
+                            with_meta(lref(2), lref(0)), // l_meta
+                        ),
+                    ),
+                    // l has no meta → [l_whnf, merge_core, l, r]
+                    demeta(
+                        local(3), // examine r
+                        // only r has meta → [r_meta, r_body, l_whnf, merge_core, l, r]
+                        force(
+                            app(lref(3), vec![lref(2), lref(1)]), // merge_core(l_whnf, r_body)
+                            // [merged, r_meta, r_body, l_whnf, merge_core, l, r]
+                            with_meta(lref(1), lref(0)), // r_meta
+                        ),
+                        // neither has meta → [r_whnf, l_whnf, merge_core, l, r]
+                        app(lref(2), vec![lref(1), lref(0)]), // merge_core(l_whnf, r_whnf)
+                    ),
+                ),
             ),
         )
     }
@@ -1325,34 +1374,78 @@ impl StgIntrinsic for DeepMerge {
         "DEEPMERGE"
     }
 
-    /// Deep merge operation
+    /// Deep merge operation, preserving metadata from both operands.
+    ///
+    /// Uses `demeta` to capture metadata from both operands before
+    /// pattern-matching blocks. RHS metadata wins when both carry metadata.
+    /// Sub-block values are still recursively deep-merged (via MergeWith).
     fn wrapper(&self, annotation: Smid) -> LambdaForm {
         use dsl::*;
+
+        // merge_deep_core: lambda(2, [l_blk, r_blk]) — deep-merges two bare
+        // blocks (no metadata). Replicates the original case/MergeWith logic.
+        let merge_deep_core = lambda(
+            2, // [l_blk, r_blk]
+            case(
+                local(0), // l_blk
+                vec![(
+                    DataConstructor::Block.tag(), // [lcons lindex] [l_blk r_blk]
+                    case(
+                        local(3), // r_blk in [lcons lindex l_blk r_blk]
+                        vec![(
+                            DataConstructor::Block.tag(), // [rcons rindex lcons lindex l_blk r_blk]
+                            MergeWith.global(lref(4), lref(5), gref(self.index())),
+                        )],
+                        // r not block: return r_whnf
+                        local(0),
+                    ),
+                )],
+                // l not block: return r_blk
+                local(2),
+            ),
+        );
 
         // Use plain lambda so the call-site annotation set by the Ann node
         // emitted by the compiler at application sites is not overwritten
         // when the intrinsic wrapper is entered.
         let _ = annotation;
         lambda(
-            2,
-            case(
-                local(0),
-                vec![(
-                    DataConstructor::Block.tag(),
-                    // [lcons lindex] [l r]
-                    case(
-                        local(3),
-                        vec![(
-                            DataConstructor::Block.tag(),
-                            // [rcons rindex] [lcons lindex] [l r]
-                            MergeWith.global(lref(4), lref(5), gref(self.index())),
-                        )],
-                        // [r] [lcons lindex] [l r]
-                        local(0),
+            2, // [l, r]
+            let_(
+                vec![merge_deep_core],
+                // [merge_deep_core, l, r]
+                demeta(
+                    local(1), // examine l
+                    // l has meta → [l_meta, l_body, merge_deep_core, l, r]
+                    demeta(
+                        local(4), // examine r
+                        // both have meta → [r_meta, r_body, l_meta, l_body, merge_deep_core, l, r]
+                        // RHS metadata wins
+                        force(
+                            app(lref(4), vec![lref(3), lref(1)]), // merge_deep_core(l_body, r_body)
+                            // [merged, r_meta, r_body, l_meta, l_body, merge_deep_core, l, r]
+                            with_meta(lref(1), lref(0)), // r_meta wins
+                        ),
+                        // only l has meta → [r_whnf, l_meta, l_body, merge_deep_core, l, r]
+                        force(
+                            app(lref(3), vec![lref(2), lref(0)]), // merge_deep_core(l_body, r_whnf)
+                            // [merged, r_whnf, l_meta, l_body, merge_deep_core, l, r]
+                            with_meta(lref(2), lref(0)), // l_meta
+                        ),
                     ),
-                )],
-                // [l] [l r]
-                local(2),
+                    // l has no meta → [l_whnf, merge_deep_core, l, r]
+                    demeta(
+                        local(3), // examine r
+                        // only r has meta → [r_meta, r_body, l_whnf, merge_deep_core, l, r]
+                        force(
+                            app(lref(3), vec![lref(2), lref(1)]), // merge_deep_core(l_whnf, r_body)
+                            // [merged, r_meta, r_body, l_whnf, merge_deep_core, l, r]
+                            with_meta(lref(1), lref(0)), // r_meta
+                        ),
+                        // neither has meta → [r_whnf, l_whnf, merge_deep_core, l, r]
+                        app(lref(2), vec![lref(1), lref(0)]), // merge_deep_core(l_whnf, r_whnf)
+                    ),
+                ),
             ),
         )
     }

--- a/tests/harness/127_merge_metadata.eu
+++ b/tests/harness/127_merge_metadata.eu
@@ -1,0 +1,67 @@
+"Metadata preservation through merge operations."
+
+# Shallow merge (catenation) metadata tests
+shallow-merge: {
+  left: {x: 1} // {tag: :left}
+  right: {y: 2} // {tag: :right}
+  plain-l: {x: 1}
+  plain-r: {y: 2}
+
+  # RHS metadata wins when both have meta
+  both: merge(left, right)
+  both-meta-tag: both meta lookup-or(:tag, :none) //= :right
+
+  # LHS metadata preserved when only LHS has meta
+  left-only: merge(left, plain-r)
+  left-meta-tag: left-only meta lookup-or(:tag, :none) //= :left
+
+  # RHS metadata preserved when only RHS has meta
+  right-only: merge(plain-l, right)
+  right-meta-tag: right-only meta lookup-or(:tag, :none) //= :right
+
+  # No metadata when neither has meta
+  neither: merge(plain-l, plain-r)
+  neither-meta: neither meta lookup-or(:tag, :none) //= :none
+
+  # Values are correctly merged in all cases
+  both-has-x: both.x //= 1
+  both-has-y: both.y //= 2
+  left-only-x: left-only.x //= 1
+  left-only-y: left-only.y //= 2
+
+  pass: [both-meta-tag, left-meta-tag, right-meta-tag, neither-meta,
+         both-has-x, both-has-y, left-only-x, left-only-y] all-true?
+}
+
+# Deep merge (<<) metadata tests
+deep-merge: {
+  left: {x: {a: 1}} // {tag: :deep-left}
+  right: {x: {b: 2}} // {tag: :deep-right}
+  plain-l: {x: {a: 1}}
+  plain-r: {x: {b: 2}}
+
+  # RHS metadata wins for deep merge when both have non-block meta
+  both: left << right
+  both-meta-tag: both meta lookup-or(:tag, :none) //= :deep-right
+
+  # LHS meta preserved when only LHS has meta
+  left-only: left << plain-r
+  left-meta-tag: left-only meta lookup-or(:tag, :none) //= :deep-left
+
+  # RHS meta preserved when only RHS has meta
+  right-only: plain-l << right
+  right-meta-tag: right-only meta lookup-or(:tag, :none) //= :deep-right
+
+  # Neither: no meta
+  neither: plain-l << plain-r
+  neither-meta: neither meta lookup-or(:tag, :none) //= :none
+
+  # Deep merge semantics preserved: sub-block values are deep-merged
+  both-a: both.x.a //= 1
+  both-b: both.x.b //= 2
+
+  pass: [both-meta-tag, left-meta-tag, right-meta-tag, neither-meta,
+         both-a, both-b] all-true?
+}
+
+RESULT: if(shallow-merge.pass ∧ deep-merge.pass, :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -639,6 +639,11 @@ pub fn test_harness_125() {
 }
 
 #[test]
+pub fn test_harness_127() {
+    run_test(&opts("127_merge_metadata.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- `Merge` and `DeepMerge` wrappers previously used `switch`/`case` to pattern-match their block arguments, which evaluates through `Meta` nodes and silently discards metadata before the merge logic runs
- Both wrappers are restructured to use `demeta` before pattern-matching, capturing metadata from both operands and re-attaching the correct metadata to the merged result
- The core merge logic is extracted into a `let_`-bound lambda to avoid duplication across the four `demeta` branches

## Metadata merging rules

| Condition | Behaviour |
|-----------|-----------|
| Both operands have metadata | RHS metadata wins (shallow and deep merge) |
| Only LHS has metadata | LHS metadata preserved |
| Only RHS has metadata | RHS metadata preserved |
| Neither has metadata | Bare merged block returned |

## Implementation notes

- De Bruijn index arithmetic was written out in full for each of the four `demeta` branches (both-have-meta, only-l, only-r, neither) and verified against the STG VM's `from_closures` binding convention
- `MergeWith` is unchanged — `DeepMerge` now strips metadata before delegating to `MergeWith` on bare block bodies; recursive calls to `DeepMerge` via `MergeWith` will pick up metadata from sub-block values through the outer `demeta` wrapper
- Chunk 3 (MergeWith metadata handling) assessed and skipped — `MergeWith` is not user-accessible and `DeepMerge` already strips metadata before calling it

## Test plan

- [x] Harness test `127_merge_metadata.eu` covers both shallow and deep merge metadata scenarios
- [x] `cargo test` — all 226 tests pass (0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)