### PR TITLE
feat: add match? structural predicate

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -408,6 +408,35 @@ deep-query-first(pattern, d, b): b deep-query(pattern) head-or(d)
 deep-query-paths(pattern, b): b deep-query-fold(pattern) map(first)
 
 ##
+## Structural matching
+##
+
+` "`any?` - predicate that matches any value. For use in match? patterns."
+any?: const(true)
+
+` "`match?(pattern, target)` - structural predicate. Returns true if `target`
+conforms to `pattern`. Pattern values are interpreted by type: blocks and
+lists recurse as sub-patterns, functions are applied as predicates, literals
+are exact equality checks. Open matching: extra keys in target are ignored."
+match?(pat, target): {
+  mv?(p, actual):
+    if(p block?, mb?(p, actual),
+    if(p list?,  ml?(p, actual),
+    if(__SATURATED(p), p = actual,
+                       p(actual))))
+
+  mb?(p, t):
+    if(t block?, p elements map(me?(t)) all-true?, false)
+
+  me?(t, [k, v]):
+    (t has(k)) ∧ mv?(v, (t lookup(k)))
+
+  ml?(p, t):
+    if(t list?, ((t count) = (p count)) ∧ (zip-with(mv?, p, t) all-true?), false)
+
+}.(mv?(pat, target))
+
+##
 ## Boolean
 ##
 

--- a/tests/harness/134_match_predicate.eu
+++ b/tests/harness/134_match_predicate.eu
@@ -1,0 +1,89 @@
+"134 structural match? predicate"
+
+` { target: :test }
+test: {
+
+  # Block: key existence with any?
+  t-any: {host: "x", port: 8080} match?({host: any?, port: any?}) //=> true
+
+  # Block: exact literal match
+  t-lit: {port: 8080} match?({port: 8080}) //=> true
+  t-lit-miss: {port: 80} match?({port: 8080}) //=> false
+
+  # Block: boolean literal match
+  t-bool: {active: true} match?({active: true}) //=> true
+  t-bool-miss: {active: false} match?({active: true}) //=> false
+
+  # Block: value predicates
+  t-pred: {port: 8080} match?({port: (> 1000)}) //=> true
+  t-pred-miss: {port: 80} match?({port: (> 1000)}) //=> false
+
+  # Block: type predicates
+  t-type: {host: "x"} match?({host: string?}) //=> true
+  t-type-miss: {host: 42} match?({host: string?}) //=> false
+
+  # Block: extra keys ignored (open matching)
+  t-open: {a: 1, b: 2, c: 3} match?({a: any?}) //=> true
+
+  # Block: missing key fails
+  t-miss-key: {a: 1} match?({b: any?}) //=> false
+
+  # Block: empty pattern matches any block
+  t-empty-pat: {a: 1} match?({}) //=> true
+
+  # Block: nested sub-pattern
+  t-nested: {server: {host: "x", port: 8080}} match?({server: {host: any?}}) //=> true
+  t-nested-miss: {server: {port: 8080}} match?({server: {host: any?}}) //=> false
+
+  # Block: deep nesting with mixed patterns
+  t-deep: {x: 1, y: {z: "hi", p: [3, {u: 42}]}}
+    match?({y: {p: [(= 3), {u: number?}]}}) //=> true
+
+  # List: exact length with predicates
+  t-list: [1, "hello", true] match?([number?, string?, (= true)]) //=> true
+
+  # List: literal match also works
+  t-list-lit: [1, "hello", true] match?([number?, string?, true]) //=> true
+
+  # List: length mismatch
+  t-list-short: [1, 2] match?([any?, any?, any?]) //=> false
+  t-list-long: [1, 2, 3, 4] match?([any?, any?, any?]) //=> false
+
+  # List: empty pattern matches empty list
+  t-list-empty: [] match?([]) //=> true
+  t-list-empty-miss: [1] match?([]) //=> false
+
+  # Non-block target against block pattern
+  t-non-block: 42 match?({x: any?}) //=> false
+  t-null-block: null match?({x: any?}) //=> false
+  t-list-block: [1, 2] match?({x: any?}) //=> false
+
+  # Non-list target against list pattern
+  t-non-list: 42 match?([any?]) //=> false
+  t-null-list: null match?([any?]) //=> false
+
+  # String predicate
+  t-str-pred: {name: "Alice"} match?({name: str.starts-with?("A")}) //=> true
+
+  # Composition with filter
+  items: [{active: true, name: "a"}, {active: false, name: "b"}, {active: true, name: "c"}]
+  t-filter: (items filter(match?({active: true})) map(_.name)) //=> ["a", "c"]
+
+  # Composition with when and ~
+  data: {server: {host: "localhost"}}
+  t-when: (data when(match?({server: {host: any?}}), (~ :server ~ :host))) //=> "localhost"
+  t-when-miss: {other: 1} when(match?({server: any?}), (~ :server)) //=> {other: 1}
+
+  # Composition with deep-fold
+  deep-data: {
+    a: {host: "10.0.0.1", port: 8080}
+    b: {name: "cache"}
+    c: {host: "10.0.0.2", port: 5432}
+  }
+  t-deep-fold: {
+    emit(s, v): if(v match?({host: any?, port: any?}), [v ~ :host], [])
+    next(s, k): null
+  }.(deep-fold(emit, next, null, deep-data)) //=> ["10.0.0.1", "10.0.0.2"]
+
+  RESULT: :PASS
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -692,6 +692,11 @@ pub fn test_lib_lens() {
 }
 
 #[test]
+pub fn test_harness_134() {
+    run_test(&opts("134_match_predicate.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Add `match?(pattern, target)` — structural predicate returning true/false
- Add `any?` — wildcard predicate (`const(true)`) for use in patterns
- Pattern dispatch: blocks/lists recurse as sub-patterns, functions are predicates, literals are equality checks
- Uses `__SATURATED` intrinsic to distinguish functions from literal values
- Pure prelude implementation, no Rust changes

## Pattern language

```eu
{host: any?}                  # key must exist
{port: 8080}                  # exact literal match
{port: (> 1000)}              # predicate
{server: {host: string?}}     # nested sub-pattern
[number?, string?, true]      # positional list pattern
```

## Composition

```eu
items filter(match?({active: true}))
data when(match?({server: {host: any?}}), (~ :server ~ :host))
```

## Test plan

- [x] Harness test 134 with comprehensive coverage: block patterns, list patterns, nested patterns, predicates, literals, composition with filter/when/deep-fold/~
- [x] Full harness suite (254 tests) passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)