### PR TITLE
perf: avoid Array copy in exact-arity function application

### DIFF
--- a/src/eval/machine/env_builder.rs
+++ b/src/eval/machine/env_builder.rs
@@ -72,6 +72,16 @@ pub trait EnvBuilder {
         args: &[SynClosure],
     ) -> Result<SynClosure, ExecutionError>;
 
+    /// Create a saturated version of a closure, consuming an existing
+    /// args array without copying it.  Use this when the caller
+    /// already owns the exact `Array<SynClosure>` to avoid an
+    /// unnecessary heap allocation.
+    fn saturate_with_array(
+        &self,
+        closure: &SynClosure,
+        args: Array<SynClosure>,
+    ) -> Result<SynClosure, ExecutionError>;
+
     /// Create a new closure with extra partial arguments
     fn partially_apply(
         &self,
@@ -201,6 +211,20 @@ impl EnvBuilder for MutatorHeapView<'_> {
         Ok(SynClosure::new_annotated(
             closure.code(),
             self.from_saturation(arg_array, closure.env(), closure.annotation())?,
+            closure.annotation(),
+        ))
+    }
+
+    /// Create a new saturated closure, consuming the args array directly
+    /// to avoid an extra heap allocation when the caller already owns it.
+    fn saturate_with_array(
+        &self,
+        closure: &SynClosure,
+        args: Array<SynClosure>,
+    ) -> Result<SynClosure, ExecutionError> {
+        Ok(SynClosure::new_annotated(
+            closure.code(),
+            self.from_saturation(args, closure.env(), closure.annotation())?,
             closure.annotation(),
         ))
     }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -858,7 +858,10 @@ impl MachineState {
 
                     match excess.cmp(&0) {
                         Ordering::Equal => {
-                            self.closure = view.saturate(&self.closure, args.as_slice())?;
+                            // Pass the args array directly instead of copying via
+                            // saturate(&[SynClosure]) → saves one Array::from_slice
+                            // allocation per exact-arity function call.
+                            self.closure = view.saturate_with_array(&self.closure, args)?;
                         }
                         Ordering::Less => {
                             self.closure = view.partially_apply(&self.closure, args.as_slice())?;


### PR DESCRIPTION
## Performance: avoid redundant array copy in saturate

### Hypothesis

Every exact-arity function call (`Ordering::Equal` in `return_fun`) called
`view.saturate(&self.closure, args.as_slice())`.  Inside `saturate`, this
immediately calls `Array::from_slice(self, args)` — allocating a new backing
array on the heap and memcpy-ing all closures into it.  But `args` is already
an owned `Array<SynClosure>` that was built by `create_arg_array` and stored
in the `ApplyTo` continuation; it contains exactly what `from_saturation`
needs.  The copy is entirely superfluous.

### Change

Added `saturate_with_array(closure, Array<SynClosure>)` to `EnvBuilder` that
passes the owned array directly to `from_saturation` without calling
`Array::from_slice`.  The `Ordering::Equal` branch in `return_fun` now calls
this variant.  All other call sites (`Ordering::Less` via `partially_apply`,
`Ordering::Greater` quorum/surplus split) are unchanged.

### Results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| bench/001 naive fib(30) | 18.35 s | 18.2 s (within noise) | ~0% |
| bench/002 thunk updates | 2.20 s | 2.22 s (within noise) | ~0% |
| bench/004 generations   | 1.704 s | 1.637 s | **−4%** |

The improvement is clearest in bench/004 (GC-heavy generational workload), where
reduced allocation count lowers GC pressure.  Compute-heavy bench/001 and
bench/002 show noise-level differences; the bump allocator makes individual
small allocations very cheap, so the saving manifests mainly as reduced GC
work.

### Regression check

Full harness suite: no regressions detected (255 harness tests, 629 lib tests,
all pass).

### Risks

Low.  The change is a pure allocation reduction with identical semantics:
`from_saturation` takes ownership of the array in both paths.  The only
difference is that we skip one intermediate heap allocation.