### PR TITLE
fix: stack trace shows function names instead of full source with docstrings

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -235,14 +235,27 @@ impl SourceMap {
             .filter_map(|smid| {
                 let info = self.source.get(smid.get())?;
 
-                // Determine the display name: prefer intrinsic display name, then source snippet
-                let display_name = info.annotation.as_deref().and_then(intrinsic_display_name);
+                // Determine the display name: prefer intrinsic display name,
+                // then annotation (function name), then source snippet
+                let display_name = info
+                    .annotation
+                    .as_deref()
+                    .and_then(|a| intrinsic_display_name(a).or(Some(a)));
 
                 let source_snippet = || {
                     let id = info.file?;
                     let source: &str = files.source(id).ok()?;
                     let span = info.span?;
-                    source.get(Range::from(span))
+                    let raw = source.get(Range::from(span))?;
+                    // Truncate to first line for readability — full
+                    // multi-line declarations (with docstrings) are too
+                    // verbose for a stack trace.
+                    let first_line = raw.lines().next().unwrap_or(raw);
+                    if first_line.len() < raw.len() {
+                        Some(format!("{first_line}…"))
+                    } else {
+                        Some(first_line.to_string())
+                    }
                 };
 
                 // Build file:line:col location string if we have a source location
@@ -264,7 +277,9 @@ impl SourceMap {
 
                 // Only include entries that have a user-visible name or source location.
                 // Entries with neither are internal machinery and are silently dropped.
-                let name = display_name.or_else(source_snippet)?;
+                let name = display_name
+                    .map(|s| s.to_string())
+                    .or_else(source_snippet)?;
 
                 // Format: "name at file:line:col" or just "name" if no location
                 let entry = match location {


### PR DESCRIPTION
The trace formatter was printing entire multi-line source snippets (including backtick docstrings) for user-defined functions because the annotation was only used for intrinsic display names. Now uses the annotation (function name) directly for all annotated entries. Source snippet fallback is truncated to first line.

Before:
```
- ` "`update-first(p?, f, l)` - apply `f` to the first...
  update-first(p?, f, l): {
    go[pre, suf]: ...
  }.(l split-when(p?) go) at [prelude]:1068:1
```

After:
```
- update-first at [prelude]:1068:1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)