### PR TITLE
fix: monadic implicit return self-references lambda vars

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -14,7 +14,7 @@ use crate::{
     common::sourcemap::{HasSmid, Smid},
     core::{
         anaphora::{BLOCK_ANAPHORA, EXPR_ANAPHORA},
-        binding::Var,
+        binding::{BoundVar, Scope, Var},
         error::CoreError,
         expr::*,
         rt,
@@ -1111,14 +1111,65 @@ fn desugar_monadic_block_implicit(
     }
 
     // Synthesise the implicit return block from all non-underscore bind names.
-    let return_pairs: Vec<(String, RcExpr)> = bind_names
+    //
+    // We need: return({a: a_λ, b: b_λ}) where a_λ, b_λ are the lambda-bound
+    // variables from the bind chain.
+    //
+    // A bare Expr::Block({a: a_λ, b: b_λ}) compiles to a letrec whose bindings
+    // shadow the lambda params — {a: a} self-references.  core::let_ and
+    // core::default_let also self-reference because close_let_scope closes
+    // binding values over the let's own names.
+    //
+    // Fix: build Let + Block manually.  The Let binding values are the
+    // lambda-bound FreeVars (NOT closed over the Let's names).  The Block body
+    // references the Let bindings via BoundVar(scope=0).  This way the Let
+    // captures the lambda vars, and the Block reads from the Let.
+    let non_underscore: Vec<(String, String)> = bind_names
         .iter()
         .zip(bind_vars.iter())
         .filter(|(name, _)| name.as_str() != "_")
-        .map(|(name, fv)| (name.clone(), core::var(smid, fv.clone())))
+        .map(|(name, fv)| (name.clone(), fv.clone()))
         .collect();
 
-    let return_expr = core::block(smid, return_pairs);
+    let return_expr = if non_underscore.is_empty() {
+        core::block(smid, std::iter::empty::<(String, RcExpr)>())
+    } else {
+        // Let bindings: each value is the lambda-bound FreeVar.
+        // These must NOT be closed over the Let's own names.
+        let let_bindings: Vec<(String, RcExpr)> = non_underscore
+            .iter()
+            .map(|(name, fv)| (name.clone(), core::var(smid, fv.clone())))
+            .collect();
+
+        // Body: Block where each key reads from the Let (BoundVar scope=0).
+        let body_block = core::block(
+            smid,
+            non_underscore.iter().enumerate().map(|(i, (name, _))| {
+                (
+                    name.clone(),
+                    RcExpr::from(Expr::Var(
+                        smid,
+                        Var::Bound(BoundVar {
+                            scope: 0,
+                            binder: i as u32,
+                            name: Some(name.clone()),
+                        }),
+                    )),
+                )
+            }),
+        );
+
+        // Construct the Let Scope directly — skip close_let_scope which
+        // would close the binding FreeVars over the Let's own names.
+        RcExpr::from(Expr::Let(
+            smid,
+            Scope {
+                pattern: let_bindings,
+                body: body_block,
+            },
+            LetType::OtherLet,
+        ))
+    };
 
     // Pop bind names from scope.
     if !bind_names.is_empty() {

--- a/tests/harness/129_monadic_implicit_return.eu
+++ b/tests/harness/129_monadic_implicit_return.eu
@@ -54,6 +54,17 @@ tests: {
     RESULT: if(result = 15, :PASS, :FAIL)
   }
 
+  ` "Implicit return where bind values are closures (not plain values)"
+  closure-values: {
+    # A monad where bind wraps values in a block — tests that the
+    # implicit return block does not self-reference the lambda params
+    wrap-bind(ma, f): f(ma.value)
+    wrap-return(a): { value: a }
+    ⟨{}⟩: { :monad bind: wrap-bind  return: wrap-return }
+    result: ⟨ a: { value: 10 }  b: { value: a + 20 } ⟩
+    RESULT: if(result.value.a = 10 && result.value.b = 30, :PASS, :FAIL)
+  }
+
   ` "Block without monad: true falls through to normal block desugaring"
   no-monad-true: {
     # 'maybe' is not registered with monad: true, so :maybe block without .expr


### PR DESCRIPTION
## Summary

- The synthesised implicit return block `{a: a, b: b}` used `Expr::Block` which compiles to a letrec — each key shadowed the enclosing lambda parameter, creating a self-referential black hole
- Fix: build `Let + Block` manually without `close_let_scope` so binding values remain as lambda-bound FreeVars
- Added test with closure-valued bindings that catches the bug (existing tests used identity monad where plain number values masked the self-reference)

## Test plan

- [x] `cargo test test_harness_129` — implicit return tests including new closure-values test
- [x] `cargo test --test harness_test` — all 235 harness tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

Fixes: eu-hybj

🤖 Generated with [Claude Code](https://claude.com/claude-code)