### PR TITLE
test: SeqList registration only (Test A for #561)

### DIFF
--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -625,6 +625,11 @@ lazy_static! {
             strict: vec![0],
     },
     Intrinsic { // 115
+            name: "seqList",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 116
             name: "SORT_NUM_LIST",
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     syntax::{
-        dsl::{data, force, lambda, local, lref, switch, unbox_num, unbox_str},
+        dsl::{case, data, force, lambda, local, lref, switch, unbox_num, unbox_str},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -90,3 +90,85 @@ impl StgIntrinsic for SeqNumList {
 }
 
 impl CallGlobal1 for SeqNumList {}
+
+/// SeqList — deep-force a list of primitives, evaluating each element
+/// and its boxed inner value to WHNF.
+///
+/// Unlike `SeqNumList` / `SeqStrList`, this accepts all primitive
+/// types (numbers, strings, symbols).  Used by `VecOf` and
+/// `SetFromList` which need fully-evaluated elements before their
+/// `execute()` methods navigate heap closures.
+///
+/// For each element, forces to WHNF.  If the result is a boxed
+/// constructor (`BoxedNumber`, `BoxedString`, `BoxedSymbol`), forces
+/// the inner value too — this ensures that computed values (e.g. from
+/// string interpolation) are fully resolved before `extract_primitive`
+/// / `navigate_local_native` attempts to read them.
+///
+/// The returned list reuses the forced/unboxed values, matching the
+/// pattern used by `SeqNumList` / `SeqStrList`.
+pub struct SeqList;
+
+impl StgIntrinsic for SeqList {
+    fn name(&self) -> &str {
+        "seqList"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        // For boxed values (BoxedNumber/String/Symbol): match
+        // destructures into [inner], force inner, then recurse on tail.
+        //
+        // Stack after BoxedX match:   [inner] [h t]
+        //   force inner →             [forced_inner] [inner] [h t]
+        //   recurse SeqList(tail) →    [seq_t] [forced_inner] [inner] [h t]
+        //   rebuild: ListCons(lref(1), lref(0))
+        //     = ListCons(forced_inner, seq_t)
+        let unbox_force_then_tail = force(
+            local(0),
+            force(
+                SeqList.global(lref(3)),
+                data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+            ),
+        );
+
+        lambda(
+            1,
+            switch(
+                local(0),
+                vec![
+                    (DataConstructor::ListNil.tag(), local(0)),
+                    (
+                        DataConstructor::ListCons.tag(), // [h t]
+                        // Force head to WHNF, then branch on constructor
+                        case(
+                            local(0),
+                            vec![
+                                (
+                                    DataConstructor::BoxedNumber.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                                (
+                                    DataConstructor::BoxedString.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                                (
+                                    DataConstructor::BoxedSymbol.tag(),
+                                    unbox_force_then_tail.clone(),
+                                ),
+                            ],
+                            // Fallback: raw atom, already fully evaluated.
+                            // [forced_h] [h t]
+                            force(
+                                SeqList.global(lref(2)),
+                                // [seq_t] [forced_h] [h t]
+                                data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        )
+    }
+}
+
+impl CallGlobal1 for SeqList {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -171,6 +171,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(stream_intrinsic::StreamNext));
     rt.add(Box::new(block::LookupFail));
     rt.add(Box::new(force::SeqNumList));
+    rt.add(Box::new(force::SeqList));
     rt.add(Box::new(list::SortNumList));
     rt.add(Box::new(graph::GraphUnionFind));
     rt.add(Box::new(graph::GraphTopoSort));


### PR DESCRIPTION
## Investigation test for PR #561

Registers SeqList in the global table but does NOT add wrapper() overrides to VecOf/SetFromList. No test changes.

- If CI passes: registration alone is safe; invocation triggers crash
- If CI fails: global wrapper compilation alone triggers crash

Will be closed after CI completes.