### PR TITLE
fix: deep-force list elements in vec.of and set.from-list

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -89,6 +89,22 @@ jobs:
         env:
           EU_GC_STRESS: "1"
 
+  asan:
+    name: AddressSanitizer
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+      - name: Build with ASAN
+        run: RUSTFLAGS="-Zsanitizer=address" cargo +nightly build --release --target x86_64-unknown-linux-gnu -Zbuild-std
+      - name: Run harness with ASAN
+        run: ASAN_OPTIONS=detect_leaks=0 ./target/x86_64-unknown-linux-gnu/release/eu test --allow-io tests/harness
+        env:
+          EU_GC_STRESS: "1"
+
   wasm:
     name: WASM Compilation Check
     runs-on: ubuntu-latest

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -625,6 +625,11 @@ lazy_static! {
             strict: vec![0],
     },
     Intrinsic { // 115
+            name: "seqList",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 116
             name: "SORT_NUM_LIST",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -625,11 +625,6 @@ lazy_static! {
             strict: vec![0],
     },
     Intrinsic { // 115
-            name: "seqList",
-            ty: function(vec![list(), list()]).unwrap(),
-            strict: vec![0],
-    },
-    Intrinsic { // 116
             name: "SORT_NUM_LIST",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
@@ -943,6 +938,11 @@ lazy_static! {
             name: "SET.SAMPLE",
             ty: function(vec![list(), unk(), unk()]).unwrap(),
             strict: vec![0, 1],
+    },
+    Intrinsic { // 178
+            name: "seqList",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![0],
     },
     ];
 }

--- a/src/eval/memory/array.rs
+++ b/src/eval/memory/array.rs
@@ -358,8 +358,11 @@ impl<T: Sized + Clone> Array<T> {
         if existing_capacity == 0 {
             8
         } else {
+            // Must grow by at least 1 — integer division of small capacities
+            // (e.g. 1/2 = 0) would otherwise leave capacity unchanged, causing
+            // an infinite resize loop and out-of-bounds write in push().
             existing_capacity
-                .checked_add(existing_capacity / 2)
+                .checked_add((existing_capacity / 2).max(1))
                 .expect("cannot grow array")
         }
     }

--- a/src/eval/memory/array.rs
+++ b/src/eval/memory/array.rs
@@ -210,11 +210,23 @@ impl<T: Sized + Clone> Array<T> {
     /// Add an item at the end
     pub fn push<'guard, A: ScopedAllocator<'guard>>(&mut self, mem: &A, item: T) {
         if self.length == self.data.capacity {
+            let old_cap = self.data.capacity;
             self.data
                 .resize(mem, Self::default_array_growth(self.data.capacity))
                 .expect("allocation failure");
+            debug_assert!(
+                self.data.capacity > old_cap,
+                "Array::push: resize did not grow capacity (was {old_cap}, now {})",
+                self.data.capacity
+            );
         }
 
+        debug_assert!(
+            self.length < self.data.capacity,
+            "Array::push: length {} >= capacity {} before write",
+            self.length,
+            self.data.capacity
+        );
         self.length += 1;
         self.write(self.length - 1, item);
     }
@@ -340,6 +352,11 @@ impl<T: Sized + Clone> Array<T> {
     /// Return pointer for index
     fn get_offset(&self, index: usize) -> Option<*mut T> {
         if index < self.length {
+            debug_assert!(
+                index < self.data.capacity,
+                "get_offset: index {index} >= capacity {}",
+                self.data.capacity,
+            );
             self.data
                 .as_ptr()
                 // SAFETY: Pointer arithmetic is valid because:
@@ -355,7 +372,7 @@ impl<T: Sized + Clone> Array<T> {
 
     /// Determine size to grow to
     fn default_array_growth(existing_capacity: usize) -> usize {
-        if existing_capacity == 0 {
+        let new_cap = if existing_capacity == 0 {
             8
         } else {
             // Must grow by at least 1 — integer division of small capacities
@@ -364,7 +381,12 @@ impl<T: Sized + Clone> Array<T> {
             existing_capacity
                 .checked_add((existing_capacity / 2).max(1))
                 .expect("cannot grow array")
-        }
+        };
+        debug_assert!(
+            new_cap > existing_capacity,
+            "default_array_growth: no growth from {existing_capacity}"
+        );
+        new_cap
     }
 
     fn write(&mut self, index: usize, item: T) -> &T {

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     syntax::{
-        dsl::{data, force, lambda, local, lref, switch, unbox_num, unbox_str},
+        dsl::{case, data, force, lambda, local, lref, switch, unbox_num, unbox_str},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -90,3 +90,85 @@ impl StgIntrinsic for SeqNumList {
 }
 
 impl CallGlobal1 for SeqNumList {}
+
+/// SeqList — deep-force a list of primitives, evaluating each element
+/// and its boxed inner value to WHNF.
+///
+/// Unlike `SeqNumList` / `SeqStrList`, this accepts all primitive
+/// types (numbers, strings, symbols).  Used by `VecOf` and
+/// `SetFromList` which need fully-evaluated elements before their
+/// `execute()` methods navigate heap closures.
+///
+/// For each element, forces to WHNF.  If the result is a boxed
+/// constructor (`BoxedNumber`, `BoxedString`, `BoxedSymbol`), forces
+/// the inner value too — this ensures that computed values (e.g. from
+/// string interpolation) are fully resolved before `extract_primitive`
+/// / `navigate_local_native` attempts to read them.
+///
+/// The returned list reuses the forced/unboxed values, matching the
+/// pattern used by `SeqNumList` / `SeqStrList`.
+pub struct SeqList;
+
+impl StgIntrinsic for SeqList {
+    fn name(&self) -> &str {
+        "seqList"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        // For boxed values (BoxedNumber/String/Symbol): match
+        // destructures into [inner], force inner, then recurse on tail.
+        //
+        // Stack after BoxedX match:   [inner] [h t]
+        //   force inner →             [forced_inner] [inner] [h t]
+        //   recurse SeqList(tail) →    [seq_t] [forced_inner] [inner] [h t]
+        //   rebuild: ListCons(lref(1), lref(0))
+        //     = ListCons(forced_inner, seq_t)
+        let unbox_force_then_tail = force(
+            local(0),
+            force(
+                SeqList.global(lref(3)),
+                data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+            ),
+        );
+
+        lambda(
+            1,
+            switch(
+                local(0),
+                vec![
+                    (DataConstructor::ListNil.tag(), local(0)),
+                    (
+                        DataConstructor::ListCons.tag(), // [h t]
+                        // Force head to WHNF, then branch on constructor
+                        case(
+                            local(0),
+                            vec![
+                                (
+                                    DataConstructor::BoxedNumber.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                                (
+                                    DataConstructor::BoxedString.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                                (
+                                    DataConstructor::BoxedSymbol.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                            ],
+                            // Fallback: raw atom, already fully evaluated.
+                            // [forced_h] [h t]
+                            force(
+                                SeqList.global(lref(2)),
+                                // [seq_t] [forced_h] [h t]
+                                data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        )
+    }
+}
+
+impl CallGlobal1 for SeqList {}

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -92,21 +92,17 @@ impl StgIntrinsic for SeqNumList {
 impl CallGlobal1 for SeqNumList {}
 
 /// SeqList — deep-force a list of primitives, evaluating each element
-/// and its boxed inner value to WHNF.
+/// to WHNF (and boxed inner values too).
 ///
 /// Unlike `SeqNumList` / `SeqStrList`, this accepts all primitive
 /// types (numbers, strings, symbols).  Used by `VecOf` and
 /// `SetFromList` which need fully-evaluated elements before their
 /// `execute()` methods navigate heap closures.
 ///
-/// For each element, forces to WHNF.  If the result is a boxed
-/// constructor (`BoxedNumber`, `BoxedString`, `BoxedSymbol`), forces
-/// the inner value too — this ensures that computed values (e.g. from
-/// string interpolation) are fully resolved before `extract_primitive`
-/// / `navigate_local_native` attempts to read them.
-///
-/// The returned list reuses the forced/unboxed values, matching the
-/// pattern used by `SeqNumList` / `SeqStrList`.
+/// Uses the same pattern as `SeqNumList`: force head, force inner
+/// (via unbox), recurse on tail, rebuild list.  The only difference
+/// is that it handles all three box types via separate branches
+/// rather than just one.
 pub struct SeqList;
 
 impl StgIntrinsic for SeqList {
@@ -115,15 +111,22 @@ impl StgIntrinsic for SeqList {
     }
 
     fn wrapper(&self, _annotation: Smid) -> LambdaForm {
-        // For boxed values (BoxedNumber/String/Symbol): match
-        // destructures into [inner], force inner, then recurse on tail.
+        // Exactly mirrors SeqNumList/SeqStrList but handles all box types.
         //
-        // Stack after BoxedX match:   [inner] [h t]
-        //   force inner →             [forced_inner] [inner] [h t]
-        //   recurse SeqList(tail) →    [seq_t] [forced_inner] [inner] [h t]
-        //   rebuild: ListCons(lref(1), lref(0))
-        //     = ListCons(forced_inner, seq_t)
-        let unbox_force_then_tail = force(
+        // For each cons cell [h, t]:
+        //   1. Force h to WHNF (switch on list, force on head)
+        //   2. If boxed (BoxedNumber/String/Symbol): unbox to get [inner],
+        //      force inner, recurse on tail, rebuild ListCons(forced_inner, seq_t)
+        //   3. If raw atom: just recurse on tail, rebuild ListCons(forced_h, seq_t)
+
+        // case already destructured BoxedX([inner]) → local(0) = inner
+        // Force inner, recurse on tail, rebuild
+        //
+        // Entry: [inner] [h t]  (inner = local(0), h = lref(1), t = lref(2))
+        // force(local(0)) → [forced] [inner] [h t]
+        // SeqList(lref(3)) = SeqList(t) → [seq_t] [forced] [inner] [h t]
+        // rebuild: ListCons(lref(1), lref(0)) = ListCons(forced, seq_t)
+        let force_inner_then_tail = force(
             local(0),
             force(
                 SeqList.global(lref(3)),
@@ -139,24 +142,25 @@ impl StgIntrinsic for SeqList {
                     (DataConstructor::ListNil.tag(), local(0)),
                     (
                         DataConstructor::ListCons.tag(), // [h t]
-                        // Force head to WHNF, then branch on constructor
+                        // Force head to WHNF then try each box type
+                        // If none match, fall through to raw atom path
                         case(
                             local(0),
                             vec![
                                 (
                                     DataConstructor::BoxedNumber.tag(),
-                                    unbox_force_then_tail.clone(),
+                                    force_inner_then_tail.clone(),
                                 ),
                                 (
                                     DataConstructor::BoxedString.tag(),
-                                    unbox_force_then_tail.clone(),
+                                    force_inner_then_tail.clone(),
                                 ),
                                 (
                                     DataConstructor::BoxedSymbol.tag(),
-                                    unbox_force_then_tail.clone(),
+                                    force_inner_then_tail.clone(),
                                 ),
                             ],
-                            // Fallback: raw atom, already fully evaluated.
+                            // Fallback: raw atom, already at WHNF
                             // [forced_h] [h t]
                             force(
                                 SeqList.global(lref(2)),

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -171,6 +171,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(stream_intrinsic::StreamNext));
     rt.add(Box::new(block::LookupFail));
     rt.add(Box::new(force::SeqNumList));
+    rt.add(Box::new(force::SeqList));
     rt.add(Box::new(list::SortNumList));
     rt.add(Box::new(graph::GraphUnionFind));
     rt.add(Box::new(graph::GraphTopoSort));

--- a/src/eval/stg/set.rs
+++ b/src/eval/stg/set.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 
 use super::{
+    force::SeqList,
     support::{
         data_list_arg, machine_return_bool, machine_return_num, machine_return_set,
         native_to_set_primitive, resolve_native_unboxing, set_arg, set_primitive_to_native,
@@ -99,6 +100,19 @@ pub struct SetFromList;
 impl StgIntrinsic for SetFromList {
     fn name(&self) -> &str {
         "SET.FROM_LIST"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        // Deep-force the list so all elements are at WHNF before execute()
+        lambda(
+            1, // [list]
+            force(
+                SeqList.global(lref(0)),
+                // [forced_list] [list]
+                app_bif(bif_index, vec![lref(0)]),
+            ),
+        )
     }
 
     fn execute(

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -20,7 +20,7 @@ use crate::eval::{
 use crate::eval::machine::env::SynClosure;
 
 use super::{
-    force::SeqNumList,
+    force::{SeqList, SeqNumList},
     support::{
         collect_num_list, machine_return_num, machine_return_vec, native_to_set_primitive,
         resolve_native_unboxing, set_primitive_to_native, vec_arg,
@@ -99,6 +99,19 @@ pub struct VecOf;
 impl StgIntrinsic for VecOf {
     fn name(&self) -> &str {
         "VEC.OF"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        // Deep-force the list so all elements are at WHNF before execute()
+        lambda(
+            1, // [list]
+            force(
+                SeqList.global(lref(0)),
+                // [forced_list] [list]
+                app_bif(bif_index, vec![lref(0)]),
+            ),
+        )
     }
 
     fn execute(

--- a/tests/harness/074_sets.eu
+++ b/tests/harness/074_sets.eu
@@ -103,6 +103,16 @@ render-checks: {
   ]
 }
 
+` "Computed (thunk) elements — set.from-list must deep-force before extraction"
+
+computed-checks: {
+  trues: [
+    (["a", "b", "c"] map("x-{}") set.from-list set.size) = 3,
+    (["a", "b", "c"] map("x-{}") set.from-list set.contains?("x-a")) = true,
+    ([1, 2, 3] map(+ 10) set.from-list set.to-list) = [11, 12, 13]
+  ]
+}
+
 pass: [
   construction-checks.trues all-true?,
   empty-checks.trues all-true?,
@@ -110,7 +120,8 @@ pass: [
   size-checks.trues all-true?,
   mutation-checks.trues all-true?,
   algebra-checks.trues all-true?,
-  render-checks.trues all-true?
+  render-checks.trues all-true?,
+  computed-checks.trues all-true?
 ] all-true?
 
 RESULT: if(pass, :PASS, :FAIL)

--- a/tests/harness/130_vec.eu
+++ b/tests/harness/130_vec.eu
@@ -40,10 +40,21 @@ test: {
   set-sample-result: set.sample(3, test-set, random.stream(42))
   set-sample-size: set-sample-result.value set.size //= 3
 
+  # Computed (thunk) elements — vec.of must deep-force before extraction
+  interp: ["a", "b", "c"] map("x-{}") vec.of
+  interp-len: interp vec.len //= 3
+  interp-first: interp vec.nth(0) //= "x-a"
+
+  computed-nums: [1, 2, 3] map(+ 10) vec.of
+  computed-nums-len: computed-nums vec.len //= 3
+  computed-nums-trip: computed-nums vec.to-list //= [11, 12, 13]
+
   RESULT: [ len, first, last, middle, mid-first
            , round-trip, round-trip-eq
            , name-count, name-first
            , sample-len, shuffle-len
            , set-sample-size
+           , interp-len, interp-first
+           , computed-nums-len, computed-nums-trip
            ] all-true? then(:PASS, :FAIL)
 }


### PR DESCRIPTION
## Summary

- Add `SeqList` — a generic list deep-forcer that evaluates each element to WHNF and forces boxed inner values (BoxedNumber/String/Symbol)
- Add custom `wrapper()` to `VecOf` and `SetFromList` that deep-force via `SeqList` before `execute()` runs
- Fixes panic: `navigate_local_native` crashing with "could not navigate to native" when list elements are unevaluated thunks (e.g. from `map` pipelines or string interpolation)

Sets, vecs, and arrays are eager data structures that deep-force their contents on construction.

Fixes: eu-ofy3

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `eu -e '["hello", "world"] map("./{}") vec.of vec.to-list'` — returns `["./hello", "./world"]` (previously panicked)
- [x] `eu -e '[1, 2, 3] map(+ 10) vec.of vec.to-list'` — returns `[11, 12, 13]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)