### PR TITLE
refactor: extract shared pipeline from wasm.rs for native testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,7 @@ pub mod export;
 pub mod import;
 pub mod syntax;
 
+pub mod wasm_pipeline;
+
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,56 +5,13 @@
 //! - `evaluate(source, format)` — evaluate eucalypt source and return JSON
 //! - `formats()` — return a JSON array of supported output format names
 //!
-//! The implementation directly uses the core eucalypt pipeline without going
-//! through the CLI driver, since `clap`, `dirs`, and related crates are not
-//! available in WASM targets.
+//! The actual evaluation pipeline lives in [`crate::wasm_pipeline`] so it can
+//! be tested on native targets.  This module is a thin wrapper that converts
+//! the pipeline result into the JSON envelope that JS callers expect.
 
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-use std::io;
-use std::rc::Rc;
-
-use codespan_reporting::files::Files;
 use wasm_bindgen::prelude::*;
 
-use crate::common::sourcemap::{Smid, SourceMap};
-use crate::core::cook;
-use crate::core::desugar::{Content, Desugarer};
-use crate::core::inline::{reduce, tag};
-use crate::core::simplify::{compress, prune};
-use crate::core::transform::fuse;
-use crate::core::unit::TranslationUnit;
-use crate::driver::io::{create_args_pseudoblock, create_io_pseudoblock};
-use crate::driver::resources::Resources;
-use crate::eval::machine::standard_machine;
-use crate::eval::stg::{self, make_standard_runtime, RenderType, StgSettings};
-use crate::export;
-use crate::import;
-use crate::syntax::input::{Input, Locator};
-use crate::syntax::rowan;
-use codespan_reporting::files::SimpleFiles;
-
-/// Step limit for WASM evaluation to prevent infinite loops from
-/// hanging the browser tab.
-const MAX_STEPS: usize = 1_000_000;
-
-/// A `Write` implementation backed by an `Rc<RefCell<Vec<u8>>>`.
-///
-/// This avoids the borrow-checker conflict that arises when `&mut Vec<u8>` is
-/// lent to an emitter that is then moved into the machine: the `Rc` clone held
-/// outside the machine can be dereferenced after the machine is dropped.
-struct SharedWriter(Rc<RefCell<Vec<u8>>>);
-
-impl io::Write for SharedWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.borrow_mut().extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
+use crate::wasm_pipeline;
 
 /// Result of evaluating eucalypt source, serialised as JSON for JS callers.
 ///
@@ -79,13 +36,13 @@ struct EvalResult {
 struct ErrorInfo {
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    location: Option<SourceLocation>,
+    location: Option<WasmSourceLocation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     notes: Option<Vec<String>>,
 }
 
 #[derive(serde::Serialize)]
-struct SourceLocation {
+struct WasmSourceLocation {
     line: usize,
     column: usize,
     end_line: usize,
@@ -102,16 +59,25 @@ struct SourceLocation {
 /// A JSON string containing an `EvalResult`.
 #[wasm_bindgen]
 pub fn evaluate(source: &str, format: &str) -> String {
-    let result = match evaluate_inner(source, format) {
+    let result = match wasm_pipeline::evaluate_pipeline(source, format) {
         Ok(output) => EvalResult {
             success: true,
             output: Some(output),
             error: None,
         },
-        Err(error_info) => EvalResult {
+        Err(e) => EvalResult {
             success: false,
             output: None,
-            error: Some(error_info),
+            error: Some(ErrorInfo {
+                message: e.message,
+                location: e.location.map(|loc| WasmSourceLocation {
+                    line: loc.line,
+                    column: loc.column,
+                    end_line: loc.end_line,
+                    end_column: loc.end_column,
+                }),
+                notes: e.notes,
+            }),
         },
     };
 
@@ -124,295 +90,4 @@ pub fn evaluate(source: &str, format: &str) -> String {
 #[wasm_bindgen]
 pub fn formats() -> String {
     r#"["yaml","json","toml","text","edn","html"]"#.to_string()
-}
-
-// ── Internal pipeline ────────────────────────────────────────────────────────
-
-fn evaluate_inner(source: &str, format: &str) -> Result<String, ErrorInfo> {
-    let mut files: SimpleFiles<String, String> = SimpleFiles::new();
-    let mut source_map = SourceMap::new();
-    let resources = Resources::default();
-
-    // 1. Parse prelude (embedded at compile time via Resources)
-    let prelude_text = resources
-        .get("prelude")
-        .expect("prelude is embedded")
-        .clone();
-    let prelude_file_id = files.add("prelude".to_string(), prelude_text.clone());
-    let prelude_parse = rowan::parse_unit(&prelude_text);
-    // Prelude parse errors are internal — treat as hard failures without location
-    if !prelude_parse.errors().is_empty() {
-        return Err(ErrorInfo {
-            message: "Internal error: prelude parse failed".to_string(),
-            location: None,
-            notes: Some(
-                prelude_parse
-                    .errors()
-                    .iter()
-                    .map(|e| e.to_string())
-                    .collect(),
-            ),
-        });
-    }
-    let prelude_ast = prelude_parse.tree();
-
-    // 2. Parse build-meta YAML (embedded at compile time)
-    let build_meta_text = resources
-        .get("build-meta")
-        .expect("build-meta is embedded")
-        .clone();
-    let build_meta_file_id = files.add("build-meta.yaml".to_string(), build_meta_text);
-    let build_meta_core =
-        import::read_to_core("yaml", &mut files, &mut source_map, build_meta_file_id).map_err(
-            |e| ErrorInfo {
-                message: format!("Internal error loading build metadata: {e}"),
-                location: None,
-                notes: None,
-            },
-        )?;
-
-    // 3. Parse user source
-    let source_file_id = files.add("<input>".to_string(), source.to_string());
-    let source_parse = rowan::parse_unit(source);
-    if !source_parse.errors().is_empty() {
-        let first_error = &source_parse.errors()[0];
-        let location = extract_parse_error_location(first_error, source_file_id, &files);
-        let message = source_parse
-            .errors()
-            .iter()
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(ErrorInfo {
-            message: format!("Parse error: {message}"),
-            location,
-            notes: None,
-        });
-    }
-    let source_ast = source_parse.tree();
-
-    // 4. Desugar prelude
-    let prelude_input = Input::new(Locator::Resource("prelude".to_string()), None, "eu");
-    let prelude_unit = {
-        let mut contents: HashMap<Input, Content> = HashMap::new();
-        contents.insert(
-            prelude_input.clone(),
-            Content::new(prelude_file_id, &prelude_ast),
-        );
-        let mut d = Desugarer::new(&contents, &mut source_map);
-        d.translate_unit(&prelude_input)
-            .map_err(|e| core_error_to_info(e, &source_map))?
-    };
-
-    // 5. Desugar user source
-    let source_input = Input::new(Locator::Literal("<input>".to_string()), None, "eu");
-    let source_unit = {
-        let mut contents: HashMap<Input, Content> = HashMap::new();
-        contents.insert(
-            source_input.clone(),
-            Content::new(source_file_id, &source_ast),
-        );
-        let mut d = Desugarer::new(&contents, &mut source_map);
-        d.translate_unit(&source_input)
-            .map_err(|e| core_error_to_info(e, &source_map))?
-    };
-
-    // 6. Create TranslationUnits for pseudo-inputs.
-    //
-    // Order matches the CLI driver: __args, __io, __build are prepended in
-    // that order (each at front), giving final merge order:
-    //   __args, __io, __build, prelude, user_source
-    let args_unit = TranslationUnit {
-        expr: create_args_pseudoblock(&[]).apply_name(Smid::default(), "__args"),
-        targets: HashSet::new(),
-        docs: Vec::new(),
-    };
-    let io_unit = TranslationUnit {
-        expr: create_io_pseudoblock(None).apply_name(Smid::default(), "__io"),
-        targets: HashSet::new(),
-        docs: Vec::new(),
-    };
-    let build_unit = TranslationUnit {
-        expr: build_meta_core.apply_name(Smid::default(), "__build"),
-        targets: HashSet::new(),
-        docs: Vec::new(),
-    };
-
-    // 7. Merge all units
-    let merged = TranslationUnit::merge(
-        [args_unit, io_unit, build_unit, prelude_unit, source_unit].into_iter(),
-    )
-    .map_err(|e| core_error_to_info(e, &source_map))?;
-
-    let mut expr = merged.expr;
-
-    // 8. Cook — operator precedence and expression anaphora
-    expr = cook::cook(expr).map_err(|e| core_error_to_info(e, &source_map))?;
-
-    // 9. Inline (2 passes)
-    for _ in 0..2 {
-        expr = tag::tag_combinators(&expr).map_err(|e| core_error_to_info(e, &source_map))?;
-        expr = reduce::inline_pass(&expr).map_err(|e| core_error_to_info(e, &source_map))?;
-    }
-
-    // 10. Fuse destructure patterns
-    expr = fuse::fuse(&expr).map_err(|e| core_error_to_info(e, &source_map))?;
-
-    // 11. Prune unused bindings (2 passes)
-    for _ in 0..2 {
-        expr = prune::prune(&expr);
-        expr = compress::compress(&expr).map_err(|e| core_error_to_info(e, &source_map))?;
-    }
-
-    // 12. Compile to STG.
-    //
-    // Use RenderDoc directly (not Headless) since WASM does not support IO
-    // monads, so we skip the headless→world-injection→RenderDoc dance that
-    // the CLI driver performs.
-    let stg_settings = StgSettings {
-        generate_annotations: true,
-        render_type: RenderType::RenderDoc,
-        heap_limit_mib: Some(256),
-        ..Default::default()
-    };
-
-    let rt = make_standard_runtime(&mut source_map);
-    let syn = stg::compile(&stg_settings, expr, rt.as_ref())
-        .map_err(|e| execution_error_to_info(e.into(), &files, &source_map))?;
-
-    // 13. Run the machine, capturing output via SharedWriter.
-    //
-    // We use `Rc<RefCell<Vec<u8>>>` instead of `&mut Vec<u8>` to avoid the
-    // borrow-checker conflict: the emitter borrows from the writer with
-    // lifetime 'a, and Machine<'a> holds the emitter. With a raw `&mut` we
-    // cannot read the Vec after machine.take_emitter() because the compiler
-    // sees the borrow as potentially lasting until Machine<'a> is dropped.
-    // The Rc clone lets us access the buffer independently once the machine
-    // and writer are both dropped.
-    let output_buf: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::new()));
-    let mut writer = SharedWriter(output_buf.clone());
-    let mut emitter = export::create_emitter(format, &mut writer).ok_or_else(|| ErrorInfo {
-        message: format!("Unknown output format: {format}"),
-        location: None,
-        notes: Some(vec![
-            "Supported formats: yaml, json, toml, text, edn, html".to_string()
-        ]),
-    })?;
-
-    emitter.stream_start();
-    let mut machine = standard_machine(&stg_settings, syn, emitter, rt.as_ref())
-        .map_err(|e| execution_error_to_info(e, &files, &source_map))?;
-
-    let ret = machine.run(Some(MAX_STEPS));
-    machine.take_emitter().stream_end();
-
-    // Drop machine and writer so output_buf becomes the sole Rc owner.
-    drop(machine);
-    drop(writer);
-
-    ret.map_err(|e| execution_error_to_info(e, &files, &source_map))?;
-
-    let output = Rc::try_unwrap(output_buf)
-        .expect("output_buf should have no remaining owners")
-        .into_inner();
-
-    String::from_utf8(output).map_err(|e| ErrorInfo {
-        message: format!("Output encoding error: {e}"),
-        location: None,
-        notes: None,
-    })
-}
-
-// ── Error conversion helpers ─────────────────────────────────────────────────
-
-fn core_error_to_info(e: crate::core::error::CoreError, source_map: &SourceMap) -> ErrorInfo {
-    let diag = e.to_diagnostic(source_map);
-    ErrorInfo {
-        message: diag.message.clone(),
-        location: None,
-        notes: if diag.notes.is_empty() {
-            None
-        } else {
-            Some(diag.notes.clone())
-        },
-    }
-}
-
-fn execution_error_to_info(
-    e: crate::eval::error::ExecutionError,
-    files: &SimpleFiles<String, String>,
-    source_map: &SourceMap,
-) -> ErrorInfo {
-    let diag = e.to_diagnostic(source_map);
-    ErrorInfo {
-        message: diag.message.clone(),
-        location: extract_location(&diag, files),
-        notes: if diag.notes.is_empty() {
-            None
-        } else {
-            Some(diag.notes.clone())
-        },
-    }
-}
-
-/// Extract source location from the first primary label of a diagnostic.
-fn extract_location(
-    diag: &codespan_reporting::diagnostic::Diagnostic<usize>,
-    files: &SimpleFiles<String, String>,
-) -> Option<SourceLocation> {
-    let label = diag.labels.first()?;
-    let start = files.location(label.file_id, label.range.start).ok()?;
-    let end = files.location(label.file_id, label.range.end).ok()?;
-    Some(SourceLocation {
-        line: start.line_number,
-        column: start.column_number,
-        end_line: end.line_number,
-        end_column: end.column_number,
-    })
-}
-
-/// Extract source location from a rowan parse error's text range.
-fn extract_parse_error_location(
-    error: &crate::syntax::rowan::ParseError,
-    file_id: usize,
-    files: &SimpleFiles<String, String>,
-) -> Option<SourceLocation> {
-    let range = parse_error_range(error)?;
-    let start_offset = usize::from(range.start());
-    let end_offset = usize::from(range.end());
-    let start = files.location(file_id, start_offset).ok()?;
-    let end = files.location(file_id, end_offset).ok()?;
-    Some(SourceLocation {
-        line: start.line_number,
-        column: start.column_number,
-        end_line: end.line_number,
-        end_column: end.column_number,
-    })
-}
-
-/// Extract the primary text range from a parse error.
-fn parse_error_range(error: &rowan::ParseError) -> Option<::rowan::TextRange> {
-    use crate::syntax::rowan::ParseError as PE;
-    match error {
-        PE::UnexpectedToken { range, .. } => Some(*range),
-        PE::UnclosedSingleQuote { range } => Some(*range),
-        PE::UnclosedDoubleQuote { range } => Some(*range),
-        PE::InvalidParenExpr { range, .. } => Some(*range),
-        PE::UnterminatedBlock { range, .. } => Some(*range),
-        PE::EmptyDeclarationBody { range } => Some(*range),
-        PE::MissingDeclarationColon { head_range } => Some(*head_range),
-        PE::MalformedDeclarationHead { range } => Some(*range),
-        PE::InvalidFormalParameter { range, .. } => Some(*range),
-        PE::InvalidOperatorName { range, .. } => Some(*range),
-        PE::InvalidPropertyName { range, .. } => Some(*range),
-        PE::SurplusContent { range } => Some(*range),
-        PE::ReservedCharacter { range } => Some(*range),
-        PE::EmptyExpression { range } => Some(*range),
-        PE::UnclosedStringInterpolation { range } => Some(*range),
-        PE::InvalidZdtLiteral { range, .. } => Some(*range),
-        PE::InvalidDoubleColon { range } => Some(*range),
-        PE::UnclosedBracketExpr { range } => Some(*range),
-        PE::MismatchedBrackets { close_range, .. } => Some(*close_range),
-        PE::UnknownBracketPair { range, .. } => Some(*range),
-    }
 }

--- a/src/wasm_pipeline.rs
+++ b/src/wasm_pipeline.rs
@@ -1,0 +1,454 @@
+//! Core evaluation pipeline shared between the WASM API and native tests.
+//!
+//! This module extracts the evaluate-from-source logic so it can be exercised
+//! by `#[cfg(test)]` unit tests on native targets without requiring
+//! `wasm_bindgen` or `serde`.
+//!
+//! The WASM module (`wasm.rs`) calls [`evaluate_pipeline`] and converts the
+//! result into the JSON envelope that JS callers expect.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::io;
+use std::rc::Rc;
+
+use codespan_reporting::files::Files;
+use codespan_reporting::files::SimpleFiles;
+
+use crate::common::sourcemap::{Smid, SourceMap};
+use crate::core::cook;
+use crate::core::desugar::{Content, Desugarer};
+use crate::core::inline::{reduce, tag};
+use crate::core::simplify::{compress, prune};
+use crate::core::transform::fuse;
+use crate::core::unit::TranslationUnit;
+use crate::driver::io::{create_args_pseudoblock, create_io_pseudoblock};
+use crate::driver::resources::Resources;
+use crate::eval::machine::standard_machine;
+use crate::eval::stg::{self, make_standard_runtime, RenderType, StgSettings};
+use crate::export;
+use crate::import;
+use crate::syntax::input::{Input, Locator};
+use crate::syntax::rowan;
+
+/// Step limit for evaluation to prevent infinite loops from hanging the
+/// browser tab (or a test runner).
+const MAX_STEPS: usize = 1_000_000;
+
+/// A `Write` implementation backed by an `Rc<RefCell<Vec<u8>>>`.
+///
+/// This avoids the borrow-checker conflict that arises when `&mut Vec<u8>` is
+/// lent to an emitter that is then moved into the machine: the `Rc` clone held
+/// outside the machine can be dereferenced after the machine is dropped.
+struct SharedWriter(Rc<RefCell<Vec<u8>>>);
+
+impl io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+// ── Error type ───────────────────────────────────────────────────────────────
+
+/// Source location within the input, expressed as 1-based line/column pairs.
+#[derive(Debug, Clone)]
+pub struct SourceLocation {
+    pub line: usize,
+    pub column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+}
+
+/// Error returned by [`evaluate_pipeline`].
+#[derive(Debug)]
+pub struct PipelineError {
+    pub message: String,
+    pub location: Option<SourceLocation>,
+    pub notes: Option<Vec<String>>,
+}
+
+impl fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+/// Evaluate eucalypt source code and return the rendered output as a string.
+///
+/// This is the core pipeline used by the WASM `evaluate()` function, extracted
+/// here so it can be tested on native targets.
+///
+/// # Arguments
+/// * `source` — eucalypt source code (declaration-style, as for a `.eu` file)
+/// * `format` — output format: `"yaml"`, `"json"`, `"toml"`, `"text"`,
+///   `"edn"`, `"html"`
+///
+/// # Returns
+/// `Ok(output)` on success, `Err(PipelineError)` on failure.
+pub fn evaluate_pipeline(source: &str, format: &str) -> Result<String, PipelineError> {
+    let mut files: SimpleFiles<String, String> = SimpleFiles::new();
+    let mut source_map = SourceMap::new();
+    let resources = Resources::default();
+
+    // 1. Parse prelude (embedded at compile time via Resources)
+    let prelude_text = resources
+        .get("prelude")
+        .expect("prelude is embedded")
+        .clone();
+    let prelude_file_id = files.add("prelude".to_string(), prelude_text.clone());
+    let prelude_parse = rowan::parse_unit(&prelude_text);
+    // Prelude parse errors are internal — treat as hard failures without location
+    if !prelude_parse.errors().is_empty() {
+        return Err(PipelineError {
+            message: "Internal error: prelude parse failed".to_string(),
+            location: None,
+            notes: Some(
+                prelude_parse
+                    .errors()
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect(),
+            ),
+        });
+    }
+    let prelude_ast = prelude_parse.tree();
+
+    // 2. Parse build-meta YAML (embedded at compile time)
+    let build_meta_text = resources
+        .get("build-meta")
+        .expect("build-meta is embedded")
+        .clone();
+    let build_meta_file_id = files.add("build-meta.yaml".to_string(), build_meta_text);
+    let build_meta_core =
+        import::read_to_core("yaml", &mut files, &mut source_map, build_meta_file_id).map_err(
+            |e| PipelineError {
+                message: format!("Internal error loading build metadata: {e}"),
+                location: None,
+                notes: None,
+            },
+        )?;
+
+    // 3. Parse user source
+    let source_file_id = files.add("<input>".to_string(), source.to_string());
+    let source_parse = rowan::parse_unit(source);
+    if !source_parse.errors().is_empty() {
+        let first_error = &source_parse.errors()[0];
+        let location = extract_parse_error_location(first_error, source_file_id, &files);
+        let message = source_parse
+            .errors()
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(PipelineError {
+            message: format!("Parse error: {message}"),
+            location,
+            notes: None,
+        });
+    }
+    let source_ast = source_parse.tree();
+
+    // 4. Desugar prelude
+    let prelude_input = Input::new(Locator::Resource("prelude".to_string()), None, "eu");
+    let prelude_unit = {
+        let mut contents: HashMap<Input, Content> = HashMap::new();
+        contents.insert(
+            prelude_input.clone(),
+            Content::new(prelude_file_id, &prelude_ast),
+        );
+        let mut d = Desugarer::new(&contents, &mut source_map);
+        d.translate_unit(&prelude_input)
+            .map_err(|e| core_error_to_pipeline_error(e, &source_map))?
+    };
+
+    // 5. Desugar user source
+    let source_input = Input::new(Locator::Literal("<input>".to_string()), None, "eu");
+    let source_unit = {
+        let mut contents: HashMap<Input, Content> = HashMap::new();
+        contents.insert(
+            source_input.clone(),
+            Content::new(source_file_id, &source_ast),
+        );
+        let mut d = Desugarer::new(&contents, &mut source_map);
+        d.translate_unit(&source_input)
+            .map_err(|e| core_error_to_pipeline_error(e, &source_map))?
+    };
+
+    // 6. Create TranslationUnits for pseudo-inputs.
+    //
+    // Order matches the CLI driver: __args, __io, __build are prepended in
+    // that order (each at front), giving final merge order:
+    //   __args, __io, __build, prelude, user_source
+    let args_unit = TranslationUnit {
+        expr: create_args_pseudoblock(&[]).apply_name(Smid::default(), "__args"),
+        targets: HashSet::new(),
+        docs: Vec::new(),
+    };
+    let io_unit = TranslationUnit {
+        expr: create_io_pseudoblock(None).apply_name(Smid::default(), "__io"),
+        targets: HashSet::new(),
+        docs: Vec::new(),
+    };
+    let build_unit = TranslationUnit {
+        expr: build_meta_core.apply_name(Smid::default(), "__build"),
+        targets: HashSet::new(),
+        docs: Vec::new(),
+    };
+
+    // 7. Merge all units
+    let merged = TranslationUnit::merge(
+        [args_unit, io_unit, build_unit, prelude_unit, source_unit].into_iter(),
+    )
+    .map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+
+    let mut expr = merged.expr;
+
+    // 8. Cook — operator precedence and expression anaphora
+    expr = cook::cook(expr).map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+
+    // 9. Inline (2 passes)
+    for _ in 0..2 {
+        expr = tag::tag_combinators(&expr)
+            .map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+        expr =
+            reduce::inline_pass(&expr).map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+    }
+
+    // 10. Fuse destructure patterns
+    expr = fuse::fuse(&expr).map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+
+    // 11. Prune unused bindings (2 passes)
+    for _ in 0..2 {
+        expr = prune::prune(&expr);
+        expr =
+            compress::compress(&expr).map_err(|e| core_error_to_pipeline_error(e, &source_map))?;
+    }
+
+    // 12. Compile to STG.
+    //
+    // Use RenderDoc directly (not Headless) since WASM does not support IO
+    // monads, so we skip the headless->world-injection->RenderDoc dance that
+    // the CLI driver performs.
+    let stg_settings = StgSettings {
+        generate_annotations: true,
+        render_type: RenderType::RenderDoc,
+        heap_limit_mib: Some(256),
+        ..Default::default()
+    };
+
+    let rt = make_standard_runtime(&mut source_map);
+    let syn = stg::compile(&stg_settings, expr, rt.as_ref())
+        .map_err(|e| execution_error_to_pipeline_error(e.into(), &files, &source_map))?;
+
+    // 13. Run the machine, capturing output via SharedWriter.
+    let output_buf: Rc<RefCell<Vec<u8>>> = Rc::new(RefCell::new(Vec::new()));
+    let mut writer = SharedWriter(output_buf.clone());
+    let mut emitter = export::create_emitter(format, &mut writer).ok_or_else(|| PipelineError {
+        message: format!("Unknown output format: {format}"),
+        location: None,
+        notes: Some(vec![
+            "Supported formats: yaml, json, toml, text, edn, html".to_string()
+        ]),
+    })?;
+
+    emitter.stream_start();
+    let mut machine = standard_machine(&stg_settings, syn, emitter, rt.as_ref())
+        .map_err(|e| execution_error_to_pipeline_error(e, &files, &source_map))?;
+
+    let ret = machine.run(Some(MAX_STEPS));
+    machine.take_emitter().stream_end();
+
+    // Drop machine and writer so output_buf becomes the sole Rc owner.
+    drop(machine);
+    drop(writer);
+
+    ret.map_err(|e| execution_error_to_pipeline_error(e, &files, &source_map))?;
+
+    let output = Rc::try_unwrap(output_buf)
+        .expect("output_buf should have no remaining owners")
+        .into_inner();
+
+    String::from_utf8(output).map_err(|e| PipelineError {
+        message: format!("Output encoding error: {e}"),
+        location: None,
+        notes: None,
+    })
+}
+
+// ── Error conversion helpers ─────────────────────────────────────────────────
+
+fn core_error_to_pipeline_error(
+    e: crate::core::error::CoreError,
+    source_map: &SourceMap,
+) -> PipelineError {
+    let diag = e.to_diagnostic(source_map);
+    PipelineError {
+        message: diag.message.clone(),
+        location: None,
+        notes: if diag.notes.is_empty() {
+            None
+        } else {
+            Some(diag.notes.clone())
+        },
+    }
+}
+
+fn execution_error_to_pipeline_error(
+    e: crate::eval::error::ExecutionError,
+    files: &SimpleFiles<String, String>,
+    source_map: &SourceMap,
+) -> PipelineError {
+    let diag = e.to_diagnostic(source_map);
+    PipelineError {
+        message: diag.message.clone(),
+        location: extract_diagnostic_location(&diag, files),
+        notes: if diag.notes.is_empty() {
+            None
+        } else {
+            Some(diag.notes.clone())
+        },
+    }
+}
+
+/// Extract source location from the first primary label of a diagnostic.
+fn extract_diagnostic_location(
+    diag: &codespan_reporting::diagnostic::Diagnostic<usize>,
+    files: &SimpleFiles<String, String>,
+) -> Option<SourceLocation> {
+    let label = diag.labels.first()?;
+    let start = files.location(label.file_id, label.range.start).ok()?;
+    let end = files.location(label.file_id, label.range.end).ok()?;
+    Some(SourceLocation {
+        line: start.line_number,
+        column: start.column_number,
+        end_line: end.line_number,
+        end_column: end.column_number,
+    })
+}
+
+/// Extract source location from a rowan parse error's text range.
+fn extract_parse_error_location(
+    error: &crate::syntax::rowan::ParseError,
+    file_id: usize,
+    files: &SimpleFiles<String, String>,
+) -> Option<SourceLocation> {
+    let range = parse_error_range(error)?;
+    let start_offset = usize::from(range.start());
+    let end_offset = usize::from(range.end());
+    let start = files.location(file_id, start_offset).ok()?;
+    let end = files.location(file_id, end_offset).ok()?;
+    Some(SourceLocation {
+        line: start.line_number,
+        column: start.column_number,
+        end_line: end.line_number,
+        end_column: end.column_number,
+    })
+}
+
+/// Extract the primary text range from a parse error.
+fn parse_error_range(error: &rowan::ParseError) -> Option<::rowan::TextRange> {
+    use crate::syntax::rowan::ParseError as PE;
+    match error {
+        PE::UnexpectedToken { range, .. } => Some(*range),
+        PE::UnclosedSingleQuote { range } => Some(*range),
+        PE::UnclosedDoubleQuote { range } => Some(*range),
+        PE::InvalidParenExpr { range, .. } => Some(*range),
+        PE::UnterminatedBlock { range, .. } => Some(*range),
+        PE::EmptyDeclarationBody { range } => Some(*range),
+        PE::MissingDeclarationColon { head_range } => Some(*head_range),
+        PE::MalformedDeclarationHead { range } => Some(*range),
+        PE::InvalidFormalParameter { range, .. } => Some(*range),
+        PE::InvalidOperatorName { range, .. } => Some(*range),
+        PE::InvalidPropertyName { range, .. } => Some(*range),
+        PE::SurplusContent { range } => Some(*range),
+        PE::ReservedCharacter { range } => Some(*range),
+        PE::EmptyExpression { range } => Some(*range),
+        PE::UnclosedStringInterpolation { range } => Some(*range),
+        PE::InvalidZdtLiteral { range, .. } => Some(*range),
+        PE::InvalidDoubleColon { range } => Some(*range),
+        PE::UnclosedBracketExpr { range } => Some(*range),
+        PE::MismatchedBrackets { close_range, .. } => Some(*close_range),
+        PE::UnknownBracketPair { range, .. } => Some(*range),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json_output_block() {
+        let result = evaluate_pipeline("result: {x: 1}", "json").unwrap();
+        let v: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        assert_eq!(v["result"]["x"], 1);
+    }
+
+    #[test]
+    fn test_yaml_output() {
+        let result = evaluate_pipeline("x: 1", "yaml").unwrap();
+        assert!(result.contains("x:"));
+    }
+
+    #[test]
+    fn test_text_output() {
+        let result = evaluate_pipeline("result: \"hello\"", "text").unwrap();
+        assert!(result.trim().contains("hello"));
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let result = evaluate_pipeline("{{{{", "json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unknown_format() {
+        let result = evaluate_pipeline("x: 1", "nosuchformat");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_step_limit() {
+        let result = evaluate_pipeline("f(x): f(x)\nmain: f(0)", "json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_nested_block() {
+        let result = evaluate_pipeline("a: {b: 2}", "json").unwrap();
+        let v: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        assert_eq!(v["a"]["b"], 2);
+    }
+
+    #[test]
+    fn test_list_output() {
+        let result = evaluate_pipeline("result: [1, 2, 3]", "json").unwrap();
+        let v: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        assert_eq!(v["result"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn test_boolean_values() {
+        let result = evaluate_pipeline("t: true\nf: false", "json").unwrap();
+        let v: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        assert_eq!(v["t"], true);
+        assert_eq!(v["f"], false);
+    }
+
+    #[test]
+    fn test_expression_evaluation() {
+        let result = evaluate_pipeline("x: 2 + 3", "json").unwrap();
+        let v: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        assert_eq!(v["x"], 5);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the core evaluation pipeline from `wasm.rs` into a new `wasm_pipeline.rs` module with a public `evaluate_pipeline(source, format)` function
- `wasm.rs` now calls `wasm_pipeline::evaluate_pipeline` and converts the result to the JSON envelope — no duplicated pipeline logic
- The shared pipeline uses `parse_unit` (declaration-style parsing), exactly matching what WASM users get — drift is structurally impossible
- `wasm_pipeline` is NOT behind `#[cfg(target_arch = "wasm32")]`, so tests run on native targets
- Add 10 unit tests covering: JSON/YAML/text output, parse errors, unknown formats, divergent programs (step limit), nested blocks, lists, booleans, expression evaluation

## Key design choices

- `PipelineError` carries message, optional `SourceLocation`, and optional notes — enough for `wasm.rs` to reconstruct `ErrorInfo` without losing location data
- `SharedWriter` (the `Rc<RefCell<Vec<u8>>>` adapter) moved to the shared module since it is part of the pipeline

## Test plan

- [x] `cargo test --lib wasm_pipeline` — all 10 new tests pass
- [x] `cargo test --lib` — 623 tests pass, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)