### PR TITLE
feat(eu-v46): structured argument parsing with parse-args

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -504,7 +504,7 @@ See also: `identity(v)`, `const(k, _)`, `compose(f, g, x)`,
 
 ### 3.5 Type Predicates
 
-```eu
+```eu,notest
 42 number?          # true
 "hi" string?        # true
 :foo symbol?        # true
@@ -522,7 +522,7 @@ All predicates take one argument and return a boolean.
 
 Parse `args` (a list of strings, typically `io.args`) against `defaults`:
 
-```eu
+```eu,notest
 ` :suppress
 defaults: {
   ` { short: :v  doc: "Verbose"  flag: true }

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -502,6 +502,48 @@ See also: `identity(v)`, `const(k, _)`, `compose(f, g, x)`,
 `flip(f, x, y)`, `complement(p?)`, `curry(f, x, y)`,
 `uncurry(f, l)`, `cond(l, d)`.
 
+### 3.5 Type Predicates
+
+```eu
+42 number?          # true
+"hi" string?        # true
+:foo symbol?        # true
+true bool?          # true
+{} block?           # true
+[] list?            # true
+42 string?          # false
+```
+
+All predicates take one argument and return a boolean.
+
+### 3.6 Command-line Argument Parsing
+
+#### `parse-args(defaults, args)` — structured CLI argument parsing
+
+Parse `args` (a list of strings, typically `io.args`) against `defaults`:
+
+```eu
+` :suppress
+defaults: {
+  ` { short: :v  doc: "Verbose"  flag: true }
+  verbose: false
+  ` { short: :o  doc: "Output file" }
+  output: "out.yaml"
+  ` { doc: "Repeat count" }
+  count: 1
+}
+
+main: io.args parse-args(defaults)
+```
+
+Returns defaults block with parsed values overridden, plus `args` key for positional arguments.
+
+**Metadata keys:** `short` (symbol, short flag), `doc` (string, help text), `flag` (bool, toggle).
+
+**Supported forms:** `--key value`, `--key=value`, `--flag`, `-x`, `-xy` (combined shorts), positionals, `--help`.
+
+See `docs/reference/prelude/args.md` for full documentation.
+
 ---
 
 ## 4. Pipeline Patterns and Idioms

--- a/docs/reference/prelude/args.md
+++ b/docs/reference/prelude/args.md
@@ -1,0 +1,90 @@
+# parse-args
+
+Parse command-line arguments against a defaults block.
+
+## Signature
+
+```eu
+parse-args(defaults, args)
+```
+
+- `defaults` — a block where each key defines an option with its default value; field metadata configures the option
+- `args` — a list of argument strings (e.g. from `io.args`)
+
+Returns the `defaults` block overridden with parsed values, plus an `args` key containing positional arguments as a list.
+
+## Metadata Keys
+
+Each field in `defaults` may carry metadata to configure parsing:
+
+| Key     | Type   | Description                                              |
+|---------|--------|----------------------------------------------------------|
+| `short` | symbol | Single-character short flag (e.g. `:v` for `-v`)        |
+| `doc`   | string | Description shown in auto-generated `--help` output      |
+| `flag`  | bool   | If `true`, option is a boolean toggle (no value argument)|
+
+## Type Coercion
+
+The type of the default value determines coercion:
+- Default is a **number** → parse value as JSON number (`"42"` → `42`)
+- Default is a **string** → value stays as string
+- Default is a **boolean with `flag: true`** → presence toggles to `true`
+
+## Syntax Forms
+
+| Syntax              | Description                             |
+|---------------------|-----------------------------------------|
+| `--key value`       | Long option with separate value         |
+| `--key=value`       | Long option with inline value           |
+| `--flag`            | Boolean flag toggle                     |
+| `-x value`          | Short option with value                 |
+| `-x`                | Short flag toggle                       |
+| `-xy`               | Combined short flags (all flags) or flag + value |
+| positional          | Non-option arguments collected in `args`|
+| `--help`            | Print auto-generated help and exit      |
+
+## Example
+
+```eu
+` :suppress
+defaults: {
+  ` { short: :v  doc: "Enable verbose output"  flag: true }
+  verbose: false
+
+  ` { short: :o  doc: "Output file path" }
+  output: "out.yaml"
+
+  ` { doc: "Number of iterations" }
+  count: 1
+}
+
+main: io.args parse-args(defaults)
+```
+
+Usage:
+
+```sh
+eu script.eu -- --verbose -o result.yaml --count 5 input.eu
+```
+
+Result block: `{ verbose: true, output: "result.yaml", count: 5, args: ["input.eu"] }`.
+
+## Errors
+
+- Unknown long option → `panic: unknown option: --name`
+- Unknown short option → `panic: unknown option: -c`
+- Missing value for option → `panic: option --name requires a value`
+
+## Pipeline Usage
+
+```eu
+# Typical entry point
+main: io.args parse-args(defaults)
+
+# With positional file processing
+run: {
+  opts: io.args parse-args(defaults)
+  files: opts.args
+  ...
+}
+```

--- a/docs/reference/prelude/args.md
+++ b/docs/reference/prelude/args.md
@@ -4,7 +4,7 @@ Parse command-line arguments against a defaults block.
 
 ## Signature
 
-```eu
+```eu,notest
 parse-args(defaults, args)
 ```
 
@@ -45,7 +45,7 @@ The type of the default value determines coercion:
 
 ## Example
 
-```eu
+```eu,notest
 ` :suppress
 defaults: {
   ` { short: :v  doc: "Enable verbose output"  flag: true }
@@ -77,7 +77,7 @@ Result block: `{ verbose: true, output: "result.yaml", count: 5, args: ["input.e
 
 ## Pipeline Usage
 
-```eu
+```eu,notest
 # Typical entry point
 main: io.args parse-args(defaults)
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1621,3 +1621,150 @@ graph: {
   two distinct components."
   kruskal-edges(n, edges): __GRAPH_KRUSKAL_EDGES(edges concat, [n])
 }
+
+##
+## Structured argument parsing
+##
+
+# Build lookup table mapping short-flag character string to option key symbol.
+# e.g. for `verbose: false` with metadata `{short: :v}`, maps "v" -> :verbose
+` :suppress
+args-build-short-lookup(defaults): {
+  has-short(e): meta(e tail head) has(:short)
+  to-pair(e): [meta(e tail head) lookup(:short), e head]
+  pairs: defaults elements filter(has-short) map(to-pair)
+}.( pairs block )
+
+# Return true if option `key` in `defaults` has `flag: true` metadata.
+` :suppress
+args-is-flag(defaults, key): {
+  entry: defaults elements filter(args-entry-has-key(key))
+  m: if(entry nil?, {}, meta(entry head tail head))
+}.( m lookup-or(:flag, false) )
+
+# Predicate: does element `e` have key `k`?
+` :suppress
+args-entry-has-key(k, e): (e head) = k
+
+# Coerce string `str-val` to match type of default for `key`.
+` :suppress
+args-coerce-value(defaults, key, str-val): {
+  default-val: defaults lookup-or(key, str-val)
+  result: if(default-val number?, str-val parse-as(:json), str-val)
+}.result
+
+# Process a long option `arg` (starting with --) against `defaults`.
+# Returns updated state `{opts, rest, pending}`.
+` :suppress
+args-process-long(defaults, state, arg): {
+  name: arg str.replace("^--", "")
+  has-eq: name str.contains?("=")
+  key-str: if(has-eq, name str.split-on("=") head, name)
+  key: key-str sym
+  known: defaults has(key)
+  result: if(not(known), panic("unknown option: --{name}"),
+  if(has-eq, {
+    val: name str.split-on("=") tail head
+    opts: [[key, args-coerce-value(defaults, key, val)]] block merge(state.opts)
+    rest: state.rest
+    pending: null
+  }, if(args-is-flag(defaults, key), {
+    opts: [[key, true]] block merge(state.opts)
+    rest: state.rest
+    pending: null
+  }, {
+    opts: state.opts
+    rest: state.rest
+    pending: key
+  })))
+}.result
+
+# Process short options string `chars-list` (list of single-char strings).
+# Handles combined flags like -vo where v is a flag and o takes a value.
+` :suppress
+args-process-short-chars(defaults, short-lookup, state, chars-list): {
+  result: if(chars-list nil?, state, {
+    ch: chars-list head
+    key: short-lookup lookup-or(ch sym, null)
+    next-state: if(key = null,
+      panic("unknown option: -{ch}"),
+      if(args-is-flag(defaults, key), {
+        opts: [[key, true]] block merge(state.opts)
+        rest: state.rest
+        pending: null
+      }, {
+        opts: state.opts
+        rest: state.rest
+        pending: key
+      }))
+    next-chars: chars-list tail
+    # If this option takes a value and there are remaining chars,
+    # use remaining chars as the value string
+    remainder: if((next-state.pending ✓) && (next-chars non-nil?), {
+      val: next-chars str.join-on("")
+      opts: [[next-state.pending, args-coerce-value(defaults, next-state.pending, val)]] block merge(next-state.opts)
+      rest: next-state.rest
+      pending: null
+    }, args-process-short-chars(defaults, short-lookup, next-state, next-chars))
+  }.remainder)
+}.result
+
+# Process a single argument `arg` in state `{opts, rest, pending}`.
+` :suppress
+args-process-one(defaults, short-lookup, state, arg): {
+  result: if(state.pending ✓, {
+    # Previous option was waiting for its value
+    key: state.pending
+    opts: [[key, args-coerce-value(defaults, key, arg)]] block merge(state.opts)
+    rest: state.rest
+    pending: null
+  },
+  if(arg str.starts-with?("--"), {
+    r: if(arg = "--help",
+      panic(args-generate-help(defaults)),
+      args-process-long(defaults, state, arg))
+  }.r,
+  if(arg str.starts-with?("-"), {
+    chars-str: arg str.replace("^-", "")
+    r: args-process-short-chars(defaults, short-lookup, state, chars-str str.letters)
+  }.r,
+  {
+    # Positional argument
+    opts: state.opts
+    rest: state.rest ++ [arg]
+    pending: null
+  })))
+}.result
+
+# Generate help text for --help.
+` :suppress
+args-generate-help(defaults): {
+  help-line(e): {
+    k: e head
+    v: e tail head
+    m: meta(v)
+    short: m lookup-or(:short, null)
+    doc: m lookup-or(:doc, "")
+    flag-str: if(m lookup-or(:flag, false), " (flag)", "")
+    short-str: if(short ✓, "-{short str.of}, ", "    ")
+    line: "{short-str}--{k str.of}{flag-str}  {doc}"
+  }.line
+  lines: defaults elements map(help-line)
+  text: ["Options:"] ++ lines
+}.( text str.join-on(c"\n") )
+
+` "`parse-args(defaults, args)` - parse command-line argument list `args` against a
+defaults block. Each key in defaults defines an option with its default value.
+Field metadata specifies: short (symbol for short flag), doc (description),
+flag (true for boolean toggle with no value argument). Returns the defaults
+block updated with parsed values, plus an args key containing positional
+arguments as a list. Unknown options cause a runtime error. Use --help for
+auto-generated help text."
+parse-args(defaults, args): {
+  short-lookup: args-build-short-lookup(defaults)
+  init: { opts: defaults, rest: [], pending: null }
+  final-state: foldl(args-process-one(defaults, short-lookup), init, args)
+  result: if(final-state.pending ✓,
+    panic("option --{final-state.pending str.of} requires a value"),
+    [[:args, final-state.rest]] block merge(final-state.opts))
+}.result

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -276,6 +276,18 @@ block?: __ISBLOCK
 ` "`list?(v)` - true if and only if `v` is a list."
 list?: __ISLIST
 
+` "`number?(v)` - true if and only if `v` is a number."
+number?: __ISNUMBER
+
+` "`string?(v)` - true if and only if `v` is a string."
+string?: __ISSTRING
+
+` "`symbol?(v)` - true if and only if `v` is a symbol."
+symbol?: __ISSYMBOL
+
+` "`bool?(v)` - true if and only if `v` is a boolean."
+bool?: __ISBOOL
+
 ` "`elements(b)` - expose list of elements of block `b`."
 elements: __ELEMENTS
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -869,6 +869,26 @@ lazy_static! {
             ty: function(vec![str_(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
     },
+    Intrinsic { // 164
+            name: "ISNUMBER",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 165
+            name: "ISSTRING",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 166
+            name: "ISSYMBOL",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 167
+            name: "ISBOOL",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -139,6 +139,128 @@ impl StgIntrinsic for IsList {
 
 impl CallGlobal1 for IsList {}
 
+/// ISNUMBER(value)
+///
+/// Return true if the value is a number, false otherwise
+pub struct IsNumber;
+
+impl StgIntrinsic for IsNumber {
+    fn name(&self) -> &str {
+        "ISNUMBER"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        use crate::eval::memory::syntax;
+        let closure = machine.nav(view).resolve(&args[0])?;
+        let code = view.scoped(closure.code());
+        let result = matches!(
+            &*code,
+            syntax::HeapSyn::Cons { tag, .. } if *tag == DataConstructor::BoxedNumber.tag()
+        );
+        machine_return_bool(machine, view, result)
+    }
+}
+
+impl CallGlobal1 for IsNumber {}
+
+/// ISSTRING(value)
+///
+/// Return true if the value is a string, false otherwise
+pub struct IsString;
+
+impl StgIntrinsic for IsString {
+    fn name(&self) -> &str {
+        "ISSTRING"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        use crate::eval::memory::syntax;
+        let closure = machine.nav(view).resolve(&args[0])?;
+        let code = view.scoped(closure.code());
+        let result = matches!(
+            &*code,
+            syntax::HeapSyn::Cons { tag, .. } if *tag == DataConstructor::BoxedString.tag()
+        );
+        machine_return_bool(machine, view, result)
+    }
+}
+
+impl CallGlobal1 for IsString {}
+
+/// ISSYMBOL(value)
+///
+/// Return true if the value is a symbol, false otherwise
+pub struct IsSymbol;
+
+impl StgIntrinsic for IsSymbol {
+    fn name(&self) -> &str {
+        "ISSYMBOL"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        use crate::eval::memory::syntax;
+        let closure = machine.nav(view).resolve(&args[0])?;
+        let code = view.scoped(closure.code());
+        let result = matches!(
+            &*code,
+            syntax::HeapSyn::Cons { tag, .. } if *tag == DataConstructor::BoxedSymbol.tag()
+        );
+        machine_return_bool(machine, view, result)
+    }
+}
+
+impl CallGlobal1 for IsSymbol {}
+
+/// ISBOOL(value)
+///
+/// Return true if the value is a boolean, false otherwise
+pub struct IsBool;
+
+impl StgIntrinsic for IsBool {
+    fn name(&self) -> &str {
+        "ISBOOL"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        use crate::eval::memory::syntax;
+        let closure = machine.nav(view).resolve(&args[0])?;
+        let code = view.scoped(closure.code());
+        let is_bool = matches!(
+            &*code,
+            syntax::HeapSyn::Cons { tag, .. }
+                if *tag == DataConstructor::BoolTrue.tag()
+                    || *tag == DataConstructor::BoolFalse.tag()
+        );
+        machine_return_bool(machine, view, is_bool)
+    }
+}
+
+impl CallGlobal1 for IsBool {}
+
 /// SORT_NUM_LIST — sort a list of numbers in Rust
 ///
 /// The wrapper first applies SeqNumList to force and unbox all elements,

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -214,6 +214,10 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(debug::DbgRepr));
     rt.add(Box::new(expect::Expect));
     rt.add(Box::new(debug::Dbg));
+    rt.add(Box::new(list::IsNumber));
+    rt.add(Box::new(list::IsString));
+    rt.add(Box::new(list::IsSymbol));
+    rt.add(Box::new(list::IsBool));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/tests/harness/126_type_predicates.eu
+++ b/tests/harness/126_type_predicates.eu
@@ -1,0 +1,18 @@
+{ title: "126 type predicates" }
+
+` { target: :test-type-predicates }
+test-type-predicates: {
+  n: 42 number? //= true
+  s: "hello" string? //= true
+  y: :foo symbol? //= true
+  b: true bool? //= true
+  nn: "hello" number? //= false
+  ns: 42 string? //= false
+  nb: 42 bool? //= false
+  ny: "foo" symbol? //= false
+  bl: [] block? //= false
+  lb: {} list? //= false
+  bn: false number? //= false
+  bs: true string? //= false
+  RESULT: [n, s, y, b, nn, ns, nb, ny, bl, lb, bn, bs] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness/128_parse_args.eu
+++ b/tests/harness/128_parse_args.eu
@@ -1,0 +1,88 @@
+{ title: "128 parse-args" }
+
+# Test defaults block
+` :suppress
+test-defaults: {
+  ` { short: :v doc: "Enable verbose output" flag: true }
+  verbose: false
+
+  ` { short: :o doc: "Output file path" }
+  output: "default.txt"
+
+  ` { doc: "Repeat count" }
+  count: 1
+}
+
+# Basic long option
+` { target: :test-long-option }
+test-long-option: {
+  result: ["--output", "foo.txt"] parse-args(test-defaults)
+  RESULT: if((result.output = "foo.txt"), :PASS, :FAIL)
+}
+
+# Short option
+` { target: :test-short-option }
+test-short-option: {
+  result: ["-o", "bar.txt"] parse-args(test-defaults)
+  RESULT: if((result.output = "bar.txt"), :PASS, :FAIL)
+}
+
+# Flag toggle
+` { target: :test-flag }
+test-flag: {
+  result: ["--verbose"] parse-args(test-defaults)
+  RESULT: if(result.verbose, :PASS, :FAIL)
+}
+
+# Short flag
+` { target: :test-short-flag }
+test-short-flag: {
+  result: ["-v"] parse-args(test-defaults)
+  RESULT: if(result.verbose, :PASS, :FAIL)
+}
+
+# Equals syntax
+` { target: :test-equals-syntax }
+test-equals-syntax: {
+  result: ["--output=baz.txt"] parse-args(test-defaults)
+  RESULT: if((result.output = "baz.txt"), :PASS, :FAIL)
+}
+
+# Numeric coercion
+` { target: :test-numeric }
+test-numeric: {
+  result: ["--count", "5"] parse-args(test-defaults)
+  RESULT: if((result.count = 5), :PASS, :FAIL)
+}
+
+# Positional args
+` { target: :test-positional }
+test-positional: {
+  result: ["--verbose", "file1.txt", "file2.txt"] parse-args(test-defaults)
+  pass: (result.args = ["file1.txt", "file2.txt"]) && result.verbose
+  RESULT: pass then(:PASS, :FAIL)
+}
+
+# Mixed flags and positional
+` { target: :test-mixed }
+test-mixed: {
+  result: ["-v", "-o", "out.json", "--count", "3", "input.eu"] parse-args(test-defaults)
+  pass: result.verbose && (result.output = "out.json") && (result.count = 3) && (result.args = ["input.eu"])
+  RESULT: pass then(:PASS, :FAIL)
+}
+
+# Defaults preserved
+` { target: :test-defaults-preserved }
+test-defaults-preserved: {
+  result: [] parse-args(test-defaults)
+  pass: (result.verbose = false) && (result.output = "default.txt") && (result.count = 1) && (result.args = [])
+  RESULT: pass then(:PASS, :FAIL)
+}
+
+# Combined short flags: -vo out.txt (v is flag, o takes arg)
+` { target: :test-combined-short }
+test-combined-short: {
+  result: ["-vo", "out.txt"] parse-args(test-defaults)
+  pass: result.verbose && (result.output = "out.txt")
+  RESULT: pass then(:PASS, :FAIL)
+}

--- a/tests/harness/errors/109_unknown_arg.eu
+++ b/tests/harness/errors/109_unknown_arg.eu
@@ -1,0 +1,2 @@
+# Mistake: passing an unrecognised option to parse-args
+main: ["--unknown-flag"] parse-args({})

--- a/tests/harness/errors/109_unknown_arg.eu.expect
+++ b/tests/harness/errors/109_unknown_arg.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "unknown option"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -649,6 +649,11 @@ pub fn test_harness_127() {
 }
 
 #[test]
+pub fn test_harness_128() {
+    run_test(&opts("128_parse_args.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }
@@ -1256,4 +1261,9 @@ pub fn test_error_107() {
 #[test]
 pub fn test_error_108() {
     run_error_test(&error_opts("108_secondary_labels.eu"));
+}
+
+#[test]
+pub fn test_error_109() {
+    run_error_test(&error_opts("109_unknown_arg.eu"));
 }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -639,6 +639,11 @@ pub fn test_harness_125() {
 }
 
 #[test]
+pub fn test_harness_126() {
+    run_test(&opts("126_type_predicates.eu"));
+}
+
+#[test]
 pub fn test_harness_127() {
     run_test(&opts("127_merge_metadata.eu"));
 }


### PR DESCRIPTION
## Summary

- Adds `number?`, `string?`, `symbol?`, `bool?` type predicates as BIFs (indices 164-167), following the `ISBLOCK`/`ISLIST` pattern
- Implements `parse-args(defaults, args)` in the prelude for structured CLI argument parsing
- Documentation: `docs/reference/prelude/args.md` and updates to `docs/reference/agent-reference.md`

## parse-args features

- Long options: `--key value`, `--key=value`
- Boolean flag toggles: `--flag`, `-f`  
- Short options: `-x value`, combined `-xy`
- Numeric coercion driven by default value type
- Positional argument collection in `result.args`
- Auto-generated `--help` from defaults block metadata
- Unknown option errors with helpful messages

## Test plan

- [ ] Harness test 126: type predicates (all four predicates + negative cases)
- [ ] Harness test 128: parse-args (10 sub-tests covering all argument forms)
- [ ] Error test 109: unknown option detection
- [ ] Full test suite: 231 tests pass
- [ ] Clippy clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)