### PR TITLE
feat(eu-uex5): replace moniker dependency with custom binding implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,8 +283,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -502,8 +502,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -561,7 +561,6 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "matches",
- "moniker",
  "ndarray",
  "ordered-float",
  "petgraph",
@@ -707,8 +706,8 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1074,26 +1073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moniker"
-version = "0.5.0"
-source = "git+https://github.com/curvelogic/moniker?rev=c620b2a69d6cad4724cba07775ed65a7ae556c9c#c620b2a69d6cad4724cba07775ed65a7ae556c9c"
-dependencies = [
- "lazy_static",
- "moniker-derive",
-]
-
-[[package]]
-name = "moniker-derive"
-version = "0.5.0"
-source = "git+https://github.com/curvelogic/moniker?rev=c620b2a69d6cad4724cba07775ed65a7ae556c9c#c620b2a69d6cad4724cba07775ed65a7ae556c9c"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "synstructure 0.10.2",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,15 +1394,6 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
@@ -1442,20 +1412,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
- "proc-macro2 1.0.106",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1652,8 +1613,8 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -1676,8 +1637,8 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -1743,8 +1704,8 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1755,23 +1716,12 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1781,21 +1731,9 @@ version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1804,8 +1742,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -1850,8 +1788,8 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -1935,12 +1873,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "url"
@@ -2044,7 +1976,7 @@ version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
- "quote 1.0.44",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2055,8 +1987,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
@@ -2147,8 +2079,8 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -2158,8 +2090,8 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -2299,10 +2231,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -2320,8 +2252,8 @@ version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 
@@ -2340,10 +2272,10 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -2374,8 +2306,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
- "proc-macro2 1.0.106",
- "quote 1.0.44",
+ "proc-macro2",
+ "quote",
  "syn 2.0.114",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ itertools = "0.10.5"
 thiserror = "1.0.37"
 url = "2.3.1"
 pretty = "0.11.3"
-moniker = { git = "https://github.com/curvelogic/moniker", rev = "c620b2a69d6cad4724cba07775ed65a7ae556c9c" }
 indexmap = "1.9.1"
 petgraph = "0.6.2"
 csv = "1.1.6"

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -3,7 +3,6 @@ use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     files::{Files, SimpleFiles},
 };
-use moniker::*;
 use std::fmt::Display;
 use std::num::NonZeroU32;
 use std::{fmt, ops::Range};
@@ -73,21 +72,6 @@ impl Smid {
     pub fn fake(index: usize) -> Smid {
         Smid::new(index)
     }
-}
-
-/// SMIDs are ignorable for name binding
-impl BoundTerm<String> for Smid {
-    fn term_eq(&self, _: &Smid) -> bool {
-        true
-    }
-
-    fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<String>) {}
-
-    fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<String>) {}
-
-    fn visit_vars(&self, _: &mut impl FnMut(&Var<String>)) {}
-
-    fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<String>)) {}
 }
 
 /// Anything that has a SMID identifying a source location.

--- a/src/core/anaphora.rs
+++ b/src/core/anaphora.rs
@@ -2,7 +2,6 @@
 use crate::common::sourcemap::{HasSmid, Smid};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
-use moniker::*;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -17,8 +16,8 @@ pub fn naked_anaphora(expr: &RcExpr) -> Option<Anaphor<Smid, i32>> {
 
 /// Sort and arrange anaphora into a binding pattern
 pub fn to_binding_pattern(
-    anaphora: &HashMap<Anaphor<Smid, i32>, FreeVar<String>>,
-) -> Result<Vec<FreeVar<String>>, CoreError> {
+    anaphora: &HashMap<Anaphor<Smid, i32>, String>,
+) -> Result<Vec<String>, CoreError> {
     let (numberless, numbered, section) = sort_anaphora(anaphora.keys().cloned());
 
     let mut types = 0;
@@ -48,16 +47,13 @@ pub fn to_binding_pattern(
     } else if !numbered.is_empty() {
         let numbers: Vec<_> = numbered.iter().filter_map(|ana| ana.number()).collect();
         let max = numbers.iter().max().unwrap();
-        let mut v: Vec<Option<FreeVar<String>>> = vec![None; *max as usize + 1];
+        let mut v: Vec<Option<String>> = vec![None; *max as usize + 1];
         for n in numbers {
             v[n as usize] = Some(anaphora.get(&Anaphor::ExplicitNumbered(n)).unwrap().clone());
         }
         Ok(v.into_iter()
             .enumerate()
-            .map(|(i, x)| {
-                x.or_else(|| Some(FreeVar::fresh_named(format!("_d{i}"))))
-                    .unwrap()
-            })
+            .map(|(i, x)| x.unwrap_or_else(|| format!("_d{i}")))
             .collect())
     } else {
         panic!("empty anaphora when forming binding pattern")
@@ -126,46 +122,43 @@ impl PrefixAnaphorIncantation {
     }
 
     /// Determine the number of the anaphor (e.g. _8 -> 8, •0 -> 0)
-    pub fn number(&self, free_var: &FreeVar<String>) -> Option<i32> {
-        match free_var.pretty_name {
-            Some(ref n) => self.number_str(n),
-            None => None,
-        }
+    pub fn number(&self, name: &str) -> Option<i32> {
+        self.number_str(name)
     }
 
-    /// Create a fresh FreeVar for this number
-    pub fn with_number(&self, n: i32) -> FreeVar<String> {
-        FreeVar::fresh_named(format!("{}{}", self.prefix, n))
+    /// Create a name for this anaphor number
+    pub fn with_number(&self, n: i32) -> String {
+        format!("{}{}", self.prefix, n)
     }
 
-    /// Create a fresh FreeVar for the unnumbered anaphor
-    pub fn numberless(&self) -> FreeVar<String> {
-        FreeVar::fresh_named(format!("{}", self.prefix))
+    /// Create a name for the unnumbered anaphor
+    pub fn numberless(&self) -> String {
+        format!("{}", self.prefix)
     }
 
-    /// Take a set of free var anaphora occuring in an expression and
+    /// Take a set of anaphor name occurrences in an expression and
     /// return a list of binders for a lambda (including "skipped" anaphora)
-    pub fn to_binding_pattern(&self, free_vars: HashSet<FreeVar<String>>) -> Vec<Binder<String>> {
-        let mut vars: Vec<FreeVar<String>> = free_vars.into_iter().collect();
-        vars.sort_unstable_by_key(|v| v.pretty_name.clone());
+    pub fn to_binding_pattern(&self, names: HashSet<String>) -> Vec<String> {
+        let mut vars: Vec<String> = names.into_iter().collect();
+        vars.sort_unstable();
         let max = vars.last().and_then(|v| self.number(v)).unwrap();
 
         if max as usize > vars.len() - 1 {
-            let mut padded: Vec<Binder<String>> = Vec::with_capacity((max + 1) as usize);
+            let mut padded: Vec<String> = Vec::with_capacity((max + 1) as usize);
             let mut i = 0;
             let mut v = 0;
             while v <= max {
                 if self.number(&vars[i]).unwrap() == v {
-                    padded.push(Binder(vars[i].clone()));
+                    padded.push(vars[i].clone());
                     i += 1;
                 } else {
-                    padded.push(Binder(self.with_number(v)));
+                    padded.push(self.with_number(v));
                 }
                 v += 1;
             }
             padded
         } else {
-            vars.into_iter().map(Binder).collect()
+            vars
         }
     }
 }
@@ -176,13 +169,10 @@ pub mod tests {
 
     #[test]
     pub fn test_number() {
-        assert_eq!(BLOCK_ANAPHORA.number(&FreeVar::fresh_named("•8")), Some(8));
-        assert_eq!(BLOCK_ANAPHORA.number(&FreeVar::fresh_named("•")), None);
-        assert_eq!(
-            EXPR_ANAPHORA.number(&FreeVar::fresh_named("_999")),
-            Some(999)
-        );
-        assert_eq!(EXPR_ANAPHORA.number(&FreeVar::fresh_named("_")), None);
+        assert_eq!(BLOCK_ANAPHORA.number("•8"), Some(8));
+        assert_eq!(BLOCK_ANAPHORA.number("•"), None);
+        assert_eq!(EXPR_ANAPHORA.number("_999"), Some(999));
+        assert_eq!(EXPR_ANAPHORA.number("_"), None);
     }
 
     #[test]
@@ -199,25 +189,25 @@ pub mod tests {
 
     #[test]
     pub fn to_binding_pattern_with_complete_anaphora_usage() {
-        let fvs: HashSet<_> = (0..3).map(|i| BLOCK_ANAPHORA.with_number(i)).collect();
-        let pattern = BLOCK_ANAPHORA.to_binding_pattern(fvs);
+        let names: HashSet<_> = (0..3).map(|i| BLOCK_ANAPHORA.with_number(i)).collect();
+        let pattern = BLOCK_ANAPHORA.to_binding_pattern(names);
         let pattern_numbers: Vec<Option<i32>> = pattern
             .iter()
-            .map(|binder: &Binder<String>| BLOCK_ANAPHORA.number(&binder.0))
+            .map(|name: &String| BLOCK_ANAPHORA.number(name))
             .collect();
         assert_eq!(pattern_numbers, vec![Some(0), Some(1), Some(2)]);
     }
 
     #[test]
     pub fn to_binding_pattern_with_incomplete_anaphora_usage() {
-        let mut fvs: HashSet<FreeVar<String>> = HashSet::new();
-        fvs.insert(BLOCK_ANAPHORA.with_number(4));
-        fvs.insert(BLOCK_ANAPHORA.with_number(2));
+        let mut names: HashSet<String> = HashSet::new();
+        names.insert(BLOCK_ANAPHORA.with_number(4));
+        names.insert(BLOCK_ANAPHORA.with_number(2));
 
-        let pattern = BLOCK_ANAPHORA.to_binding_pattern(fvs);
+        let pattern = BLOCK_ANAPHORA.to_binding_pattern(names);
         let pattern_numbers: Vec<Option<i32>> = pattern
             .iter()
-            .map(|binder: &Binder<String>| BLOCK_ANAPHORA.number(&binder.0))
+            .map(|name: &String| BLOCK_ANAPHORA.number(name))
             .collect();
         assert_eq!(
             pattern_numbers,
@@ -230,7 +220,7 @@ pub mod tests {
         let ana0 = free("_0");
         let ana1 = free("_1");
 
-        let mut hm: HashMap<Anaphor<Smid, i32>, FreeVar<String>> = HashMap::new();
+        let mut hm: HashMap<Anaphor<Smid, i32>, String> = HashMap::new();
         hm.insert(Anaphor::ExplicitNumbered(0), ana0.clone());
         hm.insert(Anaphor::ExplicitNumbered(1), ana1.clone());
         assert_eq!(to_binding_pattern(&hm).unwrap(), vec![ana0, ana1]);

--- a/src/core/binding.rs
+++ b/src/core/binding.rs
@@ -1,0 +1,37 @@
+//! Custom binding types replacing the `moniker` crate.
+//!
+//! Provides de Bruijn indexed variable binding with free/bound variable
+//! distinction, scopes, and helper operations.
+
+/// A variable reference — either free (by name) or bound (de Bruijn indexed)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Var {
+    Free(String),
+    Bound(BoundVar),
+}
+
+/// A bound variable with de Bruijn indices
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BoundVar {
+    /// How many enclosing scopes to skip (0 = innermost)
+    pub scope: u32,
+    /// Which binding within that scope (0-indexed)
+    pub binder: u32,
+    /// Original name, preserved for debugging and pretty-printing
+    pub name: Option<String>,
+}
+
+/// A scope binding pattern `P` over body `B`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scope<P, B> {
+    pub pattern: P,
+    pub body: B,
+}
+
+/// Collect the free variable name from a `Var` reference.
+pub fn var_free_name(v: &Var) -> Option<&str> {
+    match v {
+        Var::Free(n) => Some(n.as_str()),
+        Var::Bound(_) => None,
+    }
+}

--- a/src/core/cook/fill.rs
+++ b/src/core/cook/fill.rs
@@ -96,18 +96,22 @@ pub mod tests {
     use super::*;
     use crate::core::expr::acore::*;
     use crate::core::expr::core;
+    use crate::core::expr::tests::alpha_norm;
     use crate::core::expr::RcExpr;
-    use moniker::assert_term_eq;
 
     fn fill(exprs: &[RcExpr]) -> Vec<RcExpr> {
         fill_gaps(exprs).unwrap().0
+    }
+
+    fn anorm(expr: RcExpr) -> RcExpr {
+        alpha_norm(expr)
     }
 
     #[test]
     pub fn test_cat() {
         let x = free("x");
         let f = free("f");
-        assert_term_eq!(
+        assert_eq!(
             soup(fill(&[var(x.clone()), var(f.clone())])),
             soup(vec![var(x), cat(), var(f)])
         );
@@ -122,33 +126,33 @@ pub mod tests {
 
         // nb. term_eq does not verify the anaphora
 
-        assert_term_eq!(
-            soup(fill(&[l50.clone(), var(x.clone())])),
-            soup(vec![
+        assert_eq!(
+            anorm(soup(fill(&[l50.clone(), var(x.clone())]))),
+            anorm(soup(vec![
                 core::section_anaphor_left(Smid::fake(1)),
                 l50.clone(),
                 var(x.clone())
-            ])
+            ]))
         );
 
-        assert_term_eq!(
-            soup(fill(&[var(x.clone()), l50.clone()])),
-            soup(vec![
+        assert_eq!(
+            anorm(soup(fill(&[var(x.clone()), l50.clone()]))),
+            anorm(soup(vec![
                 var(x),
                 l50.clone(),
                 core::section_anaphor_right(Smid::fake(3))
-            ])
+            ]))
         );
 
-        assert_term_eq!(
-            soup(fill(&[pre10.clone(), l50.clone(), post10.clone()])),
-            soup(vec![
+        assert_eq!(
+            anorm(soup(fill(&[pre10.clone(), l50.clone(), post10.clone()]))),
+            anorm(soup(vec![
                 pre10,
                 core::section_anaphor_right(Smid::fake(3)),
                 l50,
                 core::section_anaphor_right(Smid::fake(2)),
                 post10
-            ])
+            ]))
         );
     }
 
@@ -159,7 +163,7 @@ pub mod tests {
 
         let ana = core::expr_anaphor(Smid::fake(10), None);
 
-        assert_term_eq!(
+        assert_eq!(
             soup(fill(&[ana.clone(), plus.clone(), var(x.clone())])),
             soup(vec![ana, plus, var(x)])
         );

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -1,23 +1,19 @@
 //! Distribute fixity metadata from definition site to call site.
 use crate::common::environment::SimpleEnvironment;
 use crate::common::sourcemap::Smid;
+use crate::core::binding::Var;
 use crate::core::error::CoreError;
 use crate::core::expr::*;
-use moniker::FreeVar;
-use moniker::Rec;
-use moniker::Scope;
-use moniker::Var::Free;
-use moniker::{Binder, Embed};
 use std::collections::HashMap;
 
 pub fn distribute(expr: RcExpr) -> Result<RcExpr, CoreError> {
     Distributor::default().dist(expr)
 }
 
-type Binding = (Binder<String>, Embed<RcExpr>);
+type Binding = (String, RcExpr);
 type OpMeta = (Smid, Fixity, Precedence);
-type Frame = HashMap<FreeVar<String>, OpMeta>;
-type Env = SimpleEnvironment<FreeVar<String>, OpMeta>;
+type Frame = HashMap<String, OpMeta>;
+type Env = SimpleEnvironment<String, OpMeta>;
 
 /// Distribute maintains state as we traverse through the tree
 /// accumulating correspondence between names and operator metadata
@@ -39,7 +35,7 @@ impl Distributor {
                     (expr, None)
                 }
             }
-            Expr::Operator(s, f, p, e) => (e.clone(), Some((*s, *f, *p))),
+            Expr::Operator(s, f, p, _e) => (_e.clone(), Some((*s, *f, *p))),
             _ => (expr, None),
         }
     }
@@ -52,11 +48,11 @@ impl Distributor {
         let mut frame = Frame::new();
         let mut rebound = Vec::new();
 
-        for (Binder(fv), Embed(value)) in bindings {
+        for (name, value) in bindings {
             let (expr, op_meta) = Self::expose_definition(value.clone());
-            rebound.push((Binder(fv.clone()), Embed(expr.clone())));
+            rebound.push((name.clone(), expr));
             if let Some(op_data) = op_meta {
-                frame.insert(fv.clone(), op_data);
+                frame.insert(name.clone(), op_data);
             }
         }
 
@@ -67,20 +63,25 @@ impl Distributor {
     pub fn dist(&mut self, expr: RcExpr) -> Result<RcExpr, CoreError> {
         match &*expr.inner {
             Expr::Let(s, scope, t) => {
-                // - Clone...
-                let (rec_bindings, body) = scope.clone().unbind();
+                // Open the scope fully (both binding values and body), mirroring
+                // the original `scope.clone().unbind()` from the moniker API.
+                // This is necessary so that `dist` can find operator free
+                // variables inside binding values as well as in the body.
+                let (open_bindings, body) = open_let_scope_full(scope);
 
-                let (mut new_bindings, ops) = Self::process_bindings(&rec_bindings.unrec());
+                let (mut new_bindings, ops) = Self::process_bindings(&open_bindings);
 
                 self.env.push(ops);
 
-                for (_, Embed(value)) in &mut new_bindings {
+                for (_, value) in &mut new_bindings {
                     *value = self.dist(value.clone())?;
                 }
 
+                // Re-close both the binding values and the body with
+                // `close_let_scope` (equivalent to moniker's `Scope::new`).
                 let ret = RcExpr::from(Expr::Let(
                     *s,
-                    Scope::new(Rec::new(new_bindings), self.dist(body)?),
+                    close_let_scope(new_bindings, self.dist(body)?),
                     *t,
                 ));
 
@@ -88,8 +89,8 @@ impl Distributor {
 
                 Ok(ret)
             }
-            Expr::Var(call_smid, Free(fv)) => {
-                if let Some((def_smid, fixity, precedence)) = self.env.get(fv) {
+            Expr::Var(call_smid, Var::Free(name)) => {
+                if let Some((def_smid, fixity, precedence)) = self.env.get(name) {
                     // Prefer the call-site Smid (from the user's source) over the
                     // definition-site Smid (from the prelude) so that infix operator
                     // applications carry a source location pointing at the actual
@@ -118,13 +119,11 @@ impl Distributor {
 pub mod tests {
     use super::acore::*;
     use super::*;
-    use moniker::assert_term_eq;
-    use moniker::FreeVar;
 
     #[test]
     pub fn test_sample_1() {
-        let plus = FreeVar::fresh_named("+");
-        let minus = FreeVar::fresh_named("-");
+        let plus = free("+");
+        let minus = free("-");
 
         let expr = let_(
             vec![
@@ -139,13 +138,13 @@ pub mod tests {
             soup(vec![num(1), infixl(50, var(plus)), num(2)]),
         );
 
-        assert_term_eq!(distribute(expr).unwrap(), expected);
+        assert_eq!(distribute(expr).unwrap(), expected);
     }
 
     #[test]
     pub fn test_sample_2() {
-        let plus = FreeVar::fresh_named("+");
-        let minus = FreeVar::fresh_named("-");
+        let plus = free("+");
+        let minus = free("-");
 
         let expr = let_(
             vec![(plus.clone(), infixl(50, bif("FOO")))],
@@ -163,13 +162,13 @@ pub mod tests {
             ),
         );
 
-        assert_term_eq!(distribute(expr).unwrap(), expected);
+        assert_eq!(distribute(expr).unwrap(), expected);
     }
 
     #[test]
     pub fn test_sample_3() {
-        let plus = FreeVar::fresh_named("+");
-        let minus = FreeVar::fresh_named("-");
+        let plus = free("+");
+        let minus = free("-");
 
         let expr = let_(
             vec![
@@ -184,6 +183,6 @@ pub mod tests {
             soup(vec![num(1), infixr(90, var(minus)), num(2)]),
         );
 
-        assert_term_eq!(distribute(expr).unwrap(), expected);
+        assert_eq!(distribute(expr).unwrap(), expected);
     }
 }

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -2,10 +2,9 @@
 //! precedence to turn operator soup into hierarchical expressions.
 use crate::common::sourcemap::{HasSmid, Smid};
 use crate::core::anaphora;
-use crate::core::binding::Var;
+use crate::core::binding::{Scope, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
-use crate::core::transform::succ;
 use std::collections::{HashMap, HashSet};
 
 pub mod fill;
@@ -176,7 +175,10 @@ impl Cooker {
     fn process_expr_anaphora(&mut self, expr: RcExpr) -> Result<RcExpr, CoreError> {
         let binders = anaphora::to_binding_pattern(&self.pending_expr_anaphora)?;
         self.pending_expr_anaphora.clear();
-        Ok(core::lam(expr.smid(), binders, succ::succ(&expr)?))
+        // Do NOT call succ: close_lam_scope (inside core::lam) uses close_expr_vars
+        // which already increments outer BV scope indices to account for the new lambda
+        // scope. Calling succ first would double-increment them.
+        Ok(core::lam(expr.smid(), binders, expr))
     }
 
     /// Wrap a lambda around a block-anaphoric expression, collapsing
@@ -212,13 +214,31 @@ impl Cooker {
 
             if all_alias && bindings.len() == 1 && binders.len() == 1 {
                 // Single binding: the lambda directly replaces the let
-                // scope, so the body's bound variable indices are already
-                // correct (scope 0 index 0 targets the one lambda param).
-                return Ok(core::lam(expr.smid(), binders, body.clone()));
+                // scope, so the body's BV(0,0) already points at the right
+                // slot. We do NOT go via core::lam / close_lam_scope because
+                // close_expr_vars would increment BV(0,0) → BV(1,0).
+                //
+                // Use the let binding's name (e.g. "it") rather than the
+                // anaphor var name (e.g. "_b_a[…]") so that the BoundVar
+                // name field in the body agrees with the lambda pattern,
+                // keeping the binding verifier happy.
+                let let_name = bindings[0].0.clone();
+                return Ok(RcExpr::from(Expr::Lam(
+                    expr.smid(),
+                    false,
+                    Scope {
+                        pattern: vec![let_name],
+                        body: body.clone(),
+                    },
+                )));
             }
         }
 
-        Ok(core::lam(expr.smid(), binders, succ::succ(&expr)?))
+        // Do NOT call succ::succ before core::lam: close_lam_scope (inside
+        // core::lam) uses close_expr_vars which already increments outer BV
+        // scope indices to account for the new lambda scope. Calling succ
+        // first would double-increment them.
+        Ok(core::lam(expr.smid(), binders, expr))
     }
 }
 

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -2,10 +2,10 @@
 //! precedence to turn operator soup into hierarchical expressions.
 use crate::common::sourcemap::{HasSmid, Smid};
 use crate::core::anaphora;
+use crate::core::binding::Var;
 use crate::core::error::CoreError;
 use crate::core::expr::*;
 use crate::core::transform::succ;
-use moniker::*;
 use std::collections::{HashMap, HashSet};
 
 pub mod fill;
@@ -49,10 +49,10 @@ pub struct Cooker {
     in_expr_anaphor_scope: bool,
     /// While in the scope of anaphoric lambda, collect all the
     /// anaphora for processing at the boundary of the scope
-    pending_expr_anaphora: HashMap<Anaphor<Smid, i32>, FreeVar<String>>,
+    pending_expr_anaphora: HashMap<Anaphor<Smid, i32>, String>,
     /// While in the scope of anaphoric lambda, collect all the
     /// anaphora for processing at the boundary of the scope
-    pending_block_anaphora: HashMap<Anaphor<Smid, i32>, FreeVar<String>>,
+    pending_block_anaphora: HashMap<Anaphor<Smid, i32>, String>,
 }
 
 impl Cooker {
@@ -191,25 +191,20 @@ impl Cooker {
     /// let binding is a simple alias of the anaphor var.
     fn process_block_anaphora(&mut self, expr: RcExpr) -> Result<RcExpr, CoreError> {
         let binders = anaphora::to_binding_pattern(&self.pending_block_anaphora)?;
-        let anaphora_vars: HashSet<String> = self
-            .pending_block_anaphora
-            .values()
-            .filter_map(|v| v.pretty_name.clone())
-            .collect();
+        let anaphora_vars: HashSet<String> =
+            self.pending_block_anaphora.values().cloned().collect();
         self.pending_block_anaphora.clear();
 
         // Try to collapse: if the expression is a Let with a single
         // binding whose value is our anaphor var, eliminate the let
         // and bind directly as a lambda parameter.
         if let Expr::Let(_, scope, _) = &*expr.inner {
-            let bindings = &scope.unsafe_pattern.unsafe_pattern;
-            let body = &scope.unsafe_body;
+            let bindings = &scope.pattern;
+            let body = &scope.body;
 
-            let all_alias = bindings.iter().all(|(_, Embed(val))| {
-                if let Expr::Var(_, Var::Free(fv)) = &*val.inner {
-                    fv.pretty_name
-                        .as_ref()
-                        .is_some_and(|n| anaphora_vars.contains(n))
+            let all_alias = bindings.iter().all(|(_, val)| {
+                if let Expr::Var(_, Var::Free(name)) = &*val.inner {
+                    anaphora_vars.contains(name)
                 } else {
                     false
                 }
@@ -233,11 +228,15 @@ pub mod tests {
     use super::*;
     use crate::core::expr::acore::*;
     use crate::core::expr::core;
+    use crate::core::expr::tests::alpha_norm;
     use crate::core::expr::RcExpr;
-    use moniker::assert_term_eq;
 
     fn cook_soup(exprs: &[RcExpr]) -> RcExpr {
-        cook(soup(exprs.to_vec())).unwrap()
+        alpha_norm(cook(soup(exprs.to_vec())).unwrap())
+    }
+
+    fn expected(expr: RcExpr) -> RcExpr {
+        alpha_norm(expr)
     }
 
     #[test]
@@ -255,7 +254,7 @@ pub mod tests {
         let ana0 = free("_0");
         let ana1 = free("_1");
 
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(5), l50.clone(), num(7)]),
             app(bif("L50"), vec![num(5), num(7)])
         );
@@ -263,13 +262,13 @@ pub mod tests {
         let x = free("x");
         let f = free("f");
 
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[var(x.clone()), var(f.clone())]),
             app(var(f), vec![var(x)])
         );
 
         // associates left
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(1), l50.clone(), num(2), l50.clone(), num(3)]),
             app(
                 bif("L50"),
@@ -278,7 +277,7 @@ pub mod tests {
         );
 
         // associates right
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(1), r50.clone(), num(2), r50.clone(), num(3)]),
             app(
                 bif("R50"),
@@ -287,7 +286,7 @@ pub mod tests {
         );
 
         // respects precedence in left
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(1), l40, num(2), l50.clone(), num(3), l60, num(4)]),
             app(
                 bif("L40"),
@@ -302,7 +301,7 @@ pub mod tests {
         );
 
         // respects precedence in right
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(1), r60, num(2), r50, num(3), r40, num(4)]),
             app(
                 bif("R40"),
@@ -317,19 +316,19 @@ pub mod tests {
         );
 
         // handles unary prefix
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[pre100.clone(), num(10)]),
             app(bif("PRE100"), vec![num(10)])
         );
 
         // handles unary postfix
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(10), post100.clone()]),
             app(bif("POST100"), vec![num(10)])
         );
 
         // handles mixed high precedence unary & binary
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[
                 pre100.clone(),
                 num(20),
@@ -347,7 +346,7 @@ pub mod tests {
         );
 
         // handles mixed high precedence unary & binary
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[
                 num(30),
                 post100.clone(),
@@ -365,7 +364,7 @@ pub mod tests {
         );
 
         // handles mixed low precedence unary & binary
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[pre10.clone(), num(20), l50.clone(), num(30), post10.clone()]),
             app(
                 bif("PRE10"),
@@ -377,27 +376,27 @@ pub mod tests {
         );
 
         // fills section (`l50` 20) with anaphoric var and abstracts
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[l50.clone(), num(20)]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(bif("L50"), vec![var(ana0.clone()), num(20)])
-            )
+            ))
         );
 
         // fills section (20 `l50`) with anaphoric var and abstracts
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(20), l50.clone()]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(bif("L50"), vec![num(20), var(ana0.clone())])
-            )
+            ))
         );
 
         // fills ... (unary pre) (binary)... and abstracts
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[pre10.clone(), l50.clone(), num(30), post10.clone()]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(
                     bif("PRE10"),
@@ -406,14 +405,14 @@ pub mod tests {
                         vec![app(bif("L50"), vec![var(ana0.clone()), num(30)])]
                     )]
                 )
-            )
+            ))
         );
 
         // fills ... (binary) (unary post) ... with anaphor and
         // abstracts
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[num(30), l50.clone(), post100, pre100, num(20)]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(
                     app(bif("PRE100"), vec![num(20)]),
@@ -422,13 +421,13 @@ pub mod tests {
                         vec![num(30), app(bif("POST100"), vec![var(ana0.clone())])]
                     )]
                 )
-            )
+            ))
         );
 
         // corrects pre10 pre10 pre10 pre10 with anaphor and abstracts
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[pre10.clone(), pre10.clone(), pre10.clone(), pre10.clone()]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(
                     bif("PRE10"),
@@ -440,13 +439,13 @@ pub mod tests {
                         )]
                     )]
                 )
-            )
+            ))
         );
 
         // fills pre10 l50 post10
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[pre10, l50, post10]),
-            lam(
+            expected(lam(
                 vec![ana0.clone(), ana1.clone()],
                 app(
                     bif("PRE10"),
@@ -461,13 +460,13 @@ pub mod tests {
                         )]
                     )]
                 )
-            )
+            ))
         );
     }
 
     #[test]
     pub fn test_nested_sample() {
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[
                 bif("HEAD"),
                 call(),
@@ -498,16 +497,16 @@ pub mod tests {
         let l50 = core::infixl(Smid::fake(1), 50, bif("MUL"));
         let ana0 = free("_e_n0");
 
-        assert_term_eq!(
+        assert_eq!(
             cook_soup(&[
                 core::expr_anaphor(Smid::fake(2), Some(0)),
                 l50,
                 core::expr_anaphor(Smid::fake(2), Some(0))
             ]),
-            lam(
+            expected(lam(
                 vec![ana0.clone()],
                 app(bif("MUL"), vec![var(ana0.clone()), var(ana0)])
-            )
+            ))
         );
     }
 
@@ -585,16 +584,16 @@ pub mod tests {
 
         // Should produce: DIV(lam([_0], ADD(_0, 1)), 2)
         // The section lambda stays inside — NOT lam([_0], DIV(ADD(_0, 1), 2))
-        let result = cook(outer).unwrap();
-        assert_term_eq!(
+        let result = alpha_norm(cook(outer).unwrap());
+        assert_eq!(
             result,
-            app(
+            expected(app(
                 bif("DIV"),
                 vec![
                     lam(vec![ana0.clone()], app(bif("ADD"), vec![var(ana0), num(1)])),
                     num(2)
                 ]
-            )
+            ))
         );
     }
 }

--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -6,12 +6,12 @@ use crate::{
         sourcemap::{Smid, SourceMap},
     },
     core::{
-        doc::DeclarationDocumentation, error::CoreError, expr::*, target::*, unit::TranslationUnit,
+        binding::Var, doc::DeclarationDocumentation, error::CoreError, expr::*, target::*,
+        unit::TranslationUnit,
     },
     syntax::input::*,
 };
 use codespan::Span;
-use moniker::FreeVar;
 use std::collections::{HashMap, HashSet};
 
 /// A monad specification registered for a bracket pair or used inline in block metadata.
@@ -37,7 +37,7 @@ pub enum MonadSpec {
 pub struct Desugarer<'smap> {
     /// While in the scope of anaphoric string pattern, collect all the
     /// anaphora for processing at the boundary the pattern
-    pending_string_anaphora: HashMap<Anaphor<Smid, i32>, FreeVar<String>>,
+    pending_string_anaphora: HashMap<Anaphor<Smid, i32>, String>,
     /// Targets discovered
     targets: HashSet<Target>,
     /// Doc strings discovered (path, doc)
@@ -48,8 +48,8 @@ pub struct Desugarer<'smap> {
     contents: &'smap HashMap<Input, Content<'smap>>,
     /// SourceMap
     source_map: &'smap mut SourceMap,
-    /// Track variable names so we mint appropriate free vars
-    env: DefaultingEnvironment<String, FreeVar<String>>,
+    /// Track variable names so we mint appropriate names
+    env: DefaultingEnvironment<String, String>,
     /// Current usize
     file: Vec<usize>,
     /// Registry mapping bracket pair names (e.g. `"⟦⟧"`) to their monad spec.
@@ -73,7 +73,7 @@ impl<'smap> Desugarer<'smap> {
             stack: vec![],
             contents,
             source_map,
-            env: DefaultingEnvironment::new(|k| FreeVar::fresh_named(k)),
+            env: DefaultingEnvironment::new(|k: &String| k.clone()),
             file: vec![],
             monad_registry: HashMap::new(),
         }
@@ -149,13 +149,13 @@ impl<'smap> Desugarer<'smap> {
         ast.desugar(self)
     }
 
-    /// Reference to the name to free_var representation environment
-    pub fn env(&self) -> &DefaultingEnvironment<String, FreeVar<String>> {
+    /// Reference to the name to variable name environment
+    pub fn env(&self) -> &DefaultingEnvironment<String, String> {
         &self.env
     }
 
-    /// Mutable reference to the name to free_var representation environment
-    pub fn env_mut(&mut self) -> &mut DefaultingEnvironment<String, FreeVar<String>> {
+    /// Mutable reference to the name to variable name environment
+    pub fn env_mut(&mut self) -> &mut DefaultingEnvironment<String, String> {
         &mut self.env
     }
 
@@ -186,19 +186,19 @@ impl<'smap> Desugarer<'smap> {
     }
 
     /// Reference to the pending string anaphora for calculating binders
-    pub fn pending_string_anaphora(&self) -> &HashMap<Anaphor<Smid, i32>, FreeVar<String>> {
+    pub fn pending_string_anaphora(&self) -> &HashMap<Anaphor<Smid, i32>, String> {
         &self.pending_string_anaphora
     }
 
     /// Add a pending string anaphor
-    pub fn add_pending_string_anaphor(&mut self, anaphor: Anaphor<Smid, i32>) -> FreeVar<String> {
-        let var = free(&format!("{anaphor}"));
-        self.pending_string_anaphora.insert(anaphor, var.clone());
-        var
+    pub fn add_pending_string_anaphor(&mut self, anaphor: Anaphor<Smid, i32>) -> String {
+        let name = free(&format!("{anaphor}"));
+        self.pending_string_anaphora.insert(anaphor, name.clone());
+        name
     }
 
-    /// Return the appropriate var to use for `name` in this scope
-    pub fn var(&mut self, name: &str) -> moniker::FreeVar<String> {
+    /// Return the appropriate var name to use for `name` in this scope
+    pub fn var(&mut self, name: &str) -> String {
         self.env.encounter(name.to_string());
         self.env.get(&name.to_string()).unwrap().clone()
     }
@@ -213,8 +213,8 @@ impl<'smap> Desugarer<'smap> {
     pub fn varify(&mut self, expr: RcExpr) -> RcExpr {
         match &*expr.inner {
             Expr::Name(smid, name) => {
-                let var = self.var(name);
-                RcExpr::from(Expr::Var(*smid, moniker::Var::Free(var)))
+                let var_name = self.var(name);
+                RcExpr::from(Expr::Var(*smid, Var::Free(var_name)))
             }
             _ => expr,
         }

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -14,6 +14,7 @@ use crate::{
     common::sourcemap::{HasSmid, Smid},
     core::{
         anaphora::{BLOCK_ANAPHORA, EXPR_ANAPHORA},
+        binding::Var,
         error::CoreError,
         expr::*,
         rt,
@@ -25,7 +26,6 @@ use crate::{
     },
 };
 use codespan::{ByteIndex, Span};
-use moniker::{Binder, Embed, Rec, Scope};
 use rowan::{ast::AstNode, TextRange};
 
 /// Convert a TextRange to a Span
@@ -37,14 +37,14 @@ fn text_range_to_span(range: TextRange) -> Span {
 
 /// Return type of `desugar_declaration_body_with_patterns`:
 /// `(body_expr, lambda_param_names, lambda_param_vars)`
-type PatternBodyResult = (RcExpr, Vec<String>, Vec<moniker::FreeVar<String>>);
+type PatternBodyResult = (RcExpr, Vec<String>, Vec<String>);
 
 /// Entry for a single field binding in a destructuring let.
 struct FieldBinding {
     /// Name of the field in the source block (for Lookup)
     field_name: String,
-    /// FreeVar for the binding name in the body
-    binding_var: moniker::FreeVar<String>,
+    /// Name of the binding in the body
+    binding_var: String,
 }
 
 /// Entry for a destructuring block let: synthetic param + field bindings.
@@ -59,16 +59,16 @@ struct DestructureEntry {
 struct ListElementBinding {
     /// Zero-based index of the element
     index: usize,
-    /// FreeVar for the binding name in the body
-    binding_var: moniker::FreeVar<String>,
+    /// Name of the binding in the body
+    binding_var: String,
 }
 
 /// Entry for the tail binding in a head/tail list pattern.
 struct ListTailBinding {
     /// Number of head elements to skip (i.e., the drop count)
     drop_count: usize,
-    /// FreeVar for the tail binding name in the body
-    binding_var: moniker::FreeVar<String>,
+    /// Name of the tail binding in the body
+    binding_var: String,
 }
 
 /// Entry for a destructuring list let: synthetic param + element bindings.
@@ -349,8 +349,8 @@ fn desugar_declaration_body_with_patterns(
         desugarer.env_mut().push_keys(all_env_names.iter().cloned());
     }
 
-    // Collect FreeVars for lambda binders (before desugaring body)
-    let lambda_param_vars: Vec<moniker::FreeVar<String>> = lambda_param_names
+    // Collect var names for lambda binders (before desugaring body)
+    let lambda_param_vars: Vec<String> = lambda_param_names
         .iter()
         .map(|name| desugarer.env().get(name).unwrap().clone())
         .collect();
@@ -423,22 +423,22 @@ fn desugar_declaration_body_with_patterns(
     // Wrap body in destructuring lets for each pattern, innermost first
     // (last pattern wraps outermost), preserving argument order.
     for slot in let_order.iter().rev() {
-        // Look up the synthetic param FreeVar from the lambda_param_vars
+        // Look up the synthetic param name from the lambda_param_vars
         // (the env frame has already been popped)
-        let synthetic_fv = lambda_param_vars
+        let synthetic_name_val = lambda_param_vars
             .iter()
             .zip(lambda_param_names.iter())
             .find(|(_, n)| **n == slot.synthetic_name())
-            .map(|(fv, _)| fv.clone())
+            .map(|(var_name, _)| var_name.clone())
             .unwrap();
 
         let smid = desugarer.new_smid(span);
-        let synthetic_var = RcExpr::from(Expr::Var(smid, moniker::Var::Free(synthetic_fv)));
+        let synthetic_var = RcExpr::from(Expr::Var(smid, Var::Free(synthetic_name_val)));
 
         match slot {
             DestructureLet::Block(entry) => {
                 // Each binding is: binding_var = Lookup(Var(synthetic), "field_name", None)
-                let bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                let bindings: Vec<(String, RcExpr)> = entry
                     .fields
                     .iter()
                     .map(|fb| {
@@ -448,13 +448,13 @@ fn desugar_declaration_body_with_patterns(
                             fb.field_name.clone(),
                             None,
                         ));
-                        (Binder(fb.binding_var.clone()), Embed(lookup))
+                        (fb.binding_var.clone(), lookup)
                     })
                     .collect();
 
                 body = RcExpr::from(Expr::Let(
                     smid,
-                    Scope::new(Rec::new(bindings), body),
+                    close_let_scope(bindings, body),
                     LetType::DestructureBlockLet,
                 ));
             }
@@ -470,7 +470,7 @@ fn desugar_declaration_body_with_patterns(
                 //
                 // This correctly handles lists built by the STG compiler
                 // where the nil tail is a global ref, not a local ref.
-                let mut bindings: Vec<(Binder<String>, Embed<RcExpr>)> = entry
+                let mut bindings: Vec<(String, RcExpr)> = entry
                     .elements
                     .iter()
                     .map(|eb| {
@@ -481,7 +481,7 @@ fn desugar_declaration_body_with_patterns(
                         }
                         // Apply HEAD to get the element at this position
                         let head_call = core::app(smid, core::bif(smid, "HEAD"), vec![list_expr]);
-                        (Binder(eb.binding_var.clone()), Embed(head_call))
+                        (eb.binding_var.clone(), head_call)
                     })
                     .collect();
 
@@ -491,12 +491,12 @@ fn desugar_declaration_body_with_patterns(
                     for _ in 0..tb.drop_count {
                         tail_expr = core::app(smid, core::bif(smid, "TAIL"), vec![tail_expr]);
                     }
-                    bindings.push((Binder(tb.binding_var.clone()), Embed(tail_expr)));
+                    bindings.push((tb.binding_var.clone(), tail_expr));
                 }
 
                 body = RcExpr::from(Expr::Let(
                     smid,
-                    Scope::new(Rec::new(bindings), body),
+                    close_let_scope(bindings, body),
                     LetType::DestructureListLet,
                 ));
             }
@@ -662,14 +662,13 @@ fn find_monad_spec_in_bindings(expr: &RcExpr) -> Option<super::desugarer::MonadS
     use crate::core::metadata::extract_function_name_from_expr;
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            let bindings = scope.unsafe_pattern.unsafe_pattern.clone();
+            let bindings = scope.pattern.clone();
             let mut bind_name = None;
             let mut return_name = None;
             let mut namespace = None;
-            for (binder, embed) in &bindings {
-                let key = binder.0.pretty_name.as_deref().unwrap_or("");
-                let val = extract_function_name_from_expr(&embed.0);
-                match key {
+            for (key, val_expr) in &bindings {
+                let val = extract_function_name_from_expr(val_expr);
+                match key.as_str() {
                     "bind" => bind_name = val,
                     "return" => return_name = val,
                     "namespace" => namespace = val,
@@ -903,8 +902,8 @@ fn desugar_monadic_block(
         desugarer.env_mut().push_keys(bind_names.iter().cloned());
     }
 
-    // Collect bind FreeVars while names are in scope
-    let bind_vars: Vec<moniker::FreeVar<String>> = bind_names
+    // Collect bind var names while names are in scope
+    let bind_vars: Vec<String> = bind_names
         .iter()
         .map(|name| desugarer.env().get(name).unwrap().clone())
         .collect();
@@ -1152,19 +1151,19 @@ struct RowanDeclarationComponents {
     pub name: String,
     pub args: Vec<String>,
     pub body: RcExpr,
-    pub arg_vars: Vec<moniker::FreeVar<String>>,
+    pub arg_vars: Vec<String>,
     pub is_operator: bool,
     pub fixity: Option<crate::core::expr::Fixity>,
 }
 
 /// Helper to desugar declaration body with arguments in scope
-/// Returns the desugared body and the FreeVars for the arguments
+/// Returns the desugared body and the var names for the arguments
 fn desugar_declaration_body(
     decl: &rowan_ast::Declaration,
     desugarer: &mut Desugarer,
     args: &[String],
     span: Span,
-) -> Result<(RcExpr, Vec<moniker::FreeVar<String>>), CoreError> {
+) -> Result<(RcExpr, Vec<String>), CoreError> {
     // Push args to environment if any and collect the FreeVars
     let arg_vars = if !args.is_empty() {
         desugarer.env_mut().push_keys(args.iter().cloned());
@@ -1982,7 +1981,7 @@ fn extract_declaration_name(decl: &rowan_ast::Declaration) -> Result<String, Cor
 fn rowan_declaration_to_binding(
     decl: &rowan_ast::Declaration,
     desugarer: &mut Desugarer,
-) -> Result<(Binder<String>, Embed<RcExpr>), CoreError> {
+) -> Result<(String, RcExpr), CoreError> {
     // Extract declaration name first and push to stack before body desugaring
     let name = extract_declaration_name(decl)?;
     desugarer.push(&name);
@@ -2124,7 +2123,7 @@ fn rowan_declaration_to_binding(
     // Embed in imports if required
     expr = imports.iter().rfold(expr, |acc, import| import.rebody(acc));
 
-    let ret = (Binder(declared_var), Embed(expr));
+    let ret = (declared_var, expr);
 
     // Note: Don't pop the environment here - it's shared across all declarations
     // The caller (Unit or Block) will pop it after processing all declarations
@@ -2211,12 +2210,7 @@ impl Desugarable for rowan_ast::Block {
         // Create block body mapping names to variables
         let body_elements: BlockMap<RcExpr> = bindings
             .iter()
-            .map(|(binder, embed)| {
-                (
-                    binder.0.clone().pretty_name.unwrap(),
-                    core::var(embed.0.smid(), binder.0.clone()),
-                )
-            })
+            .map(|(name, expr)| (name.clone(), core::var(expr.smid(), name.clone())))
             .collect();
 
         // Create body - check for parse-embed override
@@ -2236,7 +2230,7 @@ impl Desugarable for rowan_ast::Block {
         // Create let expression with bindings
         let mut expr = RcExpr::from(Expr::Let(
             desugarer.new_smid(span),
-            Scope::new(Rec::new(bindings), body),
+            close_let_scope(bindings, body),
             LetType::DefaultBlockLet,
         ));
 
@@ -2356,12 +2350,7 @@ impl Desugarable for rowan_ast::Unit {
         // Create unit body mapping names to variables
         let body_elements: BlockMap<RcExpr> = bindings
             .iter()
-            .map(|(binder, embed)| {
-                (
-                    binder.0.clone().pretty_name.unwrap(),
-                    core::var(embed.0.smid(), binder.0.clone()),
-                )
-            })
+            .map(|(name, expr)| (name.clone(), core::var(expr.smid(), name.clone())))
             .collect();
 
         // Remember whether there are any declarations before body_elements is moved.
@@ -2384,7 +2373,7 @@ impl Desugarable for rowan_ast::Unit {
         // Create let expression with bindings
         let mut expr = RcExpr::from(Expr::Let(
             desugarer.new_smid(span),
-            Scope::new(Rec::new(bindings), body),
+            close_let_scope(bindings, body),
             LetType::DefaultBlockLet,
         ));
 
@@ -2410,7 +2399,7 @@ impl Desugarable for rowan_ast::Unit {
                 if is_bare_expression {
                     expr = RcExpr::from(Expr::Let(
                         desugarer.new_smid(span),
-                        Scope::new(Rec::new(vec![]), stripped_meta),
+                        close_let_scope(vec![], stripped_meta),
                         LetType::DefaultBlockLet,
                     ));
                 } else {

--- a/src/core/desugar/rowan_disembed.rs
+++ b/src/core/desugar/rowan_disembed.rs
@@ -383,7 +383,7 @@ fn c_let_rowan(
 
         desugarer.env_mut().push_keys(keys.clone());
 
-        let items: Result<Vec<(moniker::FreeVar<String>, RcExpr)>, CoreError> = block
+        let items: Result<Vec<(String, RcExpr)>, CoreError> = block
             .declarations()
             .map(|decl| {
                 let name = if let Some(head) = decl.head() {

--- a/src/core/export/embed.rs
+++ b/src/core/export/embed.rs
@@ -1,11 +1,11 @@
 //! Export core as structure of eucalypt lists and blocks for
 //! processing within eucalypt.
+use crate::core::binding::Var;
 use crate::core::expr::*;
 use crate::syntax::export::embed::Embed;
 use crate::syntax::export::pretty;
 use crate::syntax::rowan::ast as rowan_ast;
 use crate::syntax::rowan::kind::{SyntaxKind, SyntaxNode};
-use moniker;
 use rowan::ast::AstNode;
 use rowan::GreenNodeBuilder;
 
@@ -155,14 +155,14 @@ impl Embed for CoreExpr {
     fn embed(&self) -> Option<rowan_ast::Soup> {
         match self {
             CoreExpr::Var(_, var) => match var {
-                moniker::Var::Free(freevar) => freevar.pretty_name.as_ref().and_then(|name| {
+                Var::Free(name) => {
                     let mut b = EmbedBuilder::new("c-var");
                     b.string(name);
                     b.finish()
-                }),
-                moniker::Var::Bound(bound) => {
+                }
+                Var::Bound(bound) => {
                     let mut b = EmbedBuilder::new("c-var");
-                    b.token(&format!("${}.{}", bound.scope.0, bound.binder.to_usize()));
+                    b.token(&format!("${}.{}", bound.scope, bound.binder));
                     b.finish()
                 }
             },
@@ -256,32 +256,18 @@ impl Embed for CoreExpr {
             CoreExpr::ErrPseudoCall => EmbedBuilder::new("e-pseudocall").finish(),
             CoreExpr::ErrPseudoCat => EmbedBuilder::new("e-pseudocat").finish(),
             CoreExpr::Let(_, scope, _) => {
-                let bindings: Vec<(String, RcExpr)> = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
-                    .iter()
-                    .filter_map(|(binder, embed)| {
-                        let name = binder.0.pretty_name.as_ref()?.clone();
-                        Some((name, embed.0.clone()))
-                    })
-                    .collect();
-
-                let entries: Vec<(String, RcExpr)> = bindings;
+                let entries: Vec<(String, RcExpr)> = scope.pattern.clone();
                 let mut b = EmbedBuilder::new("c-let");
                 b.block(&entries)?;
-                b.embed(&scope.unsafe_body)?;
+                b.embed(&scope.body)?;
                 b.finish()
             }
             CoreExpr::Lam(_, _, scope) => {
-                let param_names: Vec<String> = scope
-                    .unsafe_pattern
-                    .iter()
-                    .filter_map(|binder| binder.0.pretty_name.as_ref().cloned())
-                    .collect();
+                let param_names: Vec<String> = scope.pattern.clone();
 
                 let mut b = EmbedBuilder::new("c-lam");
                 b.string_list(&param_names);
-                b.embed(&scope.unsafe_body)?;
+                b.embed(&scope.body)?;
                 b.finish()
             }
             CoreExpr::Block(_, bm) => {

--- a/src/core/export/pretty.rs
+++ b/src/core/export/pretty.rs
@@ -1,40 +1,25 @@
 //! Export pretty printed version of core.
 use crate::common::{prettify::ToPretty, truncate::Truncated};
+use crate::core::binding::Var;
 use crate::core::expr::*;
-use moniker::Binder;
-use moniker::Embed;
-use moniker::FreeVar;
-use moniker::Var;
 use pretty::{DocAllocator, DocBuilder};
 
-impl ToPretty for Var<String> {
+impl ToPretty for Var {
     fn pretty<'b, D, A>(&'b self, allocator: &'b D) -> DocBuilder<'b, D, A>
     where
         D: DocAllocator<'b, A>,
         D::Doc: Clone,
         A: Clone,
     {
-        allocator.text(
-            self.pretty_name()
-                .cloned()
-                .unwrap_or_else(|| "?".to_string()),
-        )
-    }
-}
-
-impl ToPretty for FreeVar<String> {
-    fn pretty<'b, D, A>(&'b self, allocator: &'b D) -> DocBuilder<'b, D, A>
-    where
-        D: DocAllocator<'b, A>,
-        D::Doc: Clone,
-        A: Clone,
-    {
-        allocator.text(
-            self.pretty_name
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| "?".to_string()),
-        )
+        match self {
+            Var::Free(name) => allocator.text(name.clone()),
+            Var::Bound(bv) => allocator.text(
+                bv.name
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_else(|| format!("${}.{}", bv.scope, bv.binder)),
+            ),
+        }
     }
 }
 
@@ -81,17 +66,13 @@ impl ToPretty for RcExpr {
             Expr::Var(_, v) => v.pretty(allocator),
             Expr::Name(_, n) => allocator.text(n),
             Expr::Let(_, scope, _) => {
-                let binding_docs =
-                    scope
-                        .unsafe_pattern
-                        .unsafe_pattern
-                        .iter()
-                        .map(|(Binder(fv), Embed(def))| {
-                            fv.pretty(allocator)
-                                .append(allocator.text(" = "))
-                                .append(def.pretty(allocator))
-                                .group()
-                        });
+                let binding_docs = scope.pattern.iter().map(|(name, def)| {
+                    allocator
+                        .text(name.clone())
+                        .append(allocator.text(" = "))
+                        .append(def.pretty(allocator))
+                        .group()
+                });
 
                 allocator
                     .text("let ")
@@ -102,7 +83,7 @@ impl ToPretty for RcExpr {
                     )
                     .append(allocator.line())
                     .append(allocator.text("in "))
-                    .append(scope.unsafe_body.pretty(allocator))
+                    .append(scope.body.pretty(allocator))
                     .group()
             }
             Expr::Intrinsic(_, name) => allocator.text(name),
@@ -195,16 +176,16 @@ impl ToPretty for RcExpr {
             }
             Expr::Lam(_, _, scope) => {
                 let parameter_docs = scope
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .map(|Binder(fv)| fv.pretty(allocator));
+                    .map(|name| allocator.text(name.clone()));
 
                 allocator
                     .text("\u{03bb}(")
                     .append(allocator.intersperse(parameter_docs, allocator.text(", ")))
                     .append(allocator.text(")."))
                     .append(allocator.line())
-                    .append(scope.unsafe_body.pretty(allocator).nest(2))
+                    .append(scope.body.pretty(allocator).nest(2))
                     .group()
             }
             Expr::App(_, f, xs) => {
@@ -267,7 +248,7 @@ pub mod tests {
 
     #[test]
     pub fn test_var() {
-        assert_eq!(prettify(&free("x")), "x\n");
+        assert_eq!(prettify(&var(free("x"))), "x\n");
     }
 
     #[test]

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1055,9 +1055,8 @@ impl RcExpr {
     /// Instantiate top-level let bindings in body
     pub fn instantiate_lets(self) -> RcExpr {
         if let Some((_, scope, _)) = self.top_let() {
-            let body = open_let_scope(scope);
-            let mappings: Vec<(String, RcExpr)> = scope.pattern.clone();
-            body.substs(&mappings)
+            let (open_bindings, open_body) = open_let_scope_full(scope);
+            open_body.substs(&open_bindings)
         } else {
             self.clone()
         }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -3,11 +3,10 @@
 use crate::common::environment::SimpleEnvironment;
 use crate::common::sourcemap::HasSmid;
 use crate::common::sourcemap::*;
+use crate::core::binding::{BoundVar, Scope, Var};
 use crate::core::error::CoreError;
 use crate::syntax::input::*;
 use indexmap::IndexMap;
-use moniker::Var::Free;
-use moniker::*;
 use serde_json::Number;
 use std::collections::HashMap;
 use std::fmt;
@@ -17,23 +16,7 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 use std::str::FromStr;
 
-macro_rules! impl_bound_term_ignore {
-    ($T:ty) => {
-        impl<N: Clone + PartialEq> BoundTerm<N> for $T {
-            fn term_eq(&self, _: &$T) -> bool {
-                true
-            }
-
-            fn close_term(&mut self, _: ScopeState, _: &impl OnFreeFn<N>) {}
-
-            fn open_term(&mut self, _: ScopeState, _: &impl OnBoundFn<N>) {}
-
-            fn visit_vars(&self, _: &mut impl FnMut(&Var<N>)) {}
-
-            fn visit_mut_vars(&mut self, _: &mut impl FnMut(&mut Var<N>)) {}
-        }
-    };
-}
+pub use crate::core::binding::Var::Free;
 
 /// Primitive types in core
 ///
@@ -48,11 +31,8 @@ pub enum Primitive {
     Null,
 }
 
-impl_bound_term_ignore!(Primitive);
-
 /// Fixity of operator
-#[allow(non_local_definitions)]
-#[derive(Debug, Clone, BoundTerm, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Fixity {
     Nullary,
     UnaryPrefix,
@@ -88,40 +68,9 @@ pub type Precedence = i32;
 
 /// Blocks are implemented as insert-ordered hash map
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BlockMap<T: BoundTerm<String>>(IndexMap<String, T>);
+pub struct BlockMap<T>(IndexMap<String, T>);
 
-impl<T: BoundTerm<String>> BoundTerm<String> for BlockMap<T> {
-    fn term_eq(&self, other: &BlockMap<T>) -> bool {
-        self.0.len() == other.0.len()
-            && <_>::zip(self.0.values(), other.0.values()).all(|(l, r)| <T>::term_eq(l, r))
-    }
-
-    fn close_term(&mut self, state: ScopeState, on_free: &impl OnFreeFn<String>) {
-        for v in self.0.values_mut() {
-            v.close_term(state, on_free);
-        }
-    }
-
-    fn open_term(&mut self, state: ScopeState, on_bound: &impl OnBoundFn<String>) {
-        for v in self.0.values_mut() {
-            v.open_term(state, on_bound);
-        }
-    }
-
-    fn visit_vars(&self, on_var: &mut impl FnMut(&Var<String>)) {
-        for v in self.0.values() {
-            v.visit_vars(on_var);
-        }
-    }
-
-    fn visit_mut_vars(&mut self, on_var: &mut impl FnMut(&mut Var<String>)) {
-        for v in self.0.values_mut() {
-            v.visit_mut_vars(on_var);
-        }
-    }
-}
-
-impl<T: BoundTerm<String>> FromIterator<(String, T)> for BlockMap<T> {
+impl<T> FromIterator<(String, T)> for BlockMap<T> {
     fn from_iter<U>(iter: U) -> Self
     where
         U: IntoIterator<Item = (String, T)>,
@@ -130,7 +79,7 @@ impl<T: BoundTerm<String>> FromIterator<(String, T)> for BlockMap<T> {
     }
 }
 
-impl<T: BoundTerm<String> + Clone> BlockMap<T> {
+impl<T: Clone> BlockMap<T> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -176,7 +125,7 @@ impl<T: BoundTerm<String> + Clone> BlockMap<T> {
     }
 }
 
-impl<T: BoundTerm<String> + Clone> IntoIterator for BlockMap<T> {
+impl<T: Clone> IntoIterator for BlockMap<T> {
     type Item = (String, T);
     type IntoIter = indexmap::map::IntoIter<String, T>;
     fn into_iter(self) -> indexmap::map::IntoIter<String, T> {
@@ -198,8 +147,6 @@ pub enum LetType {
     /// Let generated from a list destructuring parameter `[a, b, c]`
     DestructureListLet,
 }
-
-impl_bound_term_ignore!(LetType);
 
 /// Which side of a source item are we inserting an implicit anaphor
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -311,8 +258,6 @@ where
     }
 }
 
-impl_bound_term_ignore!(Anaphor<Smid, i32>);
-
 impl<N> HasSmid for Anaphor<Smid, N>
 where
     N: Display + Hash + Eq + Clone,
@@ -326,8 +271,8 @@ where
     }
 }
 
-pub type LetScope<T> = Scope<Rec<Vec<(Binder<String>, Embed<T>)>>, T>;
-pub type LamScope<T> = Scope<Vec<Binder<String>>, T>;
+pub type LetScope<T> = Scope<Vec<(String, T)>, T>;
+pub type LamScope<T> = Scope<Vec<String>, T>;
 
 /// The main core expression type
 ///
@@ -355,14 +300,13 @@ pub type LamScope<T> = Scope<Vec<Binder<String>>, T>;
 /// - `ErrPseudoDot`: `[:e-pseudodot]` - Pseudo dot operator error
 /// - `ErrPseudoCall`: `[:e-pseudocall]` - Pseudo call operator error  
 /// - `ErrPseudoCat`: `[:e-pseudocat]` - Pseudo concatenation error
-#[allow(non_local_definitions)]
-#[derive(Debug, Clone, BoundTerm, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr<T>
 where
-    T: BoundTerm<String>,
+    T: Clone,
 {
     /// Variable (free or bound) - Embedding: `[:c-var "name"]`
-    Var(Smid, Var<String>),
+    Var(Smid, Var),
     /// Recursive let - Embedding: `[:c-let {bindings} body]`
     Let(Smid, LetScope<T>, LetType),
     /// Reference to built-in - Embedding: `[:c-bif :NAME]`
@@ -411,7 +355,7 @@ where
 
 pub type CoreExpr = Expr<RcExpr>;
 
-impl<T: BoundTerm<String>> HasSmid for Expr<T> {
+impl<T: Clone> HasSmid for Expr<T> {
     fn smid(&self) -> Smid {
         use self::Expr::*;
         match *self {
@@ -436,7 +380,7 @@ impl<T: BoundTerm<String>> HasSmid for Expr<T> {
     }
 }
 
-impl<T: BoundTerm<String>> Expr<T> {
+impl<T: Clone> Expr<T> {
     pub fn is_name(&self) -> bool {
         matches!(self, Expr::Name(_, _))
     }
@@ -474,8 +418,8 @@ impl<T: BoundTerm<String>> Expr<T> {
 /// purposes.
 pub fn fmap<'src, U, V>(expr: &'src Expr<U>) -> Expr<V>
 where
-    U: 'src + BoundTerm<String> + Clone,
-    V: BoundTerm<String> + Clone + From<&'src U>,
+    U: 'src + Clone,
+    V: Clone + From<&'src U>,
 {
     match expr {
         Expr::Lookup(s, e, n, fb) => {
@@ -497,15 +441,12 @@ where
         Expr::Let(s, scope, t) => Expr::Let(
             *s,
             Scope {
-                unsafe_pattern: Rec {
-                    unsafe_pattern: scope
-                        .unsafe_pattern
-                        .unsafe_pattern
-                        .iter()
-                        .map(|&(ref n, Embed(ref value))| (n.clone(), Embed(V::from(value))))
-                        .collect(),
-                },
-                unsafe_body: V::from(&scope.unsafe_body),
+                pattern: scope
+                    .pattern
+                    .iter()
+                    .map(|(n, value)| (n.clone(), V::from(value)))
+                    .collect(),
+                body: V::from(&scope.body),
             },
             *t,
         ),
@@ -513,8 +454,8 @@ where
             *s,
             *inl,
             Scope {
-                unsafe_pattern: scope.unsafe_pattern.clone(),
-                unsafe_body: V::from(&scope.unsafe_body),
+                pattern: scope.pattern.clone(),
+                body: V::from(&scope.body),
             },
         ),
         Expr::Var(s, v) => Expr::Var(*s, v.clone()),
@@ -533,8 +474,7 @@ where
 }
 
 /// The main form in which core expressions are passed around
-#[allow(non_local_definitions)]
-#[derive(Debug, Clone, BoundTerm, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RcExpr {
     pub inner: Rc<CoreExpr>,
 }
@@ -584,7 +524,7 @@ impl RcExpr {
 
     /// Apply a name to an expression using a top level let.
     pub fn apply_name<S: AsRef<str>>(&self, smid: Smid, name: S) -> RcExpr {
-        core::default_let(smid, vec![(free(name.as_ref()), self.clone())])
+        core::default_let(smid, vec![(name.as_ref().to_string(), self.clone())])
     }
 
     /// Replace the body of a let (or nested lets) with the specified body
@@ -592,41 +532,40 @@ impl RcExpr {
         self.rebody_int(&mut SimpleEnvironment::new(), new_body)
     }
 
-    /// Retrieve the actual freevars corresponding to bound names in a
-    /// let binding so we can prepare to capture using them
-    fn prepare_capture_vars(
-        scope: &Scope<Rec<Vec<(Binder<String>, Embed<RcExpr>)>>, RcExpr>,
-    ) -> HashMap<String, FreeVar<String>> {
+    /// Retrieve the bound names in a let binding so we can prepare to capture using them
+    fn prepare_capture_vars(scope: &LetScope<RcExpr>) -> HashMap<String, String> {
         scope
-            .unsafe_pattern
-            .unsafe_pattern
+            .pattern
             .iter()
-            .map(|(k, _)| {
-                let fv = k.0.clone();
-                let name = fv.clone().pretty_name.unwrap();
-                (name, fv)
-            })
+            .map(|(k, _)| (k.clone(), k.clone()))
             .collect()
     }
 
     /// Replace the body of a let (or nested lets with the specified
     /// body) after altering freevars to clones of the version bound
     /// in the lets so that they can be bound.
-    fn rebody_int(
-        &self,
-        env: &mut SimpleEnvironment<String, FreeVar<String>>,
-        new_body: RcExpr,
-    ) -> RcExpr {
+    fn rebody_int(&self, env: &mut SimpleEnvironment<String, String>, new_body: RcExpr) -> RcExpr {
         match &*self.inner {
             Expr::Let(s, scope, let_type) => {
-                let p = scope.clone().unsafe_pattern;
-
                 let bind_vars = Self::prepare_capture_vars(scope);
                 env.push(bind_vars);
 
-                let t = scope.clone().unsafe_body;
+                let t = scope.body.clone();
                 let rebodied = t.rebody_int(env, new_body);
-                let ret = RcExpr::from(Expr::Let(*s, Scope::new(p, rebodied), *let_type));
+                // Bind any free vars in rebodied that match the binding names.
+                // Use bind_free_vars (not close_expr_vars) to avoid shifting
+                // existing de Bruijn indices that are already correct from a
+                // previous merge step.
+                let names: Vec<&str> = scope.pattern.iter().map(|(n, _)| n.as_str()).collect();
+                let closed_body = bind_free_vars(&names, 0, &rebodied);
+                let ret = RcExpr::from(Expr::Let(
+                    *s,
+                    Scope {
+                        pattern: scope.pattern.clone(),
+                        body: closed_body,
+                    },
+                    *let_type,
+                ));
                 env.pop();
                 ret
             }
@@ -637,7 +576,7 @@ impl RcExpr {
                 // ensure any free vars in new_body can be captured by surroundings
                 new_body.substs_free(&|n: &str| {
                     env.get(&n.to_string())
-                        .map(|v| core::var(Smid::default(), v.clone()))
+                        .map(|v| RcExpr::from(Expr::Var(Smid::default(), Var::Free(v.clone()))))
                 })
             }
         }
@@ -682,15 +621,12 @@ impl RcExpr {
             Expr::Let(s, scope, t) => RcExpr::from(Expr::Let(
                 *s,
                 Scope {
-                    unsafe_pattern: Rec {
-                        unsafe_pattern: scope
-                            .unsafe_pattern
-                            .unsafe_pattern
-                            .iter()
-                            .map(|&(ref n, Embed(ref value))| (n.clone(), Embed(f(value.clone()))))
-                            .collect(),
-                    },
-                    unsafe_body: f(scope.unsafe_body.clone()),
+                    pattern: scope
+                        .pattern
+                        .iter()
+                        .map(|(n, value)| (n.clone(), f(value.clone())))
+                        .collect(),
+                    body: f(scope.body.clone()),
                 },
                 *t,
             )),
@@ -698,8 +634,8 @@ impl RcExpr {
                 *s,
                 *inl,
                 Scope {
-                    unsafe_pattern: scope.unsafe_pattern.clone(),
-                    unsafe_body: f(scope.unsafe_body.clone()),
+                    pattern: scope.pattern.clone(),
+                    body: f(scope.body.clone()),
                 },
             )),
             _ => self.clone(),
@@ -711,8 +647,7 @@ impl RcExpr {
     /// regardless of whether changes are required.
     ///
     /// Any transformation in f should be structural, leaving var
-    /// binding status intact as no moniker .unbinds are called. This
-    /// makes free use of unsafe_pattern and unsafe_body
+    /// binding status intact.
     pub fn walk_safe<E, F: FnMut(RcExpr) -> Result<RcExpr, E>>(
         &self,
         f: &mut F,
@@ -755,24 +690,15 @@ impl RcExpr {
             Expr::Operator(s, fx, p, e) => RcExpr::from(Expr::Operator(*s, *fx, *p, f(e.clone())?)),
             Expr::Let(s, scope, t) => {
                 let bindings = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .map(|&(ref n, Embed(ref value))| {
-                        let val = f(value.clone());
-                        match val {
-                            Ok(v) => Ok((n.clone(), Embed(v))),
-                            Err(e) => Err(e),
-                        }
-                    })
-                    .collect::<Result<Vec<(Binder<String>, Embed<RcExpr>)>, E>>()?;
+                    .map(|(n, value)| f(value.clone()).map(|v| (n.clone(), v)))
+                    .collect::<Result<Vec<(String, RcExpr)>, E>>()?;
                 RcExpr::from(Expr::Let(
                     *s,
                     Scope {
-                        unsafe_pattern: Rec {
-                            unsafe_pattern: bindings,
-                        },
-                        unsafe_body: f(scope.unsafe_body.clone())?,
+                        pattern: bindings,
+                        body: f(scope.body.clone())?,
                     },
                     *t,
                 ))
@@ -781,8 +707,8 @@ impl RcExpr {
                 *s,
                 *inl,
                 Scope {
-                    unsafe_pattern: scope.unsafe_pattern.clone(),
-                    unsafe_body: f(scope.unsafe_body.clone())?,
+                    pattern: scope.pattern.clone(),
+                    body: f(scope.body.clone())?,
                 },
             )),
             _ => self.clone(),
@@ -884,20 +810,18 @@ impl RcExpr {
             }
             Expr::Let(s, scope, t) => {
                 let new_bindings: Vec<_> = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .map(|(n, Embed(value))| (n, f(value)))
+                    .map(|(n, value)| (n, f(value)))
                     .collect();
-                let new_body = f(&scope.unsafe_body);
+                let new_body = f(&scope.body);
 
                 let bindings_same = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
                     .zip(new_bindings.iter())
-                    .all(|((_, Embed(v)), (_, new_v))| v.ptr_eq(new_v));
-                let body_same = scope.unsafe_body.ptr_eq(&new_body);
+                    .all(|((_, v), (_, new_v))| v.ptr_eq(new_v));
+                let body_same = scope.body.ptr_eq(&new_body);
 
                 if bindings_same && body_same {
                     self.clone()
@@ -905,29 +829,27 @@ impl RcExpr {
                     RcExpr::from(Expr::Let(
                         *s,
                         Scope {
-                            unsafe_pattern: Rec {
-                                unsafe_pattern: new_bindings
-                                    .into_iter()
-                                    .map(|(n, v)| (n.clone(), Embed(v)))
-                                    .collect(),
-                            },
-                            unsafe_body: new_body,
+                            pattern: new_bindings
+                                .into_iter()
+                                .map(|(n, v)| (n.clone(), v))
+                                .collect(),
+                            body: new_body,
                         },
                         *t,
                     ))
                 }
             }
             Expr::Lam(s, inl, scope) => {
-                let new_body = f(&scope.unsafe_body);
-                if scope.unsafe_body.ptr_eq(&new_body) {
+                let new_body = f(&scope.body);
+                if scope.body.ptr_eq(&new_body) {
                     self.clone()
                 } else {
                     RcExpr::from(Expr::Lam(
                         *s,
                         *inl,
                         Scope {
-                            unsafe_pattern: scope.unsafe_pattern.clone(),
-                            unsafe_body: new_body,
+                            pattern: scope.pattern.clone(),
+                            body: new_body,
                         },
                     ))
                 }
@@ -1037,15 +959,14 @@ impl RcExpr {
             }
             Expr::Let(s, scope, t) => {
                 let new_bindings: Vec<_> = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .map(|(n, Embed(value))| f(value).map(|new_v| (n, value, new_v)))
+                    .map(|(n, value)| f(value).map(|new_v| (n, value, new_v)))
                     .collect::<Result<_, E>>()?;
-                let new_body = f(&scope.unsafe_body)?;
+                let new_body = f(&scope.body)?;
 
                 let bindings_same = new_bindings.iter().all(|(_, v, new_v)| v.ptr_eq(new_v));
-                let body_same = scope.unsafe_body.ptr_eq(&new_body);
+                let body_same = scope.body.ptr_eq(&new_body);
 
                 if bindings_same && body_same {
                     self.clone()
@@ -1053,29 +974,27 @@ impl RcExpr {
                     RcExpr::from(Expr::Let(
                         *s,
                         Scope {
-                            unsafe_pattern: Rec {
-                                unsafe_pattern: new_bindings
-                                    .into_iter()
-                                    .map(|(n, _, v)| (n.clone(), Embed(v)))
-                                    .collect(),
-                            },
-                            unsafe_body: new_body,
+                            pattern: new_bindings
+                                .into_iter()
+                                .map(|(n, _, v)| (n.clone(), v))
+                                .collect(),
+                            body: new_body,
                         },
                         *t,
                     ))
                 }
             }
             Expr::Lam(s, inl, scope) => {
-                let new_body = f(&scope.unsafe_body)?;
-                if scope.unsafe_body.ptr_eq(&new_body) {
+                let new_body = f(&scope.body)?;
+                if scope.body.ptr_eq(&new_body) {
                     self.clone()
                 } else {
                     RcExpr::from(Expr::Lam(
                         *s,
                         *inl,
                         Scope {
-                            unsafe_pattern: scope.unsafe_pattern.clone(),
-                            unsafe_body: new_body,
+                            pattern: scope.pattern.clone(),
+                            body: new_body,
                         },
                     ))
                 }
@@ -1086,9 +1005,9 @@ impl RcExpr {
 
     /// Substitute expression for free variables as specified by mappings.
     /// Uses optimized try_walk to avoid unnecessary allocations.
-    pub fn substs<N: PartialEq<Var<String>>>(&self, mappings: &[(N, RcExpr)]) -> RcExpr {
+    pub fn substs(&self, mappings: &[(String, RcExpr)]) -> RcExpr {
         match &*self.inner {
-            Expr::Var(_, v) => match mappings.iter().find(|&(n, _)| n == v) {
+            Expr::Var(_, Var::Free(name)) => match mappings.iter().find(|(n, _)| n == name) {
                 Some((_, replacement)) => replacement.clone(),
                 None => self.clone(),
             },
@@ -1096,32 +1015,25 @@ impl RcExpr {
         }
     }
 
-    /// Substitute expressions for free variabbles based on name only
+    /// Substitute expressions for free variables based on name only
     /// (allowing free vars minted in other core translations to be
-    /// bound) by binders in different core translations.
+    /// bound by binders in different core translations).
     /// Uses optimized try_walk to avoid unnecessary allocations.
     pub fn substs_free<F: Fn(&str) -> Option<RcExpr>>(&self, substitute: &F) -> RcExpr {
         match &*self.inner {
-            Expr::Var(original_smid, Free(f)) => {
-                if let Some(ref name) = f.pretty_name {
-                    if let Some(replacement) = substitute(name) {
-                        // If the replacement was built with Smid::default() but the
-                        // original Var carried a meaningful call-site Smid, re-stamp
-                        // the Smid so that source locations are not lost during merge.
-                        if original_smid.is_valid() {
-                            if let Expr::Var(rep_smid, rep_var) = &*replacement.inner {
-                                if !rep_smid.is_valid() {
-                                    return RcExpr::from(Expr::Var(
-                                        *original_smid,
-                                        rep_var.clone(),
-                                    ));
-                                }
+            Expr::Var(original_smid, Var::Free(name)) => {
+                if let Some(replacement) = substitute(name) {
+                    // If the replacement was built with Smid::default() but the
+                    // original Var carried a meaningful call-site Smid, re-stamp
+                    // the Smid so that source locations are not lost during merge.
+                    if original_smid.is_valid() {
+                        if let Expr::Var(rep_smid, rep_var) = &*replacement.inner {
+                            if !rep_smid.is_valid() {
+                                return RcExpr::from(Expr::Var(*original_smid, rep_var.clone()));
                             }
                         }
-                        replacement
-                    } else {
-                        self.clone()
                     }
+                    replacement
                 } else {
                     self.clone()
                 }
@@ -1132,13 +1044,7 @@ impl RcExpr {
 
     /// Discards metadata to retrieve top-level let expression in
     /// self.
-    fn top_let(
-        &self,
-    ) -> Option<(
-        &Smid,
-        &Scope<Rec<Vec<(Binder<String>, Embed<RcExpr>)>>, RcExpr>,
-        &LetType,
-    )> {
+    fn top_let(&self) -> Option<(&Smid, &LetScope<RcExpr>, &LetType)> {
         match &*self.inner {
             Expr::Let(s, scope, lt) => Some((s, scope, lt)),
             Expr::Meta(_, expr, _) => expr.top_let(),
@@ -1149,12 +1055,8 @@ impl RcExpr {
     /// Instantiate top-level let bindings in body
     pub fn instantiate_lets(self) -> RcExpr {
         if let Some((_, scope, _)) = self.top_let() {
-            let (binders, body) = scope.clone().unbind();
-            let mappings = binders
-                .unrec()
-                .into_iter()
-                .map(|(binder, Embed(binding))| (binder, binding))
-                .collect::<Vec<_>>();
+            let body = open_let_scope(scope);
+            let mappings: Vec<(String, RcExpr)> = scope.pattern.clone();
             body.substs(&mappings)
         } else {
             self.clone()
@@ -1214,11 +1116,10 @@ impl RcExpr {
 ///     }
 /// }
 /// ```
-#[allow(non_local_definitions)]
-#[derive(Debug, Clone, BoundTerm)]
+#[derive(Debug, Clone)]
 pub struct RcFatExpr<T>
 where
-    T: BoundTerm<String> + Clone + Default,
+    T: Clone + Default,
 {
     pub inner: Rc<Expr<Self>>,
     pub data: T,
@@ -1226,7 +1127,7 @@ where
 
 impl<T> From<Expr<RcFatExpr<T>>> for RcFatExpr<T>
 where
-    T: BoundTerm<String> + Clone + Default,
+    T: Clone + Default,
 {
     fn from(expr: Expr<RcFatExpr<T>>) -> Self {
         RcFatExpr {
@@ -1322,8 +1223,301 @@ where
     }
 }
 
-pub fn free(n: &str) -> FreeVar<String> {
-    FreeVar::fresh_named(n)
+pub fn free(n: &str) -> String {
+    n.to_string()
+}
+
+/// Close a let scope: convert free variables matching binding names to bound variables.
+/// Existing bound variable scope indices are incremented to account for the new scope.
+pub fn close_let_scope(bindings: Vec<(String, RcExpr)>, body: RcExpr) -> LetScope<RcExpr> {
+    let names: Vec<String> = bindings.iter().map(|(n, _)| n.clone()).collect();
+    let name_refs: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
+    let closed_bindings: Vec<(String, RcExpr)> = bindings
+        .into_iter()
+        .map(|(n, v)| (n, close_expr_vars(&name_refs, 0, &v)))
+        .collect();
+    let closed_body = close_expr_vars(&name_refs, 0, &body);
+    Scope {
+        pattern: closed_bindings,
+        body: closed_body,
+    }
+}
+
+/// Close a lam scope: convert free variables matching parameter names to bound variables.
+pub fn close_lam_scope(params: Vec<String>, body: RcExpr) -> LamScope<RcExpr> {
+    let names: Vec<&str> = params.iter().map(|n| n.as_str()).collect();
+    let closed_body = close_expr_vars(&names, 0, &body);
+    Scope {
+        pattern: params,
+        body: closed_body,
+    }
+}
+
+/// Open a let scope: convert bound variables (scope==0) back to free variables.
+/// Existing bound variable scope indices > 0 are decremented.
+pub fn open_let_scope(scope: &LetScope<RcExpr>) -> RcExpr {
+    let names: Vec<Option<&str>> = scope
+        .pattern
+        .iter()
+        .map(|(n, _)| Some(n.as_str()))
+        .collect();
+    open_expr_vars(&names, 0, &scope.body)
+}
+
+/// Open a let scope fully — returns both the opened binding values AND the opened body.
+///
+/// Equivalent to `scope.unbind()` in the old moniker API.
+/// Converts `Var::Bound(scope=0, ...)` in ALL positions (bindings + body) back to
+/// `Var::Free(name)`, and decrements scope indices of outer references by 1.
+///
+/// Used when you need to substitute free variables INTO the binding values,
+/// e.g. in `distribute` (inline pass) which inlines lambdas into other bindings.
+pub fn open_let_scope_full(scope: &LetScope<RcExpr>) -> (Vec<(String, RcExpr)>, RcExpr) {
+    let names: Vec<Option<&str>> = scope
+        .pattern
+        .iter()
+        .map(|(n, _)| Some(n.as_str()))
+        .collect();
+    let open_bindings = scope
+        .pattern
+        .iter()
+        .map(|(n, v)| (n.clone(), open_expr_vars(&names, 0, v)))
+        .collect();
+    let open_body = open_expr_vars(&names, 0, &scope.body);
+    (open_bindings, open_body)
+}
+
+/// Open a lam scope: same but for lambda.
+pub fn open_lam_scope(scope: &LamScope<RcExpr>) -> RcExpr {
+    let names: Vec<Option<&str>> = scope.pattern.iter().map(|n| Some(n.as_str())).collect();
+    open_expr_vars(&names, 0, &scope.body)
+}
+
+/// Walk an expression, converting `Var::Free(name)` where `name` matches any of `names`
+/// into `Var::Bound(BoundVar { scope: depth, binder: i, name: Some(name) })`,
+/// WITHOUT shifting existing `Var::Bound` scope indices.
+///
+/// Used in `rebody_int` when the expression already has correct de Bruijn indices
+/// from a previous scope-building step, and we only need to bind additional free
+/// variables without disturbing the existing structure.
+pub fn bind_free_vars(names: &[&str], depth: u32, expr: &RcExpr) -> RcExpr {
+    match &*expr.inner {
+        Expr::Var(s, Var::Free(name)) => {
+            if let Some(i) = names.iter().position(|&n| n == name.as_str()) {
+                RcExpr::from(Expr::Var(
+                    *s,
+                    Var::Bound(BoundVar {
+                        scope: depth,
+                        binder: i as u32,
+                        name: Some(name.clone()),
+                    }),
+                ))
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::Let(s, scope, t) => {
+            let new_bindings = scope
+                .pattern
+                .iter()
+                .map(|(n, v)| (n.clone(), bind_free_vars(names, depth + 1, v)))
+                .collect();
+            let new_body = bind_free_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Let(
+                *s,
+                Scope {
+                    pattern: new_bindings,
+                    body: new_body,
+                },
+                *t,
+            ))
+        }
+        Expr::Lam(s, inl, scope) => {
+            let new_body = bind_free_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Lam(
+                *s,
+                *inl,
+                Scope {
+                    pattern: scope.pattern.clone(),
+                    body: new_body,
+                },
+            ))
+        }
+        _ => expr.walk(&|e| bind_free_vars(names, depth, &e)),
+    }
+}
+
+/// Walk an expression, converting `Var::Free(name)` where `name` matches any of `names`
+/// into `Var::Bound(BoundVar { scope: depth, binder: i, name: Some(name) })`.
+/// Also increments `scope` of any existing `Var::Bound` with `scope >= depth`.
+pub fn close_expr_vars(names: &[&str], depth: u32, expr: &RcExpr) -> RcExpr {
+    match &*expr.inner {
+        Expr::Var(s, Var::Free(name)) => {
+            if let Some(i) = names.iter().position(|&n| n == name.as_str()) {
+                RcExpr::from(Expr::Var(
+                    *s,
+                    Var::Bound(BoundVar {
+                        scope: depth,
+                        binder: i as u32,
+                        name: Some(name.clone()),
+                    }),
+                ))
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::Var(s, Var::Bound(bv)) if bv.scope >= depth => RcExpr::from(Expr::Var(
+            *s,
+            Var::Bound(BoundVar {
+                scope: bv.scope + 1,
+                binder: bv.binder,
+                name: bv.name.clone(),
+            }),
+        )),
+        Expr::Let(s, scope, t) => {
+            let new_bindings = scope
+                .pattern
+                .iter()
+                .map(|(n, v)| (n.clone(), close_expr_vars(names, depth + 1, v)))
+                .collect();
+            let new_body = close_expr_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Let(
+                *s,
+                Scope {
+                    pattern: new_bindings,
+                    body: new_body,
+                },
+                *t,
+            ))
+        }
+        Expr::Lam(s, inl, scope) => {
+            let new_body = close_expr_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Lam(
+                *s,
+                *inl,
+                Scope {
+                    pattern: scope.pattern.clone(),
+                    body: new_body,
+                },
+            ))
+        }
+        _ => expr.walk(&|e| close_expr_vars(names, depth, &e)),
+    }
+}
+
+/// Walk an expression, converting `Var::Bound` with `scope == depth` back to `Var::Free`.
+/// Decrements `scope` of any `Var::Bound` with `scope > depth`.
+pub fn open_expr_vars(names: &[Option<&str>], depth: u32, expr: &RcExpr) -> RcExpr {
+    match &*expr.inner {
+        Expr::Var(s, Var::Bound(bv)) => {
+            if bv.scope == depth {
+                let name = names
+                    .get(bv.binder as usize)
+                    .and_then(|n| *n)
+                    .or(bv.name.as_deref())
+                    .unwrap_or("_")
+                    .to_string();
+                RcExpr::from(Expr::Var(*s, Var::Free(name)))
+            } else if bv.scope > depth {
+                RcExpr::from(Expr::Var(
+                    *s,
+                    Var::Bound(BoundVar {
+                        scope: bv.scope - 1,
+                        binder: bv.binder,
+                        name: bv.name.clone(),
+                    }),
+                ))
+            } else {
+                expr.clone()
+            }
+        }
+        Expr::Let(s, scope, t) => {
+            let new_bindings = scope
+                .pattern
+                .iter()
+                .map(|(n, v)| (n.clone(), open_expr_vars(names, depth + 1, v)))
+                .collect();
+            let new_body = open_expr_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Let(
+                *s,
+                Scope {
+                    pattern: new_bindings,
+                    body: new_body,
+                },
+                *t,
+            ))
+        }
+        Expr::Lam(s, inl, scope) => {
+            let new_body = open_expr_vars(names, depth + 1, &scope.body);
+            RcExpr::from(Expr::Lam(
+                *s,
+                *inl,
+                Scope {
+                    pattern: scope.pattern.clone(),
+                    body: new_body,
+                },
+            ))
+        }
+        _ => expr.walk(&|e| open_expr_vars(names, depth, &e)),
+    }
+}
+
+/// Collect all free variable names in an expression.
+pub fn free_vars(expr: &RcExpr) -> std::collections::HashSet<String> {
+    let mut result = std::collections::HashSet::new();
+    collect_free_vars(expr, &mut result);
+    result
+}
+
+fn collect_free_vars(expr: &RcExpr, result: &mut std::collections::HashSet<String>) {
+    match &*expr.inner {
+        Expr::Var(_, Var::Free(name)) => {
+            result.insert(name.clone());
+        }
+        Expr::Var(_, Var::Bound(_)) => {}
+        Expr::Let(_, scope, _) => {
+            for (_, v) in &scope.pattern {
+                collect_free_vars(v, result);
+            }
+            collect_free_vars(&scope.body, result);
+        }
+        Expr::Lam(_, _, scope) => {
+            collect_free_vars(&scope.body, result);
+        }
+        Expr::Lookup(_, e, _, fb) => {
+            collect_free_vars(e, result);
+            if let Some(f) = fb {
+                collect_free_vars(f, result);
+            }
+        }
+        Expr::List(_, xs) | Expr::ArgTuple(_, xs) => {
+            for x in xs {
+                collect_free_vars(x, result);
+            }
+        }
+        Expr::Block(_, bm) => {
+            for (_, v) in bm.iter() {
+                collect_free_vars(v, result);
+            }
+        }
+        Expr::Meta(_, e, m) => {
+            collect_free_vars(e, result);
+            collect_free_vars(m, result);
+        }
+        Expr::App(_, f, xs) => {
+            collect_free_vars(f, result);
+            for x in xs {
+                collect_free_vars(x, result);
+            }
+        }
+        Expr::Soup(_, xs) => {
+            for x in xs {
+                collect_free_vars(x, result);
+            }
+        }
+        Expr::Operator(_, _, _, e) => collect_free_vars(e, result),
+        _ => {}
+    }
 }
 
 pub mod ops {
@@ -1370,7 +1564,7 @@ pub mod core {
     use super::*;
 
     /// Create a variable expression
-    pub fn var(smid: Smid, n: FreeVar<String>) -> RcExpr {
+    pub fn var(smid: Smid, n: String) -> RcExpr {
         RcExpr::from(Expr::Var(smid, Var::Free(n)))
     }
 
@@ -1408,21 +1602,13 @@ pub mod core {
     }
 
     /// Create a lambda expression
-    pub fn lam(smid: Smid, binders: Vec<FreeVar<String>>, body: RcExpr) -> RcExpr {
-        RcExpr::from(Expr::Lam(
-            smid,
-            false,
-            Scope::new(binders.into_iter().map(Binder).collect(), body),
-        ))
+    pub fn lam(smid: Smid, binders: Vec<String>, body: RcExpr) -> RcExpr {
+        RcExpr::from(Expr::Lam(smid, false, close_lam_scope(binders, body)))
     }
 
     /// Create an inlineable lambda expression
-    pub fn inline(smid: Smid, binders: Vec<FreeVar<String>>, body: RcExpr) -> RcExpr {
-        RcExpr::from(Expr::Lam(
-            smid,
-            true,
-            Scope::new(binders.into_iter().map(Binder).collect(), body),
-        ))
+    pub fn inline(smid: Smid, binders: Vec<String>, body: RcExpr) -> RcExpr {
+        RcExpr::from(Expr::Lam(smid, true, close_lam_scope(binders, body)))
     }
 
     /// Create operator soup
@@ -1466,41 +1652,26 @@ pub mod core {
     }
 
     /// Create a default let
-    pub fn default_let(smid: Smid, bindings: Vec<(FreeVar<String>, RcExpr)>) -> RcExpr {
-        let free_vars: Vec<FreeVar<String>> = bindings.iter().map(|(k, _)| k.clone()).collect();
-
-        let block_map = free_vars.iter().map(|fv| {
+    pub fn default_let(smid: Smid, bindings: Vec<(String, RcExpr)>) -> RcExpr {
+        let block_map = bindings.iter().map(|(name, _)| {
             (
-                fv.pretty_name.as_ref().unwrap().clone(),
-                RcExpr::from(Expr::Var(Smid::default(), Var::Free(fv.clone()))),
+                name.clone(),
+                RcExpr::from(Expr::Var(Smid::default(), Var::Free(name.clone()))),
             )
         });
-
         let body_block = block(smid, block_map);
-
-        let binders = bindings
-            .iter()
-            .zip(free_vars)
-            .map(|((_, v), ref fv)| (Binder(fv.clone()), Embed(v.clone())))
-            .collect();
-
         RcExpr::from(Expr::Let(
             smid,
-            Scope::new(Rec::new(binders), body_block),
+            close_let_scope(bindings, body_block),
             LetType::DefaultBlockLet,
         ))
     }
 
     /// Create a let
-    pub fn let_(smid: Smid, bindings: Vec<(FreeVar<String>, RcExpr)>, body: RcExpr) -> RcExpr {
-        let binders = bindings
-            .iter()
-            .map(|(k, v)| (Binder(k.clone()), Embed(v.clone())))
-            .collect();
-
+    pub fn let_(smid: Smid, bindings: Vec<(String, RcExpr)>, body: RcExpr) -> RcExpr {
         RcExpr::from(Expr::Let(
             smid,
-            Scope::new(Rec::new(binders), body),
+            close_let_scope(bindings, body),
             LetType::OtherLet,
         ))
     }
@@ -1579,7 +1750,7 @@ pub mod core {
     pub fn path(smid: Smid, path: &[String]) -> Option<RcExpr> {
         let mut it = path.iter();
         if let Some(base) = it.next() {
-            let body = var(smid, free(base));
+            let body = var(smid, base.clone());
             Some(it.fold(body, |e, n| lookup(smid, e, n, None)))
         } else {
             None
@@ -1592,7 +1763,7 @@ pub mod acore {
     use super::*;
 
     /// Create a variable expression
-    pub fn var(n: FreeVar<String>) -> RcExpr {
+    pub fn var(n: String) -> RcExpr {
         core::var(Smid::default(), n)
     }
 
@@ -1629,13 +1800,13 @@ pub mod acore {
         core::bif(Smid::default(), name)
     }
 
-    /// Create a lambbda
-    pub fn lam(binders: Vec<FreeVar<String>>, body: RcExpr) -> RcExpr {
+    /// Create a lambda
+    pub fn lam(binders: Vec<String>, body: RcExpr) -> RcExpr {
         core::lam(Smid::default(), binders, body)
     }
 
-    /// Create an inlineable lambbda
-    pub fn inline(binders: Vec<FreeVar<String>>, body: RcExpr) -> RcExpr {
+    /// Create an inlineable lambda
+    pub fn inline(binders: Vec<String>, body: RcExpr) -> RcExpr {
         core::inline(Smid::default(), binders, body)
     }
 
@@ -1680,12 +1851,12 @@ pub mod acore {
     }
 
     /// Create a default let
-    pub fn default_let(bindings: Vec<(FreeVar<String>, RcExpr)>) -> RcExpr {
+    pub fn default_let(bindings: Vec<(String, RcExpr)>) -> RcExpr {
         core::default_let(Smid::default(), bindings)
     }
 
     /// Create a let
-    pub fn let_(bindings: Vec<(FreeVar<String>, RcExpr)>, body: RcExpr) -> RcExpr {
+    pub fn let_(bindings: Vec<(String, RcExpr)>, body: RcExpr) -> RcExpr {
         core::let_(Smid::default(), bindings, body)
     }
 
@@ -1742,13 +1913,17 @@ pub mod acore {
 
 /// Bind all free vars of an expression to test alpha equivalence
 pub fn bound(expr: RcExpr) -> RcExpr {
-    let fvs = expr.free_vars();
+    let fvs = free_vars(&expr);
     if fvs.is_empty() {
         expr
     } else {
-        let mut binders: Vec<Binder<String>> = fvs.iter().map(|v| Binder(v.clone())).collect();
-        binders.sort_by_key(|b| b.0.pretty_name.as_ref().unwrap().to_string());
-        RcExpr::from(Expr::Lam(Smid::default(), false, Scope::new(binders, expr)))
+        let mut binders: Vec<String> = fvs.into_iter().collect();
+        binders.sort();
+        RcExpr::from(Expr::Lam(
+            Smid::default(),
+            false,
+            close_lam_scope(binders, expr),
+        ))
     }
 }
 
@@ -1756,12 +1931,270 @@ pub fn bound(expr: RcExpr) -> RcExpr {
 pub mod tests {
     use super::*;
 
+    /// Normalise an expression for structural comparison in tests.
+    ///
+    /// Replaces all `LetType` variants with `OtherLet`, all `Smid` fields with
+    /// `Smid::default()`, and renames lambda parameters to canonical `_p0`, `_p1`,
+    /// … names (updating corresponding bound variables).  This restores the
+    /// alpha-equivalence semantics of the old `moniker::assert_term_eq!`.
+    pub fn alpha_norm(expr: RcExpr) -> RcExpr {
+        alpha_norm_inner(&expr, &mut 0)
+    }
+
+    fn alpha_norm_inner(expr: &RcExpr, counter: &mut u32) -> RcExpr {
+        match &*expr.inner {
+            Expr::Var(_, v) => RcExpr::from(Expr::Var(Smid::default(), v.clone())),
+            Expr::Name(_, n) => RcExpr::from(Expr::Name(Smid::default(), n.clone())),
+            Expr::Literal(_, p) => RcExpr::from(Expr::Literal(Smid::default(), p.clone())),
+            Expr::Intrinsic(_, n) => RcExpr::from(Expr::Intrinsic(Smid::default(), n.clone())),
+            Expr::Let(_, scope, _) => {
+                let new_pattern = scope
+                    .pattern
+                    .iter()
+                    .map(|(k, v)| (k.clone(), alpha_norm_inner(v, counter)))
+                    .collect();
+                let new_body = alpha_norm_inner(&scope.body, counter);
+                RcExpr::from(Expr::Let(
+                    Smid::default(),
+                    Scope {
+                        pattern: new_pattern,
+                        body: new_body,
+                    },
+                    LetType::OtherLet,
+                ))
+            }
+            Expr::Lam(_, ann, scope) => {
+                // Rename parameters to canonical _p0, _p1, ...
+                let new_params: Vec<String> = scope
+                    .pattern
+                    .iter()
+                    .map(|_| {
+                        let n = format!("_p{}", *counter);
+                        *counter += 1;
+                        n
+                    })
+                    .collect();
+                // Rename bound vars referencing scope=0 in the body
+                let renamed_body = rename_lam_params(&scope.body, &scope.pattern, &new_params, 0);
+                let new_body = alpha_norm_inner(&renamed_body, counter);
+                RcExpr::from(Expr::Lam(
+                    Smid::default(),
+                    *ann,
+                    Scope {
+                        pattern: new_params,
+                        body: new_body,
+                    },
+                ))
+            }
+            Expr::App(_, f, args) => RcExpr::from(Expr::App(
+                Smid::default(),
+                alpha_norm_inner(f, counter),
+                args.iter().map(|a| alpha_norm_inner(a, counter)).collect(),
+            )),
+            Expr::Meta(_, e, m) => RcExpr::from(Expr::Meta(
+                Smid::default(),
+                alpha_norm_inner(e, counter),
+                alpha_norm_inner(m, counter),
+            )),
+            Expr::Lookup(_, obj, key, fb) => RcExpr::from(Expr::Lookup(
+                Smid::default(),
+                alpha_norm_inner(obj, counter),
+                key.clone(),
+                fb.as_ref().map(|f| alpha_norm_inner(f, counter)),
+            )),
+            Expr::List(_, items) => RcExpr::from(Expr::List(
+                Smid::default(),
+                items.iter().map(|i| alpha_norm_inner(i, counter)).collect(),
+            )),
+            Expr::Block(_, bm) => RcExpr::from(Expr::Block(
+                Smid::default(),
+                bm.iter()
+                    .map(|(k, v)| (k.clone(), alpha_norm_inner(v, counter)))
+                    .collect(),
+            )),
+            Expr::Soup(_, items) => RcExpr::from(Expr::Soup(
+                Smid::default(),
+                items.iter().map(|i| alpha_norm_inner(i, counter)).collect(),
+            )),
+            Expr::ArgTuple(_, args) => RcExpr::from(Expr::ArgTuple(
+                Smid::default(),
+                args.iter().map(|a| alpha_norm_inner(a, counter)).collect(),
+            )),
+            Expr::Operator(_, fix, prec, e) => RcExpr::from(Expr::Operator(
+                Smid::default(),
+                *fix,
+                *prec,
+                alpha_norm_inner(e, counter),
+            )),
+            Expr::ExprAnaphor(_, ana) => {
+                let norm_ana = normalise_anaphor(ana);
+                RcExpr::from(Expr::ExprAnaphor(Smid::default(), norm_ana))
+            }
+            Expr::BlockAnaphor(_, ana) => {
+                let norm_ana = normalise_anaphor(ana);
+                RcExpr::from(Expr::BlockAnaphor(Smid::default(), norm_ana))
+            }
+            Expr::ErrUnresolved(_, n) => {
+                RcExpr::from(Expr::ErrUnresolved(Smid::default(), n.clone()))
+            }
+            Expr::ErrRedeclaration(_, n) => {
+                RcExpr::from(Expr::ErrRedeclaration(Smid::default(), n.clone()))
+            }
+            _ => expr.clone(),
+        }
+    }
+
+    fn normalise_anaphor(ana: &Anaphor<Smid, i32>) -> Anaphor<Smid, i32> {
+        match ana {
+            // Normalise: strip smid and unify Left/Right (tests use term_eq which ignores
+            // implicit anaphor side)
+            Anaphor::Implicit(_, _) => {
+                Anaphor::Implicit(Smid::default(), ImplicitAnaphorSide::Left)
+            }
+            Anaphor::ExplicitAnonymous(_) => Anaphor::ExplicitAnonymous(Smid::default()),
+            Anaphor::ExplicitNumbered(n) => Anaphor::ExplicitNumbered(*n),
+        }
+    }
+
+    /// Rename lambda parameter names in an expression body from `old_names` to `new_names`,
+    /// updating `Var::Bound` with `scope == depth` and also `Var::Bound.name` hints.
+    fn rename_lam_params(
+        expr: &RcExpr,
+        old_names: &[String],
+        new_names: &[String],
+        depth: u32,
+    ) -> RcExpr {
+        match &*expr.inner {
+            Expr::Var(s, Var::Bound(bv)) => {
+                let mut new_bv = bv.clone();
+                if bv.scope == depth {
+                    if let Some(ref old_name) = bv.name {
+                        if let Some(pos) = old_names.iter().position(|n| n == old_name) {
+                            new_bv.name = Some(new_names[pos].clone());
+                        }
+                    }
+                }
+                RcExpr::from(Expr::Var(*s, Var::Bound(new_bv)))
+            }
+            Expr::Let(s, scope, t) => {
+                let new_bindings = scope
+                    .pattern
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            k.clone(),
+                            rename_lam_params(v, old_names, new_names, depth + 1),
+                        )
+                    })
+                    .collect();
+                let new_body = rename_lam_params(&scope.body, old_names, new_names, depth + 1);
+                RcExpr::from(Expr::Let(
+                    *s,
+                    Scope {
+                        pattern: new_bindings,
+                        body: new_body,
+                    },
+                    *t,
+                ))
+            }
+            Expr::Lam(s, ann, scope) => {
+                let new_body = rename_lam_params(&scope.body, old_names, new_names, depth + 1);
+                RcExpr::from(Expr::Lam(
+                    *s,
+                    *ann,
+                    Scope {
+                        pattern: scope.pattern.clone(),
+                        body: new_body,
+                    },
+                ))
+            }
+            _ => expr.walk(&|e| rename_lam_params(&e, old_names, new_names, depth)),
+        }
+    }
+
+    // Keep the simpler norm() for tests that only need LetType normalisation
+    fn norm(expr: RcExpr) -> RcExpr {
+        alpha_norm(expr)
+    }
+
+    /// Strip Smids without changing LetType or lambda param names.
+    /// Used in import tests where LetType must be preserved.
+    pub fn smid_strip(expr: RcExpr) -> RcExpr {
+        smid_strip_inner(&expr)
+    }
+
+    fn smid_strip_inner(expr: &RcExpr) -> RcExpr {
+        match &*expr.inner {
+            Expr::Var(_, v) => RcExpr::from(Expr::Var(Smid::default(), v.clone())),
+            Expr::Name(_, n) => RcExpr::from(Expr::Name(Smid::default(), n.clone())),
+            Expr::Literal(_, p) => RcExpr::from(Expr::Literal(Smid::default(), p.clone())),
+            Expr::Intrinsic(_, n) => RcExpr::from(Expr::Intrinsic(Smid::default(), n.clone())),
+            Expr::Let(_, scope, lt) => {
+                let new_pattern = scope
+                    .pattern
+                    .iter()
+                    .map(|(k, v)| (k.clone(), smid_strip_inner(v)))
+                    .collect();
+                let new_body = smid_strip_inner(&scope.body);
+                RcExpr::from(Expr::Let(
+                    Smid::default(),
+                    Scope {
+                        pattern: new_pattern,
+                        body: new_body,
+                    },
+                    *lt,
+                ))
+            }
+            Expr::Lam(_, ann, scope) => {
+                let new_body = smid_strip_inner(&scope.body);
+                RcExpr::from(Expr::Lam(
+                    Smid::default(),
+                    *ann,
+                    Scope {
+                        pattern: scope.pattern.clone(),
+                        body: new_body,
+                    },
+                ))
+            }
+            Expr::App(_, f, args) => RcExpr::from(Expr::App(
+                Smid::default(),
+                smid_strip_inner(f),
+                args.iter().map(smid_strip_inner).collect(),
+            )),
+            Expr::Meta(_, e, m) => RcExpr::from(Expr::Meta(
+                Smid::default(),
+                smid_strip_inner(e),
+                smid_strip_inner(m),
+            )),
+            Expr::Lookup(_, obj, key, fb) => RcExpr::from(Expr::Lookup(
+                Smid::default(),
+                smid_strip_inner(obj),
+                key.clone(),
+                fb.as_ref().map(smid_strip_inner),
+            )),
+            Expr::List(_, items) => RcExpr::from(Expr::List(
+                Smid::default(),
+                items.iter().map(smid_strip_inner).collect(),
+            )),
+            Expr::Block(_, bm) => RcExpr::from(Expr::Block(
+                Smid::default(),
+                bm.iter()
+                    .map(|(k, v)| (k.clone(), smid_strip_inner(v)))
+                    .collect(),
+            )),
+            _ => expr.walk(&|e| smid_strip_inner(&e)),
+        }
+    }
+
     #[test]
     pub fn test_substs() {
         use super::acore::*;
         let x = free("x");
         let y = free("y");
-        assert_term_eq!(var(x.clone()).substs(&[(x, var(y.clone()))]), var(y));
+        assert_eq!(
+            bound(var(x.clone()).substs(&[(x, var(y.clone()))])),
+            bound(var(y))
+        );
 
         let a = free("a");
         let b = free("b");
@@ -1769,10 +2202,12 @@ pub mod tests {
         let d = free("d");
         let e = free("e");
 
-        assert_term_eq!(
-            lam(vec![a.clone(), b.clone(), c.clone()], var(d.clone()))
-                .substs(&[(d, var(e.clone()))]),
-            lam(vec![a, b, c], var(e)),
+        assert_eq!(
+            bound(
+                lam(vec![a.clone(), b.clone(), c.clone()], var(d.clone()))
+                    .substs(&[(d, var(e.clone()))])
+            ),
+            bound(lam(vec![a, b, c], var(e))),
         );
     }
 
@@ -1788,9 +2223,9 @@ pub mod tests {
 
         let sub = |n: &str| if n == "d" { Some(var(e.clone())) } else { None };
 
-        assert_term_eq!(
-            lam(vec![a.clone(), b.clone(), c.clone()], var(d)).substs_free(&sub),
-            lam(vec![a, b, c], var(e)),
+        assert_eq!(
+            bound(lam(vec![a.clone(), b.clone(), c.clone()], var(d)).substs_free(&sub)),
+            bound(lam(vec![a, b, c], var(e))),
         );
     }
 
@@ -1804,7 +2239,7 @@ pub mod tests {
         let original = default_let(vec![(x.clone(), num(22)), (y.clone(), num(23))]);
         let expected = let_(vec![(x, num(22)), (y.clone(), num(23))], var(y.clone()));
 
-        assert_term_eq!(original.rebody(var(y)), expected);
+        assert_eq!(norm(original.rebody(var(y))), norm(expected));
     }
 
     #[test]
@@ -1824,7 +2259,7 @@ pub mod tests {
             let_(vec![(z, num(24))], var(x.clone())),
         );
 
-        assert_term_eq!(original.rebody(var(x)), expected);
+        assert_eq!(norm(original.rebody(var(x))), norm(expected));
     }
 
     #[test]
@@ -1850,7 +2285,7 @@ pub mod tests {
             str("outer meta"),
         );
 
-        assert_term_eq!(original.rebody(var(y)), expected);
+        assert_eq!(original.rebody(var(y)), expected);
     }
 
     #[test]
@@ -1869,7 +2304,7 @@ pub mod tests {
 
         let y_other = free("y");
 
-        assert_term_eq!(original.rebody(var(y_other)), expected);
+        assert_eq!(original.rebody(var(y_other)), expected);
     }
 
     #[test]
@@ -1910,7 +2345,7 @@ pub mod tests {
             ),
         );
 
-        assert_term_eq!(unit_c.unwrap(), expected);
+        assert_eq!(unit_c.unwrap(), expected);
     }
 
     #[test]
@@ -1952,7 +2387,7 @@ pub mod tests {
             ),
         );
 
-        assert_term_eq!(unit_c.unwrap(), expected);
+        assert_eq!(unit_c.unwrap(), expected);
     }
 
     #[test]
@@ -1994,7 +2429,7 @@ pub mod tests {
             ),
         );
 
-        assert_term_eq!(
+        assert_eq!(
             RcExpr::merge(vec![unit_a, unit_b, unit_c]).unwrap(),
             expected
         );

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -1,8 +1,8 @@
 //! Distribute and beta reduce inline functions
+use crate::core::binding::{Scope, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
 use crate::core::transform::succ;
-use moniker::*;
 
 /// Depth-aware substitution for beta reduction.
 ///
@@ -19,13 +19,13 @@ use moniker::*;
 /// The Embed values in that Let are inside one additional scope
 /// boundary relative to the call site, so any BV substituted in there
 /// must have its scope incremented.
-fn substs_depth<N: PartialEq<Var<String>>>(
+fn substs_depth(
     expr: &RcExpr,
-    mappings: &[(N, RcExpr)],
+    mappings: &[(String, RcExpr)],
     depth: u32,
 ) -> Result<RcExpr, CoreError> {
     match &*expr.inner {
-        Expr::Var(_, v) => match mappings.iter().find(|&(n, _)| n == v) {
+        Expr::Var(_, Var::Free(name)) => match mappings.iter().find(|(n, _)| n == name) {
             Some((_, replacement)) => {
                 // Replacement is from the call site (depth == 0).
                 // If we are now inside `depth` additional scope
@@ -39,38 +39,34 @@ fn substs_depth<N: PartialEq<Var<String>>>(
             }
             None => Ok(expr.clone()),
         },
-        // Descend into Let: the Embed values are inside the new scope
+        Expr::Var(_, Var::Bound(_)) => Ok(expr.clone()),
+        // Descend into Let: the binding values are inside the new scope
         // boundary, so depth increases by 1.
         Expr::Let(s, scope, t) => {
             let new_bindings: Result<Vec<_>, CoreError> = scope
-                .unsafe_pattern
-                .unsafe_pattern
+                .pattern
                 .iter()
-                .map(|(n, Embed(value))| {
-                    substs_depth(value, mappings, depth + 1).map(|v| (n.clone(), Embed(v)))
-                })
+                .map(|(n, value)| substs_depth(value, mappings, depth + 1).map(|v| (n.clone(), v)))
                 .collect();
-            let new_body = substs_depth(&scope.unsafe_body, mappings, depth + 1)?;
+            let new_body = substs_depth(&scope.body, mappings, depth + 1)?;
             Ok(RcExpr::from(Expr::Let(
                 *s,
                 Scope {
-                    unsafe_pattern: Rec {
-                        unsafe_pattern: new_bindings?,
-                    },
-                    unsafe_body: new_body,
+                    pattern: new_bindings?,
+                    body: new_body,
                 },
                 *t,
             )))
         }
         // Descend into Lam body: also a new scope boundary.
         Expr::Lam(s, inl, scope) => {
-            let new_body = substs_depth(&scope.unsafe_body, mappings, depth + 1)?;
+            let new_body = substs_depth(&scope.body, mappings, depth + 1)?;
             Ok(RcExpr::from(Expr::Lam(
                 *s,
                 *inl,
                 Scope {
-                    unsafe_pattern: scope.unsafe_pattern.clone(),
-                    unsafe_body: new_body,
+                    pattern: scope.pattern.clone(),
+                    body: new_body,
                 },
             )))
         }
@@ -97,37 +93,33 @@ fn inlinable(expr: &RcExpr) -> bool {
 fn distribute(expr: &RcExpr) -> Result<RcExpr, CoreError> {
     match &*expr.inner {
         Expr::Let(s, scope, _) => {
-            let (binders, body) = scope.clone().unbind();
+            let (open_bindings, body) = open_let_scope_full(scope);
 
-            let open_binders = binders.unrec();
-
-            let inlines: Vec<_> = open_binders
+            let inlines: Vec<(String, RcExpr)> = open_bindings
                 .iter()
-                .filter(|&(_, Embed(v))| inlinable(v))
+                .filter(|(_, v)| inlinable(v))
                 .cloned()
-                .map(|(Binder(k), Embed(v))| (k, v))
                 .collect();
 
             if inlines.is_empty() {
                 Ok(expr.clone())
-                // expr.walk_safe(&mut |e| distribute(&e))
             } else {
-                let bindings = open_binders
+                let bindings = open_bindings
                     .iter()
-                    .map(|(b, Embed(v))| {
+                    .map(|(name, v)| {
                         let substituted = v.substs(&inlines);
                         match distribute(&substituted) {
-                            Ok(e) => Ok((b.clone(), Embed(e))),
+                            Ok(e) => Ok((name.clone(), e)),
                             Err(e) => Err(e),
                         }
                     })
-                    .collect::<Result<Vec<(_, _)>, CoreError>>()?;
+                    .collect::<Result<Vec<(String, RcExpr)>, CoreError>>()?;
 
-                let body = distribute(&body.substs(&inlines))?;
+                let new_body = distribute(&body.substs(&inlines))?;
 
                 Ok(RcExpr::from(Expr::Let(
                     *s,
-                    Scope::new(Rec::new(bindings), body),
+                    close_let_scope(bindings, new_body),
                     LetType::OtherLet,
                 )))
             }
@@ -145,11 +137,8 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
                 // as substs doesn't succ, we can only handle
                 // inlinable lambdas here
                 Expr::Lam(_, true, scope) => {
-                    let (binders, body) = scope.clone().unbind();
-
-                    // body may not be fully open so handle any bound
-                    // variables
-                    let body = succ::pred(&body)?;
+                    let binders = scope.pattern.clone();
+                    let body = open_lam_scope(scope);
 
                     if binders.len() != xs.len() {
                         // cannot inline partial application or extra
@@ -162,7 +151,8 @@ fn beta_reduce(expr: &RcExpr) -> Result<RcExpr, CoreError> {
                             .map(beta_reduce)
                             .collect::<Result<Vec<RcExpr>, CoreError>>()?;
 
-                        let mappings = <_>::zip(binders.into_iter(), args).collect::<Vec<_>>();
+                        let mappings: Vec<(String, RcExpr)> =
+                            binders.into_iter().zip(args).collect();
 
                         let reduced = substs_depth(&body, &mappings, 0)?;
 
@@ -201,6 +191,7 @@ pub mod tests {
     use super::*;
     use crate::common::sourcemap::Smid;
     use crate::core::expr::acore::*;
+    use crate::core::expr::tests::alpha_norm;
     use crate::core::verify::binding;
     use std::iter;
 
@@ -220,7 +211,7 @@ pub mod tests {
 
         let expected = let_(vec![(f, inline(vec![x, y.clone()], var(y)))], num(23));
 
-        assert_term_eq!(inline_pass(&original).unwrap(), expected);
+        assert_eq!(inline_pass(&original).unwrap(), expected);
     }
 
     #[test]
@@ -292,7 +283,10 @@ pub mod tests {
             var(z),
         );
 
-        assert_term_eq!(inline_pass(&original).unwrap(), expected);
+        assert_eq!(
+            alpha_norm(inline_pass(&original).unwrap()),
+            alpha_norm(expected)
+        );
     }
 
     #[test]
@@ -412,35 +406,15 @@ pub mod tests {
 
         let inlined = inline_pass(&original).unwrap();
         binding::verify(&inlined).unwrap();
-        assert_term_eq!(inlined, expected);
+        assert_eq!(alpha_norm(inlined), alpha_norm(expected));
     }
 
     /// Regression test for eu-5pe9: beta-reducing a destructuring
     /// lambda (one whose body is a `DestructureListLet`) must
     /// correctly adjust scope indices in the replacement when it is
     /// placed inside the nested scope boundary of the Let.
-    ///
-    /// Previously `substs` was scope-unaware and would leave
-    /// `BV(scope=k, binder=j)` unchanged inside the Let's Embed
-    /// values, causing `compress::compress` to panic with "eliminating
-    /// used var" because prune had marked the originally-referenced
-    /// binder as eliminated.
     #[test]
     pub fn test_beta_reduce_destructuring_lambda_with_bound_arg() {
-        // Build:
-        //   let outer =
-        //     let
-        //       f = inline([__p0]) ->
-        //             DestructureListLet (a = HEAD(__p0), b = HEAD(TAIL(__p0))) in
-        //             a + b
-        //       x = 99
-        //     in f([x, 42])
-        //   in outer
-        //
-        // After inline_pass, f is beta-reduced at the call site and
-        // `x` (a BV in the argument) must be correctly placed inside
-        // the DestructureListLet with an incremented scope index.
-
         let f = free("f");
         let p0 = free("__p0");
         let a = free("a");
@@ -453,20 +427,14 @@ pub mod tests {
         // DestructureListLet: a = HEAD(__p0), b = HEAD(TAIL(__p0))
         let destr_let = RcExpr::from(Expr::Let(
             Smid::default(),
-            Scope::new(
-                Rec::new(vec![
+            close_let_scope(
+                vec![
+                    (a.clone(), app(bif("HEAD"), vec![var(p0.clone())])),
                     (
-                        Binder(a.clone()),
-                        Embed(app(bif("HEAD"), vec![var(p0.clone())])),
+                        b.clone(),
+                        app(bif("HEAD"), vec![app(bif("TAIL"), vec![var(p0.clone())])]),
                     ),
-                    (
-                        Binder(b.clone()),
-                        Embed(app(
-                            bif("HEAD"),
-                            vec![app(bif("TAIL"), vec![var(p0.clone())])],
-                        )),
-                    ),
-                ]),
+                ],
                 add_a_b,
             ),
             LetType::DestructureListLet,
@@ -489,5 +457,6 @@ pub mod tests {
         // binding-valid result
         let result = inline_pass(&inner).expect("inline_pass should not panic");
         binding::verify(&result).expect("result should have valid bindings");
+        let _ = (p0, a, b, f, x);
     }
 }

--- a/src/core/inline/tag.rs
+++ b/src/core/inline/tag.rs
@@ -1,7 +1,5 @@
 //! Tag selected lambdas as inlinable for inline pass
-use crate::core::error::CoreError;
-use crate::core::expr::{Expr, LetType, RcExpr};
-use moniker::*;
+use crate::core::expr::{Expr, LamScope, LetType, RcExpr};
 
 /// Walk the expression tagging combinators and destructuring lambdas.
 ///
@@ -12,7 +10,7 @@ use moniker::*;
 ///   `DestructureBlockLet` or `DestructureListLet`). This allows the inline
 ///   pass to distribute destructuring functions to their call sites so that
 ///   the subsequent fusion pass can simplify the resulting static lookups.
-pub fn tag_combinators(expr: &RcExpr) -> Result<RcExpr, CoreError> {
+pub fn tag_combinators(expr: &RcExpr) -> Result<RcExpr, crate::core::error::CoreError> {
     match &*expr.inner {
         Expr::Lam(s, false, scope) => {
             if combinator(scope) || destructuring(scope) {
@@ -28,8 +26,8 @@ pub fn tag_combinators(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 
 /// A lambda is a combinator if its body is a variable or a simple
 /// intrinsic/variable application to variables and literals.
-fn combinator(lam_scope: &Scope<Vec<Binder<String>>, RcExpr>) -> bool {
-    let body = &lam_scope.unsafe_body;
+fn combinator(lam_scope: &LamScope<RcExpr>) -> bool {
+    let body = &lam_scope.body;
 
     match &*body.inner {
         Expr::Var(_, _) => true,
@@ -48,11 +46,11 @@ fn combinator(lam_scope: &Scope<Vec<Binder<String>>, RcExpr>) -> bool {
 /// its body is a `DestructureBlockLet` or `DestructureListLet`. Such lambdas
 /// are safe to inline because destructuring is deterministic and the fusion
 /// pass will subsequently simplify the resulting static lookups.
-fn destructuring(lam_scope: &Scope<Vec<Binder<String>>, RcExpr>) -> bool {
-    if lam_scope.unsafe_pattern.len() != 1 {
+fn destructuring(lam_scope: &LamScope<RcExpr>) -> bool {
+    if lam_scope.pattern.len() != 1 {
         return false;
     }
-    let body = &lam_scope.unsafe_body;
+    let body = &lam_scope.body;
     matches!(
         &*body.inner,
         Expr::Let(
@@ -98,6 +96,6 @@ pub mod tests {
             app(var(f), vec![num(22), num(23)]),
         );
 
-        assert_term_eq!(tag_combinators(&original).unwrap(), expected);
+        assert_eq!(tag_combinators(&original).unwrap(), expected);
     }
 }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -1,10 +1,10 @@
 //! Facilities for dealing with metadata in core expressions at
 //! various phases
 use crate::common::sourcemap::*;
+use crate::core::binding::Var;
 use crate::core::error::*;
 use crate::core::expr::*;
 use crate::syntax::input::*;
-use moniker;
 
 /// Read typed metadata out of core expressions, mutating to persist
 /// any evaluations or transformations made along the way.
@@ -17,15 +17,15 @@ pub trait ReadMetadata<M> {
 /// Accepts:
 /// - String literal `"name"` → `"name"`
 /// - Symbol literal `:name` → `"name"`
-/// - Var expression (desugared identifier) → the pretty name
+/// - Var expression (desugared identifier) → the name
 fn extract_function_name(expr: &RcExpr) -> Option<String> {
     // Try string or symbol literal first
     if let Some(s) = (expr as &dyn Extract<String>).extract() {
         return Some(s);
     }
     // Then try Var (desugared identifier reference)
-    if let Expr::Var(_, moniker::Var::Free(fv)) = &*expr.inner {
-        return fv.pretty_name.clone();
+    if let Expr::Var(_, Var::Free(name)) = &*expr.inner {
+        return Some(name.clone());
     }
     None
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::result_large_err)]
 pub mod analyse;
 pub mod anaphora;
+pub mod binding;
 pub mod cook;
 pub mod desugar;
 pub mod doc;

--- a/src/core/simplify/compress.rs
+++ b/src/core/simplify/compress.rs
@@ -1,8 +1,8 @@
 //! Compress a pruned tree to remove all eliminated bindings
+use crate::core::binding::{BoundVar, Scope, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
 use crate::core::transform::succ;
-use moniker::{Binder, BinderIndex, BoundVar, Embed, Rec, Scope, Var};
 use std::collections::VecDeque;
 
 pub fn compress(expr: &RcExpr) -> Result<RcExpr, CoreError> {
@@ -29,13 +29,13 @@ impl ScopeCompressor {
     }
 
     /// Update a bound var according to the relevant permutation
-    fn encounter(&mut self, bound_var: &BoundVar<String>) -> Option<BoundVar<String>> {
-        let perm = &self.perms[bound_var.scope.0 as usize];
-        let reindex = perm.get(bound_var.binder.to_usize()).cloned().flatten();
+    fn encounter(&mut self, bound_var: &BoundVar) -> Option<BoundVar> {
+        let perm = &self.perms[bound_var.scope as usize];
+        let reindex = perm.get(bound_var.binder as usize).cloned().flatten();
         reindex.map(|i| BoundVar {
             scope: bound_var.scope,
-            binder: BinderIndex(i as u32),
-            pretty_name: bound_var.pretty_name.clone(),
+            binder: i as u32,
+            name: bound_var.name.clone(),
         })
     }
 
@@ -45,13 +45,10 @@ impl ScopeCompressor {
                 self.enter(permutation_from_let_scope(scope));
 
                 let new_bindings: Result<Vec<_>, CoreError> = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .filter(|&(_, Embed(ref value))| !matches!(*value.inner, Expr::ErrEliminated))
-                    .map(|&(ref n, Embed(ref value))| {
-                        self.compress(value).map(|val| (n.clone(), Embed(val)))
-                    })
+                    .filter(|(_, value)| !matches!(*value.inner, Expr::ErrEliminated))
+                    .map(|(n, value)| self.compress(value).map(|val| (n.clone(), val)))
                     .collect();
 
                 let new_bindings = match new_bindings {
@@ -62,16 +59,14 @@ impl ScopeCompressor {
                     }
                 };
 
-                let new_body = self.compress(&scope.unsafe_body)?;
+                let new_body = self.compress(&scope.body)?;
 
                 let ret = if !new_bindings.is_empty() {
                     RcExpr::from(Expr::Let(
                         *s,
                         Scope {
-                            unsafe_pattern: Rec {
-                                unsafe_pattern: new_bindings,
-                            },
-                            unsafe_body: new_body,
+                            pattern: new_bindings,
+                            body: new_body,
                         },
                         *t,
                     ))
@@ -89,8 +84,8 @@ impl ScopeCompressor {
                     *s,
                     *inl,
                     Scope {
-                        unsafe_pattern: scope.unsafe_pattern.clone(),
-                        unsafe_body: self.compress(&scope.unsafe_body)?,
+                        pattern: scope.pattern.clone(),
+                        body: self.compress(&scope.body)?,
                     },
                 ));
                 self.exit();
@@ -110,13 +105,11 @@ impl ScopeCompressor {
 }
 
 #[allow(clippy::type_complexity)]
-fn permutation_from_let_scope(
-    scope: &Scope<Rec<Vec<(Binder<String>, Embed<RcExpr>)>>, RcExpr>,
-) -> Permutation {
+fn permutation_from_let_scope(scope: &LetScope<RcExpr>) -> Permutation {
     let mut perm = Vec::new();
     let mut i = 0;
-    for (_, Embed(embed)) in &scope.unsafe_pattern.unsafe_pattern {
-        if matches!(*embed.inner, Expr::ErrEliminated) {
+    for (_, value) in &scope.pattern {
+        if matches!(*value.inner, Expr::ErrEliminated) {
             perm.push(None);
         } else {
             perm.push(Some(i));
@@ -127,9 +120,9 @@ fn permutation_from_let_scope(
     perm
 }
 
-fn permutation_from_lam_scope(scope: &Scope<Vec<Binder<String>>, RcExpr>) -> Permutation {
+fn permutation_from_lam_scope(scope: &LamScope<RcExpr>) -> Permutation {
     let mut perm = Vec::new();
-    for (i, _) in scope.unsafe_pattern.iter().enumerate() {
+    for (i, _) in scope.pattern.iter().enumerate() {
         perm.push(Some(i));
     }
 
@@ -141,7 +134,6 @@ pub mod tests {
 
     use super::*;
     use crate::core::expr::acore::*;
-    use moniker::assert_term_eq;
 
     #[test]
     pub fn test_simple() {
@@ -169,6 +161,6 @@ pub mod tests {
             var(a),
         );
 
-        assert_term_eq!(compress(&sample).unwrap(), expected);
+        assert_eq!(compress(&sample).unwrap(), expected);
     }
 }

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -4,10 +4,8 @@
 //! Includes block-level DCE: for `DefaultBlockLet` bindings that are
 //! only accessed via static `Lookup` patterns (`ns.member`), inner
 //! members that are never looked up are eliminated from the Block body.
+use crate::core::binding::{BoundVar, Scope, Var};
 use crate::core::expr::*;
-use moniker::Rec;
-use moniker::Scope;
-use moniker::{BoundTerm, BoundVar, Embed, OnBoundFn, OnFreeFn, ScopeState, Var};
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
@@ -45,8 +43,6 @@ pub enum SeenState {
 pub struct Tracker {
     seen: Cell<SeenState>,
 }
-
-impl_bound_term_ignore!(Tracker);
 
 impl Clone for Tracker {
     fn clone(&self) -> Self {
@@ -210,7 +206,7 @@ impl<'expr> ScopeTracker<'expr> {
     /// Mark the innermost let body as Seen so we traverse from there
     fn mark_body(expr: &'expr RcMarkExpr) {
         match &*expr.inner {
-            Expr::Let(_, scope, _) => Self::mark_body(&scope.unsafe_body),
+            Expr::Let(_, scope, _) => Self::mark_body(&scope.body),
             Expr::Meta(_, e, _) => Self::mark_body(e),
             _ => {
                 expr.mark();
@@ -225,12 +221,11 @@ impl<'expr> ScopeTracker<'expr> {
     /// seen and return true. Also disqualifies the binding from
     /// block-level DCE since a bare reference means the entire block
     /// value escapes.
-    fn encounter(&mut self, bound_var: &BoundVar<String>) {
+    fn encounter(&mut self, bound_var: &BoundVar) {
         if self.reachable {
-            let expr = self.scopes[bound_var.scope.0 as usize];
+            let expr = self.scopes[bound_var.scope as usize];
             if let Expr::Let(_, scope, _) = &*expr.inner {
-                let (_, Embed(rc)) =
-                    &scope.unsafe_pattern.unsafe_pattern[bound_var.binder.to_usize()];
+                let (_, rc) = &scope.pattern[bound_var.binder as usize];
                 // Disqualify from block-level DCE on bare access
                 let id: BindingId = Rc::as_ptr(&rc.inner);
                 self.block_tracker.disqualify(id);
@@ -245,12 +240,11 @@ impl<'expr> ScopeTracker<'expr> {
     ///
     /// Marks the binding as reachable (like `encounter`) but records
     /// the member access for block-level DCE instead of disqualifying.
-    fn encounter_lookup(&mut self, bound_var: &BoundVar<String>, member: &str) {
+    fn encounter_lookup(&mut self, bound_var: &BoundVar, member: &str) {
         if self.reachable {
-            let expr = self.scopes[bound_var.scope.0 as usize];
+            let expr = self.scopes[bound_var.scope as usize];
             if let Expr::Let(_, scope, _) = &*expr.inner {
-                let (_, Embed(rc)) =
-                    &scope.unsafe_pattern.unsafe_pattern[bound_var.binder.to_usize()];
+                let (_, rc) = &scope.pattern[bound_var.binder as usize];
                 let id: BindingId = Rc::as_ptr(&rc.inner);
                 if self.block_tracker.is_candidate(id) {
                     self.block_tracker.record_access(id, member.to_owned());
@@ -305,23 +299,23 @@ impl<'expr> ScopeTracker<'expr> {
             Expr::Let(_, scope, _) => {
                 // Register DefaultBlockLet bindings as candidates
                 // for block-level DCE
-                for (_, Embed(ref rc)) in &scope.unsafe_pattern.unsafe_pattern {
+                for (_, rc) in &scope.pattern {
                     if rc.inner.is_default_let() {
                         let id: BindingId = Rc::as_ptr(&rc.inner);
                         self.block_tracker.register(id);
                     }
                 }
                 self.enter(expr);
-                for (_, Embed(ref rc)) in &scope.unsafe_pattern.unsafe_pattern {
+                for (_, rc) in &scope.pattern {
                     self.soft_depend(rc, expr);
                     self.traverse(rc);
                 }
-                self.traverse(&scope.unsafe_body);
+                self.traverse(&scope.body);
                 self.exit();
             }
             Expr::Lam(_, _, scope) => {
                 self.enter(expr);
-                self.traverse(&scope.unsafe_body);
+                self.traverse(&scope.body);
                 self.exit();
             }
             Expr::Lookup(_, e, member, fb) => {
@@ -400,29 +394,23 @@ impl<'expr> ScopeTracker<'expr> {
             Expr::Let(s, scope, t) => Expr::Let(
                 *s,
                 Scope {
-                    unsafe_pattern: Rec {
-                        unsafe_pattern: scope
-                            .unsafe_pattern
-                            .unsafe_pattern
-                            .iter()
-                            .map(|&(ref n, Embed(ref value))| {
-                                if value.unseen() {
-                                    (n.clone(), Embed(RcExpr::from(Expr::ErrEliminated)))
+                    pattern: scope
+                        .pattern
+                        .iter()
+                        .map(|(n, value)| {
+                            if value.unseen() {
+                                (n.clone(), RcExpr::from(Expr::ErrEliminated))
+                            } else {
+                                let id: BindingId = Rc::as_ptr(&value.inner);
+                                if let Some(members) = self.block_tracker.accessed_members(id) {
+                                    (n.clone(), self.blank_default_block_let(value, members))
                                 } else {
-                                    let id: BindingId = Rc::as_ptr(&value.inner);
-                                    if let Some(members) = self.block_tracker.accessed_members(id) {
-                                        (
-                                            n.clone(),
-                                            Embed(self.blank_default_block_let(value, members)),
-                                        )
-                                    } else {
-                                        (n.clone(), Embed(self.blank_unseen(value)))
-                                    }
+                                    (n.clone(), self.blank_unseen(value))
                                 }
-                            })
-                            .collect(),
-                    },
-                    unsafe_body: self.blank_unseen(&scope.unsafe_body),
+                            }
+                        })
+                        .collect(),
+                    body: self.blank_unseen(&scope.body),
                 },
                 *t,
             ),
@@ -430,8 +418,8 @@ impl<'expr> ScopeTracker<'expr> {
                 *s,
                 *inl,
                 Scope {
-                    unsafe_pattern: scope.unsafe_pattern.clone(),
-                    unsafe_body: self.blank_unseen(&scope.unsafe_body),
+                    pattern: scope.pattern.clone(),
+                    body: self.blank_unseen(&scope.body),
                 },
             ),
             Expr::Lookup(s, e, n, fb) => Expr::Lookup(
@@ -479,20 +467,19 @@ impl<'expr> ScopeTracker<'expr> {
             Expr::Let(s, scope, LetType::DefaultBlockLet) => {
                 // Convert inner bindings normally
                 let new_bindings: Vec<_> = scope
-                    .unsafe_pattern
-                    .unsafe_pattern
+                    .pattern
                     .iter()
-                    .map(|&(ref n, Embed(ref value))| {
+                    .map(|(n, value)| {
                         if value.unseen() {
-                            (n.clone(), Embed(RcExpr::from(Expr::ErrEliminated)))
+                            (n.clone(), RcExpr::from(Expr::ErrEliminated))
                         } else {
-                            (n.clone(), Embed(self.blank_unseen(value)))
+                            (n.clone(), self.blank_unseen(value))
                         }
                     })
                     .collect();
 
                 // Filter the Block body to retain only accessed members
-                let new_body = match &*scope.unsafe_body.inner {
+                let new_body = match &*scope.body.inner {
                     Expr::Block(bs, block_map) => {
                         let filtered: BlockMap<RcExpr> = block_map
                             .iter()
@@ -501,16 +488,14 @@ impl<'expr> ScopeTracker<'expr> {
                             .collect();
                         RcExpr::from(Expr::Block(*bs, filtered))
                     }
-                    _ => self.blank_unseen(&scope.unsafe_body),
+                    _ => self.blank_unseen(&scope.body),
                 };
 
                 RcExpr::from(Expr::Let(
                     *s,
                     Scope {
-                        unsafe_pattern: Rec {
-                            unsafe_pattern: new_bindings,
-                        },
-                        unsafe_body: new_body,
+                        pattern: new_bindings,
+                        body: new_body,
                     },
                     LetType::DefaultBlockLet,
                 ))
@@ -531,7 +516,6 @@ pub mod tests {
     use super::*;
     use crate::core::expr::acore::*;
     use crate::core::expr::RcExpr;
-    use moniker::assert_term_eq;
 
     #[test]
     pub fn test_simple() {
@@ -548,7 +532,7 @@ pub mod tests {
             var(x),
         );
 
-        assert_term_eq!(prune(&simple), expected)
+        assert_eq!(prune(&simple), expected)
     }
 
     #[test]
@@ -577,7 +561,7 @@ pub mod tests {
             ),
         );
 
-        assert_term_eq!(prune(&nested), expected)
+        assert_eq!(prune(&nested), expected)
     }
 
     #[test]
@@ -604,7 +588,7 @@ pub mod tests {
             app(bif("BLAH"), vec![var(a), var(b)]),
         );
 
-        assert_term_eq!(prune(&expr), expected)
+        assert_eq!(prune(&expr), expected)
     }
 
     #[test]
@@ -642,7 +626,7 @@ pub mod tests {
             var(a),
         );
 
-        assert_term_eq!(prune(&expr), expected)
+        assert_eq!(prune(&expr), expected)
     }
 
     // Block-level DCE tests
@@ -673,11 +657,11 @@ pub mod tests {
         // Verify the block body is filtered (only "used" member)
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                let (_, ref ns_val) = scope.pattern[0];
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         // Block body should only contain "used"
-                        match &*inner_scope.unsafe_body.inner {
+                        match &*inner_scope.body.inner {
                             Expr::Block(_, block_map) => {
                                 assert_eq!(block_map.len(), 1);
                                 assert!(block_map.get("used").is_some());
@@ -714,7 +698,7 @@ pub mod tests {
 
         let pruned = prune(&expr);
         // All members preserved (dynamic access), result used
-        assert_term_eq!(pruned, expr);
+        assert_eq!(pruned, expr);
     }
 
     #[test]
@@ -739,7 +723,7 @@ pub mod tests {
         );
 
         let pruned = prune(&expr);
-        assert_term_eq!(pruned, expr);
+        assert_eq!(pruned, expr);
     }
 
     #[test]
@@ -774,11 +758,11 @@ pub mod tests {
         // Verify block body has only "a" and "c"
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                let (_, ref ns_val) = scope.pattern[0];
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         // Block body should contain "a" and "c" only
-                        match &*inner_scope.unsafe_body.inner {
+                        match &*inner_scope.body.inner {
                             Expr::Block(_, block_map) => {
                                 assert_eq!(block_map.len(), 2);
                                 assert!(block_map.get("a").is_some());
@@ -826,10 +810,10 @@ pub mod tests {
         // Verify the block body is filtered (only "used" member)
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                let (_, ref ns_val) = scope.pattern[0];
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
-                        match &*inner_scope.unsafe_body.inner {
+                        match &*inner_scope.body.inner {
                             Expr::Block(_, block_map) => {
                                 assert_eq!(block_map.len(), 1);
                                 assert!(block_map.get("used").is_some());
@@ -877,10 +861,10 @@ pub mod tests {
         // "used" is accessed — the fallback references "other", not "ns"
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, Embed(ref ns_val)) = scope.unsafe_pattern.unsafe_pattern[0];
+                let (_, ref ns_val) = scope.pattern[0];
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
-                        match &*inner_scope.unsafe_body.inner {
+                        match &*inner_scope.body.inner {
                             Expr::Block(_, block_map) => {
                                 assert_eq!(block_map.len(), 1);
                                 assert!(block_map.get("used").is_some());
@@ -920,6 +904,6 @@ pub mod tests {
 
         let pruned = prune(&expr);
         // ns escapes bare in body block, so all members preserved
-        assert_term_eq!(pruned, expr);
+        assert_eq!(pruned, expr);
     }
 }

--- a/src/core/transform/dynamise.rs
+++ b/src/core/transform/dynamise.rs
@@ -1,10 +1,10 @@
 //! Turn an expression into a genearalised lookup expression
 use crate::common::sourcemap::{HasSmid, Smid};
+use crate::core::binding::Var;
 use crate::core::error::CoreError;
 use crate::core::expr::*;
 use crate::core::transform::succ;
 use crate::syntax::rowan::lex as lexer;
-use moniker::*;
 
 /// Transform an expression into a dynamic generalised lookup
 ///
@@ -16,15 +16,15 @@ pub fn dynamise(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 }
 
 pub struct Dynamiser {
-    depth: ScopeOffset,
-    param: FreeVar<String>,
+    depth: u32,
+    param: String,
     wrap_lambda: bool,
 }
 
 impl Dynamiser {
     fn new(smid: Smid) -> Self {
         Dynamiser {
-            depth: ScopeOffset(0),
+            depth: 0,
             param: free(format!("__g{smid}").as_ref()),
             wrap_lambda: false,
         }
@@ -40,42 +40,42 @@ fn is_normal(n: &str) -> bool {
 impl Dynamiser {
     /// Enter a let or lambda scope increment depth
     fn enter(&mut self) {
-        self.depth = self.depth.succ();
+        self.depth += 1;
     }
 
     /// Decrement depth
     fn exit(&mut self) {
-        self.depth = self.depth.pred().unwrap();
+        self.depth -= 1;
     }
 
     /// Provide a possibly lookup-wrapped variation of the variable
     /// suitable for use in a lambda.
-    fn wrap(&mut self, s: &Smid, var: &Var<String>) -> RcExpr {
+    fn wrap(&mut self, s: &Smid, var: &Var) -> RcExpr {
         match var {
-            Var::Free(fv) => {
+            Var::Free(name) => {
                 // ignore operator names
-                if is_normal(fv.pretty_name.as_ref().unwrap()) {
+                if is_normal(name) {
                     self.wrap_lambda = true;
                     RcExpr::from(Expr::Lookup(
                         *s,
                         core::var(*s, self.param.clone()),
-                        fv.pretty_name.clone().unwrap(),
-                        Some(core::var(*s, fv.clone())),
+                        name.clone(),
+                        Some(core::var(*s, name.clone())),
                     ))
                 } else {
-                    core::var(*s, fv.clone())
+                    core::var(*s, name.clone())
                 }
             }
             Var::Bound(bv) => {
                 // if the binder is outside the scope of the dynamic
                 // expression then we insert a lookup (but not for
                 // operator names, which should not become lookups)
-                if bv.scope >= self.depth && bv.pretty_name.as_ref().is_some_and(|n| is_normal(n)) {
+                if bv.scope >= self.depth && bv.name.as_ref().is_some_and(|n| is_normal(n)) {
                     self.wrap_lambda = true;
                     RcExpr::from(Expr::Lookup(
                         *s,
                         core::var(*s, self.param.clone()),
-                        bv.pretty_name.clone().unwrap(),
+                        bv.name.clone().unwrap(),
                         Some(RcExpr::from(Expr::Var(*s, Var::Bound(bv.clone())))),
                     ))
                 } else {
@@ -89,11 +89,11 @@ impl Dynamiser {
         let expr = self.process(expr)?;
 
         if self.wrap_lambda {
-            Ok(RcExpr::from(Expr::Lam(
+            Ok(core::lam(
                 smid,
-                false, // might be arbitrarily complex - not inlinable
-                Scope::new(vec![Binder(self.param.clone())], succ::succ(&expr)?),
-            )))
+                vec![self.param.clone()],
+                succ::succ(&expr)?,
+            ))
         } else {
             Ok(expr)
         }
@@ -123,6 +123,8 @@ impl Dynamiser {
 pub mod tests {
     use super::*;
     use crate::core::expr::acore::*;
+    use crate::core::expr::bound;
+    use crate::core::expr::tests::alpha_norm;
 
     #[test]
     pub fn test_simple_dynamise() {
@@ -135,7 +137,10 @@ pub mod tests {
             lookup(var(implicit), "x", Some(var(x))),
         );
 
-        assert_term_eq!(dynamise(&original).unwrap(), expected);
+        assert_eq!(
+            alpha_norm(bound(dynamise(&original).unwrap())),
+            alpha_norm(bound(expected))
+        );
     }
 
     #[test]
@@ -150,29 +155,28 @@ pub mod tests {
             let_(vec![(z.clone(), num(24))], var(x)),
         );
 
-        assert_term_eq!(dynamise(&original).unwrap(), original);
+        assert_eq!(dynamise(&original).unwrap(), original);
 
         if let Expr::Let(_, scope, _) = &*original.inner {
-            let sublet = scope.unsafe_body.clone();
+            let sublet = scope.body.clone();
+            // The body of sublet is the x reference (a bound var into the outer let).
+            // Extract it to use as the expected fallback value in the lookup.
+            let x_fallback = if let Expr::Let(_, inner_scope, _) = &*sublet.inner {
+                inner_scope.body.clone()
+            } else {
+                panic!("expected inner let");
+            };
             let expected = lam(
                 vec![implicit.clone()],
                 let_(
                     vec![(z, num(24))],
-                    lookup(
-                        var(implicit),
-                        "x",
-                        Some(RcExpr::from(Expr::Var(
-                            Smid::default(),
-                            Var::Bound(BoundVar {
-                                scope: ScopeOffset(2),
-                                binder: BinderIndex(0),
-                                pretty_name: Some("x".to_string()),
-                            }),
-                        ))),
-                    ),
+                    lookup(var(implicit), "x", Some(x_fallback)),
                 ),
             );
-            assert_term_eq!(dynamise(&sublet).unwrap(), expected);
+            assert_eq!(
+                alpha_norm(bound(dynamise(&sublet).unwrap())),
+                alpha_norm(bound(expected))
+            );
         }
     }
 }

--- a/src/core/transform/fuse.rs
+++ b/src/core/transform/fuse.rs
@@ -92,7 +92,6 @@ pub fn fuse(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 mod tests {
     use super::*;
     use crate::core::expr::acore::*;
-    use moniker::assert_term_eq;
 
     #[test]
     fn test_fold_block_lookup_present() {
@@ -100,7 +99,7 @@ mod tests {
         let b = block([("x".to_string(), num(3)), ("y".to_string(), num(4))]);
         let expr = lookup(b, "x", None);
         let result = fuse(&expr).unwrap();
-        assert_term_eq!(result, num(3));
+        assert_eq!(result, num(3));
     }
 
     #[test]
@@ -110,7 +109,7 @@ mod tests {
         let expr = lookup(b.clone(), "z", None);
         let result = fuse(&expr).unwrap();
         // Should be unchanged: key missing and no fallback
-        assert_term_eq!(result, lookup(b, "z", None));
+        assert_eq!(result, lookup(b, "z", None));
     }
 
     #[test]
@@ -119,7 +118,7 @@ mod tests {
         let b = block([("x".to_string(), num(3))]);
         let expr = lookup(b, "z", Some(num(99)));
         let result = fuse(&expr).unwrap();
-        assert_term_eq!(result, num(99));
+        assert_eq!(result, num(99));
     }
 
     #[test]
@@ -128,7 +127,7 @@ mod tests {
         let l = list(vec![num(10), num(20), num(30)]);
         let expr = app(bif("HEAD"), vec![l]);
         let result = fuse(&expr).unwrap();
-        assert_term_eq!(result, num(10));
+        assert_eq!(result, num(10));
     }
 
     #[test]
@@ -137,7 +136,7 @@ mod tests {
         let l = list(vec![num(10), num(20), num(30)]);
         let expr = app(bif("TAIL"), vec![l]);
         let result = fuse(&expr).unwrap();
-        assert_term_eq!(result, list(vec![num(20), num(30)]));
+        assert_eq!(result, list(vec![num(20), num(30)]));
     }
 
     #[test]
@@ -147,7 +146,7 @@ mod tests {
         let tail_call = app(bif("TAIL"), vec![l]);
         let head_of_tail = app(bif("HEAD"), vec![tail_call]);
         let result = fuse(&head_of_tail).unwrap();
-        assert_term_eq!(result, num(20));
+        assert_eq!(result, num(20));
     }
 
     #[test]
@@ -159,6 +158,6 @@ mod tests {
         let expr = let_(vec![(x.clone(), head_call)], var(x.clone()));
         let result = fuse(&expr).unwrap();
         let expected = let_(vec![(x.clone(), num(1))], var(x));
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 }

--- a/src/core/transform/succ.rs
+++ b/src/core/transform/succ.rs
@@ -1,7 +1,7 @@
 //! Compress a pruned tree to remove all eliminated bindings
+use crate::core::binding::{BoundVar, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
-use moniker::{BoundVar, ScopeOffset, Var};
 
 /// Occasionally we need to push an expression with bound vars
 /// inside an extra scope, this increments de bruijn indices to
@@ -15,50 +15,43 @@ pub fn pred(expr: &RcExpr) -> Result<RcExpr, CoreError> {
 }
 
 /// Update a bound var according to increase the scope offset
-fn encounter_succ(bound_var: &BoundVar<String>) -> BoundVar<String> {
+fn encounter_succ(bound_var: &BoundVar) -> BoundVar {
     BoundVar {
-        scope: bound_var.scope.succ(),
+        scope: bound_var.scope + 1,
         binder: bound_var.binder,
-        pretty_name: bound_var.pretty_name.clone(),
+        name: bound_var.name.clone(),
     }
 }
 
 /// Update a bound var according to decrease the scope offset
-fn encounter_pred(bound_var: &BoundVar<String>) -> BoundVar<String> {
+fn encounter_pred(bound_var: &BoundVar) -> BoundVar {
     BoundVar {
-        scope: bound_var.scope.pred().unwrap(),
+        scope: bound_var.scope - 1,
         binder: bound_var.binder,
-        pretty_name: bound_var.pretty_name.clone(),
+        name: bound_var.name.clone(),
     }
 }
 
+#[derive(Default)]
 pub struct BoundVarNudger {
-    depth: ScopeOffset,
-}
-
-impl Default for BoundVarNudger {
-    fn default() -> Self {
-        BoundVarNudger {
-            depth: ScopeOffset(0),
-        }
-    }
+    depth: u32,
 }
 
 impl BoundVarNudger {
     /// Enter a let or lambda scope increment depth
     fn enter(&mut self) {
-        self.depth = self.depth.succ();
+        self.depth += 1;
     }
 
     /// Decrement depth
     fn exit(&mut self) {
-        self.depth = self.depth.pred().unwrap();
+        self.depth -= 1;
     }
 
     pub fn process(
         &mut self,
         expr: &RcExpr,
-        handle: fn(&BoundVar<String>) -> BoundVar<String>,
+        handle: fn(&BoundVar) -> BoundVar,
     ) -> Result<RcExpr, CoreError> {
         match &*expr.inner {
             Expr::Let(_, _, _) => {

--- a/src/core/verify/binding.rs
+++ b/src/core/verify/binding.rs
@@ -1,7 +1,7 @@
 //! Check we haven't disturbed de bruijn indexes during processing
+use crate::core::binding::{BoundVar, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
-use moniker::*;
 use std::collections::VecDeque;
 
 pub fn verify(expr: &RcExpr) -> Result<RcExpr, CoreError> {
@@ -22,23 +22,19 @@ impl ScopeTracker {
         self.scopes.pop_front();
     }
 
-    fn encounter(&mut self, bound_var: &BoundVar<String>) {
-        let expr = self.scopes[bound_var.scope.0 as usize].clone();
+    fn encounter(&mut self, bound_var: &BoundVar) {
+        let expr = self.scopes[bound_var.scope as usize].clone();
         match &*expr.inner {
             Expr::Let(_, scope, _) => {
-                if let Some((Binder(fv), Embed(_))) = &scope
-                    .unsafe_pattern
-                    .unsafe_pattern
-                    .get(bound_var.binder.to_usize())
-                {
-                    assert_eq!(fv.pretty_name, bound_var.pretty_name);
+                if let Some((name, _)) = scope.pattern.get(bound_var.binder as usize) {
+                    assert_eq!(Some(name.as_str()), bound_var.name.as_deref());
                 } else {
                     panic!("missing binding");
                 }
             }
             Expr::Lam(_, _, scope) => {
-                if let Some(Binder(fv)) = &scope.unsafe_pattern.get(bound_var.binder.to_usize()) {
-                    assert_eq!(fv.pretty_name, bound_var.pretty_name);
+                if let Some(name) = scope.pattern.get(bound_var.binder as usize) {
+                    assert_eq!(Some(name.as_str()), bound_var.name.as_deref());
                 } else {
                     panic!("missing lambda binding")
                 }

--- a/src/core/verify/binding.rs
+++ b/src/core/verify/binding.rs
@@ -23,13 +23,28 @@ impl ScopeTracker {
     }
 
     fn encounter(&mut self, bound_var: &BoundVar) {
+        if bound_var.scope as usize >= self.scopes.len() {
+            panic!(
+                "VERIFIER: scope OOB: scope={} binder={} name={:?} scopes.len()={}",
+                bound_var.scope,
+                bound_var.binder,
+                bound_var.name,
+                self.scopes.len()
+            );
+        }
         let expr = self.scopes[bound_var.scope as usize].clone();
         match &*expr.inner {
             Expr::Let(_, scope, _) => {
                 if let Some((name, _)) = scope.pattern.get(bound_var.binder as usize) {
-                    assert_eq!(Some(name.as_str()), bound_var.name.as_deref());
+                    assert_eq!(
+                        Some(name.as_str()),
+                        bound_var.name.as_deref(),
+                        "name mismatch for BV scope={} binder={}",
+                        bound_var.scope,
+                        bound_var.binder
+                    );
                 } else {
-                    panic!("missing binding");
+                    panic!("VERIFIER: missing Let binding: scope={} binder={} name={:?} pattern.len()={}", bound_var.scope, bound_var.binder, bound_var.name, scope.pattern.len());
                 }
             }
             Expr::Lam(_, _, scope) => {

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -2,6 +2,7 @@
 //! to STG syntax for evaluation in the machine.
 use std::{convert::TryInto, rc::Rc};
 
+use crate::core::binding::{BoundVar, Var};
 use crate::{
     common::sourcemap::{HasSmid, Smid, SourceMap},
     core::expr::{BlockMap, Expr, LamScope, LetScope, Primitive, RcExpr},
@@ -11,7 +12,6 @@ use crate::{
     },
 };
 use codespan_reporting::diagnostic::Diagnostic;
-use moniker::{BoundVar, Embed, Var};
 
 use thiserror::Error;
 
@@ -443,24 +443,26 @@ impl Context<'_> {
         }
     }
 
-    pub fn local(&self, bound_var: &BoundVar<String>) -> Result<Rc<StgSyn>, CompileError> {
+    pub fn local(&self, bound_var: &BoundVar) -> Result<Rc<StgSyn>, CompileError> {
         Ok(dsl::atom(self.lookup(bound_var)?))
     }
 
     /// Generate a STG syntax local ref corresponding to the specified
     /// Core bound variable
-    pub fn lookup(&self, bound_var: &BoundVar<String>) -> Result<Ref, CompileError> {
+    pub fn lookup(&self, bound_var: &BoundVar) -> Result<Ref, CompileError> {
         let BoundVar { scope, binder, .. } = bound_var;
 
         if self.is_synthetic() {
             self.next()?.lookup(bound_var).map(|r| r.bump(self.size))
-        } else if scope.0 == 0 {
-            Ok(self.var_refs[binder.to_usize()].clone())
+        } else if *scope == 0 {
+            Ok(self.var_refs[*binder as usize].clone())
         } else {
             let adjusted_var = BoundVar {
-                scope: scope.pred().ok_or(CompileError::BoundVarOverflowsContext)?,
+                scope: scope
+                    .checked_sub(1)
+                    .ok_or(CompileError::BoundVarOverflowsContext)?,
                 binder: bound_var.binder,
-                pretty_name: None,
+                name: None,
             };
             self.next()?
                 .lookup(&adjusted_var)
@@ -756,13 +758,13 @@ impl ProtoSyntax for ProtoLet {
     ) -> Result<Rc<StgSyn>, CompileError> {
         let scope = self.scope();
         let mut binder = LetBinder::for_scope(self.expr.clone(), context);
-        for (_, Embed(ref value)) in scope.unsafe_pattern.unsafe_pattern.iter() {
+        for (_, value) in scope.pattern.iter() {
             let annotation = value.smid();
             let index = compiler.compile_binding(&mut binder, value.clone(), annotation, false)?;
             binder.add_var_index(index);
         }
 
-        let body = compiler.compile_body(&mut binder, scope.unsafe_body.clone())?;
+        let body = compiler.compile_body(&mut binder, scope.body.clone())?;
         binder.set_body(body)?;
         binder.freeze();
 
@@ -773,11 +775,11 @@ impl ProtoSyntax for ProtoLet {
 /// ProtoVars become references into the environment once a context is
 /// available
 struct ProtoVar {
-    bound_var: BoundVar<String>,
+    bound_var: BoundVar,
 }
 
 impl ProtoVar {
-    pub fn new(bound_var: BoundVar<String>) -> Self {
+    pub fn new(bound_var: BoundVar) -> Self {
         ProtoVar { bound_var }
     }
 }
@@ -1026,19 +1028,10 @@ impl ProtoSyntax for ProtoApp {
 }
 
 /// Extract reference to bound var
-pub fn extract_bound_var<'a>(
-    smid: &'a Smid,
-    var: &'a Var<String>,
-) -> Result<&'a BoundVar<String>, CompileError> {
+pub fn extract_bound_var<'a>(smid: &'a Smid, var: &'a Var) -> Result<&'a BoundVar, CompileError> {
     match var {
         Var::Bound(bound_var) => Ok(bound_var),
-        Var::Free(free_var) => Err(CompileError::FreeVar(
-            *smid,
-            free_var
-                .pretty_name
-                .clone()
-                .unwrap_or_else(|| "<unknown>".to_string()),
-        )),
+        Var::Free(name) => Err(CompileError::FreeVar(*smid, name.clone())),
     }
 }
 
@@ -1084,7 +1077,7 @@ impl ProtoSyntax for ProtoLambda {
         context: &Context,
     ) -> Result<LambdaForm, CompileError> {
         let scope = self.scope();
-        let args = scope.unsafe_pattern.len();
+        let args = scope.pattern.len();
 
         let lambda_context = Context {
             scope: Some(self.expr.clone()),
@@ -1095,7 +1088,7 @@ impl ProtoSyntax for ProtoLambda {
 
         let mut binder = LetBinder::synthetic_let(&lambda_context);
 
-        let body = compiler.compile_body(&mut binder, scope.unsafe_body.clone())?;
+        let body = compiler.compile_body(&mut binder, scope.body.clone())?;
         binder.set_body(body)?;
         binder.freeze();
         let mut body = binder.into_stg(compiler)?;
@@ -1259,8 +1252,8 @@ impl<'rt> Compiler<'rt> {
         match &*expr.inner {
             Expr::Var(s, v) => {
                 let bound_var = extract_bound_var(s, v)?.clone();
-                if bound_var.scope.0 == 0 {
-                    if let Some(r) = binder.running_ref(bound_var.binder.to_usize()) {
+                if bound_var.scope == 0 {
+                    if let Some(r) = binder.running_ref(bound_var.binder as usize) {
                         Ok(r)
                     } else {
                         binder.add_deferred(Box::new(ProtoVar::new(bound_var)))

--- a/src/import/jsonl.rs
+++ b/src/import/jsonl.rs
@@ -43,14 +43,14 @@ pub fn read_jsonl<'smap>(
 mod tests {
     use super::*;
     use crate::core::expr::acore;
+    use crate::core::expr::tests::smid_strip;
     use codespan_reporting::files::SimpleFiles;
-    use moniker::assert_term_eq;
 
     fn parse(text: &str) -> RcExpr {
         let mut sm = SourceMap::new();
         let mut files = SimpleFiles::new();
         let file_id = files.add("test.jsonl".to_string(), text.to_string());
-        read_jsonl(&mut files, &mut sm, file_id, text).unwrap()
+        smid_strip(read_jsonl(&mut files, &mut sm, file_id, text).unwrap())
     }
 
     #[test]
@@ -59,16 +59,10 @@ mod tests {
 {"name": "Bob"}"#;
         let result = parse(input);
         let expected = acore::list(vec![
-            acore::default_let(vec![(
-                moniker::FreeVar::fresh_named("name"),
-                acore::str("Alice"),
-            )]),
-            acore::default_let(vec![(
-                moniker::FreeVar::fresh_named("name"),
-                acore::str("Bob"),
-            )]),
+            acore::default_let(vec![("name".to_string(), acore::str("Alice"))]),
+            acore::default_let(vec![("name".to_string(), acore::str("Bob"))]),
         ]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -78,10 +72,10 @@ mod tests {
 {"b": 2}"#;
         let result = parse(input);
         let expected = acore::list(vec![
-            acore::default_let(vec![(moniker::FreeVar::fresh_named("a"), acore::num(1))]),
-            acore::default_let(vec![(moniker::FreeVar::fresh_named("b"), acore::num(2))]),
+            acore::default_let(vec![("a".to_string(), acore::num(1))]),
+            acore::default_let(vec![("b".to_string(), acore::num(2))]),
         ]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -89,7 +83,7 @@ mod tests {
         let input = "1\n   \n2";
         let result = parse(input);
         let expected = acore::list(vec![acore::num(1), acore::num(2)]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -101,16 +95,13 @@ mod tests {
 null"#;
         let result = parse(input);
         let expected = acore::list(vec![
-            acore::default_let(vec![(
-                moniker::FreeVar::fresh_named("obj"),
-                acore::bool_(true),
-            )]),
+            acore::default_let(vec![("obj".to_string(), acore::bool_(true))]),
             acore::list(vec![acore::num(1), acore::num(2), acore::num(3)]),
             acore::str("string"),
             acore::num(42),
             acore::null(),
         ]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -118,10 +109,10 @@ null"#;
         let input = r#"{"single": "value"}"#;
         let result = parse(input);
         let expected = acore::list(vec![acore::default_let(vec![(
-            moniker::FreeVar::fresh_named("single"),
+            "single".to_string(),
             acore::str("value"),
         )])]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -129,6 +120,6 @@ null"#;
         let input = "1\n2\n";
         let result = parse(input);
         let expected = acore::list(vec![acore::num(1), acore::num(2)]);
-        assert_term_eq!(result, expected);
+        assert_eq!(result, expected);
     }
 }

--- a/src/import/yaml.rs
+++ b/src/import/yaml.rs
@@ -9,7 +9,6 @@ use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime};
 use codespan::{ByteIndex, ByteOffset, Span};
 use codespan_reporting::files::SimpleFiles;
 use lazy_static::lazy_static;
-use moniker::{Embed, FreeVar};
 use regex::{Regex, RegexSet};
 use std::{collections::HashMap, iter};
 use std::{convert::TryInto, str::FromStr};
@@ -121,17 +120,17 @@ impl<'smap> Receiver<'smap> {
         {
             let smid = self.new_smid(Span::new(start, end));
 
-            let fvs: HashMap<String, FreeVar<String>> =
-                entries.iter().map(|(k, _)| (k.clone(), free(k))).collect();
             let kvs = entries
                 .iter()
                 .map(|(k, v)| {
                     (
-                        fvs.get(k)
-                            .expect("free variable should exist for key")
-                            .clone(),
+                        k.clone(),
                         v.substs_free(&|n| {
-                            fvs.get(n).map(|fv| core::var(Smid::default(), fv.clone()))
+                            if entries.iter().any(|(entry_k, _)| entry_k == n) {
+                                Some(core::var(Smid::default(), n.to_string()))
+                            } else {
+                                None
+                            }
                         }),
                     )
                 })
@@ -204,21 +203,7 @@ impl<'smap> Receiver<'smap> {
     ) -> Result<Vec<(String, RcExpr)>, SourceError> {
         match &*expr.inner {
             Expr::Let(_, scope, LetType::DefaultBlockLet) => {
-                let (binders, _body) = scope.clone().unbind();
-                let entries: Vec<(String, RcExpr)> = binders
-                    .unrec()
-                    .into_iter()
-                    .map(|(binder, Embed(value))| {
-                        let name = binder.0.pretty_name.clone().ok_or_else(|| {
-                            SourceError::InvalidYaml(
-                                "merge key source has entry without a name".to_string(),
-                                self.file_id,
-                                error_span,
-                            )
-                        })?;
-                        Ok::<_, SourceError>((name, value))
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
+                let entries: Vec<(String, RcExpr)> = scope.pattern.clone();
                 Ok(entries)
             }
             Expr::List(_, items) => {
@@ -357,7 +342,7 @@ impl<'smap> Receiver<'smap> {
             .map_err(|c| SourceError::EmbeddedCoreError(c, file_id, span))?;
 
         // Extract parameter names from the Rowan ApplyTuple
-        let mut fvs: HashMap<String, FreeVar<String>> = HashMap::new();
+        let mut param_names: Vec<String> = Vec::new();
         for item in head.items() {
             // Each item in the ApplyTuple should be a single identifier
             let elements: Vec<_> = item.elements().collect();
@@ -365,17 +350,22 @@ impl<'smap> Receiver<'smap> {
                 if let crate::syntax::rowan::ast::Element::Name(name) = &elements[0] {
                     if let Some(identifier) = name.identifier() {
                         if let Some(param_name) = identifier.name() {
-                            fvs.insert(param_name.to_string(), free(param_name));
+                            param_names.push(param_name.to_string());
                         }
                     }
                 }
             }
         }
 
-        let lam_body =
-            lam_body.substs_free(&|n| fvs.get(n).map(|fv| core::var(Smid::default(), fv.clone())));
+        let lam_body = lam_body.substs_free(&|n| {
+            if param_names.contains(&n.to_string()) {
+                Some(core::var(Smid::default(), n.to_string()))
+            } else {
+                None
+            }
+        });
 
-        let core = acore::lam(fvs.values().cloned().collect(), lam_body);
+        let core = acore::lam(param_names, lam_body);
         Ok(core)
     }
 }
@@ -710,12 +700,12 @@ fn parse_bool(text: &str) -> bool {
 pub mod tests {
     use super::*;
     use crate::core::expr::acore;
+    use crate::core::expr::tests::smid_strip;
     use codespan_reporting::files::SimpleFiles;
-    use moniker::assert_term_eq;
     use std::iter;
 
     fn parse(text: &str) -> RcExpr {
-        try_parse(text).expect("YAML parse failed")
+        smid_strip(try_parse(text).expect("YAML parse failed"))
     }
 
     fn try_parse(text: &str) -> Result<RcExpr, SourceError> {
@@ -743,20 +733,20 @@ z: !!int 1234232353
                 ),
             ),
             (free("x"), acore::str("y")),
-            (free("z"), acore::num(12342323535_u64)),
+            (free("z"), acore::num(1234232353_u64)),
         ]);
 
-        assert_term_eq!(parsed, expected);
+        assert_eq!(bound(parsed), bound(expected));
     }
 
     #[test]
     pub fn test_accepts_empty_input() {
-        assert_term_eq!(parse(""), acore::block(iter::empty()));
+        assert_eq!(bound(parse("")), bound(acore::block(iter::empty())));
     }
 
     #[test]
     pub fn test_parses_key_value() {
-        assert_term_eq!(
+        assert_eq!(
             parse("a: !!int 1234"),
             acore::default_let(vec![(free("a"), acore::num(1234))])
         );
@@ -764,7 +754,7 @@ z: !!int 1234232353
 
     #[test]
     pub fn test_parses_json_data() {
-        assert_term_eq!(
+        assert_eq!(
             parse(" { a: [1, 2, 3], b: {x: \"y\"} } "),
             acore::default_let(vec![
                 (
@@ -782,7 +772,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_parses_bools() {
         let sample = "a: true\nb: True\nc: TRUE\nd: false\ne: False\nf: FALSE ";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (free("a"), acore::bool_(true)),
@@ -908,7 +898,7 @@ z: !!int 1234232353
         // Quoted strings should remain strings, not be converted to timestamps
         let parsed = parse(r#"ts: "2023-01-15T10:30:00Z""#);
         let expected = acore::default_let(vec![(free("ts"), acore::str("2023-01-15T10:30:00Z"))]);
-        assert_term_eq!(parsed, expected);
+        assert_eq!(bound(parsed), bound(expected));
     }
 
     #[test]
@@ -950,7 +940,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_anchor_alias_with_number() {
         let sample = "value: &val 42\nref: *val";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (free("value"), acore::num(42)),
@@ -962,7 +952,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_anchor_alias_with_list() {
         let sample = "items: &items [1, 2, 3]\ncopy: *items";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -980,7 +970,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_anchor_alias_with_mapping() {
         let sample = "base: &base\n  x: 1\n  y: 2\nref: *base";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1004,7 +994,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_multiple_aliases_same_anchor() {
         let sample = "source: &src hello\na: *src\nb: *src";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (free("source"), acore::str("hello")),
@@ -1036,7 +1026,7 @@ z: !!int 1234232353
     pub fn test_nested_anchors() {
         // Anchor within an anchored structure
         let sample = "outer: &outer\n  inner: &inner 42\nref_outer: *outer\nref_inner: *inner";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1055,7 +1045,7 @@ z: !!int 1234232353
     #[test]
     pub fn test_alias_in_list() {
         let sample = "name: &n Alice\npeople: [*n, Bob, *n]";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (free("name"), acore::str("Alice")),
@@ -1077,7 +1067,7 @@ z: !!int 1234232353
     pub fn test_merge_key_single() {
         // Single merge: <<: *alias
         let sample = "base: &base\n  x: 1\n  y: 2\nderived:\n  <<: *base\n  z: 3";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1103,7 +1093,7 @@ z: !!int 1234232353
     pub fn test_merge_key_override() {
         // Later keys override merged values
         let sample = "base: &base\n  x: 1\n  y: 2\nderived:\n  <<: *base\n  y: 99";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1128,7 +1118,7 @@ z: !!int 1234232353
     pub fn test_merge_key_explicit_before() {
         // Explicit keys before merge also override
         let sample = "base: &base\n  x: 1\nderived:\n  x: 99\n  <<: *base";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1147,7 +1137,7 @@ z: !!int 1234232353
     pub fn test_merge_key_multiple() {
         // Multiple merge: <<: [*a, *b] - merge in order, later overrides earlier
         let sample = "a: &a\n  x: 1\nb: &b\n  x: 2\n  y: 3\nderived:\n  <<: [*a, *b]\n  z: 4";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![
                 (
@@ -1177,7 +1167,7 @@ z: !!int 1234232353
     pub fn test_merge_key_inline() {
         // Inline merge: <<: {key: value}
         let sample = "derived:\n  <<: {x: 1, y: 2}\n  z: 3";
-        assert_term_eq!(
+        assert_eq!(
             parse(sample),
             acore::default_let(vec![(
                 free("derived"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate codespan;
 extern crate codespan_reporting;
 extern crate indexmap;
 extern crate itertools;
-extern crate moniker;
 extern crate pretty;
 extern crate regex;
 extern crate serde_json;


### PR DESCRIPTION
## Summary

- Removes the abandoned `moniker` git dependency (curvelogic fork, last release 2018, Rust 2015 edition)
- Replaces it with a purpose-built `src/core/binding.rs` module containing `Var`, `BoundVar`, and `Scope` types
- Adds scope manipulation helpers (`close_let_scope`, `open_let_scope_full`, `close_expr_vars`, etc.) in `expr.rs`
- Updates all 22+ consumer files across `core/`, `eval/stg/`, `import/`, `common/`, `syntax/`
- Fixes `fixity.rs` to use `open_let_scope_full` (equivalent to moniker's `unbind`) so operator variables inside binding values are correctly found during fixity distribution

## Key design decisions

- `BoundVar` stores `scope: u32` and `binder: u32` (de Bruijn indices) plus an optional `name` for diagnostics
- `LetScope<T>` = `Scope<Vec<(String,T)>,T>`, `LamScope<T>` = `Scope<Vec<String>,T>` — simpler than moniker's `Rec`/`Binder`/`Embed` wrappers
- `close_expr_vars` increments existing BV scope indices (correct for fresh bindings); `bind_free_vars` does not (correct for re-binding already-indexed expressions)

## Test plan

- [x] All 606 lib tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)