### PR TITLE
fix: head and tail on empty list panic with clear message

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -221,7 +221,7 @@ snoc(x, l): l ++ [x]
 (x ‖ xs): __CONS(x, xs)
 
 ` "`head(xs)` - return the head item of list `xs`, panic if empty."
-head: __HEAD
+head(xs): if(xs nil?, panic("head of empty list"), __HEAD(xs))
 
 ` { doc: "`↑xs` - return first element of list `xs`. Tight-binding prefix operator."
     precedence: 95 }
@@ -244,7 +244,7 @@ coalesce(xs): (xs nil?) then(null, (xs head)✓ then(xs head, xs tail coalesce))
 head-or(d, xs): xs nil? then(d, xs head)
 
 ` "`tail(xs)` - return list `xs` without the head item. [] causes error."
-tail: __TAIL
+tail(xs): if(xs nil?, panic("tail of empty list"), __TAIL(xs))
 
 ` "`tail-or(xs, d)` - return list `xs` without the head item or `d` for empty list."
 tail-or(d, xs): xs nil? then(d, xs tail)

--- a/tests/harness/errors/112_head_empty_list.eu
+++ b/tests/harness/errors/112_head_empty_list.eu
@@ -1,0 +1,1 @@
+result: [] head

--- a/tests/harness/errors/112_head_empty_list.eu.expect
+++ b/tests/harness/errors/112_head_empty_list.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "head of empty list"

--- a/tests/harness/errors/113_tail_empty_list.eu
+++ b/tests/harness/errors/113_tail_empty_list.eu
@@ -1,0 +1,1 @@
+result: [] tail

--- a/tests/harness/errors/113_tail_empty_list.eu.expect
+++ b/tests/harness/errors/113_tail_empty_list.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "tail of empty list"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1292,3 +1292,13 @@ pub fn test_error_110() {
 pub fn test_error_111() {
     run_error_test(&error_opts("111_missing_option_value.eu"));
 }
+
+#[test]
+pub fn test_error_112() {
+    run_error_test(&error_opts("112_head_empty_list.eu"));
+}
+
+#[test]
+pub fn test_error_113() {
+    run_error_test(&error_opts("113_tail_empty_list.eu"));
+}


### PR DESCRIPTION
`[] head` now says `panic: head of empty list` instead of `type mismatch: received a string where a structured value was expected`.

Same for `[] tail`.

## Root cause

The `__HEAD` intrinsic wrapper had a `Panic.global(str("HEAD on empty list"))` fallback for non-ListCons input. This never fired because `str("...")` produces a raw `Native::Str` value ref, but the PANIC intrinsic's default wrapper expects a `BoxedString` (it unboxes strict string args). The raw native reaches the unbox step → tag mismatch → "received a string where structured value expected" — masking the actual panic message.

## Fix

Guard with `nil?` in the prelude before delegating to the intrinsic:
```eucalypt
head(xs): if(xs nil?, panic("head of empty list"), __HEAD(xs))
tail(xs): if(xs nil?, panic("tail of empty list"), __TAIL(xs))
```

Error tests added for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)