### PR TITLE
feat: add unzip to prelude

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1221,6 +1221,9 @@ zip-with: map2
 ` "`zip(l1, l2)` - list of pairs of elements  `l1` and `l2`, until the shorter is exhausted."
 zip: zip-with(pair)
 
+` "`unzip(pairs)` - list of pairs to pair of lists. Inverse of zip."
+unzip(pairs): [pairs map(first), pairs map(second)]
+
 ` "`cross(f, xs, ys)` - apply `f` to every combination of elements from `xs` and `ys` (cartesian product)."
 cross(f, xs, ys): xs mapcat({x: •}.(ys map(f(x))))
 

--- a/tests/harness/010_prelude.eu
+++ b/tests/harness/010_prelude.eu
@@ -181,6 +181,8 @@ tests: {
     t13: [1] ++ [2] = [1, 2]
     t14: concat([[0], [:a], ["x"]]) = [0, :a, "x"]
     t15: (zip-with(pair, [:x, :y, :z], [1, 2, 3]) block) = { x: 1 y: 2 z: 3 }
+    t15b: (zip([1, 2, 3], [:a, :b, :c]) unzip) = [[1, 2, 3], [:a, :b, :c]]
+    t15c: ([] unzip) = [[], []]
     t16: ([true, false] all-true?) = false
     t17: ([true, false] any-true?) = true
     t18: ([0, 0, 0, 0] all(zero?)) = true


### PR DESCRIPTION
## Summary

`unzip(pairs)` — list of pairs to pair of lists. Inverse of `zip`.

```eu
zip([1, 2, 3], [:a, :b, :c]) unzip
# => [[1, 2, 3], [:a, :b, :c]]
```

Tests added to `010_prelude.eu` (round-trip and empty list).

## Test plan
- [x] All 265 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)