### PR TITLE
docs: idiomatic eucalypt patterns — style guide + agent reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,11 @@ For specific topics, also consult:
 9. **`str.split-on` uses regex**: `"a.b" str.split-on(".")` matches any char. Use `"[.]"`.
 10. **No whitespace before `(`**: `f(x)` is a call, `f (x)` is catenation.
 11. **Multiple imports go in one block**: `{ import: ["a.eu", "b.eu"] }` — do NOT write separate `{ import: "a.eu" }` and `{ import: "b.eu" }` blocks. Only the first block is unit metadata; the second becomes a separate expression.
+12. **`keys` returns symbols**: do NOT `map(sym)` over `keys` output — they are already symbols.
+13. **`if` with `_` anaphora doesn't make a rule**: `if(_ symbol?, x, null)` doesn't create a function — `if` evaluates its condition. Use a named function.
+14. **Use interpolation, not `str.join-on`**: `"{pfx}{name}"` not `[pfx, name] str.join-on("")`. Interpolation auto-converts values.
+15. **Use `deep-transform` for recursive rewrites**: return non-null to replace, null to recurse. Avoids nested `if(block?, ..., if(list?, ...))`.
+16. **Read `docs/eucalypt-style.md`** for idiomatic patterns: `when` over `if`, `bimap` for point-free, scope capture in blocks, sets for membership.
 
 ## Panics Are Critical
 

--- a/docs/eucalypt-style.md
+++ b/docs/eucalypt-style.md
@@ -96,3 +96,58 @@ When in doubt, ask: "how will this function most commonly be called?" and put th
 - Use blocks for local bindings: `{ x: ... y: ... }.(x + y)`, but limit to one block, do not stack this construct
 - Keep block "results"" in `.(...)` concise, preferably simple pipelines or expressions, or even just `{...}.result`
 - **Dynamic generalised lookup**: a function can return a block whose names are then used as a namespace for subsequent pipelines, e.g. `prepare(data).( edges take(k) ... )`. Use very sparingly — it can defeat static analysis. Never nest or stack dynamic lookups.
+- **Capture scope with local bindings**: when helpers share parameters, move them inside a block so they capture from scope rather than threading parameters explicitly:
+  ```eu,notest
+  # Before: f threaded through every helper
+  helper(f, x): f(x) + 1
+  go(f, xs): xs map(helper(f))
+
+  # After: f captured from enclosing block
+  go(f, xs): {
+    helper(x): f(x) + 1
+  }.(xs map(helper))
+  ```
+
+## Prefer `when` over `if` for conditional transforms
+
+- `when(pred?, f, x)` applies `f` when `pred?` matches, otherwise passes `x` through unchanged. Cleaner than `if(pred?(x), f(x), x)` which repeats `x`.
+  ```eu,notest
+  # Before: x repeated in both branches
+  if(x number?, x + 1, x)
+
+  # After
+  x when(number?, + 1)
+  ```
+
+## Prefer point-free composition
+
+- Use `bimap`, `compose` (`;`), and partial application to eliminate intermediate named functions:
+  ```eu,notest
+  # Before: named function to combine two transforms on a pair
+  transform[k, v]: [rename(k), process(v)]
+  blk map-elements(transform)
+
+  # After: bimap composes the two directly
+  blk map-elements(bimap(rename, process))
+  ```
+
+## Avoid nested `if` for type dispatch
+
+- Nested `if(block?, ..., if(list?, ..., if(symbol?, ...)))` chains are hard to read. Prefer:
+  - **`deep-transform`** for recursive structural rewriting — it handles the block/list/atom dispatch internally
+  - **`when`** for single conditional transforms
+  - **Named predicates** for readability
+
+## Sets for membership
+
+- Use sets (`set.from-list`) for repeated membership testing, not `any(= x)` over a list. Faster and reads better with `∈`:
+  ```eu,notest
+  # Before
+  allowed: [:a, :b, :c]
+  allowed any(= v)
+
+  # After
+  allowed: set.from-list[:a, :b, :c]
+  v ∈ allowed            # as expression
+  v when(∈ allowed, f)   # section as predicate
+  ```

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -844,6 +844,52 @@ The following are commonly assumed but are **not** in the prelude:
 All `str.match`, `str.split`, `str.matches?` functions use regex
 patterns.
 
+### 5.13 `if` With Anaphora Does Not Create a Rule Function
+
+```eu,notest
+# WRONG: _ creates an anaphoric function, if evaluates it as a boolean
+data deep-transform(if(_ symbol?, :replaced, null))
+
+# RIGHT: use a named function as the rule
+replace-syms(v): if(v symbol?, :replaced, null)
+data deep-transform(replace-syms)
+```
+
+`if` evaluates its first argument as a condition. `_ symbol?` in
+that position creates a function, not a boolean. Use a named
+function or `when` instead.
+
+### 5.14 `keys` Returns Symbols
+
+Block keys are symbols. `keys` returns a list of symbols — do NOT
+`map(sym)` over them:
+
+```eu,notest
+{a: 1, b: 2} keys         # [:a, :b] — already symbols
+{a: 1, b: 2} keys map(sym)  # WRONG: sym expects a string
+```
+
+### 5.15 Use `deep-transform` for Recursive Rewrites
+
+`deep-transform(rule, data)` applies `rule` at each node. Return a
+value to replace, or `null` to recurse into children. Eliminates
+hand-rolled recursive `if(block?, ..., if(list?, ...))` dispatch:
+
+```eu,notest
+# Replace all symbols matching a set
+rename(v): if(v ∈ ks, prefix(v), null)
+data deep-transform(rename)
+```
+
+### 5.16 Use `map-elements` and `bimap` for Block Transforms
+
+`map-elements(f, blk)` applies `f` to each `[key, value]` pair and
+rebuilds the block. Combine with `bimap` for point-free transforms:
+
+```eu,notest
+blk map-elements(bimap(rename-key, transform-value))
+```
+
 ---
 
 ## 6. Quick CLI Reference


### PR DESCRIPTION
## Summary

Distilled from the process of refactoring `prefix-block` from 30 lines of nested ifs to 4 lines of point-free composition.

### Style guide (`docs/eucalypt-style.md`)
- **Capture scope with local bindings** — move helpers into blocks to eliminate parameter threading
- **Prefer `when` over `if`** — for conditional transforms where the value passes through unchanged on failure
- **Prefer point-free composition** — `bimap` and partial application over intermediate named functions
- **Avoid nested `if` for type dispatch** — use `deep-transform`, `when`, named predicates
- **Sets for membership** — `set.from-list` + `∈` sections over `any(= x)` on lists

### Agent reference (`docs/reference/agent-reference.md`)
- 5.13: `if` with `_` anaphora doesn't create a rule function
- 5.14: `keys` returns symbols — don't `map(sym)`
- 5.15: `deep-transform` for recursive rewrites
- 5.16: `map-elements` + `bimap` for block transforms

### CLAUDE.md
- Critical rules 12–16 summarising the above

## Test plan
- Documentation only, no code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)