### PR TITLE
feat: IO tracing and block element traversals

### DIFF
--- a/lib/lens.eu
+++ b/lib/lens.eu
@@ -250,6 +250,28 @@ parts-of(traversal, k): {
   s(data): fmap(distribute(data), k(data collected))
 }.(s // meta(k))
 
+` "`each-element` traverses all kv pairs of a block"
+each-element(k): {
+  fmap: meta(k).fmap
+  pure: meta(k).pure
+  ap: meta(k).ap
+  walk(els): if(els nil?, pure([]),
+    ap(fmap(cons, k(els head)), walk(els tail)))
+  s(data): fmap(block, walk(data elements))
+}.(s // meta(k))
+
+` "`filtered-elements(p?)` traverses block kv pairs matching predicate `p?`"
+filtered-elements(p?, k): {
+  fmap: meta(k).fmap
+  pure: meta(k).pure
+  ap: meta(k).ap
+  walk(els): if(els nil?, pure([]),
+    if(els head p?,
+      ap(fmap(cons, k(els head)), walk(els tail)),
+      ap(fmap(cons, pure(els head)), walk(els tail))))
+  s(data): fmap(block, walk(data elements))
+}.(s // meta(k))
+
 ` { target: :test-traversals }
 example-traversals: {
   bang(s): "{s}!"
@@ -346,5 +368,44 @@ example-parts-of: {
 
   RESULT: [test-view, test-reverse, test-sort, test-filtered,
            test-deep-view, test-deep-over, test-assign
+          ] all-true? then(:PASS, :FAIL)
+}
+
+` { target: :test-element-traversals }
+example-element-traversals: {
+  data: {a: 1, b: 2, c: 3}
+
+  # each-element: to-list-of collects all kv pairs
+  test-all: data to-list-of(each-element) //= [[:a, 1], [:b, 2], [:c, 3]]
+
+  # each-element: over applies to all entries
+  test-all-over: data over(each-element ∘ _value, * 10) //= {a: 10, b: 20, c: 30}
+
+  # filtered-elements: to-list-of collects matching pairs
+  test-filt: data to-list-of(filtered-elements(by-value(_ > 1))) //= [[:b, 2], [:c, 3]]
+
+  # filtered-elements: over applies only to matching entries
+  test-filt-over: data over(filtered-elements(by-value(_ > 1)) ∘ _value, negate) //= {a: 1, b: -2, c: -3}
+
+  # filtered-elements: non-matching entries preserved
+  test-filt-preserve: data over(filtered-elements(by-key(_ = :b)) ∘ _value, + 100) lookup(:a) //= 1
+
+  # filtered-elements with key rename
+  test-key-rename: data over(filtered-elements(by-key(_ = :a)) ∘ _key, ->:x) lookup(:x) //= 1
+
+  # compose with at for nested blocks
+  nested: {items: {x: 10, y: 20, z: 30}}
+  test-nested: nested to-list-of(at(:items) ∘ filtered-elements(by-value(_ >= 20)) ∘ _value) //= [20, 30]
+  test-nested-over: (nested over(at(:items) ∘ filtered-elements(by-value(_ >= 20)) ∘ _value, + 100)).items //= {x: 10, y: 120, z: 130}
+
+  # parts-of with each-element
+  test-parts: data view(parts-of(each-element ∘ _value)) //= [1, 2, 3]
+  test-parts-rev: data over(parts-of(each-element ∘ _value), reverse) //= {a: 3, b: 2, c: 1}
+
+  RESULT: [ test-all, test-all-over
+          , test-filt, test-filt-over, test-filt-preserve
+          , test-key-rename
+          , test-nested, test-nested-over
+          , test-parts, test-parts-rev
           ] all-true? then(:PASS, :FAIL)
 }

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -1069,11 +1069,7 @@ fn desugar_monadic_block(
     };
 
     // Build bind chain from right-to-left using all pairs
-    for ((_, value), bind_var) in name_value_pairs
-        .into_iter()
-        .zip(bind_vars.into_iter())
-        .rev()
-    {
+    for ((_, value), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
         let lambda = core::lam(smid, vec![bind_var], result);
         result = match spec {
             MonadSpec::Explicit { bind_name, .. } => {
@@ -1245,11 +1241,7 @@ fn desugar_monadic_block_implicit(
         }
     };
 
-    for ((_, value), bind_var) in name_value_pairs
-        .into_iter()
-        .zip(bind_vars.into_iter())
-        .rev()
-    {
+    for ((_, value), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
         let lambda = core::lam(smid, vec![bind_var], result);
         result = match spec {
             MonadSpec::Explicit { bind_name, .. } => {

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -323,11 +323,9 @@ fn mark_ref_heap_pointers<'a>(
     out: &mut Vec<ScanPtr<'a>>,
 ) {
     match r {
-        Ref::V(Native::Str(ptr)) => {
-            if marker.mark(*ptr) {
-                // Push for scanning so HeapString::scan marks the backing bytes
-                out.push(ScanPtr::from_non_null(scope, *ptr));
-            }
+        Ref::V(Native::Str(ptr)) if marker.mark(*ptr) => {
+            // Push for scanning so HeapString::scan marks the backing bytes
+            out.push(ScanPtr::from_non_null(scope, *ptr));
         }
         Ref::V(Native::Set(ptr)) => {
             marker.mark(*ptr);


### PR DESCRIPTION
## Summary
- Add `EU_IO_TRACE=1` environment variable to trace `io.shell` and `io.exec` commands to stderr, showing command strings, stdin piping, and exit codes
- Add `each-element` and `filtered-elements` block traversals to the lens library — the traversal equivalents of the existing `element(p?)` lens, consistent with prelude naming (`elements`, `map-elements`)

## Test plan
- [x] `eu lib/lens.eu -t test-element-traversals` — PASS
- [x] All existing lens tests still pass (test-basic, test-index, test-paths, test-predicate, test-element, test-traversals, test-parts-of)
- [ ] Manual verification of `EU_IO_TRACE=1` with IO programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)