### PR TITLE
test: add missing tests for deep-transform, ∈/∉, and map-elements

### DIFF
--- a/tests/harness/015_block_fns.eu
+++ b/tests/harness/015_block_fns.eu
@@ -111,10 +111,26 @@ lookups: {
   }
 }
 
+map-elements-checks: {
+  trues: [
+    # Identity transform
+    ({a: 1, b: 2} map-elements(identity)) = {a: 1, b: 2},
+    # Transform values only (using bimap)
+    ({a: 1, b: 2} map-elements(bimap(identity, + 10))) = {a: 11, b: 12},
+    # Rename keys
+    ({x: 1} map-elements(bimap(prefix-key, identity))) = {pre-x: 1},
+    # Transform both key and value
+    ({a: 1, b: 2} map-elements(bimap(prefix-key, * 3))) = {pre-a: 3, pre-b: 6}
+  ]
+}
+
+prefix-key(k): "pre-{k}" sym
+
 pass: [ checks.trues values all-true?
       , merging.checks.trues all-true?
       , lookups.checks.trues all-true?
       , deep-merge.pass
+      , map-elements-checks.trues all-true?
       ] all-true?
 
 RESULT: if(pass, :PASS, :FAIL)

--- a/tests/harness/074_sets.eu
+++ b/tests/harness/074_sets.eu
@@ -113,6 +113,20 @@ computed-checks: {
   ]
 }
 
+` "Membership operators ∈ and ∉"
+
+operator-checks: {
+  trues: [
+    :a ∈ (set.from-list[:a, :b, :c]),
+    not(:d ∈ (set.from-list[:a, :b])),
+    :z ∉ (set.from-list[:a, :b]),
+    not(:a ∉ (set.from-list[:a, :b])),
+    1 ∈ (set.from-list[1, 2, 3]),
+    "x" ∈ (set.from-list["x", "y"]),
+    not(99 ∈ ∅)
+  ]
+}
+
 pass: [
   construction-checks.trues all-true?,
   empty-checks.trues all-true?,
@@ -121,7 +135,8 @@ pass: [
   mutation-checks.trues all-true?,
   algebra-checks.trues all-true?,
   render-checks.trues all-true?,
-  computed-checks.trues all-true?
+  computed-checks.trues all-true?,
+  operator-checks.trues all-true?
 ] all-true?
 
 RESULT: if(pass, :PASS, :FAIL)

--- a/tests/harness/143_deep_transform.eu
+++ b/tests/harness/143_deep_transform.eu
@@ -1,0 +1,28 @@
+"143 deep-transform"
+
+# Replace all symbols in a nested structure
+replace-syms(v): if(v symbol?, :replaced, null)
+
+# Double all numbers
+double-nums(v): if(v number?, v * 2, null)
+
+` { target: :test }
+test: {
+  # Replaces symbols at any depth in lists
+  list-syms: ([1, :a, [2, :b]] deep-transform(replace-syms)) //= [1, :replaced, [2, :replaced]]
+
+  # Replaces symbols in block values (not keys)
+  block-syms: ({x: :a, y: 1} deep-transform(replace-syms)) //= {x: :replaced, y: 1}
+
+  # Nested blocks and lists
+  nested: ({a: [1, :x], b: {c: :y}} deep-transform(replace-syms)) //= {a: [1, :replaced], b: {c: :replaced}}
+
+  # Doubles numbers at any depth
+  nums: ([1, [2, 3], {x: 4}] deep-transform(double-nums)) //= [2, [4, 6], {x: 8}]
+
+  # Rule returning null everywhere leaves structure unchanged
+  identity: ({a: 1, b: [2, :c]} deep-transform(-> null)) //= {a: 1, b: [2, :c]}
+
+  # Non-matching values pass through
+  mixed: ([1, "hello", :sym, true] deep-transform(replace-syms)) //= [1, "hello", :replaced, true]
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1450,3 +1450,8 @@ pub fn test_error_128() {
 pub fn test_harness_142() {
     run_test(&opts("142_consecutive_metadata_blocks.eu"));
 }
+
+#[test]
+pub fn test_harness_143() {
+    run_test(&opts("143_deep_transform.eu"));
+}


### PR DESCRIPTION
## Summary

Tests for three prelude additions that were pushed to master without tests:

- **`143_deep_transform.eu`** — new test file: symbol replacement, number doubling, nested structures, identity rule, mixed types
- **`074_sets.eu`** — `∈`/`∉` operator tests added to existing membership section
- **`015_block_fns.eu`** — `map-elements` tests added: identity, value transform, key rename, combined

## Test plan

- [x] All 265 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)