### PR TITLE
feat(prelude): rewrite random namespace to use opaque Stream type (eu-orz3)

### DIFF
--- a/docs/reference/prelude/io.md
+++ b/docs/reference/prelude/io.md
@@ -16,7 +16,7 @@
 | `io.epoch-time` | Unix epoch time at time of launch |
 | `io.args` | Command-line arguments passed after `--` separator |
 | `io.RANDOM_SEED` | Seed for random number generation (from `--seed` or system time) |
-| `io.random` | Infinite lazy stream of random floats in [0,1) |
+| `io.random` | Opaque PRNG stream; use `random.*` actions or `random.as-list` to consume |
 
 ## IO Monad
 

--- a/docs/reference/prelude/supplements/random/top.md
+++ b/docs/reference/prelude/supplements/random/top.md
@@ -3,11 +3,13 @@ stream and a set of prelude functions.
 
 ## The Random Stream
 
-The `io.random` binding is an infinite lazy list of random floats in
-`[0, 1)`, seeded from system entropy or the `--seed` command-line flag.
+The `io.random` binding is an opaque PRNG stream, seeded from system
+entropy or the `--seed` command-line flag. Use `random.*` actions to
+draw values from it, or `random.as-list` to obtain a lazy cons-list of
+floats in `[0, 1)`.
 
 ```eu
-first-random: io.random head
+first-random: random.float(io.random).value
 ```
 
 Because `io.random` is seeded from the system clock by default, it

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -36,8 +36,8 @@ io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
   ` "Seed for random number generation (from --seed or system time)"
   RANDOM_SEED: __io.RANDOM_SEED
 
-  ` "Infinite lazy stream of random floats in [0,1), seeded from system entropy or --seed flag."
-  random: random-stream(io.RANDOM_SEED)
+  ` "Opaque random stream seeded from system entropy or --seed flag. Use random.* actions or random.as-list to consume."
+  random: __STREAM_NEW(io.RANDOM_SEED)
 
   ##
   ## IO monad
@@ -117,7 +117,11 @@ monad(m): {
 ## Random number generation
 ##
 
-random-stream(seed): cons(__PRNG_FLOAT(seed), random-stream(__PRNG_NEXT(seed)))
+# Compatibility alias: deprecated, use random.stream. Returns a lazy cons-list of floats.
+random-stream(seed): random.stream(seed) random.as-list
+
+# Helper: advance an opaque stream n steps.
+stream-advance(n, s): if(n = 0, s, stream-advance(n - 1, __STREAM_ADVANCE(s)))
 
 random-ret(v, stream): { value: v, rest: stream }
 
@@ -131,16 +135,32 @@ random-bind(m, f, stream): {
 ` { doc: "Monadic random: namespace. Each operation is a state-monad action: a function from stream to a value/rest block. Use random.stream(seed) to create the initial stream, then run actions by calling them with the stream."
     monad: true }
 random: monad{bind: random-bind, return: random-ret} {
-  ` "random.stream(seed) - create the initial PRNG stream from integer seed."
-  stream(seed): random-stream(seed)
+  ` "random.stream(seed) - create an opaque PRNG stream from integer seed."
+  stream(seed): __STREAM_NEW(seed)
+
+  ` "random.as-list(stream) - convert an opaque random stream to a lazy cons-list of floats."
+  as-list(s): cons(__STREAM_VALUE(s), as-list(__STREAM_ADVANCE(s)))
 
   ` "random.float - action returning a random float in [0,1)."
-  float(stream): { value: stream head, rest: stream tail }
+  float(s): {
+    pair: __STREAM_FLOAT(s)
+    value: pair head
+    rest: pair tail head
+  }
 
   ` "random.int(n) - action returning a random integer in [0,n)."
-  int(n, stream): {
-    value: floor((stream head) * n)
-    rest: stream tail
+  int(n, s): {
+    pair: __STREAM_INT(n, s)
+    value: pair head
+    rest: pair tail head
+  }
+
+  ` "random.split - action that splits the stream into two independent streams.
+  Returns a value/rest block where value and rest are each independent streams."
+  split(s): {
+    pair: __STREAM_SPLIT(s)
+    value: pair head
+    rest: pair tail head
   }
 
   ` "random.choice(list) - action returning a random element from list."
@@ -1537,9 +1557,9 @@ set: {
   ` "`set.sample(n, s)` - random monad action: pick `n` random elements from set `s`.
   Returns value/rest block. Use within a :random block."
   sample(k, s, stream): {
-    floats: stream take(k)
+    floats: (stream random.as-list) take(k)
     value: s sample-raw(floats)
-    rest: stream drop(k)
+    rest: stream-advance(k, stream)
   }
 }
 
@@ -1574,9 +1594,9 @@ vec: {
   ` "`vec.sample(n, v)` - random monad action: pick `n` random elements
   from vec `v` without replacement. Use within a :random block."
   sample(n, v, stream): {
-    floats: stream take(n)
+    floats: (stream random.as-list) take(n)
     value: v sample-raw(floats)
-    rest: stream drop(n)
+    rest: stream-advance(n, stream)
   }
 
   ` :suppress
@@ -1586,9 +1606,9 @@ vec: {
   Use within a :random block."
   shuffle(v, stream): {
     needed: (v vec.len) - 1
-    floats: stream take(needed)
+    floats: (stream random.as-list) take(needed)
     value: v shuffle-raw(floats)
-    rest: stream drop(needed)
+    rest: stream-advance(needed, stream)
   }
 
   ` "`vec.to-list(v)` - convert vec `v` back to a cons-list."

--- a/tests/harness/078_random.eu
+++ b/tests/harness/078_random.eu
@@ -14,13 +14,13 @@ trues: [
   __PRNG_NEXT(seed) = __PRNG_NEXT(seed),
   # different seeds give different results
   __PRNG_FLOAT(seed) != __PRNG_FLOAT(99),
-  # random.stream head is in [0,1)
-  (random.stream(seed) head) >= 0,
-  (random.stream(seed) head) < 1,
-  # stream elements differ
-  (random.stream(seed) head) != (random.stream(seed) tail head),
-  # can take finite segment from stream
-  (random.stream(seed) take(5) count) = 5,
+  # random.float from stream is in [0,1)
+  (random.float(random.stream(seed)).value) >= 0,
+  (random.float(random.stream(seed)).value) < 1,
+  # as-list elements differ
+  ((random.stream(seed) random.as-list) head) != ((random.stream(seed) random.as-list) tail head),
+  # can take finite segment from as-list
+  ((random.stream(seed) random.as-list) take(5) count) = 5,
   # random.int value is in range
   (random.int(10)(random.stream(seed)).value) >= 0,
   (random.int(10)(random.stream(seed)).value) < 10,

--- a/tests/harness/120_random_monad.eu
+++ b/tests/harness/120_random_monad.eu
@@ -3,11 +3,11 @@
 seed: 42
 
 ##
-## random.stream produces a deterministic stream
+## random.stream produces a deterministic opaque stream
 ##
 ` { target: :test-stream }
 test-stream:
-  if((random.stream(seed) head) = (random.stream(seed) head),
+  if((random.float(random.stream(seed)).value) = (random.float(random.stream(seed)).value),
     { RESULT: :PASS },
     { RESULT: :FAIL })
 
@@ -102,4 +102,29 @@ test-bind-threads-state: {
   first: pair head
   second: pair tail head
   ok: first != second
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.as-list converts opaque stream to a lazy cons-list of floats
+##
+` { target: :test-as-list }
+test-as-list: {
+  s: random.stream(seed)
+  lst: s random.as-list
+  fst: lst head
+  snd: (lst tail) head
+  range-ok: (fst >= 0) && (fst < 1) && (snd >= 0) && (snd < 1)
+  diff-ok: fst != snd
+  ok: range-ok && diff-ok
+}.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))
+
+##
+## random.split produces two independent streams both yielding floats in [0,1)
+##
+` { target: :test-split }
+test-split: {
+  result: random.split(random.stream(seed))
+  float-a: random.float(result.value).value
+  float-b: random.float(result.rest).value
+  ok: (float-a >= 0) && (float-a < 1) && (float-b >= 0) && (float-b < 1)
 }.(if(ok, { RESULT: :PASS }, { RESULT: :FAIL }))

--- a/tests/harness/129_monadic_implicit_return.eu
+++ b/tests/harness/129_monadic_implicit_return.eu
@@ -68,7 +68,7 @@ tests: {
   ` "Random monad implicit return — the motivating case for eu-hybj/eu-en4j"
   random-implicit: {
     result: { :random a: random.int(20) b: random.int(a) c: random.int(b) }(random.stream(42)).value
-    ok: (result.a = 14) && (result has(:b)) && (result has(:c))
+    ok: (result.a = 13) && (result has(:b)) && (result has(:c))
     RESULT: if(ok, :PASS, :FAIL)
   }
 


### PR DESCRIPTION
## Summary

- Replace cons-list PRNG streams with opaque `Native::Stream` values throughout the `random` prelude
- `random.stream(seed)` now returns an opaque Stream via `__STREAM_NEW`
- New `random.float` uses `__STREAM_FLOAT`, `random.int` uses `__STREAM_INT`, `random.split` uses `__STREAM_SPLIT`
- New `random.as-list` bridge converts opaque stream to lazy cons-list for backwards-compatible usage
- `vec.sample`, `vec.shuffle`, `set.sample` updated to use `as-list` bridge + `stream-advance` helper
- `io.random` now returns opaque Stream directly; deprecated `random-stream` kept as compatibility alias
- Tests 078, 120, 129 updated; test 120 adds coverage for `random.as-list` and `random.split`

## Notes

- Expected value in test 129 updated from 14 → 13: `__STREAM_INT` uses modulo (`z % n`) rather than the old `floor(float * n)` approach. The underlying SplitMix64 algorithm is the same; only the mapping to integers differs.
- `__PRNG_NEXT` and `__PRNG_FLOAT` intrinsics are retained (not removed) per task instructions.

## Test plan

- [x] `cargo test test_harness_120` — random monad (all targets including new as-list/split tests)
- [x] `cargo test test_harness_130` — vec (sample/shuffle with opaque streams)
- [x] `cargo test test_harness_078` — PRNG intrinsics and stream API
- [x] `cargo test test_harness_129` — monadic implicit return with random
- [x] `cargo test --test harness_test` — full suite (254/254 pass)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)