### PR TITLE
feat: add update-first, fix split-when no-match crash

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1049,9 +1049,10 @@ drop-until(p?): drop-while(p? complement)
 
 ` "`split-after(p?, l) - split list where `p?` becomes false and return pair."
 split-after(p?, l): {
-  aux(xs, prefix): if((xs nil?) ∨ (xs head p?),
+  aux(xs, prefix): if(xs nil?, [prefix reverse, []],
+                     if(xs head p?,
                         aux(xs tail, cons(xs head, prefix)),
-                        [prefix reverse, xs])
+                        [prefix reverse, xs]))
 }.aux(l, [])
 
 ` "`split-when(p?, l) - split list where `p?` becomes true and return pair."
@@ -1063,6 +1064,12 @@ nth(n, l): l drop(n) head
 ` "`update-nth(n, f, l)` - apply `f` to element at index `n` in list `l`.
 Panics if `n` is out of range."
 update-nth(n, f, l): { rejoin([prefix, [s: suffix]]): prefix ++ (f(s) ‖ suffix) }.(l split-at(n) rejoin)
+
+` "`update-first(p?, f, l)` - apply `f` to the first element matching `p?` in list `l`.
+Returns `l` unchanged if no element matches."
+update-first(p?, f, l): {
+  go[pre, suf]: (suf nil?) then(l, pre ++ ((f(suf head)) ‖ (suf tail)))
+}.(l split-when(p?) go)
 
 ` { doc: "`l !! n` - return `n`th item of list `l` if it exists, otherwise error. For arrays, `n` must be a coordinate list (e.g. `[row, col]`) and !! delegates to `arr.get`."
     precedence: :exp }

--- a/tests/harness/010_prelude.eu
+++ b/tests/harness/010_prelude.eu
@@ -244,6 +244,24 @@ tests: {
     pass: [t1, t2, t3, t4] all-true?
   }
 
+  ` "update-first"
+  update-first-tests: {
+    t1: ([1, 2, 3, 2, 1] update-first(_ = 2, + 10) nth(1)) = 12
+    t2: ([1, 2, 3, 2, 1] update-first(_ = 2, + 10) nth(3)) = 2
+    t3: ([1, 2, 3] update-first(_ = 99, + 10)) = [1, 2, 3]
+    t4: ([1, 2, 3] update-first(_ = 2, + 10) count) = 3
+    pass: [t1, t2, t3, t4] all-true?
+  }
+
+  ` "split-when with no match"
+  split-when-tests: {
+    t1: ([1, 2, 3] split-when(_ = 99) first) = [1, 2, 3]
+    t2: ([1, 2, 3] split-when(_ = 99) second) = []
+    t3: ([] split-when(_ = 1) first) = []
+    t4: ([] split-when(_ = 1) second) = []
+    pass: [t1, t2, t3, t4] all-true?
+  }
+
 }
 
 RESULT: tests filter-values(has(:pass)) all(_.pass) then(:PASS, :FAIL)


### PR DESCRIPTION
## Summary

- **`update-first(p?, f, l)`**: applies `f` to the first element matching `p?`, returns `l` unchanged if no match. Non-recursive, uses `split-when`.
- **`split-after` fix**: crashed when predicate never matched — `(xs nil?) ∨ (xs head p?)` entered the true branch on nil, then called `xs tail` / `xs head` on empty list. Fixed by separating the nil check.
- Tests for both.

## Test plan

- [x] `cargo test test_harness_010` — prelude tests pass
- [x] All 236 harness tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)