### PR TITLE
fix: -e expressions now see prelude monad: true registrations

### DIFF
--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -119,6 +119,17 @@ impl<'smap> Desugarer<'smap> {
         self.monad_namespace_registry.get(name)
     }
 
+    /// Seed the monad namespace registry with entries from a previous
+    /// translation unit (e.g. the prelude).
+    pub fn seed_monad_namespace_registry(&mut self, registry: &HashMap<String, MonadSpec>) {
+        self.monad_namespace_registry.extend(registry.clone());
+    }
+
+    /// Drain the monad namespace registry for persistence across units.
+    pub fn drain_monad_namespace_registry(&mut self) -> HashMap<String, MonadSpec> {
+        std::mem::take(&mut self.monad_namespace_registry)
+    }
+
     /// Desugar content at locator (and imports) to create a new
     /// translation unit.
     pub fn translate_unit(&mut self, input: &Input) -> Result<TranslationUnit, CoreError> {

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -14,7 +14,7 @@ use crate::{
     common::sourcemap::{HasSmid, Smid},
     core::{
         anaphora::{BLOCK_ANAPHORA, EXPR_ANAPHORA},
-        binding::Var,
+        binding::{BoundVar, Scope, Var},
         error::CoreError,
         expr::*,
         rt,
@@ -1111,14 +1111,65 @@ fn desugar_monadic_block_implicit(
     }
 
     // Synthesise the implicit return block from all non-underscore bind names.
-    let return_pairs: Vec<(String, RcExpr)> = bind_names
+    //
+    // We need: return({a: a_λ, b: b_λ}) where a_λ, b_λ are the lambda-bound
+    // variables from the bind chain.
+    //
+    // A bare Expr::Block({a: a_λ, b: b_λ}) compiles to a letrec whose bindings
+    // shadow the lambda params — {a: a} self-references.  core::let_ and
+    // core::default_let also self-reference because close_let_scope closes
+    // binding values over the let's own names.
+    //
+    // Fix: build Let + Block manually.  The Let binding values are the
+    // lambda-bound FreeVars (NOT closed over the Let's names).  The Block body
+    // references the Let bindings via BoundVar(scope=0).  This way the Let
+    // captures the lambda vars, and the Block reads from the Let.
+    let non_underscore: Vec<(String, String)> = bind_names
         .iter()
         .zip(bind_vars.iter())
         .filter(|(name, _)| name.as_str() != "_")
-        .map(|(name, fv)| (name.clone(), core::var(smid, fv.clone())))
+        .map(|(name, fv)| (name.clone(), fv.clone()))
         .collect();
 
-    let return_expr = core::block(smid, return_pairs);
+    let return_expr = if non_underscore.is_empty() {
+        core::block(smid, std::iter::empty::<(String, RcExpr)>())
+    } else {
+        // Let bindings: each value is the lambda-bound FreeVar.
+        // These must NOT be closed over the Let's own names.
+        let let_bindings: Vec<(String, RcExpr)> = non_underscore
+            .iter()
+            .map(|(name, fv)| (name.clone(), core::var(smid, fv.clone())))
+            .collect();
+
+        // Body: Block where each key reads from the Let (BoundVar scope=0).
+        let body_block = core::block(
+            smid,
+            non_underscore.iter().enumerate().map(|(i, (name, _))| {
+                (
+                    name.clone(),
+                    RcExpr::from(Expr::Var(
+                        smid,
+                        Var::Bound(BoundVar {
+                            scope: 0,
+                            binder: i as u32,
+                            name: Some(name.clone()),
+                        }),
+                    )),
+                )
+            }),
+        );
+
+        // Construct the Let Scope directly — skip close_let_scope which
+        // would close the binding FreeVars over the Let's own names.
+        RcExpr::from(Expr::Let(
+            smid,
+            Scope {
+                pattern: let_bindings,
+                body: body_block,
+            },
+            LetType::OtherLet,
+        ))
+    };
 
     // Pop bind names from scope.
     if !bind_names.is_empty() {

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -78,6 +78,14 @@ pub struct SourceLoader {
     args: Vec<String>,
     /// Seed for random number generation
     seed: Option<i64>,
+    /// Persisted monad namespace registry across translation units.
+    ///
+    /// The desugarer's monad_namespace_registry records which namespaces
+    /// have `monad: true` metadata.  Since each translation unit gets a
+    /// fresh Desugarer, registrations from the prelude would be lost when
+    /// desugaring `-e` expressions.  This field carries them forward.
+    monad_namespace_registry:
+        std::collections::HashMap<String, crate::core::desugar::desugarer::MonadSpec>,
 }
 
 impl Default for SourceLoader {
@@ -95,6 +103,7 @@ impl Default for SourceLoader {
             lib_path: Vec::new(),
             args: Vec::new(),
             seed: None,
+            monad_namespace_registry: std::collections::HashMap::new(),
         }
     }
 }
@@ -115,6 +124,7 @@ impl SourceLoader {
             lib_path,
             args: Vec::new(),
             seed: None,
+            monad_namespace_registry: std::collections::HashMap::new(),
         }
     }
 
@@ -389,9 +399,15 @@ impl SourceLoader {
             }
         }
 
-        // Desugar all the content starting from the input specified
+        // Desugar all the content starting from the input specified.
+        // Seed the desugarer with the persisted monad namespace registry
+        // so that `-e` expressions see `monad: true` from the prelude.
         let mut desugarer = Desugarer::new(&desugarables, &mut self.source_map);
+        desugarer.seed_monad_namespace_registry(&self.monad_namespace_registry);
         let unit = desugarer.translate_unit(input)?;
+        // Persist any newly registered monad namespaces for later units.
+        self.monad_namespace_registry
+            .extend(desugarer.drain_monad_namespace_registry());
         self.translation_units.insert(input.clone(), unit);
         Ok(&self.translation_units[input])
     }

--- a/tests/harness/129_monadic_implicit_return.eu
+++ b/tests/harness/129_monadic_implicit_return.eu
@@ -65,6 +65,33 @@ tests: {
     RESULT: if(result.value.a = 10 && result.value.b = 30, :PASS, :FAIL)
   }
 
+  ` "Random monad implicit return — the motivating case for eu-hybj/eu-en4j"
+  random-implicit: {
+    result: { :random a: random.int(20) b: random.int(a) c: random.int(b) }(random.stream(42)).value
+    ok: (result.a = 14) && (result has(:b)) && (result has(:c))
+    RESULT: if(ok, :PASS, :FAIL)
+  }
+
+  ` ":let monad — sequential redefinition with .expr"
+  let-explicit: {
+    x: 2
+    result: { :let x: x + 2  x: x * 10 }.x
+    RESULT: if(result = 40, :PASS, :FAIL)
+  }
+
+  ` ":let block equals normal block for non-shadowing bindings"
+  let-equiv: {
+    a: { a: 1 b: 2 }
+    b: { :let a: 1 b: 2 }
+    RESULT: if(a.a = b.a && a.b = b.b, :PASS, :FAIL)
+  }
+
+  ` ":let with shadowing and implicit return"
+  let-shadow-implicit: {
+    result: { :let a: 1  a: a * 2 }
+    RESULT: if(result.a = 2, :PASS, :FAIL)
+  }
+
   ` "Block without monad: true falls through to normal block desugaring"
   no-monad-true: {
     # 'maybe' is not registered with monad: true, so :maybe block without .expr

--- a/tests/harness/129_monadic_implicit_return.eu
+++ b/tests/harness/129_monadic_implicit_return.eu
@@ -54,6 +54,17 @@ tests: {
     RESULT: if(result = 15, :PASS, :FAIL)
   }
 
+  ` "Implicit return where bind values are closures (not plain values)"
+  closure-values: {
+    # A monad where bind wraps values in a block — tests that the
+    # implicit return block does not self-reference the lambda params
+    wrap-bind(ma, f): f(ma.value)
+    wrap-return(a): { value: a }
+    ⟨{}⟩: { :monad bind: wrap-bind  return: wrap-return }
+    result: ⟨ a: { value: 10 }  b: { value: a + 20 } ⟩
+    RESULT: if(result.value.a = 10 && result.value.b = 30, :PASS, :FAIL)
+  }
+
   ` "Block without monad: true falls through to normal block desugaring"
   no-monad-true: {
     # 'maybe' is not registered with monad: true, so :maybe block without .expr


### PR DESCRIPTION
## Summary

- Each `translate()` call created a fresh `Desugarer`, so `monad: true` registrations from the prelude were lost when desugaring `-e` expressions
- The monad namespace registry is now persisted in `SourceLoader` and seeded into each new `Desugarer` via `seed_monad_namespace_registry`
- After each translation, newly discovered registrations are drained back to `SourceLoader`

Includes the fix from PR #565 (implicit return self-reference) as a dependency.

## Tests added

- `random-implicit`: `{ :random a: random.int(20) b: random.int(a) c: random.int(b) }` — the motivating case
- `let-explicit`: `{ :let x: x + 2 x: x * 10 }.x` — sequential redefinition with `.expr`
- `let-equiv`: `{ a: 1 b: 2 }` equals `{ :let a: 1 b: 2 }` — non-shadowing equivalence
- `let-shadow-implicit`: `{ :let a: 1 a: a * 2 }` produces `{a: 2}` — shadowing with implicit return

## Test plan

- [x] `cargo test test_harness_129` — all sub-tests pass
- [x] `cargo test --test harness_test` — all 235 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `eu -e '{ :random a: random.int(20) b: random.int(a) c: random.int(b) }(random.stream(42)).value'` returns `{a: 14, b: 2, c: 0}`

Fixes: eu-en4j

🤖 Generated with [Claude Code](https://claude.com/claude-code)