### PR TITLE
fix: graceful error when current directory is inaccessible

### DIFF
--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -1020,7 +1020,21 @@ impl EucalyptOptions {
         }
 
         // add current working directory as a lib path
-        self.lib_path.insert(0, std::env::current_dir()?);
+        match std::env::current_dir() {
+            Ok(cwd) => self.lib_path.insert(0, cwd),
+            Err(e) => {
+                eprintln!(
+                    "warning: cannot access current directory ({}); file imports may fail",
+                    e
+                );
+                eprintln!(
+                    "  help: this often happens after a git operation deletes and recreates a directory"
+                );
+                eprintln!(
+                    "  help: try `cd .` or `cd $PWD` to refresh your shell's directory handle"
+                );
+            }
+        }
 
         // For pipes, default json stdin (but not if -e evaluand provided)
         if self.explicit_inputs.is_empty()


### PR DESCRIPTION
Instead of panicking with `failed to process CLI defaults: Io(Os { code: 2, kind: NotFound })`, warn and continue. The missing cwd is added as a lib path for file imports — if it's unavailable, imports may fail but the binary shouldn't crash.

Common after git operations that delete/recreate directories (rebase, branch switch) leaving the shell with a stale handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)