### PR TITLE
fix: dbg and ▶ no longer crash on non-renderable values

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1058,11 +1058,14 @@ assert(p?, s, v): if(v p?, v, panic(s))
 #
 
 ` { doc: "`dbg(opts, v)` - print value `v` to stderr and return `v` unchanged. opts keys: label (string)." }
-dbg(opts, v): {result: __DBG(lookup-or(:label, "", opts), v render-as(:json), v)}.result
+# Render a value for debug output: JSON for blocks/lists, DBG_REPR for everything else
+__dbg-render(v): if(v block?, v render-as(:json), if(v list?, v render-as(:json), __DBG_REPR(v)))
+
+dbg(opts, v): {result: __DBG(lookup-or(:label, "", opts), __dbg-render(v), v)}.result
 
 ` { doc: "`▶v` - debug-trace value or function. On a value, prints it to stderr and returns it. On a function, returns a wrapped version that traces each output."
     precedence: 85 }
-__dbg-val(v): {result: __DBG("", v render-as(:json), v)}.result
+__dbg-val(v): {result: __DBG("", __dbg-render(v), v)}.result
 __dbg-after(f, x): ▶(f(x))
 (▶ v): if(__SATURATED(v), __dbg-val(v), __dbg-after(v))
 


### PR DESCRIPTION
## Summary

- `dbg` and `▶` no longer crash on IO actions, streams, vecs, sets, or other non-renderable values
- Uses `render-as(:json)` for blocks and lists (preserving detailed JSON output)
- Falls back to `__DBG_REPR` for everything else (readable placeholders like `<io-action>`, `<stream>`, `<unevaluated>`)

## Before

```eu,notest
{ :io r: "echo hello" io.shell dbg{label: "cmd"} }.(r.stdout)
# => error: expected a primitive value but found an unevaluated function application
```

## After

```eu,notest
{ :io r: "echo hello" io.shell dbg{label: "cmd"} }.(r.stdout)
# stderr: ▶ cmd: <unevaluated>
# => "hello\n"
```

## Test plan

- [x] IO action: prints `<unevaluated>`, continues to execute
- [x] Plain values: unchanged (`▶ 42`)
- [x] Blocks: full JSON rendering preserved
- [x] Lists: full JSON rendering preserved
- [x] All 254 harness tests pass
- [x] All 16 debug error tests (116-125) pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)