### PR TITLE
refactor: unify stream producers with LazyProducer trait

### DIFF
--- a/docs/development/unified-streams-spec.md
+++ b/docs/development/unified-streams-spec.md
@@ -1,0 +1,228 @@
+# Unified Stream Producers
+
+**Status**: Spec  
+**Bead**: eu-0a1w  
+**Date**: 2026-04-19
+
+## 1. Overview
+
+Replace the import-specific `StreamProducer` / `StreamTable` /
+`STREAM_NEXT` mechanism with a unified `LazyProducer` trait and
+`ProducerTable`. All handle-based lazy producers (file imports, future
+IO streams) register in one table and use one BIF (`PRODUCER_NEXT`)
+to build memoised lazy cons cells.
+
+Rename `Native::Stream(u64)` to `Native::Prng(u64)` — the pure PRNG
+state stays separate from handle-based producers.
+
+User-visible behaviour is unchanged — imports still produce lazy lists.
+
+## 2. LazyProducer Trait
+
+New trait replacing `StreamProducer`:
+
+```rust
+/// A lazy producer of STG values, accessed via a handle in ProducerTable.
+pub trait LazyProducer {
+    /// Produce the next value, or None if exhausted.
+    fn next(&mut self) -> Option<Rc<StgSyn>>;
+
+    /// Whether this producer is pure (same state → same output).
+    /// Pure producers can safely be forked/shared in future.
+    /// Import and IO producers are not pure.
+    fn is_pure(&self) -> bool { false }
+}
+```
+
+Existing implementations (`JsonlProducer`, `CsvProducer`,
+`TextProducer`) implement `LazyProducer` instead of `StreamProducer`.
+The trait method signature is identical — `next(&mut self) ->
+Option<Rc<StgSyn>>` — so migration is mechanical.
+
+## 3. ProducerTable
+
+Replaces `StreamTable`. Same thread-local pattern:
+
+```rust
+pub struct ProducerTable {
+    handles: HashMap<u32, Rc<RefCell<Box<dyn LazyProducer>>>>,
+    next_id: u32,
+}
+
+thread_local! {
+    static PRODUCER_TABLE: RefCell<ProducerTable> = RefCell::new(ProducerTable::new());
+}
+
+pub fn register_producer(producer: Box<dyn LazyProducer>) -> u32;
+pub fn producer_next(handle: u32) -> Option<Rc<StgSyn>>;
+```
+
+## 4. Native Type Changes
+
+### Rename: Native::Stream → Native::Prng
+
+```rust
+// Before
+Native::Stream(u64)
+
+// After
+Native::Prng(u64)
+```
+
+All references updated: `stream_arg()` → `prng_arg()`, pattern
+matches, Display impl, GC scanning. The PRNG intrinsics
+(`STREAM_NEW`, `STREAM_VALUE`, `STREAM_ADVANCE`, `STREAM_FLOAT`,
+`STREAM_INT`, `STREAM_SPLIT`) are unchanged in behaviour — only the
+Native variant name changes. The intrinsic names stay as `STREAM_*`
+to avoid breaking the prelude.
+
+### New: Native::Producer
+
+```rust
+Native::Producer(u32)  // handle into ProducerTable
+```
+
+A u32 handle — no heap pointers, no GC scanning needed (same as the
+u64 in Prng). The ProducerTable owns the actual producer via
+`Rc<RefCell<Box<dyn LazyProducer>>>`.
+
+## 5. PRODUCER_NEXT BIF
+
+Replaces `STREAM_NEXT`. Same proven cons-cell building pattern:
+
+```rust
+pub struct ProducerNext;
+
+impl StgIntrinsic for ProducerNext {
+    fn name(&self) -> &str { "PRODUCER_NEXT" }
+
+    fn execute(&self, ..., args: &[Ref]) -> Result<(), ExecutionError> {
+        let handle = num_arg(..., &args[0])? as u32;
+        match producer_next(handle) {
+            Some(value_syn) => {
+                // Build: Let([value, tail_thunk], Cons(ListCons, [L(0), L(1)]))
+                // - value: non-updatable binding holding current element
+                // - tail_thunk: updatable thunk calling PRODUCER_NEXT(handle)
+                // Update continuation memoises — producer advances at most once
+                // per cons cell position
+            }
+            None => {
+                // Exhausted — return Nil
+            }
+        }
+    }
+
+    fn inlinable(&self) -> bool { false }  // side-effecting
+}
+```
+
+The cons-cell construction logic is copied from the current
+`StreamNext` implementation. The only change is the function name
+and the handle lookup going through `ProducerTable` instead of
+`StreamTable`.
+
+## 6. Import Registration Path
+
+Current path:
+```
+driver/source.rs: load_stream()
+  → import/mod.rs: create_stream_import(format, path)
+    → creates JsonlProducer / CsvProducer / TextProducer
+    → register_stream(Box::new(producer)) → u32 handle
+  → returns core expr: App(Bif("STREAM_NEXT"), [Num(handle)])
+```
+
+New path:
+```
+driver/source.rs: load_stream()
+  → import/mod.rs: create_stream_import(format, path)
+    → creates JsonlProducer / CsvProducer / TextProducer
+    → register_producer(Box::new(producer)) → u32 handle
+  → returns core expr: App(Bif("PRODUCER_NEXT"), [Num(handle)])
+```
+
+Mechanical change — only the function name and BIF name differ.
+
+## 7. Files Changed
+
+| File | Change |
+|------|--------|
+| `src/eval/memory/syntax.rs` | Rename `Stream(u64)` → `Prng(u64)`, add `Producer(u32)`. Update Display, GC scan, mark_ref_heap_pointers (Producer has no heap pointers). |
+| `src/eval/stg/stream.rs` | Replace `StreamProducer` trait with `LazyProducer`. Replace `StreamTable` with `ProducerTable`. Rename public functions. |
+| `src/eval/stg/stream_intrinsic.rs` | Replace `StreamNext` with `ProducerNext`. Update BIF registration. |
+| `src/eval/stg/stream_prng.rs` | Update `stream_arg()` → `prng_arg()`, `Native::Stream` → `Native::Prng` in all intrinsics. |
+| `src/eval/stg/support.rs` | Rename `stream_arg()` → `prng_arg()`. |
+| `src/eval/stg/mod.rs` | Update intrinsic registration: `PRODUCER_NEXT` replaces `STREAM_NEXT`. |
+| `src/eval/intrinsics.rs` | Update BIF name mapping. |
+| `src/import/stream.rs` | `impl LazyProducer for JsonlProducer/CsvProducer/TextProducer` (was `StreamProducer`). |
+| `src/import/mod.rs` | `register_producer()` instead of `register_stream()`. BIF name `PRODUCER_NEXT`. |
+| `src/driver/source.rs` | Call `register_producer()`, reference `PRODUCER_NEXT`. |
+| `src/eval/stg/debug.rs` | Update display for `Native::Prng`. |
+| `src/eval/stg/assert.rs` | Update display for `Native::Prng`. |
+| `src/eval/stg/expect.rs` | Update display for `Native::Prng` if referenced. |
+| `src/eval/types.rs` | Update `IntrinsicType` if `Stream` is referenced. |
+| `src/common/sourcemap.rs` | Update BIF name mapping if `STREAM_NEXT` is listed. |
+| `lib/prelude.eu` | No changes — prelude uses `__STREAM_NEW` etc. which still work (intrinsic names unchanged). |
+
+## 8. What Does NOT Change
+
+- PRNG intrinsic names: `STREAM_NEW`, `STREAM_VALUE`, `STREAM_ADVANCE`,
+  `STREAM_FLOAT`, `STREAM_INT`, `STREAM_SPLIT` — all unchanged
+- Prelude random namespace — unchanged
+- User-visible import behaviour — unchanged (imports produce lazy lists)
+- Random `as-list` bridge — unchanged
+- `is_stream_format()` in import — unchanged (or renamed to
+  `is_producer_format()` for consistency)
+
+## 9. Testing
+
+### Acceptance criteria
+
+1. `cargo test --test harness_test` — all tests pass (imports and
+   random streams work as before)
+2. Specifically verify streaming import tests if any exist, or create
+   a test with `jsonl-stream` format
+3. `cargo test --lib` — unit tests pass
+4. Random stream tests (harness tests using `random.*`) pass
+
+### Manual verification
+
+```sh
+# Streaming JSONL import
+echo '{"a":1}\n{"a":2}' > /tmp/test.jsonl
+echo '{ import: "jsonl-stream@/tmp/test.jsonl" } main: map(_.a)' > /tmp/test.eu
+eu /tmp/test.eu
+# Expected: [1, 2]
+
+# Random streams still work
+eu -e 'random.stream(42) random.as-list take(5)'
+# Expected: list of 5 floats
+```
+
+## 10. Future: Adding New Producer Types
+
+To add a new lazy producer (e.g. streaming IO):
+
+```rust
+struct IoLineProducer {
+    reader: BufReader<ChildStdout>,
+}
+
+impl LazyProducer for IoLineProducer {
+    fn next(&mut self) -> Option<Rc<StgSyn>> {
+        let mut line = String::new();
+        match self.reader.read_line(&mut line) {
+            Ok(0) => None,
+            Ok(_) => Some(dsl::box_str(line.trim_end())),
+            Err(_) => None,
+        }
+    }
+}
+
+// Registration:
+let handle = register_producer(Box::new(IoLineProducer { reader }));
+// Returns lazy list via PRODUCER_NEXT(handle)
+```
+
+One trait implementation, one registration call. No new Native
+variants, no new BIFs, no GC changes.

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -402,7 +402,7 @@ pub fn intrinsic_display_name(name: &str) -> Option<&str> {
         "LOOKUP_FAIL" => Some("lookup"),
 
         // Random / streams
-        "STREAM_NEXT" => Some("stream.next"),
+        "PRODUCER_NEXT" => Some("producer.next"),
 
         // Internal machinery — filter out of traces
         //

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -580,7 +580,7 @@ lazy_static! {
             strict: vec![0],
     },
     Intrinsic { // 106
-            name: "STREAM_NEXT",
+            name: "PRODUCER_NEXT",
             ty: function(vec![num(), unk()]).unwrap(),
             strict: vec![0],
     },

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -52,7 +52,9 @@ pub enum Native {
     /// A vector of primitive values (O(1) indexed access)
     Vec(RefPtr<HeapVec>),
     /// An opaque PRNG stream state (SplitMix64 state word)
-    Stream(u64),
+    Prng(u64),
+    /// A handle into the ProducerTable for lazy producers
+    Producer(u32),
 }
 
 impl PartialEq for Native {
@@ -67,7 +69,8 @@ impl PartialEq for Native {
             (Native::Set(a), Native::Set(b)) => a == b,
             (Native::NdArray(a), Native::NdArray(b)) => a == b,
             (Native::Vec(a), Native::Vec(b)) => a == b,
-            (Native::Stream(a), Native::Stream(b)) => a == b,
+            (Native::Prng(a), Native::Prng(b)) => a == b,
+            (Native::Producer(a), Native::Producer(b)) => a == b,
             _ => false,
         }
     }
@@ -87,7 +90,8 @@ impl Native {
             Native::Set(_) => "set",
             Native::NdArray(_) => "array",
             Native::Vec(_) => "vec",
-            Native::Stream(_) => "stream",
+            Native::Prng(_) => "prng",
+            Native::Producer(_) => "producer",
         }
     }
 }
@@ -121,8 +125,11 @@ impl fmt::Display for Native {
             Native::Vec(_) => {
                 write!(f, "<vec>")
             }
-            Native::Stream(_) => {
-                write!(f, "<stream>")
+            Native::Prng(_) => {
+                write!(f, "<prng>")
+            }
+            Native::Producer(_) => {
+                write!(f, "<producer>")
             }
         }
     }
@@ -684,8 +691,11 @@ pub mod repr {
             memory::syntax::Ref::V(memory::syntax::Native::Vec(_)) => {
                 stg::syntax::Ref::V(stg::syntax::Native::Sym("<vec>".to_string()))
             }
-            memory::syntax::Ref::V(memory::syntax::Native::Stream(_)) => {
-                stg::syntax::Ref::V(stg::syntax::Native::Sym("<stream>".to_string()))
+            memory::syntax::Ref::V(memory::syntax::Native::Prng(_)) => {
+                stg::syntax::Ref::V(stg::syntax::Native::Sym("<prng>".to_string()))
+            }
+            memory::syntax::Ref::V(memory::syntax::Native::Producer(_)) => {
+                stg::syntax::Ref::V(stg::syntax::Native::Sym("<producer>".to_string()))
             }
         }
     }

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -136,7 +136,8 @@ fn format_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicM
             let v = view.scoped(*ptr);
             format!("<vec [{}]>", v.len())
         }
-        Native::Stream(state) => format!("<stream {state}>"),
+        Native::Prng(state) => format!("<prng {state}>"),
+        Native::Producer(handle) => format!("<producer {handle}>"),
     }
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -111,7 +111,8 @@ fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicM
             let v = view.scoped(*ptr);
             format!("<vec({})>", v.len())
         }
-        Native::Stream(state) => format!("<stream({state})>"),
+        Native::Prng(state) => format!("<prng({state})>"),
+        Native::Producer(handle) => format!("<producer({handle})>"),
     }
 }
 

--- a/src/eval/stg/emit.rs
+++ b/src/eval/stg/emit.rs
@@ -249,7 +249,9 @@ impl StgIntrinsic for EmitNative {
             memory::syntax::Native::Zdt(dt) => {
                 emitter.scalar(&RenderMetadata::empty(), &Primitive::ZonedDateTime(dt));
             }
-            memory::syntax::Native::Index(_) | memory::syntax::Native::Stream(_) => {
+            memory::syntax::Native::Index(_)
+            | memory::syntax::Native::Prng(_)
+            | memory::syntax::Native::Producer(_) => {
                 return Err(ExecutionError::NotScalar(Smid::default()));
             }
         }
@@ -302,7 +304,9 @@ impl StgIntrinsic for EmitTagNative {
             memory::syntax::Native::Zdt(dt) => {
                 emitter.scalar(&RenderMetadata::new(tag), &Primitive::ZonedDateTime(dt));
             }
-            memory::syntax::Native::Index(_) | memory::syntax::Native::Stream(_) => {
+            memory::syntax::Native::Index(_)
+            | memory::syntax::Native::Prng(_)
+            | memory::syntax::Native::Producer(_) => {
                 return Err(ExecutionError::NotScalar(Smid::default()));
             }
         }

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -168,7 +168,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(set::SetDiff));
     rt.add(Box::new(block::IsBlock));
     rt.add(Box::new(list::IsList));
-    rt.add(Box::new(stream_intrinsic::StreamNext));
+    rt.add(Box::new(stream_intrinsic::ProducerNext));
     rt.add(Box::new(stream_prng::StreamNew));
     rt.add(Box::new(stream_prng::StreamValue));
     rt.add(Box::new(stream_prng::StreamAdvance));

--- a/src/eval/stg/printf.rs
+++ b/src/eval/stg/printf.rs
@@ -459,9 +459,14 @@ pub fn fmt(
                     "cannot format vec".to_string(),
                 ))
             }
-            Native::Stream(_) => {
+            Native::Prng(_) => {
                 return Err(PrintfError::InvalidFormatString(
-                    "cannot format stream".to_string(),
+                    "cannot format prng".to_string(),
+                ))
+            }
+            Native::Producer(_) => {
+                return Err(PrintfError::InvalidFormatString(
+                    "cannot format producer".to_string(),
                 ))
             }
         }

--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -1,8 +1,8 @@
-//! Streaming file import infrastructure
+//! Lazy producer infrastructure
 //!
-//! Provides `StreamProducer` trait and a global handle table for
+//! Provides `LazyProducer` trait and a global handle table for
 //! registering producers at import time and accessing them at runtime
-//! via the `__STREAM_NEXT` intrinsic.
+//! via the `PRODUCER_NEXT` intrinsic.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -10,40 +10,47 @@ use std::rc::Rc;
 
 use super::syntax::StgSyn;
 
-/// A producer that yields values lazily from an IO source.
+/// A lazy producer of STG values, accessed via a handle in ProducerTable.
 ///
 /// Each call to `next()` advances the underlying source (file cursor,
 /// CSV parser, etc.) and returns the next value as pre-compiled STG
 /// syntax, or `None` when the source is exhausted.
-pub trait StreamProducer {
+pub trait LazyProducer {
     /// Produce the next value as STG syntax, or `None` if exhausted.
     fn next(&mut self) -> Option<Rc<StgSyn>>;
+
+    /// Whether this producer is pure (same state → same output).
+    /// Pure producers can safely be forked/shared in future.
+    /// Import and IO producers are not pure.
+    fn is_pure(&self) -> bool {
+        false
+    }
 }
 
-/// A reference-counted, interiorly-mutable stream producer handle.
-pub type StreamHandle = Rc<RefCell<Box<dyn StreamProducer>>>;
+/// A reference-counted, interiorly-mutable producer handle.
+pub type ProducerHandle = Rc<RefCell<Box<dyn LazyProducer>>>;
 
-/// Table mapping numeric handles to stream producers.
+/// Table mapping numeric handles to lazy producers.
 ///
 /// Producers are registered at import time and looked up at runtime
-/// by the `__STREAM_NEXT` intrinsic.
-pub struct StreamTable {
-    handles: HashMap<u32, StreamHandle>,
+/// by the `PRODUCER_NEXT` intrinsic.
+pub struct ProducerTable {
+    handles: HashMap<u32, ProducerHandle>,
     next_id: u32,
 }
 
-impl Default for StreamTable {
+impl Default for ProducerTable {
     fn default() -> Self {
-        StreamTable {
+        ProducerTable {
             handles: HashMap::new(),
             next_id: 1,
         }
     }
 }
 
-impl StreamTable {
+impl ProducerTable {
     /// Register a producer and return its handle ID.
-    pub fn register(&mut self, producer: Box<dyn StreamProducer>) -> u32 {
+    pub fn register(&mut self, producer: Box<dyn LazyProducer>) -> u32 {
         let id = self.next_id;
         self.next_id += 1;
         self.handles.insert(id, Rc::new(RefCell::new(producer)));
@@ -51,27 +58,27 @@ impl StreamTable {
     }
 
     /// Look up a producer by handle ID.
-    pub fn get(&self, handle: u32) -> Option<&StreamHandle> {
+    pub fn get(&self, handle: u32) -> Option<&ProducerHandle> {
         self.handles.get(&handle)
     }
 }
 
 thread_local! {
-    /// Global stream table, accessible from both import and runtime code.
-    static STREAM_TABLE: RefCell<StreamTable> = RefCell::new(StreamTable::default());
+    /// Global producer table, accessible from both import and runtime code.
+    static PRODUCER_TABLE: RefCell<ProducerTable> = RefCell::new(ProducerTable::default());
 }
 
-/// Register a stream producer in the global table and return its handle ID.
-pub fn register_stream(producer: Box<dyn StreamProducer>) -> u32 {
-    STREAM_TABLE.with(|table| table.borrow_mut().register(producer))
+/// Register a lazy producer in the global table and return its handle ID.
+pub fn register_producer(producer: Box<dyn LazyProducer>) -> u32 {
+    PRODUCER_TABLE.with(|table| table.borrow_mut().register(producer))
 }
 
-/// Drain all remaining values from a stream producer.
+/// Drain all remaining values from a producer.
 ///
 /// Returns a vector of all STG syntax values, consuming the
 /// producer to exhaustion.
-pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
-    STREAM_TABLE.with(|table| {
+pub fn producer_drain(handle: u32) -> Vec<Rc<StgSyn>> {
+    PRODUCER_TABLE.with(|table| {
         let table = table.borrow();
         match table.get(handle) {
             Some(producer) => {
@@ -87,12 +94,12 @@ pub fn stream_drain(handle: u32) -> Vec<Rc<StgSyn>> {
     })
 }
 
-/// Advance a stream producer by a single step.
+/// Advance a producer by a single step.
 ///
 /// Returns `Some(value)` if the producer yielded an element, or
-/// `None` if the stream is exhausted or the handle is invalid.
-pub fn stream_next(handle: u32) -> Option<Rc<StgSyn>> {
-    STREAM_TABLE.with(|table| {
+/// `None` if the producer is exhausted or the handle is invalid.
+pub fn producer_next(handle: u32) -> Option<Rc<StgSyn>> {
+    PRODUCER_TABLE.with(|table| {
         let table = table.borrow();
         match table.get(handle) {
             Some(producer) => producer.borrow_mut().next(),

--- a/src/eval/stg/stream_intrinsic.rs
+++ b/src/eval/stg/stream_intrinsic.rs
@@ -1,6 +1,6 @@
-//! __STREAM_NEXT intrinsic implementation
+//! PRODUCER_NEXT intrinsic implementation
 //!
-//! Produces a lazy cons cell for each stream element, allowing the
+//! Produces a lazy cons cell for each producer element, allowing the
 //! STG machine's Update mechanism to memoise the result of each
 //! tail thunk.
 
@@ -22,27 +22,27 @@ use crate::{
     },
 };
 
-use super::{stream::stream_next, support::num_arg, tags::DataConstructor};
+use super::{stream::producer_next, support::num_arg, tags::DataConstructor};
 
-/// STREAM_NEXT(handle)
+/// PRODUCER_NEXT(handle)
 ///
-/// Advances the stream producer by one element. If the stream is
+/// Advances the producer by one element. If the producer is
 /// exhausted, returns Nil. Otherwise, builds a lazy cons cell whose
 /// head is the current value and whose tail is an updatable thunk
-/// that calls STREAM_NEXT(handle) again when forced.
+/// that calls PRODUCER_NEXT(handle) again when forced.
 ///
 /// The `update=true` flag on the tail thunk ensures the STG
 /// machine's Update continuation memoises the result, so repeated
 /// traversals of the same cons cell share work and the producer is
 /// advanced at most once per list position.
-pub struct StreamNext;
+pub struct ProducerNext;
 
-impl StgIntrinsic for StreamNext {
+impl StgIntrinsic for ProducerNext {
     fn name(&self) -> &str {
-        "STREAM_NEXT"
+        "PRODUCER_NEXT"
     }
 
-    /// Disable wrapper inlining — the side-effecting nature of stream
+    /// Disable wrapper inlining — the side-effecting nature of producer
     /// advancement means the Bif node must not be duplicated by the
     /// compiler's `ProtoInline` substitution.
     fn inlinable(&self) -> bool {
@@ -60,15 +60,15 @@ impl StgIntrinsic for StreamNext {
         let handle = handle_num.as_u64().ok_or_else(|| {
             ExecutionError::Panic(
                 Smid::default(),
-                "stream handle must be a positive integer".to_string(),
+                "producer handle must be a positive integer".to_string(),
             )
         })? as u32;
 
-        // Advance the stream by one element
-        let value_stg = match stream_next(handle) {
+        // Advance the producer by one element
+        let value_stg = match producer_next(handle) {
             Some(v) => v,
             None => {
-                // Stream exhausted — return Nil
+                // Producer exhausted — return Nil
                 let nil = view.nil()?;
                 return machine.set_closure(SynClosure::new(nil.as_ptr(), machine.root_env()));
             }
@@ -81,7 +81,7 @@ impl StgIntrinsic for StreamNext {
         //
         // - Binding 0 (value): the current element, as a non-updatable value
         // - Binding 1 (tail_thunk): an updatable thunk (arity=0, update=true)
-        //   whose body calls STREAM_NEXT(handle) again — memoised by the STG
+        //   whose body calls PRODUCER_NEXT(handle) again — memoised by the STG
         //   Update continuation so the producer advances at most once per position
         let value_ptr = load(&view, machine.symbol_pool_mut(), value_stg)?;
 
@@ -108,4 +108,4 @@ impl StgIntrinsic for StreamNext {
     }
 }
 
-impl CallGlobal1 for StreamNext {}
+impl CallGlobal1 for ProducerNext {}

--- a/src/eval/stg/stream_prng.rs
+++ b/src/eval/stg/stream_prng.rs
@@ -1,6 +1,6 @@
 //! Intrinsics for opaque PRNG stream values backed by SplitMix64.
 //!
-//! These intrinsics expose `Native::Stream(u64)` — an opaque state word —
+//! These intrinsics expose `Native::Prng(u64)` — an opaque state word —
 //! through six operations:
 //!
 //! - `STREAM_NEW`     — seed a new stream from an integer
@@ -33,15 +33,15 @@ use super::{
     tags::DataConstructor,
 };
 
-/// Extract a `Native::Stream` state word from a ref, or return a
+/// Extract a `Native::Prng` state word from a ref, or return a
 /// `TypeMismatch` error.
-fn stream_arg(
+fn prng_arg(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     arg: &Ref,
 ) -> Result<u64, ExecutionError> {
     let native = machine.nav(view).resolve_native(arg)?;
-    if let Native::Stream(state) = native {
+    if let Native::Prng(state) = native {
         Ok(state)
     } else {
         Err(ExecutionError::TypeMismatch(
@@ -53,7 +53,7 @@ fn stream_arg(
     }
 }
 
-/// Return a `Native::Stream(state)` atom as the machine result.
+/// Return a `Native::Prng(state)` atom as the machine result.
 fn machine_return_stream(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
@@ -62,7 +62,7 @@ fn machine_return_stream(
     use crate::eval::memory::syntax::HeapSyn;
     machine.set_closure(crate::eval::machine::env::SynClosure::new(
         view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Stream(state)),
+            evaluand: Ref::V(Native::Prng(state)),
         })?
         .as_ptr(),
         machine.root_env(),
@@ -70,7 +70,7 @@ fn machine_return_stream(
 }
 
 /// Build and return a two-element list `[first, second]` where both
-/// elements are `Native::Stream` values.
+/// elements are `Native::Prng` values.
 fn machine_return_stream_pair(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
@@ -88,7 +88,7 @@ fn machine_return_stream_pair(
 
     bindings.push(LambdaForm::value(
         view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Stream(second)),
+            evaluand: Ref::V(Native::Prng(second)),
         })?
         .as_ptr(),
     ));
@@ -103,7 +103,7 @@ fn machine_return_stream_pair(
 
     bindings.push(LambdaForm::value(
         view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Stream(first)),
+            evaluand: Ref::V(Native::Prng(first)),
         })?
         .as_ptr(),
     ));
@@ -154,7 +154,7 @@ fn machine_return_float_stream(
 
     bindings.push(LambdaForm::value(
         view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Stream(stream_state)),
+            evaluand: Ref::V(Native::Prng(stream_state)),
         })?
         .as_ptr(),
     ));
@@ -217,7 +217,7 @@ fn machine_return_int_stream(
 
     bindings.push(LambdaForm::value(
         view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Stream(stream_state)),
+            evaluand: Ref::V(Native::Prng(stream_state)),
         })?
         .as_ptr(),
     ));
@@ -263,7 +263,7 @@ fn machine_return_int_stream(
 
 /// `STREAM_NEW(seed)` — create a new stream from an integer seed.
 ///
-/// Returns `Native::Stream(state)` where `state` is derived from the seed
+/// Returns `Native::Prng(state)` where `state` is derived from the seed
 /// via `seed_to_u64`.
 pub struct StreamNew;
 
@@ -305,7 +305,7 @@ impl StgIntrinsic for StreamValue {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let state = stream_arg(machine, view, &args[0])?;
+        let state = prng_arg(machine, view, &args[0])?;
         let (_, z) = splitmix64(state);
         let float_val = (z >> 11) as f64 / ((1u64 << 53) as f64);
         let result = Number::from_f64(float_val).ok_or_else(|| {
@@ -338,7 +338,7 @@ impl StgIntrinsic for StreamAdvance {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let state = stream_arg(machine, view, &args[0])?;
+        let state = prng_arg(machine, view, &args[0])?;
         let (next_state, _) = splitmix64(state);
         machine_return_stream(machine, view, next_state)
     }
@@ -366,7 +366,7 @@ impl StgIntrinsic for StreamFloat {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let state = stream_arg(machine, view, &args[0])?;
+        let state = prng_arg(machine, view, &args[0])?;
         let (next_state, z) = splitmix64(state);
         let float_val = (z >> 11) as f64 / ((1u64 << 53) as f64);
         machine_return_float_stream(machine, view, float_val, next_state)
@@ -397,7 +397,7 @@ impl StgIntrinsic for StreamInt {
     ) -> Result<(), ExecutionError> {
         let n_num = num_arg(machine, view, &args[0])?;
         let n = n_num.as_u64().unwrap_or(1).max(1);
-        let state = stream_arg(machine, view, &args[1])?;
+        let state = prng_arg(machine, view, &args[1])?;
         let (next_state, z) = splitmix64(state);
         let int_val = z % n;
         machine_return_int_stream(machine, view, int_val, next_state)
@@ -426,7 +426,7 @@ impl StgIntrinsic for StreamSplit {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let state = stream_arg(machine, view, &args[0])?;
+        let state = prng_arg(machine, view, &args[0])?;
         let (next_state, z) = splitmix64(state);
         machine_return_stream_pair(machine, view, next_state, z)
     }

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -128,7 +128,8 @@ impl StgIntrinsic for Str {
             Native::Set(_) => "<set>".to_string(),
             Native::NdArray(_) => "<array>".to_string(),
             Native::Vec(_) => "<vec>".to_string(),
-            Native::Stream(_) => "<stream>".to_string(),
+            Native::Prng(_) => "<prng>".to_string(),
+            Native::Producer(_) => "<producer>".to_string(),
         };
         machine_return_str(machine, view, text)
     }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -65,7 +65,9 @@ fn native_type(native: &Native) -> IntrinsicType {
         Native::Zdt(_) => IntrinsicType::ZonedDateTime,
         Native::NdArray(_) => IntrinsicType::Array,
         Native::Vec(_) => IntrinsicType::Vec,
-        Native::Index(_) | Native::Set(_) | Native::Stream(_) => IntrinsicType::Unknown,
+        Native::Index(_) | Native::Set(_) | Native::Prng(_) | Native::Producer(_) => {
+            IntrinsicType::Unknown
+        }
     }
 }
 

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -82,40 +82,40 @@ pub fn is_stream_format(_format: &str) -> bool {
 }
 
 /// Create a streaming import by registering a producer and returning
-/// a core expression that calls `STREAM_NEXT(handle)`.
+/// a core expression that calls `PRODUCER_NEXT(handle)`.
 ///
 /// The `path` must be a resolved filesystem path (or "-" for stdin
 /// with text-stream).
 #[cfg(not(target_arch = "wasm32"))]
 pub fn create_stream_import(format: &str, path: &str) -> Result<RcExpr, SourceError> {
     use crate::core::expr::acore;
-    use crate::eval::stg::stream::register_stream;
+    use crate::eval::stg::stream::register_producer;
 
     let handle = match format {
         "jsonl-stream" => {
             let producer = stream::JsonlProducer::open(path).map_err(|e| {
                 SourceError::InvalidSource(format!("cannot open for streaming: {e}"), 0)
             })?;
-            register_stream(Box::new(producer))
+            register_producer(Box::new(producer))
         }
         "csv-stream" => {
             let producer = stream::CsvProducer::open(path).map_err(|e| {
                 SourceError::InvalidSource(format!("cannot open for streaming: {e}"), 0)
             })?;
-            register_stream(Box::new(producer))
+            register_producer(Box::new(producer))
         }
         "text-stream" => {
             let producer = stream::TextProducer::open(path).map_err(|e| {
                 SourceError::InvalidSource(format!("cannot open for streaming: {e}"), 0)
             })?;
-            register_stream(Box::new(producer))
+            register_producer(Box::new(producer))
         }
         _ => return Err(SourceError::UnknownSourceFormat(format.to_string(), 0)),
     };
 
-    // Return: STREAM_NEXT(handle)
+    // Return: PRODUCER_NEXT(handle)
     Ok(acore::app(
-        acore::bif("STREAM_NEXT"),
+        acore::bif("PRODUCER_NEXT"),
         vec![acore::num(handle as i64)],
     ))
 }

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -9,7 +9,7 @@ use std::io::{BufRead, BufReader};
 use std::rc::Rc;
 
 use crate::eval::stg::json_to_stg::json_to_stg;
-use crate::eval::stg::stream::StreamProducer;
+use crate::eval::stg::stream::LazyProducer;
 use crate::eval::stg::syntax::dsl;
 use crate::eval::stg::syntax::StgSyn;
 
@@ -31,7 +31,7 @@ impl JsonlProducer {
     }
 }
 
-impl StreamProducer for JsonlProducer {
+impl LazyProducer for JsonlProducer {
     fn next(&mut self) -> Option<Rc<StgSyn>> {
         loop {
             self.line_buf.clear();
@@ -72,7 +72,7 @@ impl CsvProducer {
     }
 }
 
-impl StreamProducer for CsvProducer {
+impl LazyProducer for CsvProducer {
     fn next(&mut self) -> Option<Rc<StgSyn>> {
         let record = match self.reader.records().next() {
             Some(Ok(rec)) => rec,
@@ -113,7 +113,7 @@ impl TextProducer {
     }
 }
 
-impl StreamProducer for TextProducer {
+impl LazyProducer for TextProducer {
     fn next(&mut self) -> Option<Rc<StgSyn>> {
         self.line_buf.clear();
         match self.reader.read_line(&mut self.line_buf) {


### PR DESCRIPTION
## Summary

- Rename `Native::Stream(u64)` → `Native::Prng(u64)` to clarify it holds only PRNG state
- Add `Native::Producer(u32)` for handle-based lazy producers (no heap pointers, no GC scanning)
- Replace `StreamProducer` trait with `LazyProducer` (adds `is_pure()` for future use)
- Replace `StreamTable` with `ProducerTable`, `register_stream` → `register_producer`, `stream_next` → `producer_next`
- Replace `StreamNext` BIF with `ProducerNext` (intrinsic name `PRODUCER_NEXT`)
- PRNG intrinsic names (`STREAM_NEW`, `STREAM_VALUE`, etc.) are unchanged — prelude unaffected

Implements the spec at `docs/development/unified-streams-spec.md`.

## Test plan

- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --lib` — all 631 unit tests pass
- [x] `cargo test --test harness_test` — all 269 harness tests pass (imports and random streams both work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)