### PR TITLE
feat: warning diagnostic infrastructure (eu-x5yl)

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -176,6 +176,38 @@ impl SourceMap {
         }
     }
 
+    /// Create a warning diagnostic for a value with a SMID.
+    ///
+    /// Identical in structure to [`diagnostic`], but uses
+    /// `Diagnostic::warning()` rather than `Diagnostic::error()`.
+    /// Used by the type checker to emit non-blocking diagnostics.
+    pub fn warning_diagnostic<W>(&self, warning: &W) -> Diagnostic<usize>
+    where
+        W: HasSmid + Display,
+    {
+        let diag = Diagnostic::warning().with_message(format!("{warning}"));
+
+        match self.source_info(warning) {
+            Some(&SourceInfo {
+                file: Some(file),
+                span: Some(span),
+                ..
+            }) => diag.with_labels(vec![Label::primary(file, span)]),
+            Some(SourceInfo {
+                file: None,
+                annotation: Some(ref ann),
+                ..
+            }) => {
+                if let Some(display) = intrinsic_display_name(ann) {
+                    diag.with_notes(vec![format!("in {display}")])
+                } else {
+                    diag
+                }
+            }
+            _ => diag,
+        }
+    }
+
     /// Create a default diagnostic for an exception with a SMID
     pub fn diagnostic<E>(&self, error: &E) -> Diagnostic<usize>
     where

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,5 +16,6 @@ pub mod rt;
 pub mod simplify;
 pub mod target;
 pub mod transform;
+pub mod typecheck;
 pub mod unit;
 pub mod verify;

--- a/src/core/typecheck/error.rs
+++ b/src/core/typecheck/error.rs
@@ -1,0 +1,123 @@
+//! Type diagnostic messages for the gradual type checker.
+//!
+//! `TypeWarning` is the primary diagnostic produced by the type checker.
+//! Type issues are always warnings, never errors — they do not block evaluation.
+use crate::common::sourcemap::{HasSmid, Smid, SourceMap};
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+
+/// A type-level warning emitted by the gradual type checker.
+///
+/// Type issues are reported as warnings so that they never prevent evaluation.
+/// The `--strict` flag in `eu check` can promote these to errors.
+#[derive(Debug, Clone)]
+pub struct TypeWarning {
+    /// Human-readable description of the warning.
+    pub message: String,
+    /// Source location associated with the warning.
+    pub smid: Smid,
+    /// The expected type (as a display string), if applicable.
+    pub expected: Option<String>,
+    /// The found type (as a display string), if applicable.
+    pub found: Option<String>,
+    /// Additional notes shown below the primary diagnostic.
+    pub notes: Vec<String>,
+}
+
+impl HasSmid for TypeWarning {
+    fn smid(&self) -> Smid {
+        self.smid
+    }
+}
+
+impl std::fmt::Display for TypeWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl TypeWarning {
+    /// Construct a simple type warning with no location or type details.
+    pub fn new(message: impl Into<String>) -> Self {
+        TypeWarning {
+            message: message.into(),
+            smid: Smid::default(),
+            expected: None,
+            found: None,
+            notes: vec![],
+        }
+    }
+
+    /// Attach a source location (Smid) to this warning.
+    pub fn at(mut self, smid: Smid) -> Self {
+        self.smid = smid;
+        self
+    }
+
+    /// Attach expected/found type information to this warning.
+    pub fn with_types(mut self, expected: impl Into<String>, found: impl Into<String>) -> Self {
+        self.expected = Some(expected.into());
+        self.found = Some(found.into());
+        self
+    }
+
+    /// Append a note to this warning.
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.notes.push(note.into());
+        self
+    }
+
+    /// Convert this warning to a `codespan-reporting` `Diagnostic::warning()`.
+    ///
+    /// Uses the source map to resolve the Smid to a file and span if possible.
+    pub fn to_diagnostic(&self, source_map: &SourceMap) -> Diagnostic<usize> {
+        let mut diag = Diagnostic::warning().with_message(&self.message);
+
+        if let Some(info) = source_map.source_info_for_smid(self.smid) {
+            if let (Some(file), Some(span)) = (info.file, info.span) {
+                let mut label = Label::primary(file, span);
+                // Annotate the label with type information when available
+                if let (Some(exp), Some(fnd)) = (&self.expected, &self.found) {
+                    label = label.with_message(format!("expected {exp}, found {fnd}"));
+                }
+                diag = diag.with_labels(vec![label]);
+            }
+        }
+
+        if !self.notes.is_empty() {
+            diag = diag.with_notes(self.notes.clone());
+        }
+
+        diag
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::sourcemap::SourceMap;
+
+    #[test]
+    fn type_warning_renders_as_warning_diagnostic() {
+        let source_map = SourceMap::new();
+        let warning = TypeWarning::new("type mismatch");
+        let diag = warning.to_diagnostic(&source_map);
+        // The diagnostic should carry warning severity
+        use codespan_reporting::diagnostic::Severity;
+        assert_eq!(diag.severity, Severity::Warning);
+        assert_eq!(diag.message, "type mismatch");
+    }
+
+    #[test]
+    fn type_warning_with_types_and_note() {
+        let source_map = SourceMap::new();
+        let warning = TypeWarning::new("type mismatch")
+            .with_types("number", "string")
+            .with_note("double expects a number argument");
+        let diag = warning.to_diagnostic(&source_map);
+        use codespan_reporting::diagnostic::Severity;
+        assert_eq!(diag.severity, Severity::Warning);
+        assert_eq!(diag.notes, vec!["double expects a number argument"]);
+        assert!(warning.expected.as_deref() == Some("number"));
+        assert!(warning.found.as_deref() == Some("string"));
+    }
+}

--- a/src/core/typecheck/mod.rs
+++ b/src/core/typecheck/mod.rs
@@ -1,0 +1,8 @@
+//! Gradual type checker for eucalypt.
+//!
+//! This module will house the type inference and checking passes that run
+//! on simplified core expressions after cooking and verification.
+//!
+//! Type issues are always reported as warnings — they never prevent evaluation.
+//! See `docs/development/gradual-typing-spec.md` for the full specification.
+pub mod error;

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -4,7 +4,7 @@
 //! another implementation or interpreting core directly
 use crate::{
     common::{prettify, sourcemap::*},
-    core::expr::*,
+    core::{expr::*, typecheck::error::TypeWarning},
     driver::{
         error::EucalyptError,
         io_run::{inject_world_and_run, io_run_and_render, IoRunError},
@@ -345,6 +345,23 @@ impl<'a> Executor<'a> {
             }
             Ok(code) => Ok(code),
         }
+    }
+
+    /// Emit type warnings to stderr and return whether any were emitted.
+    ///
+    /// When `strict` is `true`, the caller should treat the presence of warnings
+    /// as an error (non-zero exit).  This method always renders warnings as
+    /// `Diagnostic::warning()` regardless of the strict flag — the caller is
+    /// responsible for propagating the exit code.
+    pub fn emit_warnings(&mut self, warnings: &[TypeWarning]) -> bool {
+        if warnings.is_empty() {
+            return false;
+        }
+        for warning in warnings {
+            let diag = warning.to_diagnostic(&self.source_map);
+            self.diagnose_to_stderr(&diag);
+        }
+        true
     }
 
     /// Print a diagnostic to stderr

--- a/src/driver/lsp/diagnostics.rs
+++ b/src/driver/lsp/diagnostics.rs
@@ -4,6 +4,7 @@
 //! We convert these to LSP `Diagnostic` objects with line/column
 //! positions by scanning the source text for line breaks.
 
+use crate::core::typecheck::error::TypeWarning;
 use crate::syntax::rowan::ParseError;
 use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use rowan::TextRange;
@@ -15,6 +16,62 @@ pub fn diagnostics_from_parse_errors(source: &str, errors: &[ParseError]) -> Vec
         .iter()
         .map(|err| to_diagnostic(&line_index, err))
         .collect()
+}
+
+/// Convert a collection of type warnings into LSP diagnostics.
+///
+/// Type warnings use `DiagnosticSeverity::WARNING` and the source identifier
+/// `"eucalypt-types"` so that editors can distinguish them from parse errors.
+///
+/// The `source` parameter is the source text of the file being checked, used
+/// to resolve byte-offset spans (from `TextRange`) to LSP line/column positions.
+pub fn diagnostics_from_type_warnings(
+    source: &str,
+    warnings: &[TypeWarning],
+    files: &codespan_reporting::files::SimpleFiles<String, String>,
+) -> Vec<Diagnostic> {
+    let line_index = LineIndex::new(source);
+    warnings
+        .iter()
+        .filter_map(|w| type_warning_to_lsp_diagnostic(&line_index, w, files))
+        .collect()
+}
+
+/// Convert a single `TypeWarning` to an LSP `Diagnostic`.
+///
+/// Returns `None` if the warning has no resolvable source location.
+fn type_warning_to_lsp_diagnostic(
+    _line_index: &LineIndex<'_>,
+    warning: &TypeWarning,
+    _files: &codespan_reporting::files::SimpleFiles<String, String>,
+) -> Option<Diagnostic> {
+    let mut message = warning.message.clone();
+    if let (Some(exp), Some(fnd)) = (&warning.expected, &warning.found) {
+        message = format!("{message}: expected {exp}, found {fnd}");
+    }
+
+    // Use a zero-width range at (0,0) when no concrete source location is
+    // available.  Callers that need precise positions should attach Smids via
+    // `TypeWarning::at` — span resolution will be plumbed through once the
+    // type checker is integrated.
+    let fallback_range = Range {
+        start: lsp_types::Position {
+            line: 0,
+            character: 0,
+        },
+        end: lsp_types::Position {
+            line: 0,
+            character: 0,
+        },
+    };
+
+    Some(Diagnostic {
+        range: fallback_range,
+        severity: Some(DiagnosticSeverity::WARNING),
+        source: Some("eucalypt-types".to_string()),
+        message,
+        ..Diagnostic::default()
+    })
 }
 
 /// Convert a single parse error to an LSP diagnostic.
@@ -404,5 +461,31 @@ mod tests {
             10,
             "UTF-16 col 3 on line 1 should be byte 10"
         );
+    }
+
+    #[test]
+    fn type_warnings_produce_warning_diagnostics() {
+        use crate::core::typecheck::error::TypeWarning;
+        use codespan_reporting::files::SimpleFiles;
+
+        let source = "x: 1\n";
+        let files: SimpleFiles<String, String> = SimpleFiles::new();
+        let warnings = vec![TypeWarning::new("type mismatch")
+            .with_types("number", "string")
+            .with_note("double expects a number")];
+        let diags = diagnostics_from_type_warnings(source, &warnings, &files);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diags[0].source.as_deref(), Some("eucalypt-types"));
+    }
+
+    #[test]
+    fn empty_type_warnings_gives_no_diagnostics() {
+        use codespan_reporting::files::SimpleFiles;
+
+        let source = "x: 1\n";
+        let files: SimpleFiles<String, String> = SimpleFiles::new();
+        let diags = diagnostics_from_type_warnings(source, &[], &files);
+        assert!(diags.is_empty());
     }
 }

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -590,13 +590,26 @@ fn on_prepare_rename(
 }
 
 /// Parse the document and publish diagnostics to the client.
+///
+/// Collects both parse errors (as `DiagnosticSeverity::ERROR`) and any type
+/// warnings (as `DiagnosticSeverity::WARNING`) and sends them in a single
+/// `textDocument/publishDiagnostics` notification.  The type warning slice is
+/// currently always empty — it will be populated once the type checker is
+/// integrated into the LSP pipeline.
 fn publish_diagnostics(
     connection: &Connection,
     uri: Url,
     text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use codespan_reporting::files::SimpleFiles;
+
     let parse = crate::syntax::rowan::parse_unit(text);
-    let diags = diagnostics::diagnostics_from_parse_errors(text, parse.errors());
+    let mut diags = diagnostics::diagnostics_from_parse_errors(text, parse.errors());
+
+    // Merge type warnings (currently none — placeholder for future type checker)
+    let files: SimpleFiles<String, String> = SimpleFiles::new();
+    let type_warnings = diagnostics::diagnostics_from_type_warnings(text, &[], &files);
+    diags.extend(type_warnings);
 
     let params = PublishDiagnosticsParams {
         uri,

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -372,6 +372,9 @@ pub struct EucalyptOptions {
 
     // IO monad permission flag
     pub allow_io: bool,
+
+    // Promote type warnings to errors (used by `eu check --strict`)
+    pub strict: bool,
 }
 
 impl From<EucalyptCli> for EucalyptOptions {
@@ -640,6 +643,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             args,
             seed,
             allow_io,
+            strict: false,
         }
     }
 }
@@ -875,6 +879,14 @@ impl EucalyptOptions {
     /// Whether IO monad operations (shell execution) are permitted
     pub fn allow_io(&self) -> bool {
         self.allow_io
+    }
+
+    /// Whether type warnings should be treated as hard errors
+    ///
+    /// When `true`, the presence of any `TypeWarning` causes a non-zero exit.
+    /// Set by `eu check --strict`.
+    pub fn strict(&self) -> bool {
+        self.strict
     }
 
     /// Get the error output format


### PR DESCRIPTION
## Summary

- **`src/core/typecheck/error.rs`** (new): `TypeWarning` struct with builder API and `to_diagnostic()` → `Diagnostic::warning()`. Tests verify severity is `Warning`.
- **`src/common/sourcemap.rs`**: `warning_diagnostic()` method — same logic as `diagnostic()` but produces `Diagnostic::warning()`.
- **`src/driver/eval.rs`**: `Executor::emit_warnings()` renders `TypeWarning` slices to stderr; always returns zero exit code (warnings never block evaluation).
- **`src/driver/options.rs`**: `strict: bool` field + `strict()` accessor for future `eu check --strict` support.
- **`src/driver/lsp/diagnostics.rs`**: `diagnostics_from_type_warnings()` converts `TypeWarning` → `DiagnosticSeverity::WARNING` with `source: "eucalypt-types"`. Tests cover non-empty and empty cases.
- **`src/driver/lsp/mod.rs`**: `publish_diagnostics` now merges type warnings (currently empty) alongside parse errors — ready for the type checker to populate.

## Exit code behaviour

- Parse errors → non-zero (unchanged)
- Runtime errors → non-zero (unchanged)  
- Type warnings → zero exit (`emit_warnings` path)
- `--strict` → caller promotes warnings to errors (field in place, enforcement to follow in `eu check` subcommand)

## Test plan

- [x] `cargo test --lib` — 635 tests pass (includes new `TypeWarning` unit tests and LSP diagnostic tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)