### PR TITLE
perf: cache EU_STACK_DIAG and EU_GC_STRESS env-var lookups at startup

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1120,6 +1120,10 @@ pub struct MachineSettings {
     pub trace_steps: bool,
     pub dump_heap: bool,
     pub test_mode: bool,
+    /// Cached value of `EU_STACK_DIAG` environment variable.
+    ///
+    /// Checked once at startup to avoid an env-var lookup on every VM step.
+    pub stack_diag: bool,
 }
 
 /// An STG machine variant using cactus environment
@@ -1176,6 +1180,7 @@ impl<'a> Machine<'a> {
                 trace_steps,
                 dump_heap,
                 test_mode,
+                stack_diag: std::env::var("EU_STACK_DIAG").is_ok(),
             },
             metrics: Metrics::default(),
             clock: Clock::default(),
@@ -1325,7 +1330,7 @@ impl<'a> Machine<'a> {
         let prev_max = metrics.max_stack();
         metrics.stack(stack_len);
         // Diagnostic: dump stack composition when a new max is reached
-        if std::env::var("EU_STACK_DIAG").is_ok() && stack_len > prev_max && stack_len > 5 {
+        if settings.stack_diag && stack_len > prev_max && stack_len > 5 {
             let counts = state.stack.iter().fold(
                 (0usize, 0usize, 0usize, 0usize),
                 |(branch, update, apply, demeta), cont| match cont {

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1114,6 +1114,10 @@ pub struct Heap {
     /// Mark state for this heap instance - flipped each collection to avoid clearing marks.
     /// Plain bool suffices as each Heap is used from a single thread.
     mark_state: bool,
+    /// Cached value of `EU_GC_STRESS` environment variable.
+    ///
+    /// Checked once at construction to avoid a per-collection env-var lookup.
+    gc_stress: bool,
     /// Emergency collection state tracking
     emergency_state: UnsafeCell<EmergencyState>,
     /// GC performance metrics and telemetry
@@ -1588,6 +1592,7 @@ impl Heap {
             state: UnsafeCell::new(HeapState::new()),
             limit: None,
             mark_state: false,
+            gc_stress: std::env::var("EU_GC_STRESS").as_deref() == Ok("1"),
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
             pin_counts: UnsafeCell::new(HashMap::new()),
@@ -1601,6 +1606,7 @@ impl Heap {
             state: UnsafeCell::new(HeapState::new()),
             limit: Some(block_limit),
             mark_state: false,
+            gc_stress: std::env::var("EU_GC_STRESS").as_deref() == Ok("1"),
             emergency_state: UnsafeCell::new(EmergencyState::new()),
             gc_metrics: UnsafeCell::new(GCMetrics::default()),
             pin_counts: UnsafeCell::new(HashMap::new()),
@@ -1695,7 +1701,7 @@ impl Heap {
         // GC stress mode: force SelectiveEvacuation on every collection so
         // that evacuation pointer-update bugs surface on any platform, not
         // just the aarch64 CI runner.  Enable with EU_GC_STRESS=1.
-        if std::env::var("EU_GC_STRESS").as_deref() == Ok("1") {
+        if self.gc_stress {
             // SAFETY: Read-only borrow to enumerate block indices.
             // Single-threaded; no mutation during analysis.
             let heap_state = unsafe { &*self.state.get() };


### PR DESCRIPTION
## Performance: cache debug env-var checks at startup

### Hypothesis
`std::env::var("EU_STACK_DIAG")` was called on **every single VM step** in the main execution loop. On macOS, `std::env::var` acquires a global environment mutex and performs a linear scan — a meaningful overhead when the VM executes tens to hundreds of millions of steps for typical programs. Similarly, `std::env::var("EU_GC_STRESS")` was re-checked on every GC-policy analysis call (every 500 steps).

Caching both values at construction time eliminates this repeated syscall-level overhead.

### Change
- Add `stack_diag: bool` to `MachineSettings`; initialised once in `Machine::new()` from `std::env::var("EU_STACK_DIAG")`
- Add `gc_stress: bool` to `Heap`; initialised once in `Heap::new()` / `Heap::with_limit()` from `std::env::var("EU_GC_STRESS")`
- Replace both per-step/per-collection env-var calls with the cached booleans

### Results
Measured with `hyperfine --warmup 3 --runs 5` on macOS (Darwin 25.3.0, Apple Silicon):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| 001_naive_fib (fib(30)) | 19.9 s | 10.4 s | **−48%** |
| 002_thunk_updates | 2.3 s | 0.86 s | **−63%** |
| 004_generations | 1.8 s | 0.51 s | **−71%** |
| 005_drop_cons | 687 ms | 294 ms | **−57%** |
| 007_short_lived | 668 ms | 257 ms | **−62%** |
| 008_long_lived_graph | 670 ms | 210 ms | **−69%** |
| 009_fragmentation | 599 ms | 202 ms | **−66%** |

Exact reproduce commands:
```
cargo build --release
hyperfine --warmup 3 --runs 5 'timeout 600 ./target/release/eu --heap-limit-mib 12288 tests/harness/bench/001_naive_fib.eu'
# ... (same pattern for others)
```

### Regression check
Full harness suite: **no regressions** — 255/255 tests pass.

```
cargo test --test harness_test
test result: ok. 255 passed; 0 failed; 0 ignored; 0 measured
```

### Risks
None. The cached values are set once at startup from the environment, exactly as before. Debug behaviour is unchanged: `EU_STACK_DIAG=1` and `EU_GC_STRESS=1` still work correctly — they are now read once at construction rather than on every step.