### PR TITLE
fix: gc_debug ordering, vec precedence clarity, mark_count docs

### DIFF
--- a/src/eval/memory/gc_debug.rs
+++ b/src/eval/memory/gc_debug.rs
@@ -25,12 +25,13 @@ static FLAGS_INITIALISED: AtomicBool = AtomicBool::new(false);
 
 /// Initialise GC debug flags from environment variables.
 ///
-/// Called lazily on first use.  Thread-safe (idempotent, relaxed atomics).
+/// Called lazily on first use.  Thread-safe (idempotent, acquire/release
+/// ordering ensures the flag stores are visible before `FLAGS_INITIALISED`).
 fn ensure_initialised() {
-    if !FLAGS_INITIALISED.load(Ordering::Relaxed) {
+    if !FLAGS_INITIALISED.load(Ordering::Acquire) {
         GC_POISON_ENABLED.store(std::env::var("EU_GC_POISON").is_ok(), Ordering::Relaxed);
         GC_VERIFY_ENABLED.store(std::env::var("EU_GC_VERIFY").is_ok(), Ordering::Relaxed);
-        FLAGS_INITIALISED.store(true, Ordering::Relaxed);
+        FLAGS_INITIALISED.store(true, Ordering::Release);
     }
 }
 

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1116,8 +1116,11 @@ pub struct Heap {
     gc_metrics: UnsafeCell<GCMetrics>,
     /// Pin counts by block base address.
     pin_counts: UnsafeCell<HashMap<usize, usize>>,
-    /// Counter of mark_object calls — used by GC verify to detect
-    /// objects that were missed during the mark phase.
+    /// Number of objects marked (cumulative across all GC cycles).
+    ///
+    /// Incremented by `mark_object()` each time an object is marked.
+    /// Never reset to zero — `verify_mark_integrity` uses a before/after
+    /// snapshot to detect objects missed during a single mark phase.
     mark_count: std::cell::Cell<u64>,
 }
 

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -370,7 +370,7 @@ impl StgIntrinsic for VecSample {
         let mut indices: Vec<usize> = (0..len).collect();
         for (i, &f) in floats.iter().take(count).enumerate() {
             let remaining = len - i;
-            let j = i + (f * remaining as f64) as usize % remaining;
+            let j = i + (((f * remaining as f64) as usize) % remaining);
             indices.swap(i, j);
         }
         let sampled: Vec<Primitive> = indices[..count]
@@ -425,7 +425,7 @@ impl StgIntrinsic for VecShuffle {
             if i == 0 {
                 break;
             }
-            let j = (f * (i + 1) as f64) as usize % (i + 1);
+            let j = ((f * (i + 1) as f64) as usize) % (i + 1);
             elements.swap(i, j);
         }
         machine_return_vec(


### PR DESCRIPTION
## Summary

- **gc_debug acquire/release ordering (eu-op38)**: Changed `ensure_initialised()` to use `Acquire` on the flag load and `Release` on the flag store, ensuring the inner `Relaxed` stores to `GC_POISON_ENABLED` / `GC_VERIFY_ENABLED` are visible to other threads before the initialised flag is observed as `true`.
- **vec precedence clarity (eu-0s11)**: Added explicit parentheses around the Fisher-Yates index calculations in `VecSample::execute` and `VecShuffle::execute` to make cast-then-modulo precedence unambiguous.
- **mark_count doc comment (eu-rjql)**: Replaced the terse field comment on `mark_count` in `Heap` with a doc comment explaining its cumulative lifecycle and how `verify_mark_integrity` uses before/after snapshots rather than resets.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --lib` — 613 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)