### PR TITLE
fix: AllocHeader alignment for wasm32 compatibility

### DIFF
--- a/src/eval/memory/header.rs
+++ b/src/eval/memory/header.rs
@@ -49,12 +49,21 @@ impl HeaderBits {
 /// Object Header
 ///
 /// Immix requires:
-///  - a mark bit (for mark phase)
-///  - a forwarded bit (to support evacuation)
-///  - forwarding pointer (to support evacuation)
-///  - pinning (supported at the block level via Heap::pin_block /
-///    Heap::unpin_block, not per-object)
+/// - a mark bit (for mark phase)
+/// - a forwarded bit (to support evacuation)
+/// - forwarding pointer (to support evacuation)
+/// - pinning (supported at the block level via `Heap::pin_block` /
+///   `Heap::unpin_block`, not per-object)
+///
+/// On 64-bit targets the natural layout is already 16 bytes. On wasm32 the
+/// fields only occupy 12 bytes, and without explicit alignment objects would
+/// start at `base + 12` — not 8-byte aligned — causing misaligned pointer
+/// panics for types containing `f64`/`u64`. `align(16)` pads the struct to
+/// 16 bytes on all targets so that `ptr.offset(-1)` in `get_header` and
+/// `ptr.add(size_of::<AllocHeader>())` in `alloc` are always consistent and
+/// properly aligned.
 #[derive(Debug)]
+#[repr(C, align(16))]
 pub struct AllocHeader {
     /// Header bits for object state
     bits: HeaderBits,

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -3278,8 +3278,8 @@ pub mod tests {
         assert_eq!(size_of::<AllocHeader>(), 16, "AllocHeader size changed");
         assert_eq!(
             align_of::<AllocHeader>(),
-            8,
-            "AllocHeader natural alignment"
+            16,
+            "AllocHeader alignment (forced to 16 for wasm32 compatibility)"
         );
 
         let heap = Heap::new();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -98,11 +98,7 @@ mod wasm_tests {
     use super::*;
     use wasm_bindgen_test::*;
 
-    /// Full evaluation test — currently ignored due to runtime panic:
-    /// `std::time::Instant` is not available on `wasm32-unknown-unknown`.
-    /// Re-enable once the timing code is fully gated (bead eu-f8z8).
     #[wasm_bindgen_test]
-    #[ignore = "wasm32: std::time::Instant not available"]
     fn test_evaluate_json_success() {
         let result = evaluate("x: 1", "json");
         let parsed: serde_json::Value =


### PR DESCRIPTION
## Summary
- Add `#[repr(C, align(16))]` to `AllocHeader` so it is always 16 bytes on all targets
- On wasm32, the header was 12 bytes, causing objects to start at `base+12` (not 8-byte aligned), triggering misaligned pointer panics for types containing `f64`/`u64`
- Un-ignores the `test_evaluate_json_success` wasm-bindgen test now that both the `web_time` Instant fix and alignment fix are in place
- All 3 WASM tests now pass, all 240 harness tests pass, all 623 lib tests pass

## Test plan
- [x] `cargo test --lib` — 623 passed
- [x] `cargo test --test harness_test` — 240 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `wasm-bindgen-test-runner` WASM tests — 3 passed (including full evaluation)
- [x] `cargo build --target wasm32-unknown-unknown --lib` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)