### PR TITLE
feat: harmonise assertion/expectation operators via unified __EXPECT

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -226,7 +226,7 @@ From highest to lowest binding:
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
 | 10 | apply | right | `@` | Function application |
-| 5 | meta | right | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//!` | Metadata / assertions |
+| 5 | meta | right | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata / assertions |
 
 **User-defined operators** default to left-associative, precedence 50.
 Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
@@ -416,15 +416,16 @@ either operand is an array. Scalar broadcasting is supported.
 
 | Operator | Description |
 |----------|-------------|
-| `e //= v` | Test `e` equals `v`, return `true`/`false` |
-| `e //=? f` | Test `f(e)` is `true`, return `true`/`false` |
-| `e //!` | Test `e` is `true`, return `true`/`false` |
+| `e //= v` | Expect `e` equals `v`, return `true`/`false` |
+| `e //=? f` | Expect `f(e)` is `true`, return `true`/`false` |
+| `e //!` | Expect `e` is `true`, return `true`/`false` |
 
-**Assertions** (always panic on failure):
+**Assertions** (return `e`, panic on failure in normal mode):
 
 | Operator | Description |
 |----------|-------------|
-| `e //=> v` | Assert `e` equals `v` (panic with expected/actual on failure) |
+| `e //=> v` | Assert `e` equals `v`, return `e` |
+| `e //=?> f` | Assert `f(e)` is `true`, return `e` |
 
 ## Command Line Quick Reference
 

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -263,7 +263,7 @@ From highest (tightest) to lowest binding:
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
 | 10 | apply | right | `@` | Function application |
-| 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//!` | Metadata and assertions |
+| 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
 
 **Named precedence levels** for use in operator metadata: `:lookup`,
 `:call`, `:bool-unary`, `:exp`, `:prod`, `:sum`, `:shift`, `:bitwise`,
@@ -973,19 +973,31 @@ All functions verified against `lib/prelude.eu`:
 
 All at precedence 5 (`:meta`).
 
-**Test expectations** (panic in normal mode, return `false` in test mode):
+**Expectations** (return boolean; panic in normal mode, return `false` in test mode):
 
 | Operator | Description |
 |----------|-------------|
-| `e //= v` | Test `e` equals `v`; returns `true`/`false`, emits diagnostic on failure |
-| `e //=? f` | Test `f(e)` is `true`; returns `true`/`false`, emits diagnostic on failure |
-| `e //!` | Test `e` is `true`; returns `true`/`false`, emits diagnostic on failure |
+| `e //= v` | Expect `e` equals `v`; returns `true` on success |
+| `e //=? f` | Expect `f(e)` is `true`; returns `true` on success |
+| `e //!` | Expect `e` is `true`; returns `true` on success |
 
-**Assertions** (always panic on failure, return `e` on success):
+**Assertions** (return `e`; panic in normal mode, return `false` in test mode):
 
 | Operator | Description |
 |----------|-------------|
-| `e //=> v` | Assert `e` equals `v`, panic with expected/actual on failure |
+| `e //=> v` | Assert `e` equals `v`; returns `e` on success |
+| `e //=?> f` | Assert `f(e)` is `true`; returns `e` on success |
+
+Assertions are useful in pipelines — they validate a value and pass
+it through:
+
+```eu,notest
+data //=?> non-nil? map(process) //=?> (count > 0)
+```
+
+All expectation and assertion operators use the same unified
+`__EXPECT` BIF. On failure, they emit a diagnostic showing the
+expected and actual values.
 
 **Metadata operators:**
 
@@ -999,12 +1011,8 @@ All at precedence 5 (`:meta`).
 | BIF | Signature | Description |
 |-----|-----------|-------------|
 | `__DBG_REPR(v)` | `unk → str` | Render any eucalypt value as a compact human-readable string (e.g. `42`, `"hello"`, `:foo`, `true`, `null`, `[]`, `{block}`) |
-| `__EXPECT(actual, expected_repr, pass)` | `unk × str × bool → bool` | Test infrastructure primitive: returns `pass` as a boolean; on failure prints `EXPECT FAILED: expected <expected_repr>, got <actual_repr>` to stderr |
+| `__EXPECT(actual, repr, pass, ret)` | `unk × str × bool × unk → unk` | Unified expectation/assertion: returns `ret` on success; on failure emits diagnostic and panics (normal) or returns `false` (test mode) |
 | `__DBG(label, v)` | `str × unk → unk` | Print debug output to stderr; return `v` transparently |
-
-`__DBG_REPR` is used internally by `//=` and `//!` to format diagnostic
-messages. It can also be used directly in test harnesses when you need
-a string representation of a value for comparison or display.
 
 ---
 

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1032,47 +1032,54 @@ assert(p?, s, v): if(v p?, v, panic(s))
 # In test mode: return false on failure, allowing test harness to collect results.
 #
 
-` { doc: "`e //= v` - test that expression `e` evaluates to `v`, return boolean.
+` { doc: "`e //= v` - expect `e` evaluates to `v`, return boolean.
 
     On success: return true.
-    On failure (normal mode): panic with EXPECT FAILED diagnostic.
+    On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //= v): __EXPECT(e, __DBG_REPR(v), e = v)
+(e //= v): __EXPECT(e, __DBG_REPR(v), e = v, true)
 
-` { doc: "`e //=? f` - test that expression `e` satisfies predicate `f`, return boolean.
+` { doc: "`e //=? f` - expect `e` satisfies predicate `f`, return boolean.
 
     On success: return true.
-    On failure (normal mode): panic with EXPECT FAILED diagnostic.
+    On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //=? f): __EXPECT(e, "to satisfy predicate", e f)
+(e //=? f): __EXPECT(e, "to satisfy predicate", e f, true)
 
-` { doc: "`e //!` - test that expression `e` is true, return boolean.
+` { doc: "`e //!` - expect `e` is true, return boolean.
 
     On success: return true.
-    On failure (normal mode): panic with EXPECT FAILED diagnostic.
+    On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
     export: :suppress
     precedence: :meta }
-(e //!): __EXPECT(e, "true", e = true)
+(e //!): __EXPECT(e, "true", e = true, true)
 
-#
-# Assertions (always panic on failure, return the value on success)
-#
+` { doc: "`e //=> v` - assert `e` evaluates to `v`, return `e`.
 
-` { doc: "`e //=> v` - assert expression `e` evaluates to `v` and return `e`.
-
-    On failure, reports the expected and actual values:
-    assertion failed: expected v, got e"
+    On success: return e (pass-through).
+    On failure (normal mode): panic with diagnostic.
+    On failure (test mode): emit diagnostic to stderr, return false."
     export: :suppress
     associates: :left
     precedence: :meta }
-(e //=> v): if(e = v, e, __ASSERT_FAIL(e, v))
+(e //=> v): __EXPECT(e, __DBG_REPR(v), e = v, e)
+
+` { doc: "`e //=?> f` - assert `e` satisfies predicate `f`, return `e`.
+
+    On success: return e (pass-through).
+    On failure (normal mode): panic with diagnostic.
+    On failure (test mode): emit diagnostic to stderr, return false."
+    export: :suppress
+    associates: :left
+    precedence: :meta }
+(e //=?> f): __EXPECT(e, "to satisfy predicate", e f, e)
 
 #
 # Debug tracing

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -851,8 +851,8 @@ lazy_static! {
     },
     Intrinsic { // 160
             name: "EXPECT",
-            ty: function(vec![unk(), str_(), bool_(), bool_()]).unwrap(),
-            strict: vec![1, 2],
+            ty: function(vec![unk(), str_(), bool_(), unk(), unk()]).unwrap(),
+            strict: vec![0, 1, 2],
     },
     Intrinsic { // 161
             name: "DBG",

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -196,6 +196,18 @@ pub trait CallGlobal3: StgIntrinsic {
     }
 }
 
+pub trait CallGlobal4: StgIntrinsic {
+    fn global(
+        &self,
+        x: crate::eval::stg::syntax::Ref,
+        y: crate::eval::stg::syntax::Ref,
+        z: crate::eval::stg::syntax::Ref,
+        w: crate::eval::stg::syntax::Ref,
+    ) -> Rc<StgSyn> {
+        dsl::app(self.gref(), vec![x, y, z, w])
+    }
+}
+
 pub trait CallGlobal7: StgIntrinsic {
     #[allow(clippy::too_many_arguments)]
     fn global(

--- a/src/eval/stg/expect.rs
+++ b/src/eval/stg/expect.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 use crate::eval::{
     emit::Emitter,
     error::ExecutionError,
-    machine::intrinsic::{CallGlobal3, IntrinsicMachine, StgIntrinsic},
+    machine::intrinsic::{CallGlobal4, IntrinsicMachine, StgIntrinsic},
     memory::{
         mutator::MutatorHeapView,
         syntax::{HeapSyn, Ref},
@@ -39,22 +39,26 @@ fn resolve_bool(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &R
     }
 }
 
-/// `__EXPECT(actual, expected_repr, pass)` — unified expectation BIF.
+/// `__EXPECT(actual, expected_repr, pass, success_value)` — unified
+/// expectation / assertion BIF.
 ///
 /// Behaviour:
-/// - `pass` is `true` → return `true` (success, no output).
+/// - `pass` is `true` → return `success_value` unchanged.
 /// - `pass` is `false` → emit a "EXPECT FAILED" diagnostic to stderr
 ///   with the expected representation and the actual value rendered
-///   by `render_debug_repr`, then return `false`.
+///   by `render_debug_repr`, then:
+///   - In test mode: return `false`.
+///   - In normal mode: raise `AssertionFailed` error.
 ///
 /// The `actual` argument is lazy (not forced by the wrapper) so that
-/// unforced thunks render as `<unevaluated>` in failure messages
-/// rather than triggering evaluation side-effects. The operator
-/// implementations (`//=`, `//!`) already force `actual` via the
-/// equality check passed as `pass`, so in practice `actual` is
-/// usually already at WHNF when `__EXPECT` runs.
+/// unforced thunks render as `<unevaluated>` in failure messages.
 ///
-/// `expected_repr` and `pass` are strict.
+/// For boolean expectations (`//=`, `//!`, `//=?`), pass `true` as
+/// `success_value`. For pass-through assertions (`//=>`, `//=?>`),
+/// pass the actual value as `success_value`.
+///
+/// `expected_repr` and `pass` are strict. `success_value` is lazy
+/// (only returned on success, never inspected on failure).
 pub struct Expect;
 
 impl StgIntrinsic for Expect {
@@ -72,10 +76,13 @@ impl StgIntrinsic for Expect {
         // args[0] = actual value (lazy — rendered only on failure)
         // args[1] = expected representation string (strict)
         // args[2] = pass boolean (strict)
+        // args[3] = success return value (lazy — returned on success)
         let pass = resolve_bool(machine, view, &args[2]);
 
         if pass {
-            machine_return_bool(machine, view, true)
+            // Return the success value (args[3]) as-is
+            let closure = machine.nav(view).resolve(&args[3])?;
+            machine.set_closure(closure)
         } else {
             let expected_repr = str_arg(machine, view, &args[1])?;
             let actual_repr = render_debug_repr(machine, view, &args[0]);
@@ -96,4 +103,4 @@ impl StgIntrinsic for Expect {
     }
 }
 
-impl CallGlobal3 for Expect {}
+impl CallGlobal4 for Expect {}


### PR DESCRIPTION
## Summary

All assertion and expectation operators now go through a single `__EXPECT` BIF with consistent behaviour.

### Before
| Operator | Returns | Mechanism | Failure rendering |
|---|---|---|---|
| `//=` | bool | `__EXPECT` (3-arg) | `<unevaluated>` (bug) |
| `//=?` | bool | `__EXPECT` | `<unevaluated>` |
| `//!` | bool | `__EXPECT` | `<unevaluated>` |
| `//=>` | value | `__ASSERT_FAIL` | correct |

### After
| Operator | Returns | Mechanism | Failure rendering |
|---|---|---|---|
| `//=` | bool | `__EXPECT` (4-arg) | correct |
| `//=?` | bool | `__EXPECT` | correct |
| `//!` | bool | `__EXPECT` | correct |
| `//=>` | LHS value | `__EXPECT` | correct |
| `//=?>` (**new**) | LHS value | `__EXPECT` | correct |

### Changes
- `__EXPECT` extended to 4 args: `(actual, expected_repr, pass, success_value)`
- Arg 0 (`actual`) now strict — fixes pre-existing `<unevaluated>` in failure messages
- `//=>` uses `__EXPECT(e, repr, e = v, e)` instead of `if(e = v, e, __ASSERT_FAIL(e, v))`
- New `//=?>` operator: `e //=?> pred` asserts predicate and returns `e`
- `CallGlobal4` trait added

## Test plan
- [x] All 268 tests pass
- [x] clippy clean
- [x] Failure messages show actual values (42, "hello", true, etc.)
- [x] `//=?>` works for predicate assertions with pass-through
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)