### PR TITLE
feat: add ~ safe navigation operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -240,6 +240,7 @@ From highest (tightest) to lowest binding:
 |------|------|-------|-----------|-------------|
 | 95 | -- | prefix | `↑` | Head (tight prefix) |
 | 90 | lookup | left | `.` (built-in) | Property lookup |
+| 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
 | 90 | call | left | (built-in) | Function call |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
 | 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |

--- a/docs/reference/prelude/blocks.md
+++ b/docs/reference/prelude/blocks.md
@@ -16,6 +16,7 @@
 | `lookup-in(b, s)` | Look up symbol `s` in block `b`, error if not found |
 | `lookup-or(s, d, b)` | Look up symbol `s` in block `b`, default `d` if not found |
 | `lookup-or-in(b, s, d)` | Look up symbol `s` in block `b`, default `d` if not found |
+| `b ~ :k` | Safe key lookup — returns value at key `:k` if `b` is a block containing `:k`, else `null`. Null-propagating: returns `null` for non-block and null inputs. Left-associative, precedence 90. |
 | `lookup-alts(syms, d, b)` | Look up symbols `syms` in turn in block `b` until a value is found, default `d` if none |
 | `lookup-across(s, d, bs)` | Look up symbol `s` in turn in each of blocks `bs` until a value is found, default `d` if none |
 | `lookup-path(ks, b)` | Look up value at key path `ks` in block `b` |

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -319,6 +319,11 @@ lookup-or(s, d, b): __LOOKUPOR(s, d, b)
 ` "`lookup-or-in(b, s, d)` - look up symbol `s` in block `b`, default `d` if not found."
 lookup-or-in(b, s, d): lookup-or(s, d, b)
 
+` { doc: "a ~ :k - safe key lookup. Returns value at key :k if a is a block containing :k, else null. Null-propagating for chained navigation."
+    associates: :left
+    precedence: :lookup }
+(a ~ k): __SAFE_LOOKUP(a, k)
+
 ` "`lookup-alts(syms, d, b)` - look up symbols `syms` in turn in block `b` until a value is found, default `d` if none."
 lookup-alts(syms, d, b): foldr(lookup-or-in(b), d, syms)
 
@@ -621,10 +626,6 @@ rem(a, b): __REM(a, b)
     precedence: :bitwise }
 (l ⊕ r): __BITXOR(l, r)
 
-` { doc: "`~ n` - bitwise NOT of integer `n`."
-    export: :suppress
-    precedence: :bool-unary }
-(~ n): __BITNOT(n)
 
 ` { doc: "`n ≪ k` - left shift `n` by `k` bits."
     export: :suppress

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -626,6 +626,10 @@ rem(a, b): __REM(a, b)
     precedence: :bitwise }
 (l ⊕ r): __BITXOR(l, r)
 
+` { doc: "`⊝ n` - bitwise NOT (complement) of integer `n`."
+    export: :suppress
+    precedence: :bool-unary }
+(⊝ n): __BITNOT(n)
 
 ` { doc: "`n ≪ k` - left shift `n` by `k` bits."
     export: :suppress

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -944,6 +944,11 @@ lazy_static! {
             ty: function(vec![list(), list()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 179
+            name: "SAFE_LOOKUP",
+            ty: function(vec![any(), any(), any()]).unwrap(),
+            strict: vec![0, 1],
+    },
     ];
 }
 

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -847,6 +847,204 @@ fn store_index_in_block(
 
 impl CallGlobal3 for LookupOr {}
 
+/// SAFE_LOOKUP(obj, k) — safe key lookup with null propagation.
+///
+/// Returns the value at key `k` if `obj` is a block containing `k`,
+/// otherwise returns `null` (Unit). Null-propagating: if `obj` is
+/// `null` or any non-block value, returns `null` rather than erroring.
+///
+/// Uses the same hybrid index/linear-search strategy as `LookupOr`.
+pub struct SafeLookup(pub NativeVariant);
+
+impl StgIntrinsic for SafeLookup {
+    fn name(&self) -> &str {
+        "SAFE_LOOKUP"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        use dsl::*;
+
+        let bif_index: u8 = intrinsics::index(self.name())
+            .expect("SAFE_LOOKUP must be registered")
+            .try_into()
+            .unwrap();
+
+        // find: [list k find] — linear search with no default arg; returns
+        // Unit on miss.
+        let find = lambda(
+            3, // [list k find]
+            case(
+                local(0),
+                vec![
+                    (
+                        DataConstructor::ListCons.tag(), // [h t] [list k find]
+                        switch(
+                            MatchesKey.global(lref(0), lref(3)),
+                            vec![
+                                (
+                                    DataConstructor::BoolTrue.tag(),
+                                    // [h t] [list k find]
+                                    ExtractValue.global(lref(0)),
+                                ),
+                                (
+                                    DataConstructor::BoolFalse.tag(),
+                                    app(lref(4), vec![lref(1), lref(3), lref(4)]),
+                                ),
+                            ],
+                        ),
+                    ),
+                    (
+                        DataConstructor::ListNil.tag(), // key not found — return null
+                        unit(),
+                    ),
+                ],
+                call::bif::panic(str("bad block content")),
+            ),
+        );
+
+        // Arguments are passed as (obj, k) from the prelude: __SAFE_LOOKUP(a, k)
+        // so local(0) = obj, local(1) = k
+        lambda(
+            2, // [obj k]
+            case(
+                local(0), // scrutinise obj
+                vec![(
+                    DataConstructor::Block.tag(),
+                    // Matched Block! env: [blocklist blockindex] [obj k]
+                    // L(0)=blocklist, L(1)=blockindex, L(2)=obj, L(3)=k
+                    letrec_(
+                        vec![find], // [find] [blocklist blockindex] [obj k]
+                        // L(0)=find, L(1)=blocklist, L(2)=blockindex, L(3)=obj, L(4)=k
+                        match self.0 {
+                            NativeVariant::Unboxed => {
+                                // k is already an unboxed sym (L(4))
+                                // BIF args: sym=L(4), blocklist=L(1), blockindex=L(2), block=L(3)
+                                case(
+                                    app_bif(bif_index, vec![lref(4), lref(1), lref(2), lref(3)]),
+                                    vec![
+                                        (
+                                            DataConstructor::ListCons.tag(),
+                                            // [value _] [find] [blocklist blockindex] [obj k]
+                                            local(0),
+                                        ),
+                                        (
+                                            DataConstructor::ListNil.tag(),
+                                            // [] [find] [blocklist blockindex] [obj k]
+                                            // call find(blocklist, k, find)
+                                            app(lref(0), vec![lref(1), lref(4), lref(0)]),
+                                        ),
+                                    ],
+                                    // fallback (native return — shouldn't happen)
+                                    // [native] [find] [blocklist blockindex] [obj k]
+                                    app(lref(1), vec![lref(2), lref(5), lref(1)]),
+                                )
+                            }
+                            NativeVariant::Boxed => {
+                                // k is a boxed sym at L(4); unbox it first
+                                unbox_sym(
+                                    local(4),
+                                    // [sym] [find] [blocklist blockindex] [obj k]
+                                    // L(0)=sym, L(1)=find, L(2)=blocklist, L(3)=blockindex, L(4)=obj, L(5)=k
+                                    // BIF args: sym=L(0), blocklist=L(2), blockindex=L(3), block=L(4)
+                                    case(
+                                        app_bif(
+                                            bif_index,
+                                            vec![lref(0), lref(2), lref(3), lref(4)],
+                                        ),
+                                        vec![
+                                            (
+                                                DataConstructor::ListCons.tag(),
+                                                // [value _] [sym] [find] [blocklist blockindex] [obj k]
+                                                local(0),
+                                            ),
+                                            (
+                                                DataConstructor::ListNil.tag(),
+                                                // [] [sym] [find] [blocklist blockindex] [obj k]
+                                                // call find(blocklist, sym, find)
+                                                app(lref(1), vec![lref(2), lref(0), lref(1)]),
+                                            ),
+                                        ],
+                                        // fallback (native return — shouldn't happen)
+                                        // [native] [sym] [find] [blocklist blockindex] [obj k]
+                                        app(lref(2), vec![lref(3), lref(1), lref(2)]),
+                                    ),
+                                )
+                            }
+                        },
+                    ),
+                )],
+                unit(), // non-block (including null): return null
+            ),
+        )
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args: [sym_key, blocklist, blockindex, block]
+        // Same BIF logic as LookupOr: return ListCons on hit, ListNil on miss.
+        // The wrapper handles the null-propagation for non-block values.
+        if let Ok(Native::Index(ref map)) = machine.nav(view).resolve_native(&args[2]) {
+            if let Ok(Native::Sym(sym_id)) = machine.nav(view).resolve_native(&args[0]) {
+                if let Some(&position) = map.get(&sym_id) {
+                    if let Some(value) = walk_list_to_position(machine, view, &args[1], position) {
+                        let value_env =
+                            view.from_closure(value, machine.root_env(), Smid::default())?;
+                        let nil_ref = Ref::V(Native::Num(serde_json::Number::from(0)));
+                        let cons = view.data(
+                            DataConstructor::ListCons.tag(),
+                            Array::from_slice(&view, &[Ref::L(0), nil_ref]),
+                        )?;
+                        return machine.set_closure(SynClosure::new(cons.as_ptr(), value_env));
+                    }
+                }
+            }
+            // Index exists but key not found — return ListNil
+            let nil = view.nil()?;
+            return machine.set_closure(SynClosure::new(nil.as_ptr(), machine.root_env()));
+        }
+
+        // No index — check if we should build one
+        let count = count_list(machine, view, &args[1]);
+
+        if count >= BLOCK_INDEX_THRESHOLD {
+            // Build index
+            let map = build_index(machine, view, &args[1]);
+
+            if let Ok(Native::Sym(sym_id)) = machine.nav(view).resolve_native(&args[0]) {
+                if let Some(&position) = map.get(&sym_id) {
+                    if let Some(value) = walk_list_to_position(machine, view, &args[1], position) {
+                        // Store the index for future lookups
+                        store_index_in_block(view, machine, &args[3], map);
+
+                        let value_env =
+                            view.from_closure(value, machine.root_env(), Smid::default())?;
+                        let nil_ref = Ref::V(Native::Num(serde_json::Number::from(0)));
+                        let cons = view.data(
+                            DataConstructor::ListCons.tag(),
+                            Array::from_slice(&view, &[Ref::L(0), nil_ref]),
+                        )?;
+                        return machine.set_closure(SynClosure::new(cons.as_ptr(), value_env));
+                    }
+                }
+                // Key not found — store index for future lookups
+                store_index_in_block(view, machine, &args[3], map);
+            }
+            // Key wasn't a native sym — delegate to find loop
+        }
+
+        // No index or below threshold — return ListNil to signal "use find loop"
+        let nil = view.nil()?;
+        machine.set_closure(SynClosure::new(nil.as_ptr(), machine.root_env()))
+    }
+}
+
+impl CallGlobal2 for SafeLookup {}
+
 /// LOOKUP(k, block)
 pub struct Lookup;
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -95,6 +95,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(block::DeepMerge));
     rt.add(Box::new(block::LookupOr(NativeVariant::Boxed)));
     rt.add(Box::new(block::LookupOr(NativeVariant::Unboxed)));
+    rt.add(Box::new(block::SafeLookup(NativeVariant::Boxed)));
     rt.add(Box::new(block::Lookup));
     rt.add(Box::new(emit::Emit0));
     rt.add(Box::new(emit::EmitT));

--- a/tests/harness/084_bitwise.eu
+++ b/tests/harness/084_bitwise.eu
@@ -27,9 +27,9 @@ tests: {
 
   bitwise-not: {
     ` "NOT of zero is -1"
-    a: (~ 0) //= (0 - 1)
+    a: bit.not(0) //= (0 - 1)
     ` "NOT of -1 is zero"
-    b: (~ (0 - 1)) //= 0
+    b: bit.not(0 - 1) //= 0
   }
 
   shifts: {

--- a/tests/harness/084_bitwise.eu
+++ b/tests/harness/084_bitwise.eu
@@ -30,6 +30,9 @@ tests: {
     a: bit.not(0) //= (0 - 1)
     ` "NOT of -1 is zero"
     b: bit.not(0 - 1) //= 0
+    ` "NOT via ⊝ operator"
+    c: (⊝ 0) //= (0 - 1)
+    d: (⊝ (0 - 1)) //= 0
   }
 
   shifts: {

--- a/tests/harness/132_safe_navigation.eu
+++ b/tests/harness/132_safe_navigation.eu
@@ -30,10 +30,40 @@ test: {
   # Used with map and anaphora to extract an optional field
   map-extract: ([{name: "alice"}, {age: 30}] map(_ ~ :name)) //= ["alice", null]
 
+  # Mixed ~ and . precedence
+  data: {a: {b: {c: {d: 42}}}}
+
+  # ~ then . — safe nav into :a, then dot the rest
+  mix-1: (data ~ :a .b .c .d) //= 42
+
+  # ~ then . then ~ — interleaved
+  data2: {a: {b: {c: {d: 99}}}}
+  mix-2: (data2 ~ :a .b .c ~ :d) //= 99
+
+  # ~ fails early then continuing with ~ propagates null
+  mix-3: (data ~ :missing ~ :b ~ :c) //= null
+
+  # Known structure via . then safe nav for optional part
+  # NB: (data ~ :missing .b) would error — . is not safe, use ~ for uncertain keys
+
+  # . first, then ~ for optional final key
+  data3: {a: {b: {c: 7}}}
+  mix-4: (data3.a.b ~ :c) //= 7
+  mix-5: (data3.a.b ~ :missing) //= null
+
+  # Realistic: dot into known structure, safe-nav into optional part
+  config: {server: {db: {host: "localhost", port: 5432}}}
+  mix-6: (config.server.db ~ :host) //= "localhost"
+  mix-7: (config.server.db ~ :ssl) //= null
+  mix-8: (config.server ~ :cache ~ :host) //= null
+
   RESULT: [ basic, missing, null-prop
           , num-nav, str-nav, list-nav, bool-nav
           , chain, chain-miss
           , section, section-miss
           , map-extract
+          , mix-1, mix-2, mix-3
+          , mix-4, mix-5
+          , mix-6, mix-7, mix-8
           ] all-true? then(:PASS, :FAIL)
 }

--- a/tests/harness/132_safe_navigation.eu
+++ b/tests/harness/132_safe_navigation.eu
@@ -1,0 +1,39 @@
+"132 safe navigation operator ~"
+
+` { target: :test }
+test: {
+  # Basic lookup — key present
+  basic: ({a: 1, b: 2} ~ :a) //= 1
+
+  # Missing key returns null
+  missing: ({a: 1} ~ :b) //= null
+
+  # Null propagation — null input
+  null-prop: (null ~ :a) //= null
+
+  # Non-block inputs return null
+  num-nav: (42 ~ :a) //= null
+  str-nav: ("hello" ~ :a) //= null
+  list-nav: ([1, 2, 3] ~ :a) //= null
+  bool-nav: (true ~ :a) //= null
+
+  # Chained navigation — all present
+  chain: ({x: {y: {z: 42}}} ~ :x ~ :y ~ :z) //= 42
+
+  # Chain with missing intermediate returns null
+  chain-miss: ({x: {y: 1}} ~ :x ~ :z ~ :w) //= null
+
+  # Used with anaphora to extract an optional field (right-section style)
+  section: ({a: 42, b: 99} ~ :a) //= 42
+  section-miss: ({b: 99} ~ :a) //= null
+
+  # Used with map and anaphora to extract an optional field
+  map-extract: ([{name: "alice"}, {age: 30}] map(_ ~ :name)) //= ["alice", null]
+
+  RESULT: [ basic, missing, null-prop
+          , num-nav, str-nav, list-nav, bool-nav
+          , chain, chain-miss
+          , section, section-miss
+          , map-extract
+          ] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -674,6 +674,11 @@ pub fn test_harness_131() {
 }
 
 #[test]
+pub fn test_harness_132() {
+    run_test(&opts("132_safe_navigation.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Add `~` binary operator for null-safe key lookup on blocks
- `block ~ :key` returns value if present, `null` otherwise
- `null ~ :key` propagates null through chains
- Non-blocks return `null` (no error)
- Left-associative, precedence 90 (same level as `.`)
- Sections like `(~ :server ~ :host)` create safe navigation functions
- New `SafeLookup` intrinsic with BIF fast-path indexed lookup
- Existing prefix `~` (BITNOT) moved to `bit.not` (function still available)

## Test plan

- [x] New harness test 132 covering: basic lookup, missing key, null propagation, non-block inputs, chained navigation, map/anaphora usage
- [x] Bitwise test 084 updated for `bit.not` — passes
- [x] Full harness suite (251 tests) passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)