### PR TITLE
fix(import): Rule 3 alias binding + ImportGraph locator identity (eu-c9fr, eu-v0t6)

### DIFF
--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -85,6 +85,13 @@ pub struct Desugarer<'smap> {
     /// transitive dependency is pulled in first and a later direct import of
     /// the same file would create a duplicate.
     import_seen_nested: HashSet<(usize, Option<String>)>,
+    /// Rule 3 — alias table for same-file-different-name direct imports.
+    ///
+    /// When a file is imported directly (depth == 1) under a name for the
+    /// first time, its `(file_id → name)` is recorded here.  A subsequent
+    /// direct import of the same file under a *different* name emits an
+    /// alias binding `let { new_name = old_name }` instead of re-desugaring.
+    import_first_direct: HashMap<usize, String>,
 }
 
 impl<'smap> Desugarer<'smap> {
@@ -108,6 +115,7 @@ impl<'smap> Desugarer<'smap> {
             monad_namespace_registry: HashMap::new(),
             import_seen_direct: HashSet::new(),
             import_seen_nested: HashSet::new(),
+            import_first_direct: HashMap::new(),
         }
     }
 
@@ -213,20 +221,52 @@ impl<'smap> Desugarer<'smap> {
     ///   when encountered again as a nested import.  Multiple direct
     ///   imports of the same file are allowed because each may serve a
     ///   different scope position in the unit.
+    ///
+    /// **Rule 3**: when a file is imported directly a second time under a
+    /// *different* name, an alias binding is emitted instead of re-desugaring.
+    /// For example, if `lens=lens.eu` was already imported, a subsequent
+    /// `optics=lens.eu` emits `let { optics = lens }` referencing the
+    /// already-bound name.
     pub fn translate_import(
         &mut self,
         smid: Smid,
         import: Input,
     ) -> Result<Option<RcExpr>, CoreError> {
-        if let Some(source) = self.contents.get(&import) {
+        // Look up content by exact Input key, falling back to locator match.
+        // The fallback is needed when the same file is imported under multiple
+        // names (eu-v0t6): the ImportGraph deduplicates by locator, so only the
+        // first-registered Input is in the contents map.
+        let source_lookup = self.contents.get(&import).or_else(|| {
+            self.contents
+                .iter()
+                .find(|(k, _)| k.locator() == import.locator())
+                .map(|(_, v)| v)
+        });
+        if let Some(source) = source_lookup {
             let file_id = source.file_id();
             let import_name = import.name().clone();
-            let guard_key = (file_id, import_name);
+            let guard_key = (file_id, import_name.clone());
 
             // `file.len()` is the current nesting depth:
             //   1 = direct import from the top-level unit
             //   2+ = nested/transitive import
             let is_nested = self.file.len() > 1;
+
+            // Rule 3: if this file was already imported *directly* under a
+            // different name, emit an alias binding rather than re-desugaring.
+            // This avoids duplicating content and prevents nested imports from
+            // being incorrectly suppressed on the second pass.
+            if !is_nested {
+                if let Some(first_name) = self.import_first_direct.get(&file_id).cloned() {
+                    if let Some(new_name) = &import_name {
+                        if &first_name != new_name {
+                            let alias_rhs =
+                                RcExpr::from(Expr::Var(smid, Var::Free(first_name.clone())));
+                            return Ok(Some(alias_rhs.apply_name(smid, new_name)));
+                        }
+                    }
+                }
+            }
 
             // Suppress if already seen transitively, OR if already seen
             // directly and we're now inside a nested import.
@@ -241,6 +281,12 @@ impl<'smap> Desugarer<'smap> {
                 self.import_seen_nested.insert(guard_key);
             } else {
                 self.import_seen_direct.insert(guard_key);
+                // Record the first direct named import for Rule 3 alias resolution.
+                if let Some(ref name) = import_name {
+                    self.import_first_direct
+                        .entry(file_id)
+                        .or_insert_with(|| name.clone());
+                }
             }
 
             self.file.push(file_id);

--- a/src/syntax/import.rs
+++ b/src/syntax/import.rs
@@ -101,13 +101,20 @@ impl ImportGraph {
         }
     }
 
-    /// Find the node index for the specified input
+    /// Find the node index for the specified input by locator identity.
+    ///
+    /// Two inputs with the same locator (file path / URL) but different names
+    /// are treated as the same graph node — the locator is the stable identity
+    /// after resolution.
     fn find_index(&self, input: &Input) -> Option<NodeIndex> {
-        self.graph.node_indices().find(|&i| &self.graph[i] == input)
+        self.graph
+            .node_indices()
+            .find(|&i| self.graph[i].locator() == input.locator())
     }
 
-    /// Add locator to the graph if it isn't already there and return
-    /// node index of the node.
+    /// Add an input to the graph if it isn't already there and return
+    /// the node index.  Deduplication is by locator, so `lens=lens.eu`
+    /// and `optics=lens.eu` resolve to the same node.
     fn encounter_input(&mut self, input: Input) -> NodeIndex {
         match self.find_index(&input) {
             Some(i) => i,

--- a/tests/harness/139_import_alias_rule3.eu
+++ b/tests/harness/139_import_alias_rule3.eu
@@ -1,0 +1,12 @@
+"139 import alias rule 3 — same file imported under two names"
+
+# alias_common.eu is imported twice: once as 'original' and once as 'alias'.
+# Rule 3 should emit `let { alias = original }` for the second import
+# so that both names work as access paths.
+
+` { import: ["original=testdata/alias_common.eu", "alias=testdata/alias_common.eu"], target: :test }
+test: {
+  # Both names should resolve to the same value
+  original-accessible: original.common-val //= 42
+  alias-accessible: alias.common-val //= 42
+}

--- a/tests/harness/testdata/alias_common.eu
+++ b/tests/harness/testdata/alias_common.eu
@@ -1,0 +1,1 @@
+common-val: 42

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -717,6 +717,11 @@ pub fn test_harness_138() {
 }
 
 #[test]
+pub fn test_harness_139() {
+    run_test(&opts("139_import_alias_rule3.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- **Rule 3 (eu-c9fr)**: When a file is imported directly a second time under a different name (e.g. `lens=lens.eu` then `optics=lens.eu`), emit an alias binding `let { optics = lens }` instead of re-desugaring. Tracked via a new `import_first_direct: HashMap<usize, String>` field in `Desugarer`. This avoids content duplication and prevents nested imports being incorrectly suppressed on the second pass.

- **ImportGraph locator identity (eu-v0t6)**: `encounter_input` / `find_index` now deduplicate by `Locator` rather than full `Input` equality. Two inputs pointing to the same file but with different alias names are now a single graph node, which prevents cycle-detection false negatives for self-imports under an alias.

- **Locator-based content fallback**: `translate_import` falls back to a locator-based content lookup when the exact `Input` key isn't in the `desugarables` map (necessary after the ImportGraph change since only the first-registered Input is stored).

- **Harness test 139**: exercises the same-file-two-names case (`original=alias_common.eu` + `alias=alias_common.eu`), confirming both names resolve to the same value.

## Test plan
- [x] `cargo test test_harness_13` — tests 130–139 all pass
- [x] `cargo test --lib` — 629 lib tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)