### PR TITLE
feat: IO shell command tracing via EU_IO_TRACE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ The project includes a sophisticated garbage collector:
 | `EU_GC_VERIFY=1` | After each GC mark phase, re-traverse from roots and verify no reachable objects were missed. Panics if any unmarked-but-reachable objects are found. |
 | `EU_STACK_DIAG=1` | Log continuation stack composition to stderr whenever a new max stack depth is reached. |
 | `EU_ERROR_TRACE_DUMP=1` | Dump full env trace and stack trace Smid details as diagnostic notes on every execution error. Useful for debugging which source locations are available at error time. |
+| `EU_IO_TRACE=1` | Trace all `io.shell` and `io.exec` commands to stderr before execution. Shows the command string and whether stdin is piped. |
 
 The crash signal handler (SIGSEGV/SIGBUS diagnostics) is always active and has no environment variable — it installs unconditionally in `main()`.
 

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -1180,7 +1180,7 @@ fn run_spec(spec: &ActionSpec) -> Result<CommandResult, IoRunError> {
             }
         }
     }
-    match spec {
+    let result = match spec {
         ActionSpec::Shell {
             cmd,
             stdin,
@@ -1192,7 +1192,14 @@ fn run_spec(spec: &ActionSpec) -> Result<CommandResult, IoRunError> {
             stdin,
             timeout_secs,
         } => execute_exec(cmd, args, stdin.as_deref(), *timeout_secs),
+    };
+    if *IO_TRACE {
+        match &result {
+            Ok(r) => eprintln!("IO TRACE: → exit {}", r.exit_code),
+            Err(e) => eprintln!("IO TRACE: → error: {e}"),
+        }
     }
+    result
 }
 
 // ─── Error message extraction ─────────────────────────────────────────────────

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -1156,8 +1156,30 @@ fn run_command(
     }
 }
 
+/// Whether IO tracing is enabled (cached from `EU_IO_TRACE` env var).
+static IO_TRACE: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| std::env::var("EU_IO_TRACE").is_ok());
+
 /// Dispatch an `ActionSpec` to the appropriate executor.
 fn run_spec(spec: &ActionSpec) -> Result<CommandResult, IoRunError> {
+    if *IO_TRACE {
+        match spec {
+            ActionSpec::Shell { cmd, stdin, .. } => {
+                eprintln!(
+                    "IO TRACE: shell {cmd:?}{}",
+                    if stdin.is_some() { " (with stdin)" } else { "" }
+                );
+            }
+            ActionSpec::Exec {
+                cmd, args, stdin, ..
+            } => {
+                eprintln!(
+                    "IO TRACE: exec {cmd:?} {args:?}{}",
+                    if stdin.is_some() { " (with stdin)" } else { "" }
+                );
+            }
+        }
+    }
     match spec {
         ActionSpec::Shell {
             cmd,


### PR DESCRIPTION
## Summary

`EU_IO_TRACE=1` traces all `io.shell` and `io.exec` commands to stderr before execution.

```
$ EU_IO_TRACE=1 eu -I my-io-script.eu
IO TRACE: shell "git rev-parse HEAD"
IO TRACE: shell "cat config.yaml"
IO TRACE: exec "curl" ["-s", "https://api.example.com"]
---
...output...
```

Cached at startup via `LazyLock`, consistent with `EU_STACK_DIAG` and `EU_GC_POISON`.

Closes eu-b5e2.

## Test plan
- [x] All 269 tests pass
- [x] clippy clean
- [x] Trace appears on stderr with `EU_IO_TRACE=1`
- [x] No output without the env var
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)