### PR TITLE
feat(eval): Vec type for O(1) indexed access (eu-v5n1) [rebased]

### DIFF
--- a/docs/reference/prelude/vecs.md
+++ b/docs/reference/prelude/vecs.md
@@ -1,0 +1,54 @@
+# Vecs
+
+Vecs are compact, indexed collections of primitive values (numbers, strings,
+symbols) that provide O(1) indexed access and efficient slicing. They are
+designed for large datasets where random access matters.
+
+## Construction
+
+| Function | Description |
+|----------|-------------|
+| `vec.of` | Convert a list of primitives to a vec |
+| `vec.to-list` | Convert a vec back to a cons-list |
+
+```eu
+v: [1, 2, 3, 4, 5] vec.of
+l: v vec.to-list          # [1, 2, 3, 4, 5]
+```
+
+## Indexed Access
+
+| Function | Description |
+|----------|-------------|
+| `vec.len` | Return the number of elements |
+| `vec.nth(n)` | Return element at 0-based index `n` (error if out of bounds) |
+| `vec.slice(from, to)` | Return sub-vec `[from, to)`, indices clamped to length |
+
+```eu
+v: [10, 20, 30, 40, 50] vec.of
+n: v vec.len              # 5
+x: v vec.nth(2)           # 30
+s: v vec.slice(1, 4)      # vec of [20, 30, 40]
+```
+
+## Sampling and Shuffling
+
+These functions accept a numeric seed for deterministic results.
+
+| Function | Description |
+|----------|-------------|
+| `vec.sample(n, seed)` | Pick `n` elements without replacement via partial Fisher-Yates |
+| `vec.shuffle(seed)` | Return a new vec with all elements in random order |
+
+```eu
+v: [1, 2, 3, 4, 5] vec.of
+sampled: v vec.sample(2, 42)    # 2 random elements
+shuffled: v vec.shuffle(99)     # all 5 in random order
+```
+
+## Notes
+
+- Vecs store primitive values only (numbers, strings, symbols); blocks and
+  lists cannot be stored in a vec.
+- Vecs render as YAML/JSON sequences (same as lists).
+- Use `vec.of` to convert an existing list, and `vec.to-list` to convert back.

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1518,6 +1518,38 @@ set: {
 
 
 ##
+## Vecs (O(1) indexed access)
+##
+
+` { export: :suppress
+    doc: "Functions for working with vecs — flat primitive sequences with O(1) indexed access." }
+vec: {
+
+  ` "`vec.of(xs)` - convert list `xs` of primitive values to a vec for O(1) indexed access."
+  of: '__VEC.OF'
+
+  ` "`vec.len(v)` - return the number of elements in vec `v`."
+  len: '__VEC.LEN'
+
+  ` "`vec.nth(n, v)` - return the element at index `n` (0-based) in vec `v`."
+  nth: '__VEC.NTH'
+
+  ` "`vec.slice(from, to, v)` - return a new vec with elements in the range `[from, to)` of `v`."
+  slice: '__VEC.SLICE'
+
+  ` "`vec.sample(n, seed, v)` - pick `n` random elements from vec `v` without replacement using integer `seed`."
+  sample: '__VEC.SAMPLE'
+
+  ` "`vec.shuffle(seed, v)` - return a new vec with elements of `v` in random order using integer `seed`."
+  shuffle: '__VEC.SHUFFLE'
+
+  ` "`vec.to-list(v)` - convert vec `v` back to a cons-list."
+  to-list: '__VEC.TO_LIST'
+}
+
+
+
+##
 ## N-dimensional arrays (tensors)
 ##
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -889,6 +889,41 @@ lazy_static! {
             ty: function(vec![any(), bool_()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 168
+            name: "VEC.OF",
+            ty: function(vec![list(), unk()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 169
+            name: "VEC.LEN",
+            ty: function(vec![unk(), num()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 170
+            name: "VEC.NTH",
+            ty: function(vec![num(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
+    Intrinsic { // 171
+            name: "VEC.SLICE",
+            ty: function(vec![num(), num(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1, 2],
+    },
+    Intrinsic { // 172
+            name: "VEC.SAMPLE",
+            ty: function(vec![num(), num(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1, 2],
+    },
+    Intrinsic { // 173
+            name: "VEC.SHUFFLE",
+            ty: function(vec![num(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1],
+    },
+    Intrinsic { // 174
+            name: "VEC.TO_LIST",
+            ty: function(vec![unk(), list()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/memory/mod.rs
+++ b/src/eval/memory/mod.rs
@@ -17,3 +17,4 @@ pub mod set;
 pub mod string;
 pub mod symbol;
 pub mod syntax;
+pub mod vec;

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -14,6 +14,7 @@ use super::ndarray::HeapNdArray;
 use super::set::HeapSet;
 use super::string::HeapString;
 use super::symbol::SymbolId;
+use super::vec::HeapVec;
 use super::{
     alloc::{ScopedPtr, StgObject},
     array::Array,
@@ -48,6 +49,8 @@ pub enum Native {
     Set(RefPtr<HeapSet>),
     /// An n-dimensional array of f64 values
     NdArray(RefPtr<HeapNdArray>),
+    /// A vector of primitive values (O(1) indexed access)
+    Vec(RefPtr<HeapVec>),
 }
 
 impl PartialEq for Native {
@@ -61,6 +64,7 @@ impl PartialEq for Native {
             (Native::Index(_), Native::Index(_)) => true,
             (Native::Set(a), Native::Set(b)) => a == b,
             (Native::NdArray(a), Native::NdArray(b)) => a == b,
+            (Native::Vec(a), Native::Vec(b)) => a == b,
             _ => false,
         }
     }
@@ -79,6 +83,7 @@ impl Native {
             Native::Index(_) => "block index",
             Native::Set(_) => "set",
             Native::NdArray(_) => "array",
+            Native::Vec(_) => "vec",
         }
     }
 }
@@ -108,6 +113,9 @@ impl fmt::Display for Native {
             }
             Native::NdArray(_) => {
                 write!(f, "<array>")
+            }
+            Native::Vec(_) => {
+                write!(f, "<vec>")
             }
         }
     }
@@ -320,6 +328,9 @@ fn mark_ref_heap_pointers<'a>(
         Ref::V(Native::NdArray(ptr)) => {
             marker.mark(*ptr);
         }
+        Ref::V(Native::Vec(ptr)) => {
+            marker.mark(*ptr);
+        }
         _ => {}
     }
 }
@@ -350,6 +361,11 @@ fn update_ref_heap_pointers(r: &mut Ref, heap: &CollectorHeapView<'_>) {
             }
         }
         Ref::V(Native::NdArray(ptr)) => {
+            if let Some(new_ptr) = heap.forwarded_to(*ptr) {
+                *ptr = new_ptr;
+            }
+        }
+        Ref::V(Native::Vec(ptr)) => {
             if let Some(new_ptr) = heap.forwarded_to(*ptr) {
                 *ptr = new_ptr;
             }
@@ -659,6 +675,9 @@ pub mod repr {
             }
             memory::syntax::Ref::V(memory::syntax::Native::NdArray(_)) => {
                 stg::syntax::Ref::V(stg::syntax::Native::Sym("<array>".to_string()))
+            }
+            memory::syntax::Ref::V(memory::syntax::Native::Vec(_)) => {
+                stg::syntax::Ref::V(stg::syntax::Native::Sym("<vec>".to_string()))
             }
         }
     }

--- a/src/eval/memory/vec.rs
+++ b/src/eval/memory/vec.rs
@@ -1,0 +1,128 @@
+//! Native vec type for the eucalypt VM.
+//!
+//! Vecs contain only primitive values (numbers, strings, symbols) and
+//! provide O(1) indexed access, slicing, and random sampling.
+
+use super::alloc::StgObject;
+use super::set::Primitive;
+
+/// A vector of primitive values, stored on the heap.
+///
+/// GC does not trace into vec contents because primitives contain no
+/// heap references (strings are owned, symbols are interned IDs).
+#[derive(Debug, Clone)]
+pub struct HeapVec {
+    elements: Vec<Primitive>,
+}
+
+impl StgObject for HeapVec {}
+
+impl HeapVec {
+    /// Create an empty vec.
+    pub fn empty() -> Self {
+        HeapVec {
+            elements: Vec::new(),
+        }
+    }
+
+    /// Create a vec from an iterator of primitives.
+    pub fn from_primitives(iter: impl Iterator<Item = Primitive>) -> Self {
+        HeapVec {
+            elements: iter.collect(),
+        }
+    }
+
+    /// Return the number of elements.
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Return whether the vec is empty.
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Return the element at the given index, or None if out of bounds.
+    pub fn get(&self, index: usize) -> Option<&Primitive> {
+        self.elements.get(index)
+    }
+
+    /// Return a sub-vec containing elements in the range `[from, to)`.
+    ///
+    /// Indices are clamped to the vec length.
+    pub fn slice(&self, from: usize, to: usize) -> Self {
+        let from = from.min(self.elements.len());
+        let to = to.min(self.elements.len()).max(from);
+        HeapVec {
+            elements: self.elements[from..to].to_vec(),
+        }
+    }
+
+    /// Return all elements as a slice.
+    pub fn elements(&self) -> &[Primitive] {
+        &self.elements
+    }
+}
+
+impl PartialEq for HeapVec {
+    fn eq(&self, other: &Self) -> bool {
+        self.elements == other.elements
+    }
+}
+
+impl Eq for HeapVec {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ordered_float::OrderedFloat;
+
+    #[test]
+    fn empty_vec_has_no_elements() {
+        let v = HeapVec::empty();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+    }
+
+    #[test]
+    fn from_primitives_preserves_order() {
+        let v = HeapVec::from_primitives(
+            vec![
+                Primitive::Num(OrderedFloat(1.0)),
+                Primitive::Num(OrderedFloat(2.0)),
+                Primitive::Num(OrderedFloat(3.0)),
+            ]
+            .into_iter(),
+        );
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.get(0), Some(&Primitive::Num(OrderedFloat(1.0))));
+        assert_eq!(v.get(2), Some(&Primitive::Num(OrderedFloat(3.0))));
+    }
+
+    #[test]
+    fn get_returns_none_out_of_bounds() {
+        let v = HeapVec::from_primitives(vec![Primitive::Num(OrderedFloat(1.0))].into_iter());
+        assert!(v.get(1).is_none());
+    }
+
+    #[test]
+    fn slice_clamps_to_bounds() {
+        let v = HeapVec::from_primitives(
+            vec![
+                Primitive::Num(OrderedFloat(1.0)),
+                Primitive::Num(OrderedFloat(2.0)),
+                Primitive::Num(OrderedFloat(3.0)),
+            ]
+            .into_iter(),
+        );
+        let s = v.slice(1, 3);
+        assert_eq!(s.len(), 2);
+        assert_eq!(s.get(0), Some(&Primitive::Num(OrderedFloat(2.0))));
+        // Clamping beyond end
+        let s2 = v.slice(2, 100);
+        assert_eq!(s2.len(), 1);
+        // Empty when from >= to
+        let s3 = v.slice(3, 3);
+        assert_eq!(s3.len(), 0);
+    }
+}

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -132,6 +132,10 @@ fn format_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicM
                 .join(",");
             format!("<array [{shape}]>")
         }
+        Native::Vec(ptr) => {
+            let v = view.scoped(*ptr);
+            format!("<vec [{}]>", v.len())
+        }
     }
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -97,6 +97,10 @@ fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicM
         Native::Zdt(dt) => dt.to_rfc3339(),
         Native::Index(_) => "<block-index>".to_string(),
         Native::Set(_) => "<set>".to_string(),
+        Native::Vec(ptr) => {
+            let v = view.scoped(*ptr);
+            format!("<vec [{}]>", v.len())
+        }
         Native::NdArray(ptr) => {
             let arr = view.scoped(*ptr);
             let shape = arr

--- a/src/eval/stg/emit.rs
+++ b/src/eval/stg/emit.rs
@@ -15,6 +15,7 @@ use crate::{
             ndarray::HeapNdArray,
             set::{HeapSet, Primitive as SetPrimitive},
             syntax::{Ref, RefPtr},
+            vec::HeapVec,
         },
         primitive::Primitive,
     },
@@ -99,6 +100,23 @@ fn emit_ndarray(
 ) {
     let arr: crate::eval::memory::alloc::ScopedPtr<'_, HeapNdArray> = view.scoped(arr_ref);
     emit_ndarray_data(emitter, &arr, metadata);
+}
+
+/// Emit a vec as a sequence of scalars in element order.
+fn emit_vec(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    emitter: &mut dyn Emitter,
+    vec_ref: RefPtr<HeapVec>,
+    metadata: &RenderMetadata,
+) {
+    let vec: crate::eval::memory::alloc::ScopedPtr<'_, HeapVec> = view.scoped(vec_ref);
+    emitter.sequence_start(metadata);
+    for elem in vec.elements() {
+        let prim = set_primitive_to_render_primitive(elem, machine);
+        emitter.scalar(&RenderMetadata::empty(), &prim);
+    }
+    emitter.sequence_end();
 }
 
 /// Interpret arg as tag if it exists otherwise None
@@ -214,6 +232,9 @@ impl StgIntrinsic for EmitNative {
             memory::syntax::Native::NdArray(ptr) => {
                 emit_ndarray(view, emitter, ptr, &RenderMetadata::empty());
             }
+            memory::syntax::Native::Vec(ptr) => {
+                emit_vec(machine, view, emitter, ptr, &RenderMetadata::empty());
+            }
             memory::syntax::Native::Sym(id) => {
                 let primitive = Primitive::Sym(machine.symbol_pool().resolve(id).to_string());
                 emitter.scalar(&RenderMetadata::empty(), &primitive);
@@ -263,6 +284,9 @@ impl StgIntrinsic for EmitTagNative {
             }
             memory::syntax::Native::NdArray(ptr) => {
                 emit_ndarray(view, emitter, ptr, &RenderMetadata::new(tag));
+            }
+            memory::syntax::Native::Vec(ptr) => {
+                emit_vec(machine, view, emitter, ptr, &RenderMetadata::new(tag));
             }
             memory::syntax::Native::Sym(id) => {
                 let primitive = Primitive::Sym(machine.symbol_pool().resolve(id).to_string());

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -40,6 +40,7 @@ pub mod syntax;
 pub mod tags;
 mod testing;
 pub mod time;
+pub mod vec;
 pub mod version;
 pub mod wrap;
 
@@ -218,6 +219,13 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(list::IsString));
     rt.add(Box::new(list::IsSymbol));
     rt.add(Box::new(list::IsBool));
+    rt.add(Box::new(vec::VecOf));
+    rt.add(Box::new(vec::VecLen));
+    rt.add(Box::new(vec::VecNth));
+    rt.add(Box::new(vec::VecSlice));
+    rt.add(Box::new(vec::VecSample));
+    rt.add(Box::new(vec::VecShuffle));
+    rt.add(Box::new(vec::VecToList));
     rt.prepare(source_map);
     Box::new(rt)
 }

--- a/src/eval/stg/printf.rs
+++ b/src/eval/stg/printf.rs
@@ -454,6 +454,11 @@ pub fn fmt(
                     "cannot format array".to_string(),
                 ))
             }
+            Native::Vec(_) => {
+                return Err(PrintfError::InvalidFormatString(
+                    "cannot format vec".to_string(),
+                ))
+            }
         }
         Ok(output)
     } else if !fmt_string.starts_with('%') {

--- a/src/eval/stg/prng.rs
+++ b/src/eval/stg/prng.rs
@@ -20,7 +20,7 @@ const GOLDEN: u64 = 0x9e3779b97f4a7c15;
 /// Advance the SplitMix64 state and produce an output value.
 ///
 /// Returns `(next_state, output)` where `output` is the mixed result.
-fn splitmix64(seed: u64) -> (u64, u64) {
+pub(super) fn splitmix64(seed: u64) -> (u64, u64) {
     let state = seed.wrapping_add(GOLDEN);
     let mut z = state;
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
@@ -31,7 +31,7 @@ fn splitmix64(seed: u64) -> (u64, u64) {
 
 /// Convert a seed Number to u64, treating signed values via
 /// reinterpretation of the bit pattern.
-fn seed_to_u64(n: &Number) -> u64 {
+pub(super) fn seed_to_u64(n: &Number) -> u64 {
     if let Some(v) = n.as_u64() {
         v
     } else if let Some(v) = n.as_i64() {

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -127,6 +127,7 @@ impl StgIntrinsic for Str {
             Native::Index(idx) => format!("<index:{}>", idx.len()),
             Native::Set(_) => "<set>".to_string(),
             Native::NdArray(_) => "<array>".to_string(),
+            Native::Vec(_) => "<vec>".to_string(),
         };
         machine_return_str(machine, view, text)
     }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -16,6 +16,7 @@ use crate::eval::{
         ndarray::HeapNdArray,
         set::HeapSet,
         syntax::StgBuilder,
+        vec::HeapVec,
     },
     stg::tags::DataConstructor,
 };
@@ -32,6 +33,7 @@ fn native_type(native: &Native) -> IntrinsicType {
         Native::Sym(_) => IntrinsicType::Symbol,
         Native::Zdt(_) => IntrinsicType::ZonedDateTime,
         Native::NdArray(_) => IntrinsicType::Array,
+        Native::Vec(_) => IntrinsicType::Vec,
         Native::Index(_) | Native::Set(_) => IntrinsicType::Unknown,
     }
 }
@@ -575,6 +577,40 @@ pub fn machine_return_ndarray(
     machine.set_closure(SynClosure::new(
         view.alloc(HeapSyn::Atom {
             evaluand: Ref::V(Native::NdArray(ptr)),
+        })?
+        .as_ptr(),
+        machine.root_env(),
+    ))
+}
+
+/// Helper for intrinsics to access a vec arg.
+pub fn vec_arg<'guard>(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'guard>,
+    arg: &Ref,
+) -> Result<ScopedPtr<'guard, HeapVec>, ExecutionError> {
+    let native = machine.nav(view).resolve_native(arg)?;
+    if let Native::Vec(ptr) = native {
+        Ok(view.scoped(ptr))
+    } else {
+        Err(ExecutionError::TypeMismatch(
+            machine.annotation(),
+            IntrinsicType::Vec,
+            native_type(&native),
+        ))
+    }
+}
+
+/// Return a vec from an intrinsic.
+pub fn machine_return_vec(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView,
+    vec: HeapVec,
+) -> Result<(), ExecutionError> {
+    let ptr = view.alloc(vec)?.as_ptr();
+    machine.set_closure(SynClosure::new(
+        view.alloc(HeapSyn::Atom {
+            evaluand: Ref::V(Native::Vec(ptr)),
         })?
         .as_ptr(),
         machine.root_env(),

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -74,13 +74,14 @@ fn extract_primitive(
         }
         HeapSyn::Cons { args: cargs, .. } => {
             // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol, BoxedZdt)
-            let inner_ref = cargs
-                .get(0)
-                .ok_or_else(|| ExecutionError::Panic(Smid::default(), "empty boxed value in vec".to_string()))?;
+            let inner_ref = cargs.get(0).ok_or_else(|| {
+                ExecutionError::Panic(Smid::default(), "empty boxed value in vec".to_string())
+            })?;
             let native = item_closure.navigate_local_native(&view, inner_ref.clone());
             native_to_set_primitive(view, &native)
         }
-        _ => Err(ExecutionError::Panic(Smid::default(), 
+        _ => Err(ExecutionError::Panic(
+            Smid::default(),
             "non-primitive value in vec construction".to_string(),
         )),
     }
@@ -116,13 +117,19 @@ impl StgIntrinsic for VecOf {
                         let h_ref = cons_args
                             .get(0)
                             .ok_or_else(|| {
-                                ExecutionError::Panic(Smid::default(), "malformed cons cell".to_string())
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    "malformed cons cell".to_string(),
+                                )
                             })?
                             .clone();
                         let t_ref = cons_args
                             .get(1)
                             .ok_or_else(|| {
-                                ExecutionError::Panic(Smid::default(), "malformed cons cell".to_string())
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    "malformed cons cell".to_string(),
+                                )
                             })?
                             .clone();
                         let head = resolve_list_ref(&current, machine, view, &h_ref)?;
@@ -130,10 +137,16 @@ impl StgIntrinsic for VecOf {
                         current = resolve_list_ref(&current, machine, view, &t_ref)?;
                     }
                     Ok(DataConstructor::ListNil) => break,
-                    _ => return Err(ExecutionError::Panic(Smid::default(), "expected list in vec.of".to_string())),
+                    _ => {
+                        return Err(ExecutionError::Panic(
+                            Smid::default(),
+                            "expected list in vec.of".to_string(),
+                        ))
+                    }
                 },
                 _ => {
-                    return Err(ExecutionError::Panic(Smid::default(), 
+                    return Err(ExecutionError::Panic(
+                        Smid::default(),
                         "expected list data in vec.of".to_string(),
                     ))
                 }
@@ -194,18 +207,18 @@ impl StgIntrinsic for VecNth {
         let n = match &native_n {
             Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.nth: index must be a number".to_string(),
                 ))
             }
         };
         let v = vec_arg(machine, view, &args[1])?;
         let prim = v.get(n).ok_or_else(|| {
-            ExecutionError::Panic(Smid::default(), format!(
-                "vec.nth: index {} out of bounds (len {})",
-                n,
-                v.len()
-            ))
+            ExecutionError::Panic(
+                Smid::default(),
+                format!("vec.nth: index {} out of bounds (len {})", n, v.len()),
+            )
         })?;
         let native = set_primitive_to_native(machine, view, prim)?;
         // Return a boxed value (BoxedNumber/BoxedString/BoxedSymbol) so that the
@@ -216,7 +229,8 @@ impl StgIntrinsic for VecNth {
             Native::Str(_) => DataConstructor::BoxedString.tag(),
             Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.nth: unexpected native type in vec element".to_string(),
                 ))
             }
@@ -256,7 +270,8 @@ impl StgIntrinsic for VecSlice {
         let from = match &native_from {
             Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.slice: from must be a number".to_string(),
                 ))
             }
@@ -264,7 +279,8 @@ impl StgIntrinsic for VecSlice {
         let to = match &native_to {
             Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.slice: to must be a number".to_string(),
                 ))
             }
@@ -300,7 +316,8 @@ impl StgIntrinsic for VecSample {
         let n = match &native_n {
             Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.sample: count must be a number".to_string(),
                 ))
             }
@@ -308,7 +325,8 @@ impl StgIntrinsic for VecSample {
         let seed_num = match &native_seed {
             Native::Num(num) => num.clone(),
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.sample: seed must be a number".to_string(),
                 ))
             }
@@ -358,7 +376,8 @@ impl StgIntrinsic for VecShuffle {
         let seed_num = match &native_seed {
             Native::Num(num) => num.clone(),
             _ => {
-                return Err(ExecutionError::Panic(Smid::default(), 
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
                     "vec.shuffle: seed must be a number".to_string(),
                 ))
             }
@@ -420,7 +439,8 @@ impl StgIntrinsic for VecToList {
                 Native::Str(_) => DataConstructor::BoxedString.tag(),
                 Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
                 _ => {
-                    return Err(ExecutionError::Panic(Smid::default(), 
+                    return Err(ExecutionError::Panic(
+                        Smid::default(),
                         "unexpected native type in vec".to_string(),
                     ))
                 }

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -1,0 +1,458 @@
+//! Vec intrinsics for the eucalypt VM.
+//!
+//! These intrinsics operate on `Native::Vec` values, providing
+//! construction, indexed access, slicing, sampling, and conversion.
+
+use crate::eval::{
+    emit::Emitter,
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal1, CallGlobal2, CallGlobal3, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        mutator::MutatorHeapView,
+        set::Primitive,
+        syntax::{HeapSyn, Native, Ref},
+        vec::HeapVec,
+    },
+    stg::tags::DataConstructor,
+};
+
+use crate::eval::machine::env::SynClosure;
+
+use super::{
+    prng::{seed_to_u64, splitmix64},
+    support::{
+        machine_return_num, machine_return_vec, native_to_set_primitive, resolve_native_unboxing,
+        set_primitive_to_native, vec_arg,
+    },
+};
+
+use crate::eval::memory::{
+    alloc::ScopedAllocator, array::Array, syntax::LambdaForm, syntax::StgBuilder,
+};
+
+/// Resolve a ref from within a cons closure context.
+///
+/// Compiled eucalypt lists use `Ref::G` for the nil tail and `Ref::L`
+/// for other elements. `navigate_local` only handles `Ref::L`, so this
+/// helper dispatches correctly for all ref types.
+fn resolve_list_ref(
+    closure: &SynClosure,
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> Result<SynClosure, ExecutionError> {
+    use crate::eval::memory::alloc::ScopedAllocator;
+    match r {
+        Ref::L(_) => Ok(closure.navigate_local(&view, r.clone())),
+        Ref::G(i) => machine.nav(view).global(*i),
+        Ref::V(n) => {
+            let ptr = view
+                .alloc(HeapSyn::Atom {
+                    evaluand: Ref::V(n.clone()),
+                })?
+                .as_ptr();
+            Ok(SynClosure::new(ptr, machine.root_env()))
+        }
+    }
+}
+
+/// Extract a primitive from a closure representing a list element.
+///
+/// Handles both raw atom closures (`Atom { Ref::V(native) }`) and
+/// boxed constructor closures (`Cons { BoxedNumber | BoxedString | … }`).
+fn extract_primitive(
+    item_closure: &SynClosure,
+    _machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+) -> Result<Primitive, ExecutionError> {
+    let code = view.scoped(item_closure.code());
+    match &*code {
+        HeapSyn::Atom { evaluand } => {
+            let native = item_closure.navigate_local_native(&view, evaluand.clone());
+            native_to_set_primitive(view, &native)
+        }
+        HeapSyn::Cons { args: cargs, .. } => {
+            // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol, BoxedZdt)
+            let inner_ref = cargs
+                .get(0)
+                .ok_or_else(|| ExecutionError::Panic("empty boxed value in vec".to_string()))?;
+            let native = item_closure.navigate_local_native(&view, inner_ref.clone());
+            native_to_set_primitive(view, &native)
+        }
+        _ => Err(ExecutionError::Panic(
+            "non-primitive value in vec construction".to_string(),
+        )),
+    }
+}
+
+/// VEC.OF — convert a list of primitives to a vec.
+pub struct VecOf;
+
+impl StgIntrinsic for VecOf {
+    fn name(&self) -> &str {
+        "VEC.OF"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // Resolve the list closure using the machine navigator (handles L, G, V).
+        let mut current = machine.nav(view).resolve(&args[0])?;
+        let mut primitives = Vec::new();
+
+        loop {
+            let code = view.scoped(current.code());
+            match &*code {
+                HeapSyn::Cons {
+                    tag,
+                    args: cons_args,
+                } => match (*tag).try_into() {
+                    Ok(DataConstructor::ListCons) => {
+                        let h_ref = cons_args
+                            .get(0)
+                            .ok_or_else(|| {
+                                ExecutionError::Panic("malformed cons cell".to_string())
+                            })?
+                            .clone();
+                        let t_ref = cons_args
+                            .get(1)
+                            .ok_or_else(|| {
+                                ExecutionError::Panic("malformed cons cell".to_string())
+                            })?
+                            .clone();
+                        let head = resolve_list_ref(&current, machine, view, &h_ref)?;
+                        primitives.push(extract_primitive(&head, machine, view)?);
+                        current = resolve_list_ref(&current, machine, view, &t_ref)?;
+                    }
+                    Ok(DataConstructor::ListNil) => break,
+                    _ => return Err(ExecutionError::Panic("expected list in vec.of".to_string())),
+                },
+                _ => {
+                    return Err(ExecutionError::Panic(
+                        "expected list data in vec.of".to_string(),
+                    ))
+                }
+            }
+        }
+
+        machine_return_vec(
+            machine,
+            view,
+            HeapVec::from_primitives(primitives.into_iter()),
+        )
+    }
+}
+
+impl CallGlobal1 for VecOf {}
+
+/// VEC.LEN — return the number of elements in a vec.
+pub struct VecLen;
+
+impl StgIntrinsic for VecLen {
+    fn name(&self) -> &str {
+        "VEC.LEN"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let v = vec_arg(machine, view, &args[0])?;
+        let n = serde_json::Number::from(v.len() as u64);
+        machine_return_num(machine, view, n)
+    }
+}
+
+impl CallGlobal1 for VecLen {}
+
+/// VEC.NTH — return the element at index n (0-based).
+///
+/// Returns an error if the index is out of bounds.
+pub struct VecNth;
+
+impl StgIntrinsic for VecNth {
+    fn name(&self) -> &str {
+        "VEC.NTH"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let native_n = resolve_native_unboxing(machine, view, &args[0])?;
+        let n = match &native_n {
+            Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.nth: index must be a number".to_string(),
+                ))
+            }
+        };
+        let v = vec_arg(machine, view, &args[1])?;
+        let prim = v.get(n).ok_or_else(|| {
+            ExecutionError::Panic(format!(
+                "vec.nth: index {} out of bounds (len {})",
+                n,
+                v.len()
+            ))
+        })?;
+        let native = set_primitive_to_native(machine, view, prim)?;
+        // Return a boxed value (BoxedNumber/BoxedString/BoxedSymbol) so that the
+        // result is comparable via the EQ wrapper's Cons branches, matching the
+        // format of list elements and the output of other intrinsics.
+        let box_tag = match &native {
+            Native::Num(_) => DataConstructor::BoxedNumber.tag(),
+            Native::Str(_) => DataConstructor::BoxedString.tag(),
+            Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.nth: unexpected native type in vec element".to_string(),
+                ))
+            }
+        };
+        machine.set_closure(crate::eval::machine::env::SynClosure::new(
+            view.alloc(HeapSyn::Cons {
+                tag: box_tag,
+                args: Array::from_slice(&view, &[Ref::V(native)]),
+            })?
+            .as_ptr(),
+            machine.root_env(),
+        ))
+    }
+}
+
+impl CallGlobal2 for VecNth {}
+
+/// VEC.SLICE — return a sub-vec `[from, to)`.
+///
+/// Indices are clamped to the vec length.
+pub struct VecSlice;
+
+impl StgIntrinsic for VecSlice {
+    fn name(&self) -> &str {
+        "VEC.SLICE"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let native_from = resolve_native_unboxing(machine, view, &args[0])?;
+        let native_to = resolve_native_unboxing(machine, view, &args[1])?;
+        let from = match &native_from {
+            Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.slice: from must be a number".to_string(),
+                ))
+            }
+        };
+        let to = match &native_to {
+            Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.slice: to must be a number".to_string(),
+                ))
+            }
+        };
+        let v = vec_arg(machine, view, &args[2])?;
+        machine_return_vec(machine, view, v.slice(from, to))
+    }
+}
+
+impl CallGlobal3 for VecSlice {}
+
+/// VEC.SAMPLE — pick `n` random elements without replacement.
+///
+/// Uses a partial Fisher-Yates shuffle on an index array seeded by
+/// SplitMix64. Returns a new vec of the sampled elements.
+pub struct VecSample;
+
+impl StgIntrinsic for VecSample {
+    fn name(&self) -> &str {
+        "VEC.SAMPLE"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args: [n, seed, vec]
+        let native_n = resolve_native_unboxing(machine, view, &args[0])?;
+        let native_seed = resolve_native_unboxing(machine, view, &args[1])?;
+        let n = match &native_n {
+            Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.sample: count must be a number".to_string(),
+                ))
+            }
+        };
+        let seed_num = match &native_seed {
+            Native::Num(num) => num.clone(),
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.sample: seed must be a number".to_string(),
+                ))
+            }
+        };
+        let v = vec_arg(machine, view, &args[2])?;
+        let len = v.len();
+        let count = n.min(len);
+        // Partial Fisher-Yates on an index vector
+        let mut indices: Vec<usize> = (0..len).collect();
+        let mut state = seed_to_u64(&seed_num);
+        for i in 0..count {
+            let (next_state, z) = splitmix64(state);
+            state = next_state;
+            let j = i + (z as usize % (len - i));
+            indices.swap(i, j);
+        }
+        let sampled: Vec<Primitive> = indices[..count]
+            .iter()
+            .filter_map(|&idx| v.get(idx))
+            .cloned()
+            .collect();
+        machine_return_vec(machine, view, HeapVec::from_primitives(sampled.into_iter()))
+    }
+}
+
+impl CallGlobal3 for VecSample {}
+
+/// VEC.SHUFFLE — return a new vec with elements in random order.
+///
+/// Uses a full Fisher-Yates shuffle seeded by SplitMix64.
+pub struct VecShuffle;
+
+impl StgIntrinsic for VecShuffle {
+    fn name(&self) -> &str {
+        "VEC.SHUFFLE"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args: [seed, vec]
+        let native_seed = resolve_native_unboxing(machine, view, &args[0])?;
+        let seed_num = match &native_seed {
+            Native::Num(num) => num.clone(),
+            _ => {
+                return Err(ExecutionError::Panic(
+                    "vec.shuffle: seed must be a number".to_string(),
+                ))
+            }
+        };
+        let v = vec_arg(machine, view, &args[1])?;
+        let mut elements: Vec<Primitive> = v.elements().to_vec();
+        let len = elements.len();
+        let mut state = seed_to_u64(&seed_num);
+        // Full Fisher-Yates shuffle
+        for i in (1..len).rev() {
+            let (next_state, z) = splitmix64(state);
+            state = next_state;
+            let j = z as usize % (i + 1);
+            elements.swap(i, j);
+        }
+        machine_return_vec(
+            machine,
+            view,
+            HeapVec::from_primitives(elements.into_iter()),
+        )
+    }
+}
+
+impl CallGlobal2 for VecShuffle {}
+
+/// VEC.TO_LIST — convert a vec to a cons-list.
+///
+/// Elements are wrapped in the appropriate box constructors
+/// (BoxedNumber, BoxedString, BoxedSymbol) matching the list format.
+pub struct VecToList;
+
+impl StgIntrinsic for VecToList {
+    fn name(&self) -> &str {
+        "VEC.TO_LIST"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let elements: Vec<Primitive> = vec_arg(machine, view, &args[0])?.elements().to_vec();
+
+        // Build a list of boxed values in reverse (same pattern as SetToList)
+        let mut bindings = vec![LambdaForm::value(
+            view.alloc(HeapSyn::Cons {
+                tag: DataConstructor::ListNil.tag(),
+                args: Array::default(),
+            })?
+            .as_ptr(),
+        )];
+
+        for prim in elements.into_iter().rev() {
+            let native = set_primitive_to_native(machine, view, &prim)?;
+            let box_tag = match &native {
+                Native::Num(_) => DataConstructor::BoxedNumber.tag(),
+                Native::Str(_) => DataConstructor::BoxedString.tag(),
+                Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
+                _ => {
+                    return Err(ExecutionError::Panic(
+                        "unexpected native type in vec".to_string(),
+                    ))
+                }
+            };
+            bindings.push(LambdaForm::value(
+                view.alloc(HeapSyn::Cons {
+                    tag: box_tag,
+                    args: Array::from_slice(&view, &[Ref::V(native)]),
+                })?
+                .as_ptr(),
+            ));
+            let len = bindings.len();
+            bindings.push(LambdaForm::value(
+                view.alloc(HeapSyn::Cons {
+                    tag: DataConstructor::ListCons.tag(),
+                    args: Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
+                })?
+                .as_ptr(),
+            ));
+        }
+
+        let list_index = bindings.len() - 1;
+        let syn = view
+            .letrec(
+                Array::from_slice(&view, &bindings),
+                view.atom(Ref::L(list_index))?,
+            )?
+            .as_ptr();
+        machine.set_closure(crate::eval::machine::env::SynClosure::new(
+            syn,
+            machine.root_env(),
+        ))
+    }
+}
+
+impl CallGlobal1 for VecToList {}

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -3,6 +3,7 @@
 //! These intrinsics operate on `Native::Vec` values, providing
 //! construction, indexed access, slicing, sampling, and conversion.
 
+use crate::common::sourcemap::Smid;
 use crate::eval::{
     emit::Emitter,
     error::ExecutionError,
@@ -75,11 +76,11 @@ fn extract_primitive(
             // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol, BoxedZdt)
             let inner_ref = cargs
                 .get(0)
-                .ok_or_else(|| ExecutionError::Panic("empty boxed value in vec".to_string()))?;
+                .ok_or_else(|| ExecutionError::Panic(Smid::default(), "empty boxed value in vec".to_string()))?;
             let native = item_closure.navigate_local_native(&view, inner_ref.clone());
             native_to_set_primitive(view, &native)
         }
-        _ => Err(ExecutionError::Panic(
+        _ => Err(ExecutionError::Panic(Smid::default(), 
             "non-primitive value in vec construction".to_string(),
         )),
     }
@@ -115,13 +116,13 @@ impl StgIntrinsic for VecOf {
                         let h_ref = cons_args
                             .get(0)
                             .ok_or_else(|| {
-                                ExecutionError::Panic("malformed cons cell".to_string())
+                                ExecutionError::Panic(Smid::default(), "malformed cons cell".to_string())
                             })?
                             .clone();
                         let t_ref = cons_args
                             .get(1)
                             .ok_or_else(|| {
-                                ExecutionError::Panic("malformed cons cell".to_string())
+                                ExecutionError::Panic(Smid::default(), "malformed cons cell".to_string())
                             })?
                             .clone();
                         let head = resolve_list_ref(&current, machine, view, &h_ref)?;
@@ -129,10 +130,10 @@ impl StgIntrinsic for VecOf {
                         current = resolve_list_ref(&current, machine, view, &t_ref)?;
                     }
                     Ok(DataConstructor::ListNil) => break,
-                    _ => return Err(ExecutionError::Panic("expected list in vec.of".to_string())),
+                    _ => return Err(ExecutionError::Panic(Smid::default(), "expected list in vec.of".to_string())),
                 },
                 _ => {
-                    return Err(ExecutionError::Panic(
+                    return Err(ExecutionError::Panic(Smid::default(), 
                         "expected list data in vec.of".to_string(),
                     ))
                 }
@@ -193,14 +194,14 @@ impl StgIntrinsic for VecNth {
         let n = match &native_n {
             Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.nth: index must be a number".to_string(),
                 ))
             }
         };
         let v = vec_arg(machine, view, &args[1])?;
         let prim = v.get(n).ok_or_else(|| {
-            ExecutionError::Panic(format!(
+            ExecutionError::Panic(Smid::default(), format!(
                 "vec.nth: index {} out of bounds (len {})",
                 n,
                 v.len()
@@ -215,7 +216,7 @@ impl StgIntrinsic for VecNth {
             Native::Str(_) => DataConstructor::BoxedString.tag(),
             Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.nth: unexpected native type in vec element".to_string(),
                 ))
             }
@@ -255,7 +256,7 @@ impl StgIntrinsic for VecSlice {
         let from = match &native_from {
             Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.slice: from must be a number".to_string(),
                 ))
             }
@@ -263,7 +264,7 @@ impl StgIntrinsic for VecSlice {
         let to = match &native_to {
             Native::Num(n) => n.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.slice: to must be a number".to_string(),
                 ))
             }
@@ -299,7 +300,7 @@ impl StgIntrinsic for VecSample {
         let n = match &native_n {
             Native::Num(num) => num.as_u64().unwrap_or(0) as usize,
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.sample: count must be a number".to_string(),
                 ))
             }
@@ -307,7 +308,7 @@ impl StgIntrinsic for VecSample {
         let seed_num = match &native_seed {
             Native::Num(num) => num.clone(),
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.sample: seed must be a number".to_string(),
                 ))
             }
@@ -357,7 +358,7 @@ impl StgIntrinsic for VecShuffle {
         let seed_num = match &native_seed {
             Native::Num(num) => num.clone(),
             _ => {
-                return Err(ExecutionError::Panic(
+                return Err(ExecutionError::Panic(Smid::default(), 
                     "vec.shuffle: seed must be a number".to_string(),
                 ))
             }
@@ -419,7 +420,7 @@ impl StgIntrinsic for VecToList {
                 Native::Str(_) => DataConstructor::BoxedString.tag(),
                 Native::Sym(_) => DataConstructor::BoxedSymbol.tag(),
                 _ => {
-                    return Err(ExecutionError::Panic(
+                    return Err(ExecutionError::Panic(Smid::default(), 
                         "unexpected native type in vec".to_string(),
                     ))
                 }

--- a/src/eval/types.rs
+++ b/src/eval/types.rs
@@ -14,6 +14,7 @@ pub enum IntrinsicType {
     Number,
     ZonedDateTime,
     Array,
+    Vec,
     List(Box<IntrinsicType>),
     Function(Box<IntrinsicType>, Box<IntrinsicType>),
     Record(HashMap<String, IntrinsicType>),
@@ -31,6 +32,7 @@ impl fmt::Display for IntrinsicType {
             IntrinsicType::Number => write!(f, "number"),
             IntrinsicType::ZonedDateTime => write!(f, "datetime"),
             IntrinsicType::Array => write!(f, "array"),
+            IntrinsicType::Vec => write!(f, "vec"),
             IntrinsicType::List(t) => write!(f, "list of {}", *t),
             IntrinsicType::Function(i, o) => write!(f, "{i} -> {o}"),
             IntrinsicType::Record(hm) => {
@@ -157,6 +159,10 @@ pub fn list() -> Box<IntrinsicType> {
 
 pub fn arr() -> Box<IntrinsicType> {
     Box::new(IntrinsicType::Array)
+}
+
+pub fn vec_type() -> Box<IntrinsicType> {
+    Box::new(IntrinsicType::Vec)
 }
 
 pub fn block() -> Box<IntrinsicType> {

--- a/tests/harness/130_vec.eu
+++ b/tests/harness/130_vec.eu
@@ -1,0 +1,41 @@
+#!/usr/bin/env eu
+# Vec type tests
+
+vec-basics: {
+  data: [1, 2, 3, 4, 5] vec.of
+
+  len: data vec.len //= 5
+  first: data vec.nth(0) //= 1
+  last: data vec.nth(4) //= 5
+
+  middle: data vec.slice(1, 4) vec.len //= 3
+  mid-first: data vec.slice(1, 4) vec.nth(0) //= 2
+
+  round-trip: [10, 20, 30] vec.of vec.to-list head //= 10
+
+  pass: [len, first, last, middle, mid-first, round-trip] all-true?
+}
+
+vec-sampling: {
+  data: [1, 2, 3, 4, 5] vec.of
+
+  sampled: data vec.sample(2, 42)
+  sample-len: sampled vec.len //= 2
+
+  shuffled: data vec.shuffle(42)
+  shuffle-len: shuffled vec.len //= 5
+
+  pass: [sample-len, shuffle-len] all-true?
+}
+
+vec-strings: {
+  names: ["alice", "bob", "charlie"] vec.of
+  name-count: names vec.len //= 3
+  name-first: names vec.nth(0) //= "alice"
+
+  rendered: [1, 2, 3] vec.of vec.to-list //= [1, 2, 3]
+
+  pass: [name-count, name-first, rendered] all-true?
+}
+
+RESULT: if(vec-basics.pass ∧ vec-sampling.pass ∧ vec-strings.pass, :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -659,6 +659,11 @@ pub fn test_harness_129() {
 }
 
 #[test]
+pub fn test_harness_130() {
+    run_test(&opts("130_vec.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

Rebased version of PR #549 (`feat/furnace-vec-type`) onto current `planning/0.5.1`.

**Changes from original PR:**
- Updates `ExecutionError::Panic` calls in `vec.rs` to use `Panic(Smid::default(), msg)` following the source-location improvements merged in eu-gwse (PR #550)
- Adds `Native::Vec` arm to `render_native()` in `debug.rs` (renders as `<vec [N]>`) to handle the new variant in the debug functions added by eu-x6ry

All other functionality is identical to the original PR #549.

## Original PR content

Introduces HeapVec, Native::Vec, and seven vec.* intrinsics for efficient indexed access to large primitive collections:

- HeapVec wrapping Vec<Primitive> with O(1) get/slice
- Native::Vec variant + GC scanning
- VEC.OF, VEC.LEN, VEC.NTH, VEC.SLICE, VEC.SAMPLE, VEC.SHUFFLE, VEC.TO_LIST
- Prelude bindings: vec.of, vec.len, vec.nth(n), vec.slice(from, to), vec.sample(n, seed), vec.shuffle(seed), vec.to-list
- Harness test 126 covering construction, indexed access, slicing, sampling/shuffling, and string elements
- Reference documentation at docs/reference/prelude/vecs.md

## Test plan
- [ ] Harness test 126 passes (vec construction, indexed access, slicing, sampling)
- [ ] All 233 harness tests pass
- [ ] Clippy clean
- [ ] Cargo fmt clean

Closes #549 (supersedes original PR with compatibility fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)