### PR TITLE
feat: state monad library (eu-1lfi)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,5 +6,6 @@ fn main() {
     println!("cargo:rerun-if-changed=lib/prelude.eu");
     println!("cargo:rerun-if-changed=lib/test.eu");
     println!("cargo:rerun-if-changed=lib/lens.eu");
+    println!("cargo:rerun-if-changed=lib/state.eu");
     println!("cargo:rerun-if-changed=build-meta.yaml");
 }

--- a/lib/state.eu
+++ b/lib/state.eu
@@ -1,0 +1,79 @@
+{ import: "resource:lens"
+  doc: "State monad for Eucalypt. Each state action is a function state -> [value, new-state]. Use state.run(action, initial) to execute a computation and state.exec / state.eval to extract just the final state or final value." }
+
+# ─── Primitive bind / return ────────────────────────────────────────────────
+
+` "state-ret(v, s) - wrap value v in the state monad: returns [v, s] unchanged."
+state-ret(v, s): [v, s]
+
+` "state-bind(action, f, s) - run action on s, pass result value to f, run f's action on new state."
+state-bind(action, f, s): {
+  pair: action(s)
+  val: pair head
+  new-s: pair tail head
+  run: f(val)(new-s)
+}.(run)
+
+# ─── Primitive actions ───────────────────────────────────────────────────────
+
+` "state-get(s) - state action: return the whole state as the value."
+state-get(s): [s, s]
+
+` "state-put(k, v, s) - state action: set key k to value v in the state block."
+state-put(k, v, s): [null, alter-value(k, v, s)]
+
+` "state-lift(f, s) - state action: apply f to the state (transforming it), return null."
+state-lift(f, s): [null, f(s)]
+
+` "state-query(f, s) - state action: apply f to the state and return the result; state unchanged."
+state-query(f, s): [f(s), s]
+
+` "state-modify(k, f, s) - state action: update key k by applying f to its current value."
+state-modify(k, f, s): [null, update-value(k, f, s)]
+
+# ─── Lens operators ──────────────────────────────────────────────────────────
+
+set-at(lens, v, s): [null, over(lens, -> v, s)]
+
+mod-at(lens, f, s): [null, over(lens, f, s)]
+
+` { doc: "l =! v — state action: set the focus of lens l to v.  If l is a symbol, wraps with at."
+    fixity: "infix-left"
+    precedence: 10 }
+(l =! v): if(l symbol?, set-at(at(l), v), set-at(l, v))
+
+` { doc: "l %! f — state action: modify the focus of lens l with f.  If l is a symbol, wraps with at."
+    fixity: "infix-left"
+    precedence: 10 }
+(l %! f): if(l symbol?, mod-at(at(l), f), mod-at(l, f))
+
+# ─── Namespace (enables { :state ... } blocks) ───────────────────────────────
+
+` { doc: "State monad namespace.  Each declaration in a colon-state block is a monadic bind step."
+    monad: true }
+state: monad{bind: state-bind, return: state-ret} {
+
+  ` "state.get - action returning the whole state as the value."
+  get: state-get
+
+  ` "state.put(k, v) - action setting key k to v in the state."
+  put: state-put
+
+  ` "state.lift(f) - action applying pure function f to transform the state."
+  lift: state-lift
+
+  ` "state.query(f) - action reading from state via f, leaving state unchanged."
+  query: state-query
+
+  ` "state.modify(k, f) - action updating key k by applying f to its current value."
+  modify: state-modify
+
+  ` "state.run(action, initial) - run a state action starting from initial state; returns [value, final-state]."
+  run(action, initial): action(initial)
+
+  ` "state.eval(action, initial) - run a state action and return only the final value."
+  eval(action, initial): action(initial) head
+
+  ` "state.exec(action, initial) - run a state action and return only the final state."
+  exec(action, initial): action(initial) tail head
+}

--- a/src/driver/resources.rs
+++ b/src/driver/resources.rs
@@ -27,6 +27,11 @@ impl Default for Resources {
                 .expect("lens.eu is valid UTF-8"),
         );
         content.insert(
+            "state".to_string(),
+            String::from_utf8(include_bytes!("../../lib/state.eu").to_vec())
+                .expect("state.eu is valid UTF-8"),
+        );
+        content.insert(
             "package".to_string(),
             String::from_utf8(include_bytes!("../../Cargo.lock").to_vec())
                 .expect("Cargo.lock is valid UTF-8"),

--- a/tests/harness/140_state_monad.eu
+++ b/tests/harness/140_state_monad.eu
@@ -1,0 +1,106 @@
+"140 state monad library"
+
+# Import state.eu and test basic state operations.
+
+` { import: "resource:state", target: :test }
+test: {
+  initial: { count: 0, items: [] }
+
+  # state.get returns the whole state as value, unchanged state
+  get-test: {
+    result: state.run(state.get, initial)
+    value: result head
+    final-s: result tail head
+    value-ok: (value.count) //= 0
+    state-ok: (final-s.count) //= 0
+  }
+
+  # state.put sets a key
+  put-test: {
+    action: state.put(:count, 42)
+    result: state.run(action, initial)
+    value: result head
+    final-s: result tail head
+    value-ok: value //= null
+    state-ok: (final-s.count) //= 42
+  }
+
+  # state.query reads from state
+  query-test: {
+    action: state.query(_.count)
+    result: state.run(action, initial)
+    value: result head
+    value-ok: value //= 0
+  }
+
+  # state.modify updates a key
+  modify-test: {
+    action: state.modify(:count, + 5)
+    result: state.run(action, initial)
+    final-s: result tail head
+    state-ok: (final-s.count) //= 5
+  }
+
+  # state.then chains two actions, discarding first result
+  bind-test: {
+    # modify count then query — state.then runs modify, ignores result, runs query
+    action: state.modify(:count, + 1) state.then(state.query(_.count))
+    result: state.run(action, initial)
+    value: result head
+    value-ok: value //= 1
+  }
+
+  # { :state ... } block syntax: get count, increment, return old count
+  block-test: {
+    computation: { :state
+      c: state.query(_.count)
+      _ : (:count =! (c + 10))
+    }.(c)
+    result: state.run(computation, initial)
+    value: result head
+    final-s: result tail head
+    value-ok: value //= 0
+    state-ok: (final-s.count) //= 10
+  }
+
+  # state.eval and state.exec helpers
+  eval-test: {
+    action: state.modify(:count, + 99)
+    final-val: state.eval(action, initial)
+    final-val-ok: final-val //= null
+  }
+
+  exec-test: {
+    action: state.modify(:count, + 99)
+    final-s: state.exec(action, initial)
+    state-ok: (final-s.count) //= 99
+  }
+
+  # =! operator (symbol auto-at)
+  op-set-test: {
+    action: :count =! 7
+    result: state.run(action, initial)
+    final-s: result tail head
+    state-ok: (final-s.count) //= 7
+  }
+
+  # %! operator (symbol auto-at)
+  op-mod-test: {
+    action: :count %! (* 3)
+    result: state.run(action, {count: 4})
+    final-s: result tail head
+    state-ok: (final-s.count) //= 12
+  }
+
+  RESULT: [ get-test.value-ok, get-test.state-ok
+          , put-test.value-ok, put-test.state-ok
+          , query-test.value-ok
+          , modify-test.state-ok
+          , bind-test.value-ok
+          , block-test.value-ok, block-test.state-ok
+          , eval-test.final-val-ok
+          , exec-test.state-ok
+          , op-set-test.state-ok
+          , op-mod-test.state-ok
+          ] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -717,6 +717,11 @@ pub fn test_harness_138() {
 }
 
 #[test]
+pub fn test_harness_140() {
+    run_test(&opts("140_state_monad.eu"));
+}
+
+#[test]
 pub fn test_gc_001() {
     run_test(&opts("gc/gc_001_basic_collection.eu"));
 }


### PR DESCRIPTION
## Summary

- Add `lib/state.eu` implementing a general-purpose state monad
- Each state action is a function `state -> [value, new-state]`
- Provides `state-ret`/`state-bind` primitives, `state-get`/`state-put`/`state-lift`/`state-query`/`state-modify` actions
- Lens integration via `=!` (set) and `%!` (modify) infix operators
- `state` namespace with `monad: true` enables `{ :state ... }` monadic block syntax
- Registered as `resource:state` in `resources.rs` and `build.rs`
- Harness test 140 covers all operations including block syntax, lens operators, and monad utilities (`then`, `eval`, `exec`)

## Implementation notes

- Primitive action names use `state-` prefix (e.g. `state-get`) to avoid circular self-references in the namespace block, where mutually-recursive let bindings would make `get: get` loop
- Unit-level `{ import: "resource:lens" }` metadata brings lens functions into scope for all declarations (declaration-level metadata only scopes to that declaration's body)

## Test plan

- [x] `cargo test test_harness_140` passes (PASS result)
- [x] Full harness suite: 262 tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)