### PR TITLE
feat(platform): Windows support (eu-vzi)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -45,7 +45,7 @@ jobs:
     name: Test Suite
     strategy:
       matrix:
-        os: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && fromJSON('["ubuntu-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -268,6 +268,48 @@ jobs:
           name: eu_aarch64
           path: target/release/eu_aarch64
 
+  release-candidate-windows:
+    needs: [lint, test, audit]
+    name: Release Windows
+    runs-on: windows-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and install temporary eu
+        run: cargo install --path . --target-dir C:\eu-install
+      - name: Prepare build files for new version
+        shell: pwsh
+        run: |
+          $env:OSTYPE = "Windows"
+          $env:HOSTTYPE = "x86_64"
+          eu build.eu -t build-meta > build-meta.yaml.new
+          Move-Item -Force build-meta.yaml.new build-meta.yaml
+          $tag = eu build.eu -t version
+          echo "TAG_NAME=$tag" >> $env:GITHUB_ENV
+      - name: Build release
+        run: cargo build --all --release
+      - name: Rename binary
+        run: |
+          copy target\release\eu.exe target\release\eu_windows_amd64.exe
+      - name: Run final test with release binary
+        run: |
+          target\release\eu_windows_amd64.exe version
+          target\release\eu_windows_amd64.exe test tests/harness
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: eu_windows_amd64.exe
+          path: target/release/eu_windows_amd64.exe
+
   prepare-release:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
@@ -275,6 +317,7 @@ jobs:
       - release-candidate-linux
       - release-candidate-linux-arm
       - release-candidate-macos
+      - release-candidate-windows
     steps:
 
       - uses: actions/download-artifact@v4
@@ -288,6 +331,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: eu_aarch64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: eu_windows_amd64.exe
 
       - uses: actions/download-artifact@v4
         with:
@@ -309,7 +356,7 @@ jobs:
 
       - name: Generate SHA256SUMS
         run: |
-          sha256sum *.tgz > SHA256SUMS
+          sha256sum *.tgz eu_windows_amd64.exe > SHA256SUMS
 
       - name: Query binary for version number
         run: |
@@ -327,6 +374,7 @@ jobs:
             eucalypt-x86_64-linux.tgz
             eucalypt-aarch64-linux.tgz
             eucalypt-aarch64-osx.tgz
+            eu_windows_amd64.exe
             SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ base64 = "0.22"
 sha2 = "0.10"
 rowan = "0.15.3"
 ndarray = "0.16"
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -1058,14 +1058,25 @@ impl Mutator for BuildRenderDoc {
 
 // ─── Shell execution ──────────────────────────────────────────────────────────
 
-/// Execute a shell command via `sh -c`.
+/// Execute a shell command via the platform shell.
+///
+/// On Unix, uses `sh -c`. On Windows, uses `pwsh -NoProfile -Command`
+/// (PowerShell Core). Shell command strings are inherently
+/// platform-specific.
 fn execute_shell(
     cmd: &str,
     stdin_data: Option<&str>,
     timeout_secs: u64,
 ) -> Result<CommandResult, IoRunError> {
-    let mut command = Command::new("sh");
-    command.args(["-c", cmd]);
+    let command = if cfg!(windows) {
+        let mut c = Command::new("pwsh");
+        c.args(["-NoProfile", "-Command", cmd]);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.args(["-c", cmd]);
+        c
+    };
     run_command(command, stdin_data, timeout_secs)
 }
 

--- a/src/eval/machine/crash.rs
+++ b/src/eval/machine/crash.rs
@@ -41,7 +41,7 @@ pub enum GcEventKind {
 }
 
 impl GcEventKind {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(unix)]
     fn label(self) -> &'static [u8] {
         match self {
             Self::Empty => b"empty",
@@ -56,7 +56,7 @@ impl GcEventKind {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(unix)]
     fn from_u8(v: u8) -> Self {
         match v {
             1 => Self::CollectionStart,
@@ -145,7 +145,7 @@ impl GcEventRing {
     ///
     /// Safe to call from a signal handler because it only reads
     /// fixed-size arrays and an atomic counter — no allocations.
-    #[cfg(any(not(target_arch = "wasm32"), test))]
+    #[cfg(any(unix, test))]
     fn iter_raw(&self) -> impl Iterator<Item = GcEvent> + '_ {
         let total = self.pos.load(Ordering::Relaxed);
         let count = total.min(GC_EVENT_RING_SIZE);
@@ -282,8 +282,8 @@ pub fn unregister_crash_diagnostics() {
 /// Install the SIGSEGV and SIGBUS signal handlers.
 ///
 /// This should be called once, early in `main()`, before any
-/// evaluation begins. On WASM this is a no-op.
-#[cfg(not(target_arch = "wasm32"))]
+/// evaluation begins. On WASM and Windows this is a no-op.
+#[cfg(unix)]
 pub fn install_crash_handler() {
     unsafe {
         let mut action: libc::sigaction = std::mem::zeroed();
@@ -300,10 +300,14 @@ pub fn install_crash_handler() {
 #[cfg(target_arch = "wasm32")]
 pub fn install_crash_handler() {}
 
+/// No-op on Windows — SIGSEGV/SIGBUS signal handlers are Unix-specific.
+#[cfg(not(any(unix, target_arch = "wasm32")))]
+pub fn install_crash_handler() {}
+
 /// Signal-safe integer formatting into a fixed buffer.
 ///
 /// Returns the number of bytes written.
-#[cfg(any(not(target_arch = "wasm32"), test))]
+#[cfg(any(unix, test))]
 fn format_u64(mut val: u64, buf: &mut [u8]) -> usize {
     if val == 0 {
         if !buf.is_empty() {
@@ -329,7 +333,7 @@ fn format_u64(mut val: u64, buf: &mut [u8]) -> usize {
 /// Signal-safe hex formatting into a fixed buffer.
 ///
 /// Returns the number of bytes written.
-#[cfg(any(not(target_arch = "wasm32"), test))]
+#[cfg(any(unix, test))]
 fn format_hex(mut val: u64, buf: &mut [u8]) -> usize {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     if val == 0 {
@@ -364,13 +368,13 @@ fn format_hex(mut val: u64, buf: &mut [u8]) -> usize {
 /// # Safety
 ///
 /// Uses `libc::write` which is async-signal-safe.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(unix)]
 unsafe fn write_stderr(data: &[u8]) {
     libc::write(libc::STDERR_FILENO, data.as_ptr().cast(), data.len());
 }
 
 /// Write a labelled u64 value to stderr (signal-safe).
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(unix)]
 unsafe fn write_field(label: &[u8], value: u64) {
     let mut buf = [0u8; 20];
     let len = format_u64(value, &mut buf);
@@ -388,7 +392,7 @@ unsafe fn write_field(label: &[u8], value: u64) {
 /// This is called from the OS signal delivery mechanism. It must
 /// only use async-signal-safe operations (no heap allocation, no
 /// locks, no stdio). We use `libc::write` for all output.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(unix)]
 unsafe extern "C" fn crash_signal_handler(
     sig: libc::c_int,
     info: *mut libc::siginfo_t,


### PR DESCRIPTION
## Summary

- Gates Unix-only crash signal handler (SIGSEGV/SIGBUS via `libc::sigaction`) behind `#[cfg(unix)]` instead of `#[cfg(not(target_arch = "wasm32"))]`; adds Windows no-op stub for `install_crash_handler()`
- Moves `libc` dependency to `[target.'cfg(unix)'.dependencies]` so it is not required on Windows
- Dispatches `io.shell` to `pwsh -NoProfile -Command` on Windows and `sh -c` on Unix
- Adds `windows-latest` to the CI test matrix (master-push builds)
- Adds `release-candidate-windows` job producing `eu_windows_amd64.exe`
- Includes Windows binary in `prepare-release` SHA256SUMS and GitHub release artefacts

## Test plan

- [ ] `cargo build` clean on macOS/Linux (no libc gate regression)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo test --lib` all 606 tests pass
- [ ] Windows CI job (`release-candidate-windows`) builds and runs harness on push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)