### PR TITLE
feat: add interleave to prelude

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1224,6 +1224,9 @@ zip: zip-with(pair)
 ` "`unzip(pairs)` - list of pairs to pair of lists. Inverse of zip."
 unzip(pairs): [pairs map(first), pairs map(second)]
 
+` "`interleave(a, b)` - alternate elements from lists `a` and `b`. When one is exhausted, the remainder of the other is appended."
+interleave(a, b): if(a nil?, b, cons(a head, interleave(b, a tail)))
+
 ` "`cross(f, xs, ys)` - apply `f` to every combination of elements from `xs` and `ys` (cartesian product)."
 cross(f, xs, ys): xs mapcat({x: •}.(ys map(f(x))))
 

--- a/tests/harness/010_prelude.eu
+++ b/tests/harness/010_prelude.eu
@@ -188,6 +188,8 @@ tests: {
     t15f: interleave([1], []) = [1]
     t15g: interleave([1, 2], [3, 4]) = [1, 3, 2, 4]
     t15h: interleave([], []) = []
+    t15i: interleave([1, 2, 3, 4, 5], [:a]) = [1, :a, 2, 3, 4, 5]
+    t15j: interleave([:x], [1, 2, 3, 4, 5]) = [:x, 1, 2, 3, 4, 5]
     t16: ([true, false] all-true?) = false
     t17: ([true, false] any-true?) = true
     t18: ([0, 0, 0, 0] all(zero?)) = true

--- a/tests/harness/010_prelude.eu
+++ b/tests/harness/010_prelude.eu
@@ -183,6 +183,11 @@ tests: {
     t15: (zip-with(pair, [:x, :y, :z], [1, 2, 3]) block) = { x: 1 y: 2 z: 3 }
     t15b: (zip([1, 2, 3], [:a, :b, :c]) unzip) = [[1, 2, 3], [:a, :b, :c]]
     t15c: ([] unzip) = [[], []]
+    t15d: interleave([1, 2, 3], [:a, :b]) = [1, :a, 2, :b, 3]
+    t15e: interleave([], [:a, :b]) = [:a, :b]
+    t15f: interleave([1], []) = [1]
+    t15g: interleave([1, 2], [3, 4]) = [1, 3, 2, 4]
+    t15h: interleave([], []) = []
     t16: ([true, false] all-true?) = false
     t17: ([true, false] any-true?) = true
     t18: ([0, 0, 0, 0] all(zero?)) = true


### PR DESCRIPTION
## Summary

`interleave(a, b)` — alternate elements from two lists, appending the remainder when one is exhausted.

```eu
interleave([1, 2, 3], [:a, :b])  # => [1, :a, 2, :b, 3]
```

Implementation swaps lists on each recursion — no nested `if` needed.

Tests added to `010_prelude.eu`: equal length, unequal, empty left, empty right, both empty.

## Test plan
- [x] All 266 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)