### PR TITLE
fix: stack traces show function names instead of source snippets

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -235,14 +235,25 @@ impl SourceMap {
             .filter_map(|smid| {
                 let info = self.source.get(smid.get())?;
 
-                // Determine the display name: prefer intrinsic display name, then source snippet
-                let display_name = info.annotation.as_deref().and_then(intrinsic_display_name);
+                // Determine the display name: prefer intrinsic display name,
+                // then annotation (function name), then source snippet
+                let display_name = info
+                    .annotation
+                    .as_deref()
+                    .and_then(|a| intrinsic_display_name(a).or(Some(a)));
 
-                let source_snippet = || {
+                let source_snippet = || -> Option<String> {
                     let id = info.file?;
                     let source: &str = files.source(id).ok()?;
                     let span = info.span?;
-                    source.get(Range::from(span))
+                    let raw = source.get(Range::from(span))?;
+                    // Truncate to first line as a safety net
+                    let first_line = raw.lines().next().unwrap_or(raw);
+                    if first_line.len() < raw.len() {
+                        Some(format!("{first_line}…"))
+                    } else {
+                        Some(first_line.to_string())
+                    }
                 };
 
                 // Build file:line:col location string if we have a source location
@@ -264,7 +275,9 @@ impl SourceMap {
 
                 // Only include entries that have a user-visible name or source location.
                 // Entries with neither are internal machinery and are silently dropped.
-                let name = display_name.or_else(source_snippet)?;
+                let name = display_name
+                    .map(|s| s.to_string())
+                    .or_else(source_snippet)?;
 
                 // Format: "name at file:line:col" or just "name" if no location
                 let entry = match location {
@@ -408,7 +421,7 @@ pub fn intrinsic_display_name(name: &str) -> Option<&str> {
         // Internal constants and data constructors
         "KNIL" | "K[]" | "K{}" | "DQ" | "IFIELDS" | "SUPPRESSES" | "REQUIRES" => None,
 
-        // Unknown — show as-is (should not normally appear)
-        other => Some(other),
+        // Unknown — not an intrinsic
+        _ => None,
     }
 }

--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -197,9 +197,18 @@ impl<'smap> Desugarer<'smap> {
         &mut self.env
     }
 
-    /// Record source position and mint a SMID for it
+    /// Record source position and mint a SMID for it.
+    ///
+    /// If we are inside a declaration (stack is non-empty), the SMID
+    /// is automatically annotated with the current declaration name so
+    /// that stack traces show function names instead of source snippets.
     pub fn new_smid(&mut self, span: Span) -> Smid {
-        self.source_map.add(*self.file.last().unwrap(), span)
+        let file = *self.file.last().unwrap();
+        if let Some(name) = self.stack.last() {
+            self.source_map.add_annotated(file, span, name.clone())
+        } else {
+            self.source_map.add(file, span)
+        }
     }
 
     /// Record an annotated source position and mint a SMID for it


### PR DESCRIPTION
## Summary

Stack traces showed full source text (including docstrings) for user-defined functions because their SMIDs had no annotation. Now `Desugarer.new_smid()` automatically annotates with the current declaration name from the name stack.

Also fixed `intrinsic_display_name` catch-all which was returning user function names as intrinsic display names, causing secondary labels to say "in 'transform'" instead of "called from here".

Before:
```
- ` "`update-first(p?, f, l)` - apply...
  update-first(p?, f, l): {
    go[pre, suf]: ...
  }.(l split-when(p?) go) at [prelude]:1068:1
- go[pre, suf]: (suf nil?) then(l, ...) at [prelude]:1071:3
```

After:
```
- update-first at [prelude]:1068:1
- update-first at [prelude]:1071:3
```

## Test plan

- [x] All 236 harness tests pass (including error test 108)
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)