### PR TITLE
feat: add parts-of lens combinator

### DIFF
--- a/docs/guide/navigating-nested-data.md
+++ b/docs/guide/navigating-nested-data.md
@@ -323,6 +323,32 @@ records over(each ∘ at(:score), -> 0)
 data when(match?{status: "draft"}, -> {status: "published"})
 ```
 
+### Working with All Foci as a List
+
+Sometimes you want to operate on all the traversed values *as a
+group* rather than individually — sorting them, reversing them, or
+replacing them with a specific list. `parts-of(traversal)` turns a
+traversal into a lens that focuses on the list of all foci:
+
+```eu,notest
+# Sort all scores (the list [10, 20, 5] is sorted, then distributed back)
+records over(parts-of(each ∘ at(:score)), sort-nums)
+
+# Reverse the y values in a deep structure
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+data over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse)
+# => {x: [{y: 3}, {y: 2}, {y: 1}]}
+
+# Only reverse filtered positions — non-matching elements stay put
+[1, 4, 2, 5, 3] over(parts-of(filtered(> 2)), reverse)
+# => [1, 3, 2, 5, 4]
+```
+
+`view(parts-of(traversal), data)` gives the same result as
+`to-list-of(traversal, data)`. The difference is that `parts-of`
+also supports `over` — the transformed list is distributed back into
+the original positions.
+
 ### Lens Consumers
 
 | Function | Description |
@@ -330,6 +356,7 @@ data when(match?{status: "draft"}, -> {status: "published"})
 | `view(lens, data)` | Extract the focused value (single-focus lenses only) |
 | `over(lens, fn, data)` | Apply `fn` at each focus, return whole structure |
 | `to-list-of(traversal, data)` | Collect all foci into a list |
+| `parts-of(traversal)` | Turn a traversal into a lens on the list of foci |
 
 ### Lens and Traversal Constructors
 
@@ -358,6 +385,7 @@ data when(match?{status: "draft"}, -> {status: "published"})
 | Modify a value deep in a structure | `over` + lens | `data over(‹:server :port›, + 1)` |
 | Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.upper)` |
 | Collect values from all elements | `to-list-of` + `each` | `items to-list-of(each ∘ at(:name))` |
+| Sort/reverse/replace all foci | `parts-of` + traversal | `items over(parts-of(each ∘ at(:score)), sort-nums)` |
 
 **Rules of thumb:**
 

--- a/docs/superpowers/specs/2026-04-13-parts-of-design.md
+++ b/docs/superpowers/specs/2026-04-13-parts-of-design.md
@@ -1,0 +1,148 @@
+# parts-of Lens Combinator
+
+**Bead**: eu-fa2x
+**Status**: Design (brainstorming)
+**Date**: 2026-04-13
+
+## Overview
+
+`parts-of(traversal)` turns a traversal into a lens that focuses on
+the list of all traversed values. Assigning a list replaces the
+traversed elements in order.
+
+## Semantics
+
+```eu,notest
+view(parts-of(each), [1, 2, 3])                    # => [1, 2, 3]
+over(parts-of(each), reverse, [1, 2, 3])            # => [3, 2, 1]
+over(parts-of(each), sort-nums, [3, 1, 2])          # => [1, 2, 3]
+
+# Deep composition
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+view(parts-of(at(:x) ∘ each ∘ at(:y)), data)        # => [1, 2, 3]
+over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse, data)
+  # => {x: [{y: 3}, {y: 2}, {y: 1}]}
+```
+
+## How Eucalypt Lenses Work
+
+A lens/traversal is a function `(b -> fb) -> (a -> fa)` where the
+behaviour is controlled by metadata on `k`:
+
+| Consumer | `fmap` | `pure` | `ap` | Result |
+|----------|--------|--------|------|--------|
+| `view` | `flip(const)` | — | — | Extract focus |
+| `over` | `identity` | `identity` | `identity` | Apply fn, rebuild |
+| `to-list-of` | `flip(const)` | `-> []` | `++` | Collect foci |
+
+## Approach: State-Based Distribution
+
+`parts-of(traversal)` is a lens. When applied with continuation `k`:
+
+### View (collect)
+
+Same as `to-list-of(traversal, data)` — collect all foci into a
+list, then pass to `k`.
+
+### Over (distribute)
+
+1. Collect all foci: `collected = to-list-of(traversal, data)`
+2. Apply `k` to the collected list (via the lens protocol, `k`
+   transforms the list)
+3. Run the traversal again with a stateful functor that replaces
+   each focus by consuming from the transformed list
+
+The stateful distribution functor:
+
+```eu,notest
+# Each "value" is a state action: remaining-list -> [result, rest]
+dist-fmap(f, action, s): {
+  r: action(s)
+}.([f(r head), r tail head])
+
+dist-pure(v, s): [v, s]
+
+dist-ap(f-action, x-action, s): {
+  r1: f-action(s)
+  r2: x-action(r1 tail head)
+}.([r1 head(r2 head), r2 tail head])
+```
+
+The traversal is run with:
+- `fmap: dist-fmap` — wraps each focus replacement in a state action
+- `pure: dist-pure` — non-focused positions pass through unchanged
+- `ap: dist-ap` — sequences the state actions
+
+The "replace" function passed to each focus is `(old-val) -> pop
+next from remaining list` — ignoring the old value and consuming
+from the state.
+
+The result is a state action `remaining-list -> [rebuilt-structure,
+rest]`. Apply it to the transformed list to get the final structure.
+
+## Implementation Sketch
+
+```eu,notest
+parts-of(traversal, k): {
+  fmap: meta(k).fmap
+
+  # Collect all foci
+  collected: to-list-of(traversal)
+
+  # Distribution: run traversal with stateful functor
+  dist-fmap(f, action, s): {
+    r: action(s)
+  }.([f(r head), r tail head])
+
+  dist-pure(v, s): [v, s]
+
+  dist-ap(f-action, x-action, s): {
+    r1: f-action(s)
+    r2: x-action(r1 tail head)
+  }.([r1 head(r2 head), r2 tail head])
+
+  # The "replace" function: ignore old value, pop from list
+  pop(old, remaining): [remaining head, remaining tail]
+
+  # Run traversal with distribution functor, seeded with new values
+  distribute(new-vals, data):
+    (data traversal(pop // { fmap: dist-fmap, pure: dist-pure, ap: dist-ap })
+      (new-vals)) head
+
+  # Lens body: fmap over the collected list, then distribute
+  s(data): fmap(distribute(data), k(data collected))
+}.(s // meta(k))
+```
+
+## Open Questions
+
+1. **Does the distribution functor compose correctly through
+   lens ∘ traversal ∘ lens chains?** The `at` lens uses `fmap` but
+   not `pure`/`ap`. When `parts-of` wraps a composition, the inner
+   lenses need to thread state correctly.
+
+2. **What happens if the transformed list has a different length?**
+   Haskell's `parts-of` silently drops excess or fills with the
+   original. We should probably error or document the requirement
+   that lengths must match.
+
+3. **Performance**: two full traversals (collect + distribute).
+   Acceptable for the use cases but worth noting.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `lib/lens.eu` | `parts-of` definition + tests |
+
+No Rust changes needed.
+
+## Testing
+
+- `view(parts-of(each), [1, 2, 3])` => `[1, 2, 3]`
+- `over(parts-of(each), reverse, [1, 2, 3])` => `[3, 2, 1]`
+- `over(parts-of(each), sort-nums, [3, 1, 2])` => `[1, 2, 3]`
+- `over(parts-of(filtered(> 2)), reverse, [1, 4, 2, 5, 3])` =>
+  `[1, 5, 2, 4, 3]` (only filtered positions swapped)
+- Deep: `over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse, data)`
+- `view(parts-of(at(:x) ∘ each ∘ at(:y)), data)` => list of y values

--- a/lib/lens.eu
+++ b/lib/lens.eu
@@ -223,6 +223,33 @@ filtered(p?, k): {
       ap(fmap(cons, pure(data head)), s(data tail))))
 }.(s // meta(k))
 
+# parts-of — turn a traversal into a lens on the list of foci
+
+` "`parts-of(traversal)` turns a traversal into a lens focusing on the list of all foci.
+view collects foci into a list. over applies a list transformation and distributes results back."
+parts-of(traversal, k): {
+  fmap: meta(k).fmap
+
+  # State applicative for distribution pass — uses {value, state}
+  # blocks to hold intermediate results (which may be partial fns)
+  s-fmap(f, action, st): { r: action(st) }.({value: f(r.value), state: r.state})
+  s-pure(v, st): {value: v, state: st}
+  s-ap(fa, xa, st): { r1: fa(st)  r2: xa(r1.state) }.({value: r1.value(r2.value), state: r2.state})
+
+  # Pop next value from state, ignore old focus
+  pop(old, st): {value: st head, state: st tail}
+
+  # Collect all foci via to-list-of
+  collected(data): data to-list-of(traversal)
+
+  # Distribute: run traversal with stateful pop, seeded with new values
+  distribute(data, new-vals):
+    (data traversal(pop // { fmap: s-fmap, pure: s-pure, ap: s-ap }))(new-vals).value
+
+  # Lens: fmap over collected list, distribute back
+  s(data): fmap(distribute(data), k(data collected))
+}.(s // meta(k))
+
 ` { target: :test-traversals }
 example-traversals: {
   bang(s): "{s}!"
@@ -293,5 +320,31 @@ example-traversals: {
           , test-lt-list, test-lt-over
           , test-fl-list, test-fl-over
           , test-deep, test-deep-over
+          ] all-true? then(:PASS, :FAIL)
+}
+
+` { target: :test-parts-of }
+example-parts-of: {
+
+  # view collects foci into a list
+  test-view: [1, 2, 3] view(parts-of(each)) //= [1, 2, 3]
+
+  # over applies list transform and distributes back
+  test-reverse: [1, 2, 3] over(parts-of(each), reverse) //= [3, 2, 1]
+  test-sort: [3, 1, 2] over(parts-of(each), sort-nums) //= [1, 2, 3]
+
+  # filtered: only targeted positions affected
+  test-filtered: [1, 4, 2, 5, 3] over(parts-of(filtered(> 2)), reverse) //= [1, 3, 2, 5, 4]
+
+  # deep composition: lens ∘ traversal ∘ lens
+  ldata: {x: [{y: 1}, {y: 2}, {y: 3}]}
+  test-deep-view: ldata view(parts-of(at(:x) ∘ each ∘ at(:y))) //= [1, 2, 3]
+  test-deep-over: (ldata over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse)).x map(_.y) //= [3, 2, 1]
+
+  # assign a specific list
+  test-assign: [1, 2, 3] over(parts-of(each), -> [10, 20, 30]) //= [10, 20, 30]
+
+  RESULT: [test-view, test-reverse, test-sort, test-filtered,
+           test-deep-view, test-deep-over, test-assign
           ] all-true? then(:PASS, :FAIL)
 }


### PR DESCRIPTION
## Summary

`parts-of(traversal)` turns a traversal into a lens focusing on the list of all foci.

```eu
[1, 2, 3] over(parts-of(each), reverse)           # => [3, 2, 1]
[3, 1, 2] over(parts-of(each), sort-nums)          # => [1, 2, 3]

data: {x: [{y: 1}, {y: 2}, {y: 3}]}
data view(parts-of(at(:x) ∘ each ∘ at(:y)))        # => [1, 2, 3]
data over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse)
  # => {x: [{y: 3}, {y: 2}, {y: 1}]}

# Only filtered positions affected
[1, 4, 2, 5, 3] over(parts-of(filtered(> 2)), reverse)  # => [1, 3, 2, 5, 4]
```

Uses a state applicative for the distribution pass — {value, state} blocks thread replacement values through the traversal. Pure eucalypt, no Rust changes.

Spec at `docs/superpowers/specs/2026-04-13-parts-of-design.md`.

Closes eu-fa2x.

## Test plan

- [x] All 269 tests pass (including new test-parts-of section in lens.eu)
- [x] 7 test cases: view, reverse, sort, filtered, deep view, deep over, assign
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)