### PR TITLE
fix(errors): include actual value in TypeMismatch error messages

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -10,6 +10,18 @@ use thiserror::Error;
 
 use super::{memory::bump, stg::compiler::CompileError};
 
+/// Format a type mismatch error message, including the actual value when available.
+fn format_type_mismatch(
+    expected: &IntrinsicType,
+    actual: &IntrinsicType,
+    value: &Option<String>,
+) -> String {
+    match value {
+        Some(v) => format!("type mismatch: expected {expected}, found {actual} {v}"),
+        None => format!("type mismatch: expected {expected}, found {actual}"),
+    }
+}
+
 /// Generate contextual help notes for type mismatch errors
 fn type_mismatch_notes(expected: &IntrinsicType, actual: &IntrinsicType) -> Vec<String> {
     use IntrinsicType::*;
@@ -575,8 +587,8 @@ pub enum ExecutionError {
     InvalidCode(Smid),
     #[error("{}", format_lookup_failure(.1, .2, .3))]
     LookupFailure(Smid, String, Vec<String>, Vec<String>),
-    #[error("type mismatch: expected {1}, found {2}")]
-    TypeMismatch(Smid, IntrinsicType, IntrinsicType),
+    #[error("{}", format_type_mismatch(.1, .2, .3))]
+    TypeMismatch(Smid, Box<IntrinsicType>, Box<IntrinsicType>, Option<String>),
     #[error("unknown intrinsic {1}")]
     UnknownIntrinsic(Smid, String),
     #[error("{}", format_not_callable(.1))]
@@ -715,7 +727,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::FreeVar(s, _) => *s,
             ExecutionError::InvalidCode(s) => *s,
             ExecutionError::LookupFailure(s, _, _, _) => *s,
-            ExecutionError::TypeMismatch(s, _, _) => *s,
+            ExecutionError::TypeMismatch(s, _, _, _) => *s,
             ExecutionError::UnknownIntrinsic(s, _) => *s,
             ExecutionError::NotCallable(s, _) => *s,
             ExecutionError::NotValue(s, _) => *s,
@@ -915,7 +927,7 @@ impl ExecutionError {
         }
 
         let notes = match inner {
-            ExecutionError::TypeMismatch(_, expected, actual) => {
+            ExecutionError::TypeMismatch(_, expected, actual, _) => {
                 type_mismatch_notes(expected, actual)
             }
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {

--- a/src/eval/stg/stream_prng.rs
+++ b/src/eval/stg/stream_prng.rs
@@ -46,8 +46,9 @@ fn stream_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            crate::eval::types::IntrinsicType::Unknown,
-            crate::eval::types::IntrinsicType::Unknown,
+            Box::new(crate::eval::types::IntrinsicType::Unknown),
+            Box::new(crate::eval::types::IntrinsicType::Unknown),
+            None,
         ))
     }
 }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -25,6 +25,36 @@ use crate::{
     eval::{memory::syntax::*, types::IntrinsicType},
 };
 
+/// Format a native value for inclusion in error messages.
+///
+/// Returns a short human-readable description of the value, or `None` for
+/// types that are not easily represented as a short string (arrays, vecs, etc.).
+fn describe_native(
+    native: &Native,
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+) -> Option<String> {
+    match native {
+        Native::Num(n) => Some(n.to_string()),
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            let text = (*scoped).as_str();
+            const MAX_LEN: usize = 40;
+            if text.len() > MAX_LEN {
+                Some(format!("\"{}…\"", &text[..MAX_LEN]))
+            } else {
+                Some(format!("\"{text}\""))
+            }
+        }
+        Native::Sym(id) => {
+            let name = machine.symbol_pool().resolve(*id);
+            Some(format!(":{name}"))
+        }
+        Native::Zdt(dt) => Some(dt.to_rfc3339()),
+        _ => None,
+    }
+}
+
 /// Map a resolved native value to its intrinsic type for error reporting
 fn native_type(native: &Native) -> IntrinsicType {
     match native {
@@ -72,8 +102,9 @@ pub fn num_arg(
         Ok(Native::Num(n)) => Ok(n),
         Ok(native) => Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::Number,
-            native_type(&native),
+            Box::new(IntrinsicType::Number),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         )),
         Err(_) => {
             // resolve_native failed — likely a Cons (block/list). Inspect the
@@ -100,8 +131,9 @@ pub fn str_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::String,
-            native_type(&native),
+            Box::new(IntrinsicType::String),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         ))
     }
 }
@@ -156,8 +188,9 @@ pub fn str_arg_ref(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::String,
-            native_type(&native),
+            Box::new(IntrinsicType::String),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         ))
     }
 }
@@ -174,8 +207,9 @@ pub fn sym_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::Symbol,
-            native_type(&native),
+            Box::new(IntrinsicType::Symbol),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         ))
     }
 }
@@ -192,8 +226,9 @@ pub fn zdt_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::ZonedDateTime,
-            native_type(&native),
+            Box::new(IntrinsicType::ZonedDateTime),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         ))
     }
 }
@@ -325,8 +360,9 @@ impl Iterator for StrListIterator<'_> {
         } else {
             Some(Err(ExecutionError::TypeMismatch(
                 Smid::default(),
-                IntrinsicType::String,
-                native_type(&native),
+                Box::new(IntrinsicType::String),
+                Box::new(native_type(&native)),
+                None,
             )))
         }
     }
@@ -561,8 +597,9 @@ pub fn ndarray_arg<'guard>(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::Array,
-            native_type(&native),
+            Box::new(IntrinsicType::Array),
+            Box::new(native_type(&native)),
+            None,
         ))
     }
 }
@@ -595,8 +632,9 @@ pub fn vec_arg<'guard>(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            IntrinsicType::Vec,
-            native_type(&native),
+            Box::new(IntrinsicType::Vec),
+            Box::new(native_type(&native)),
+            None,
         ))
     }
 }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -40,8 +40,9 @@ fn describe_native(
             let scoped = view.scoped(*s);
             let text = (*scoped).as_str();
             const MAX_LEN: usize = 40;
-            if text.len() > MAX_LEN {
-                Some(format!("\"{}…\"", &text[..MAX_LEN]))
+            if text.chars().count() > MAX_LEN {
+                let truncated: String = text.chars().take(MAX_LEN).collect();
+                Some(format!("\"{}…\"", truncated))
             } else {
                 Some(format!("\"{text}\""))
             }

--- a/tests/harness/errors/127_type_mismatch_value_str.eu
+++ b/tests/harness/errors/127_type_mismatch_value_str.eu
@@ -1,0 +1,6 @@
+#!/usr/bin/env eu
+
+# Type mismatch error should include the actual value in the message.
+# When "hello" is passed where a number is expected, the error
+# should say 'found string "hello"'.
+x: "hello" + 1

--- a/tests/harness/errors/127_type_mismatch_value_str.eu.expect
+++ b/tests/harness/errors/127_type_mismatch_value_str.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch: expected number, found string \"hello\""

--- a/tests/harness/errors/128_type_mismatch_value_sym.eu
+++ b/tests/harness/errors/128_type_mismatch_value_sym.eu
@@ -1,0 +1,6 @@
+#!/usr/bin/env eu
+
+# Type mismatch error should include the actual symbol value in the message.
+# When :foo is passed where a number is expected, the error
+# should say 'found symbol :foo'.
+x: :foo + 1

--- a/tests/harness/errors/128_type_mismatch_value_sym.eu.expect
+++ b/tests/harness/errors/128_type_mismatch_value_sym.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch: expected number, found symbol :foo"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1410,3 +1410,13 @@ pub fn test_error_125() {
 pub fn test_error_126() {
     run_error_test(&error_opts("126_stray_colon_in_call_args.eu"));
 }
+
+#[test]
+pub fn test_error_127() {
+    run_error_test(&error_opts("127_type_mismatch_value_str.eu"));
+}
+
+#[test]
+pub fn test_error_128() {
+    run_error_test(&error_opts("128_type_mismatch_value_sym.eu"));
+}


### PR DESCRIPTION
## Summary

- `TypeMismatch` error messages now include the actual value when it is a native scalar (string, symbol, number, datetime)
- A `describe_native` helper formats the value for display (with truncation for long strings)
- The `TypeMismatch` variant gains an `Option<String>` payload; the two `IntrinsicType` fields are boxed to keep enum size under clippy's `result_large_err` threshold
- Two new harness tests (127, 128) verify the new messages

## Before / After

**Before:**
```
error: type mismatch: expected number, found string
error: type mismatch: expected number, found symbol
```

**After:**
```
error: type mismatch: expected number, found string "hello"
error: type mismatch: expected number, found symbol :foo
```

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test test_error` — 120 tests pass (including 2 new)
- [x] Manual: `eu -e '"hello" + 1'` shows value in error message
- [x] Manual: `eu -e ':foo + 1'` shows symbol in error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)