### PR TITLE
feat: type representation and annotation parser (eu-ps21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -3,6 +3,7 @@ extern crate eucalypt;
 use std::process;
 use std::thread;
 
+use eucalypt::driver::check;
 use eucalypt::driver::format;
 use eucalypt::driver::lsp;
 use eucalypt::driver::options::EucalyptOptions;
@@ -69,6 +70,17 @@ fn run() -> i32 {
     // Format mode handles its own input loading
     if opt.format() {
         match format::format(&opt) {
+            Ok(exit) => return exit,
+            Err(e) => {
+                eprintln!("{e}");
+                return 2;
+            }
+        }
+    }
+
+    // Check mode: validate type annotations then exit
+    if opt.check() {
+        match check::check(&opt) {
             Ok(exit) => return exit,
             Err(e) => {
                 eprintln!("{e}");

--- a/src/core/typecheck/env.rs
+++ b/src/core/typecheck/env.rs
@@ -1,0 +1,190 @@
+//! Scoped type environment mapping names to `TypeScheme`s.
+//!
+//! `TypeEnv` tracks the types of all names currently in scope. It supports
+//! push/pop for entering and leaving nested scopes (blocks, let bindings).
+
+use std::collections::HashMap;
+
+use super::types::TypeScheme;
+
+/// A single scope frame: a mapping from names to their type schemes.
+type Frame = HashMap<String, TypeScheme>;
+
+/// Scoped type environment.
+///
+/// Scopes are maintained as a stack of frames. When looking up a name, frames
+/// are searched from innermost (most recent) to outermost.
+#[derive(Debug, Clone, Default)]
+pub struct TypeEnv {
+    frames: Vec<Frame>,
+}
+
+impl TypeEnv {
+    /// Create an empty type environment.
+    pub fn new() -> Self {
+        TypeEnv { frames: Vec::new() }
+    }
+
+    /// Push a new (empty) scope frame.
+    pub fn push_scope(&mut self) {
+        self.frames.push(Frame::new());
+    }
+
+    /// Pop the innermost scope frame, discarding its bindings.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no frames to pop (indicates a logic error in the
+    /// caller — mismatched push/pop calls).
+    pub fn pop_scope(&mut self) {
+        self.frames
+            .pop()
+            .expect("TypeEnv::pop_scope called with no frames on the stack");
+    }
+
+    /// Bind `name` to `scheme` in the innermost scope.
+    ///
+    /// If there are no frames, a top-level frame is created automatically so
+    /// that bindings can be inserted before any explicit `push_scope` call.
+    pub fn bind(&mut self, name: impl Into<String>, scheme: TypeScheme) {
+        if self.frames.is_empty() {
+            self.frames.push(Frame::new());
+        }
+        self.frames.last_mut().unwrap().insert(name.into(), scheme);
+    }
+
+    /// Look up `name`, searching from innermost to outermost scope.
+    ///
+    /// Returns `None` if the name is not bound in any frame.
+    pub fn lookup(&self, name: &str) -> Option<&TypeScheme> {
+        for frame in self.frames.iter().rev() {
+            if let Some(scheme) = frame.get(name) {
+                return Some(scheme);
+            }
+        }
+        None
+    }
+
+    /// Returns `true` if `name` is bound in any scope.
+    pub fn contains(&self, name: &str) -> bool {
+        self.lookup(name).is_some()
+    }
+
+    /// Number of scope frames currently on the stack.
+    pub fn depth(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Iterate over all bindings visible from the current scope (innermost
+    /// binding wins when there are name collisions across frames).
+    pub fn bindings(&self) -> impl Iterator<Item = (&str, &TypeScheme)> {
+        // Collect names we've already seen so inner frames shadow outer ones.
+        let mut seen = std::collections::HashSet::new();
+        self.frames
+            .iter()
+            .rev()
+            .flat_map(|frame| frame.iter())
+            .filter_map(move |(name, scheme)| {
+                if seen.insert(name.as_str()) {
+                    Some((name.as_str(), scheme))
+                } else {
+                    None
+                }
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::typecheck::types::Type;
+
+    fn number_scheme() -> TypeScheme {
+        TypeScheme::mono(Type::Number)
+    }
+
+    fn string_scheme() -> TypeScheme {
+        TypeScheme::mono(Type::String)
+    }
+
+    #[test]
+    fn empty_env_lookup_returns_none() {
+        let env = TypeEnv::new();
+        assert!(env.lookup("x").is_none());
+    }
+
+    #[test]
+    fn bind_and_lookup() {
+        let mut env = TypeEnv::new();
+        env.bind("x", number_scheme());
+        assert_eq!(env.lookup("x"), Some(&number_scheme()));
+    }
+
+    #[test]
+    fn inner_scope_shadows_outer() {
+        let mut env = TypeEnv::new();
+        env.bind("x", number_scheme());
+
+        env.push_scope();
+        env.bind("x", string_scheme());
+
+        assert_eq!(env.lookup("x"), Some(&string_scheme()));
+
+        env.pop_scope();
+        assert_eq!(env.lookup("x"), Some(&number_scheme()));
+    }
+
+    #[test]
+    fn outer_binding_visible_in_inner_scope() {
+        let mut env = TypeEnv::new();
+        env.bind("y", number_scheme());
+
+        env.push_scope();
+        assert_eq!(env.lookup("y"), Some(&number_scheme()));
+        env.pop_scope();
+    }
+
+    #[test]
+    fn pop_removes_inner_bindings() {
+        let mut env = TypeEnv::new();
+        env.push_scope();
+        env.bind("z", string_scheme());
+        env.pop_scope();
+
+        assert!(env.lookup("z").is_none());
+    }
+
+    #[test]
+    fn depth_tracks_frames() {
+        let mut env = TypeEnv::new();
+        assert_eq!(env.depth(), 0);
+        env.push_scope();
+        assert_eq!(env.depth(), 1);
+        env.push_scope();
+        assert_eq!(env.depth(), 2);
+        env.pop_scope();
+        assert_eq!(env.depth(), 1);
+    }
+
+    #[test]
+    fn contains() {
+        let mut env = TypeEnv::new();
+        env.bind("a", number_scheme());
+        assert!(env.contains("a"));
+        assert!(!env.contains("b"));
+    }
+
+    #[test]
+    fn bindings_iterator_shadows_correctly() {
+        let mut env = TypeEnv::new();
+        env.bind("x", number_scheme());
+        env.bind("y", string_scheme());
+        env.push_scope();
+        env.bind("x", string_scheme()); // shadows outer x
+
+        let bindings: HashMap<_, _> = env.bindings().collect();
+        assert_eq!(bindings["x"], &string_scheme());
+        assert_eq!(bindings["y"], &string_scheme());
+        assert_eq!(bindings.len(), 2);
+    }
+}

--- a/src/core/typecheck/mod.rs
+++ b/src/core/typecheck/mod.rs
@@ -1,8 +1,19 @@
-//! Gradual type checker for eucalypt.
+//! Gradual type system for eucalypt.
 //!
-//! This module will house the type inference and checking passes that run
-//! on simplified core expressions after cooking and verification.
+//! This module provides the foundational type infrastructure:
+//!
+//! - [`types`] — `Type` enum, `TypeScheme`, and `TypeVarId`
+//! - [`parse`] — recursive descent parser for type annotation strings
+//! - [`env`] — scoped type environment (`TypeEnv`)
+//! - [`error`] — `TypeWarning` diagnostic produced by the type checker
+//!
+//! The type checker itself (bidirectional checking, subtyping, instantiation)
+//! lives in downstream beads and is not yet implemented here.
 //!
 //! Type issues are always reported as warnings — they never prevent evaluation.
 //! See `docs/development/gradual-typing-spec.md` for the full specification.
+
+pub mod env;
 pub mod error;
+pub mod parse;
+pub mod types;

--- a/src/core/typecheck/parse.rs
+++ b/src/core/typecheck/parse.rs
@@ -1,0 +1,1039 @@
+//! Hand-written recursive descent parser for type annotation strings.
+//!
+//! Parses the type grammar defined in the gradual typing spec (section 4).
+//! This is entirely separate from the eucalypt expression parser — type
+//! annotations live in metadata strings and are parsed on demand.
+//!
+//! Grammar (summary):
+//! ```text
+//! type       ::= union
+//! union      ::= arrow ( '|' arrow )*
+//! arrow      ::= primary ( '->' primary )*         # right-associative
+//! primary    ::= 'number' | 'string' | 'symbol' | 'bool' | 'null'
+//!              | 'datetime' | 'any' | 'top' | 'never'
+//!              | 'set' | 'vec' | 'array'
+//!              | LOWER_IDENT                        # type variable
+//!              | '[' type ']'                       # list
+//!              | 'IO' '(' type ')'
+//!              | 'Lens' '(' type ',' type ')'
+//!              | 'Traversal' '(' type ',' type ')'
+//!              | '{' row '}'                        # record
+//!              | '(' paren_body ')'                 # grouping / tuple
+//! paren_body ::= type
+//!              | type ','
+//!              | type ( ',' type )+ ','?
+//! row        ::= field ( ',' field )* ( ',' '..' )?
+//! field      ::= IDENT ':' type
+//! ```
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use super::types::{Type, TypeVarId};
+
+// ── Error type ──────────────────────────────────────────────────────────────
+
+/// A parse error with a byte-offset position into the original annotation string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// Byte offset in the source string where the error was detected.
+    pub position: usize,
+    pub message: String,
+}
+
+impl ParseError {
+    fn new(position: usize, message: impl Into<String>) -> Self {
+        ParseError {
+            position,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "type annotation parse error at position {}: {}",
+            self.position, self.message
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+// ── Lexer ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    // Keywords / primitives
+    Number,
+    String,
+    Symbol,
+    Bool,
+    Null,
+    Datetime,
+    Any,
+    Top,
+    Never,
+    Set,
+    Vec,
+    Array,
+    // Type constructors
+    Io,
+    Lens,
+    Traversal,
+    // Identifiers (type variables and record field names)
+    Ident(String),
+    // Punctuation
+    LBracket, // [
+    RBracket, // ]
+    LParen,   // (
+    RParen,   // )
+    LBrace,   // {
+    RBrace,   // }
+    Arrow,    // ->
+    Pipe,     // |
+    Colon,    // :
+    Comma,    // ,
+    DotDot,   // ..
+    // End of input
+    Eof,
+}
+
+struct Lexer<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(input: &'a str) -> Self {
+        Lexer { input, pos: 0 }
+    }
+
+    fn remaining(&self) -> &str {
+        &self.input[self.pos..]
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.input.len()
+            && self.input[self.pos..].starts_with(|c: char| c.is_ascii_whitespace())
+        {
+            self.pos += 1;
+        }
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.remaining().chars().next()
+    }
+
+    /// Lex the next token, returning it together with the position at which it started.
+    fn next_token(&mut self) -> Result<(Token, usize), ParseError> {
+        self.skip_whitespace();
+        let start = self.pos;
+
+        if self.pos >= self.input.len() {
+            return Ok((Token::Eof, start));
+        }
+
+        let ch = self.peek_char().unwrap();
+
+        match ch {
+            '[' => {
+                self.pos += 1;
+                Ok((Token::LBracket, start))
+            }
+            ']' => {
+                self.pos += 1;
+                Ok((Token::RBracket, start))
+            }
+            '(' => {
+                self.pos += 1;
+                Ok((Token::LParen, start))
+            }
+            ')' => {
+                self.pos += 1;
+                Ok((Token::RParen, start))
+            }
+            '{' => {
+                self.pos += 1;
+                Ok((Token::LBrace, start))
+            }
+            '}' => {
+                self.pos += 1;
+                Ok((Token::RBrace, start))
+            }
+            '|' => {
+                self.pos += 1;
+                Ok((Token::Pipe, start))
+            }
+            ':' => {
+                self.pos += 1;
+                Ok((Token::Colon, start))
+            }
+            ',' => {
+                self.pos += 1;
+                Ok((Token::Comma, start))
+            }
+            '.' => {
+                if self.remaining().starts_with("..") {
+                    self.pos += 2;
+                    Ok((Token::DotDot, start))
+                } else {
+                    Err(ParseError::new(
+                        start,
+                        "unexpected character '.' (did you mean '..'?)".to_string(),
+                    ))
+                }
+            }
+            '-' => {
+                if self.remaining().starts_with("->") {
+                    self.pos += 2;
+                    Ok((Token::Arrow, start))
+                } else {
+                    Err(ParseError::new(
+                        start,
+                        "unexpected character '-' (did you mean '->'?)".to_string(),
+                    ))
+                }
+            }
+            c if c.is_ascii_alphabetic() => {
+                // Consume identifier
+                let ident_start = self.pos;
+                while self.pos < self.input.len() {
+                    let next = self.input[self.pos..].chars().next().unwrap();
+                    if next.is_ascii_alphanumeric() || next == '_' || next == '-' {
+                        self.pos += next.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
+                let ident = &self.input[ident_start..self.pos];
+                let tok = match ident {
+                    "number" => Token::Number,
+                    "string" => Token::String,
+                    "symbol" => Token::Symbol,
+                    "bool" => Token::Bool,
+                    "null" => Token::Null,
+                    "datetime" => Token::Datetime,
+                    "any" => Token::Any,
+                    "top" => Token::Top,
+                    "never" => Token::Never,
+                    "set" => Token::Set,
+                    "vec" => Token::Vec,
+                    "array" => Token::Array,
+                    "IO" => Token::Io,
+                    "Lens" => Token::Lens,
+                    "Traversal" => Token::Traversal,
+                    other => Token::Ident(other.to_string()),
+                };
+                Ok((tok, start))
+            }
+            other => Err(ParseError::new(
+                start,
+                format!("unexpected character '{other}'"),
+            )),
+        }
+    }
+}
+
+// ── Parser ──────────────────────────────────────────────────────────────────
+
+struct Parser<'a> {
+    lexer: Lexer<'a>,
+    /// One-token lookahead buffer: `(token, position)`.
+    peeked: Option<(Token, usize)>,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Parser {
+            lexer: Lexer::new(input),
+            peeked: None,
+        }
+    }
+
+    /// Current byte position in the source string.
+    fn pos(&mut self) -> usize {
+        if let Some((_, p)) = &self.peeked {
+            *p
+        } else {
+            self.lexer.pos
+        }
+    }
+
+    fn peek(&mut self) -> Result<&Token, ParseError> {
+        if self.peeked.is_none() {
+            let tok = self.lexer.next_token()?;
+            self.peeked = Some(tok);
+        }
+        Ok(&self.peeked.as_ref().unwrap().0)
+    }
+
+    fn advance(&mut self) -> Result<(Token, usize), ParseError> {
+        if let Some(t) = self.peeked.take() {
+            Ok(t)
+        } else {
+            self.lexer.next_token()
+        }
+    }
+
+    fn expect(&mut self, expected: &Token) -> Result<usize, ParseError> {
+        let (tok, tok_pos) = self.advance()?;
+        if &tok == expected {
+            Ok(tok_pos)
+        } else {
+            Err(ParseError::new(
+                tok_pos,
+                format!("expected {expected:?}, got {tok:?}"),
+            ))
+        }
+    }
+
+    // ── Grammar productions ─────────────────────────────────────────────────
+
+    /// Parse a complete type expression and verify no trailing input remains.
+    fn parse_type_toplevel(&mut self) -> Result<Type, ParseError> {
+        let ty = self.parse_union()?;
+        let (tok, pos) = self.advance()?;
+        if tok != Token::Eof {
+            return Err(ParseError::new(
+                pos,
+                format!("unexpected trailing input: {tok:?}"),
+            ));
+        }
+        Ok(ty)
+    }
+
+    /// `union ::= arrow ( '|' arrow )*`
+    fn parse_union(&mut self) -> Result<Type, ParseError> {
+        let mut variants = vec![self.parse_arrow()?];
+        loop {
+            if self.peek()? == &Token::Pipe {
+                self.advance()?;
+                variants.push(self.parse_arrow()?);
+            } else {
+                break;
+            }
+        }
+        if variants.len() == 1 {
+            Ok(variants.remove(0))
+        } else {
+            Ok(Type::Union(variants))
+        }
+    }
+
+    /// `arrow ::= primary ( '->' primary )*`  (right-associative)
+    fn parse_arrow(&mut self) -> Result<Type, ParseError> {
+        let lhs = self.parse_primary()?;
+        if self.peek()? == &Token::Arrow {
+            self.advance()?;
+            // Right-associative: recurse via parse_arrow
+            let rhs = self.parse_arrow()?;
+            Ok(Type::Function(Box::new(lhs), Box::new(rhs)))
+        } else {
+            Ok(lhs)
+        }
+    }
+
+    /// Parse a primary type expression.
+    fn parse_primary(&mut self) -> Result<Type, ParseError> {
+        let (tok, tok_pos) = self.advance()?;
+        match tok {
+            Token::Number => Ok(Type::Number),
+            Token::String => Ok(Type::String),
+            Token::Symbol => Ok(Type::Symbol),
+            Token::Bool => Ok(Type::Bool),
+            Token::Null => Ok(Type::Null),
+            Token::Datetime => Ok(Type::DateTime),
+            Token::Any => Ok(Type::Any),
+            Token::Top => Ok(Type::Top),
+            Token::Never => Ok(Type::Never),
+            Token::Set => Ok(Type::Set),
+            Token::Vec => Ok(Type::Vec),
+            Token::Array => Ok(Type::Array),
+            Token::Ident(name) => {
+                // Type variable — must begin with a lowercase ASCII letter
+                if name.starts_with(|c: char| c.is_ascii_lowercase()) {
+                    Ok(Type::Var(TypeVarId(name)))
+                } else {
+                    Err(ParseError::new(
+                        tok_pos,
+                        format!("unknown type constructor '{name}' (type variables must start with a lowercase letter)"),
+                    ))
+                }
+            }
+            Token::LBracket => {
+                // `[` type `]`
+                let inner = self.parse_union()?;
+                self.expect(&Token::RBracket)?;
+                Ok(Type::List(Box::new(inner)))
+            }
+            Token::LParen => self.parse_paren_body(tok_pos),
+            Token::LBrace => self.parse_record(tok_pos),
+            Token::Io => {
+                // `IO` `(` type `)`
+                self.expect(&Token::LParen)?;
+                let inner = self.parse_union()?;
+                self.expect(&Token::RParen)?;
+                Ok(Type::IO(Box::new(inner)))
+            }
+            Token::Lens => {
+                // `Lens` `(` type `,` type `)`
+                self.expect(&Token::LParen)?;
+                let a = self.parse_union()?;
+                self.expect(&Token::Comma)?;
+                let b = self.parse_union()?;
+                self.expect(&Token::RParen)?;
+                Ok(Type::Lens(Box::new(a), Box::new(b)))
+            }
+            Token::Traversal => {
+                // `Traversal` `(` type `,` type `)`
+                self.expect(&Token::LParen)?;
+                let a = self.parse_union()?;
+                self.expect(&Token::Comma)?;
+                let b = self.parse_union()?;
+                self.expect(&Token::RParen)?;
+                Ok(Type::Traversal(Box::new(a), Box::new(b)))
+            }
+            other => Err(ParseError::new(
+                tok_pos,
+                format!("expected a type, got {other:?}"),
+            )),
+        }
+    }
+
+    /// Parse the interior of `(...)` — grouping or tuple.
+    ///
+    /// Called after `(` has been consumed.
+    ///
+    /// ```text
+    /// paren_body ::= type               -- grouping: (A -> B)
+    ///              | type ','           -- 1-tuple: (A,)
+    ///              | type (',' type)+ ','?  -- n-tuple: (A, B) or (A, B,)
+    /// ```
+    fn parse_paren_body(&mut self, _open_pos: usize) -> Result<Type, ParseError> {
+        // Empty parens `()` are not valid in the grammar.
+        if self.peek()? == &Token::RParen {
+            let (_, pos) = self.advance()?;
+            return Err(ParseError::new(
+                pos,
+                "empty parentheses '()' are not a valid type (use 'null' for the unit type)",
+            ));
+        }
+
+        let first = self.parse_union()?;
+
+        match self.peek()? {
+            Token::RParen => {
+                // Grouping: `(T)`
+                self.advance()?;
+                Ok(first)
+            }
+            Token::Comma => {
+                // Could be 1-tuple `(A,)` or multi-tuple `(A, B, ...)`
+                self.advance()?; // consume ','
+                let mut elems = vec![first];
+
+                loop {
+                    match self.peek()? {
+                        Token::RParen => {
+                            // Trailing comma — close the tuple
+                            self.advance()?;
+                            break;
+                        }
+                        _ => {
+                            elems.push(self.parse_union()?);
+                            match self.peek()? {
+                                Token::Comma => {
+                                    self.advance()?;
+                                }
+                                Token::RParen => {
+                                    self.advance()?;
+                                    break;
+                                }
+                                _ => {
+                                    let pos = self.pos();
+                                    return Err(ParseError::new(
+                                        pos,
+                                        "expected ',' or ')' in tuple type",
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(Type::Tuple(elems))
+            }
+            _ => {
+                let pos = self.pos();
+                Err(ParseError::new(
+                    pos,
+                    "expected ')' or ',' after type in parentheses",
+                ))
+            }
+        }
+    }
+
+    /// Parse the interior of `{...}` — a record type.
+    ///
+    /// Called after `{` has been consumed.
+    ///
+    /// ```text
+    /// row   ::= field (',' field)* (',' '..')?
+    ///         | '..'
+    /// field ::= IDENT ':' type
+    /// ```
+    fn parse_record(&mut self, _open_pos: usize) -> Result<Type, ParseError> {
+        // Empty open record: `{..}`
+        if self.peek()? == &Token::DotDot {
+            self.advance()?;
+            self.expect(&Token::RBrace)?;
+            return Ok(Type::Record {
+                fields: BTreeMap::new(),
+                open: true,
+            });
+        }
+
+        // Empty closed record: `{}`
+        if self.peek()? == &Token::RBrace {
+            self.advance()?;
+            return Ok(Type::Record {
+                fields: BTreeMap::new(),
+                open: false,
+            });
+        }
+
+        let mut fields = BTreeMap::new();
+        let mut open = false;
+
+        loop {
+            // Check for `..` (open marker) or a field name
+            let pos = self.pos();
+            match self.peek()? {
+                Token::DotDot => {
+                    self.advance()?;
+                    open = true;
+                    self.expect(&Token::RBrace)?;
+                    break;
+                }
+                Token::RBrace => {
+                    self.advance()?;
+                    break;
+                }
+                Token::Ident(_) => {
+                    let (tok, field_pos) = self.advance()?;
+                    let field_name = match tok {
+                        Token::Ident(name) => name,
+                        _ => unreachable!(),
+                    };
+                    self.expect(&Token::Colon)?;
+                    let field_type = self.parse_union()?;
+                    if fields.contains_key(&field_name) {
+                        return Err(ParseError::new(
+                            field_pos,
+                            format!("duplicate field '{field_name}' in record type"),
+                        ));
+                    }
+                    fields.insert(field_name, field_type);
+
+                    // After a field: expect ',' or '}'
+                    match self.peek()? {
+                        Token::Comma => {
+                            self.advance()?;
+                            // After comma: could be another field, `..`, or `}`
+                        }
+                        Token::RBrace => {
+                            self.advance()?;
+                            break;
+                        }
+                        _ => {
+                            let p = self.pos();
+                            return Err(ParseError::new(p, "expected ',' or '}' in record type"));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        pos,
+                        "expected a field name or '..' in record type",
+                    ));
+                }
+            }
+        }
+
+        Ok(Type::Record { fields, open })
+    }
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Parse a type annotation string into a `Type`.
+///
+/// Returns a `ParseError` with byte-offset position information if the
+/// annotation is malformed.
+///
+/// # Examples
+///
+/// ```
+/// use eucalypt::core::typecheck::parse::parse_type;
+/// use eucalypt::core::typecheck::types::Type;
+///
+/// assert_eq!(parse_type("number").unwrap(), Type::Number);
+/// assert_eq!(
+///     parse_type("[string]").unwrap(),
+///     Type::List(Box::new(Type::String))
+/// );
+/// ```
+pub fn parse_type(input: &str) -> Result<Type, ParseError> {
+    let mut parser = Parser::new(input);
+    parser.parse_type_toplevel()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::typecheck::types::{Type, TypeVarId};
+    use std::collections::BTreeMap;
+
+    fn var(name: &str) -> Type {
+        Type::Var(TypeVarId(name.to_string()))
+    }
+
+    // ── Primitives ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_primitives() {
+        assert_eq!(parse_type("number").unwrap(), Type::Number);
+        assert_eq!(parse_type("string").unwrap(), Type::String);
+        assert_eq!(parse_type("symbol").unwrap(), Type::Symbol);
+        assert_eq!(parse_type("bool").unwrap(), Type::Bool);
+        assert_eq!(parse_type("null").unwrap(), Type::Null);
+        assert_eq!(parse_type("datetime").unwrap(), Type::DateTime);
+        assert_eq!(parse_type("any").unwrap(), Type::Any);
+        assert_eq!(parse_type("top").unwrap(), Type::Top);
+        assert_eq!(parse_type("never").unwrap(), Type::Never);
+        assert_eq!(parse_type("set").unwrap(), Type::Set);
+        assert_eq!(parse_type("vec").unwrap(), Type::Vec);
+        assert_eq!(parse_type("array").unwrap(), Type::Array);
+    }
+
+    // ── Type variables ──────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_type_var() {
+        assert_eq!(parse_type("a").unwrap(), var("a"));
+        assert_eq!(parse_type("result").unwrap(), var("result"));
+    }
+
+    #[test]
+    fn parse_uppercase_ident_fails() {
+        let err = parse_type("Foo").unwrap_err();
+        assert!(err.message.contains("unknown type constructor"));
+    }
+
+    // ── List ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_list() {
+        assert_eq!(
+            parse_type("[number]").unwrap(),
+            Type::List(Box::new(Type::Number))
+        );
+    }
+
+    #[test]
+    fn parse_list_of_var() {
+        assert_eq!(parse_type("[a]").unwrap(), Type::List(Box::new(var("a"))));
+    }
+
+    // ── Tuple ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_1_tuple() {
+        assert_eq!(
+            parse_type("(string,)").unwrap(),
+            Type::Tuple(vec![Type::String])
+        );
+    }
+
+    #[test]
+    fn parse_2_tuple() {
+        assert_eq!(
+            parse_type("(symbol, any)").unwrap(),
+            Type::Tuple(vec![Type::Symbol, Type::Any])
+        );
+    }
+
+    #[test]
+    fn parse_3_tuple_trailing_comma() {
+        assert_eq!(
+            parse_type("(number, string, bool,)").unwrap(),
+            Type::Tuple(vec![Type::Number, Type::String, Type::Bool])
+        );
+    }
+
+    #[test]
+    fn parse_grouping() {
+        // `(A -> B)` is grouping, not a tuple
+        assert_eq!(
+            parse_type("(number -> string)").unwrap(),
+            Type::Function(Box::new(Type::Number), Box::new(Type::String))
+        );
+    }
+
+    #[test]
+    fn parse_empty_parens_fails() {
+        assert!(parse_type("()").is_err());
+    }
+
+    // ── Function (arrow) ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_simple_function() {
+        assert_eq!(
+            parse_type("number -> string").unwrap(),
+            Type::Function(Box::new(Type::Number), Box::new(Type::String))
+        );
+    }
+
+    #[test]
+    fn parse_curried_function() {
+        // Right-associative: a -> b -> c  ≡  a -> (b -> c)
+        assert_eq!(
+            parse_type("number -> number -> number").unwrap(),
+            Type::Function(
+                Box::new(Type::Number),
+                Box::new(Type::Function(
+                    Box::new(Type::Number),
+                    Box::new(Type::Number)
+                ))
+            )
+        );
+    }
+
+    #[test]
+    fn parse_higher_order_function() {
+        // (a -> b) -> [a] -> [b]
+        assert_eq!(
+            parse_type("(a -> b) -> [a] -> [b]").unwrap(),
+            Type::Function(
+                Box::new(Type::Function(Box::new(var("a")), Box::new(var("b")))),
+                Box::new(Type::Function(
+                    Box::new(Type::List(Box::new(var("a")))),
+                    Box::new(Type::List(Box::new(var("b"))))
+                ))
+            )
+        );
+    }
+
+    // ── Union ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_union() {
+        assert_eq!(
+            parse_type("number | string").unwrap(),
+            Type::Union(vec![Type::Number, Type::String])
+        );
+    }
+
+    #[test]
+    fn parse_union_three_variants() {
+        assert_eq!(
+            parse_type("number | string | bool").unwrap(),
+            Type::Union(vec![Type::Number, Type::String, Type::Bool])
+        );
+    }
+
+    #[test]
+    fn parse_union_of_functions() {
+        // number -> number | string -> string
+        // = (number -> number) | (string -> string) since arrow binds tighter than pipe
+        assert_eq!(
+            parse_type("number -> number | string -> string").unwrap(),
+            Type::Union(vec![
+                Type::Function(Box::new(Type::Number), Box::new(Type::Number)),
+                Type::Function(Box::new(Type::String), Box::new(Type::String)),
+            ])
+        );
+    }
+
+    // ── Record ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_closed_record() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::String);
+        assert_eq!(
+            parse_type("{name: string}").unwrap(),
+            Type::Record {
+                fields,
+                open: false
+            }
+        );
+    }
+
+    #[test]
+    fn parse_open_record() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::String);
+        assert_eq!(
+            parse_type("{name: string, ..}").unwrap(),
+            Type::Record { fields, open: true }
+        );
+    }
+
+    #[test]
+    fn parse_fully_open_record() {
+        assert_eq!(
+            parse_type("{..}").unwrap(),
+            Type::Record {
+                fields: BTreeMap::new(),
+                open: true
+            }
+        );
+    }
+
+    #[test]
+    fn parse_empty_closed_record() {
+        assert_eq!(
+            parse_type("{}").unwrap(),
+            Type::Record {
+                fields: BTreeMap::new(),
+                open: false
+            }
+        );
+    }
+
+    #[test]
+    fn parse_multi_field_record() {
+        let mut fields = BTreeMap::new();
+        fields.insert("stdout".to_string(), Type::String);
+        fields.insert("stderr".to_string(), Type::String);
+        fields.insert("exit-code".to_string(), Type::Number);
+        assert_eq!(
+            parse_type("{stdout: string, stderr: string, exit-code: number}").unwrap(),
+            Type::Record {
+                fields,
+                open: false
+            }
+        );
+    }
+
+    #[test]
+    fn parse_duplicate_field_fails() {
+        assert!(parse_type("{a: number, a: string}").is_err());
+    }
+
+    // ── IO, Lens, Traversal ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_io() {
+        assert_eq!(
+            parse_type("IO(string)").unwrap(),
+            Type::IO(Box::new(Type::String))
+        );
+    }
+
+    #[test]
+    fn parse_io_record() {
+        assert_eq!(
+            parse_type("IO({stdout: string, stderr: string, exit-code: number})").unwrap(),
+            Type::IO(Box::new(Type::Record {
+                fields: {
+                    let mut m = BTreeMap::new();
+                    m.insert("stdout".to_string(), Type::String);
+                    m.insert("stderr".to_string(), Type::String);
+                    m.insert("exit-code".to_string(), Type::Number);
+                    m
+                },
+                open: false
+            }))
+        );
+    }
+
+    #[test]
+    fn parse_lens() {
+        assert_eq!(
+            parse_type("Lens({..}, any)").unwrap(),
+            Type::Lens(
+                Box::new(Type::Record {
+                    fields: BTreeMap::new(),
+                    open: true
+                }),
+                Box::new(Type::Any)
+            )
+        );
+    }
+
+    #[test]
+    fn parse_traversal() {
+        assert_eq!(
+            parse_type("Traversal([a], a)").unwrap(),
+            Type::Traversal(Box::new(Type::List(Box::new(var("a")))), Box::new(var("a")))
+        );
+    }
+
+    // ── Round-trip ──────────────────────────────────────────────────────────
+
+    fn roundtrip(input: &str) {
+        let ty = parse_type(input).unwrap_or_else(|e| panic!("parse failed for '{input}': {e}"));
+        let displayed = ty.to_string();
+        let ty2 = parse_type(&displayed)
+            .unwrap_or_else(|e| panic!("re-parse failed for '{displayed}': {e}"));
+        assert_eq!(
+            ty, ty2,
+            "round-trip mismatch for '{input}': display gave '{displayed}'"
+        );
+    }
+
+    #[test]
+    fn roundtrip_primitives() {
+        for prim in &[
+            "number", "string", "symbol", "bool", "null", "datetime", "any", "top", "never", "set",
+            "vec", "array",
+        ] {
+            roundtrip(prim);
+        }
+    }
+
+    #[test]
+    fn roundtrip_list() {
+        roundtrip("[number]");
+        roundtrip("[a]");
+        roundtrip("[[string]]");
+    }
+
+    #[test]
+    fn roundtrip_function() {
+        roundtrip("number -> string");
+        roundtrip("number -> number -> number");
+    }
+
+    #[test]
+    fn roundtrip_io() {
+        roundtrip("IO(string)");
+        roundtrip("IO({stdout: string, stderr: string, exit-code: number})");
+    }
+
+    #[test]
+    fn roundtrip_lens() {
+        roundtrip("Lens({..}, any)");
+    }
+
+    #[test]
+    fn roundtrip_traversal() {
+        roundtrip("Traversal([a], a)");
+    }
+
+    #[test]
+    fn roundtrip_record() {
+        roundtrip("{name: string, ..}");
+        roundtrip("{name: string}");
+        roundtrip("{..}");
+    }
+
+    #[test]
+    fn roundtrip_union() {
+        roundtrip("number | string");
+        roundtrip("number | string | bool");
+    }
+
+    #[test]
+    fn roundtrip_higher_order() {
+        roundtrip("(a -> b) -> [a] -> [b]");
+        roundtrip("(b -> a -> b) -> b -> [a] -> b");
+    }
+
+    #[test]
+    fn roundtrip_function_with_union_argument() {
+        // LHS union: `(number | string) -> bool` must not display as
+        // `number | string -> bool` (which re-parses as a union).
+        roundtrip("(number | string) -> bool");
+        // RHS union: `number -> (string | bool)` must not display as
+        // `number -> string | bool` (which re-parses as a union).
+        roundtrip("number -> (string | bool)");
+        // Both sides union.
+        roundtrip("(number | null) -> (string | bool)");
+    }
+
+    // ── Error cases ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn error_empty_input() {
+        let err = parse_type("").unwrap_err();
+        assert!(err.message.contains("expected a type"));
+    }
+
+    #[test]
+    fn error_trailing_junk() {
+        let err = parse_type("number garbage").unwrap_err();
+        assert!(err.message.contains("unexpected trailing input"));
+    }
+
+    #[test]
+    fn error_unclosed_bracket() {
+        assert!(parse_type("[number").is_err());
+    }
+
+    #[test]
+    fn error_unclosed_paren() {
+        assert!(parse_type("(number").is_err());
+    }
+
+    #[test]
+    fn error_unclosed_brace() {
+        assert!(parse_type("{name: string").is_err());
+    }
+
+    #[test]
+    fn error_bad_char() {
+        let err = parse_type("number @ string").unwrap_err();
+        assert!(err.message.contains("unexpected character"));
+    }
+
+    #[test]
+    fn error_position_reported() {
+        let err = parse_type("[number").unwrap_err();
+        // Position should be non-zero (after `[number`)
+        assert!(err.position > 0);
+    }
+
+    // ── Spec examples ───────────────────────────────────────────────────────
+
+    #[test]
+    fn spec_map_type() {
+        // (a -> b) -> [a] -> [b]
+        let ty = parse_type("(a -> b) -> [a] -> [b]").unwrap();
+        assert!(matches!(ty, Type::Function(_, _)));
+    }
+
+    #[test]
+    fn spec_fold_type() {
+        // (b -> a -> b) -> b -> [a] -> b
+        let ty = parse_type("(b -> a -> b) -> b -> [a] -> b").unwrap();
+        assert!(matches!(ty, Type::Function(_, _)));
+    }
+
+    #[test]
+    fn spec_io_shell_type() {
+        // string -> IO({stdout: string, stderr: string, exit-code: number})
+        parse_type("string -> IO({stdout: string, stderr: string, exit-code: number})").unwrap();
+    }
+
+    #[test]
+    fn spec_lens_at_type() {
+        // symbol -> Lens({..}, any)
+        parse_type("symbol -> Lens({..}, any)").unwrap();
+    }
+
+    #[test]
+    fn spec_elements_type() {
+        // {..} -> [(symbol, any)]
+        let ty = parse_type("{..} -> [(symbol, any)]").unwrap();
+        assert!(matches!(ty, Type::Function(_, _)));
+    }
+}

--- a/src/core/typecheck/types.rs
+++ b/src/core/typecheck/types.rs
@@ -1,0 +1,351 @@
+//! Type representation for eucalypt's gradual type system.
+//!
+//! This module defines the `Type` enum covering all type forms from the
+//! gradual typing spec, plus `TypeScheme` for polymorphic types.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// A unique identifier for a type variable within a `TypeScheme`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TypeVarId(pub String);
+
+impl fmt::Display for TypeVarId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A constraint on a type variable (reserved for future use).
+///
+/// Currently unused — constraints are always an empty `Vec`. Included
+/// in `TypeScheme` so the representation is future-proof without
+/// breaking changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Constraint {
+    pub function: String,
+    pub args: Vec<Type>,
+}
+
+/// A polymorphic type scheme: `forall vars. body` with optional constraints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScheme {
+    pub vars: Vec<TypeVarId>,
+    /// Reserved for future constraint support — always empty for now.
+    pub constraints: Vec<Constraint>,
+    pub body: Type,
+}
+
+impl TypeScheme {
+    /// Monomorphic scheme: no type variables.
+    pub fn mono(ty: Type) -> Self {
+        TypeScheme {
+            vars: Vec::new(),
+            constraints: Vec::new(),
+            body: ty,
+        }
+    }
+
+    /// Polymorphic scheme with the given type variables.
+    pub fn poly(vars: Vec<TypeVarId>, ty: Type) -> Self {
+        TypeScheme {
+            vars,
+            constraints: Vec::new(),
+            body: ty,
+        }
+    }
+}
+
+impl fmt::Display for TypeScheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.vars.is_empty() {
+            write!(f, "{}", self.body)
+        } else {
+            write!(f, "forall")?;
+            for v in &self.vars {
+                write!(f, " {v}")?;
+            }
+            write!(f, ". {}", self.body)
+        }
+    }
+}
+
+/// All type forms in eucalypt's gradual type system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Type {
+    // ── Primitives ──────────────────────────────────────────────────────────
+    /// Integer and floating-point numbers.
+    Number,
+    /// String values.
+    String,
+    /// Symbolic atoms (`:name`).
+    Symbol,
+    /// Boolean: `true` or `false`.
+    Bool,
+    /// The null value.
+    Null,
+    /// Zoned date-time values.
+    DateTime,
+
+    // ── Special ─────────────────────────────────────────────────────────────
+    /// Gradual/dynamic — consistent with every type in both directions.
+    /// The checker does not flag errors involving `any`.
+    Any,
+    /// Supertype of all types — accepts any value, but nothing can be done
+    /// with it without narrowing first.
+    Top,
+    /// Bottom type — subtype of all types. Represents unreachable code or
+    /// empty collections.
+    Never,
+
+    // ── Composite ───────────────────────────────────────────────────────────
+    /// Homogeneous list: `[T]`.
+    List(Box<Type>),
+    /// Tuple: `(A, B)` or the 1-tuple `(A,)`.
+    Tuple(Vec<Type>),
+    /// Ordered set of primitives.
+    Set,
+    /// Flat vector of primitives (O(1) indexed access).
+    Vec,
+    /// N-dimensional array of numbers (floats).
+    Array,
+    /// IO action producing a value of type `T`.
+    IO(Box<Type>),
+    /// Lens focusing on a `B` within an `A`.
+    Lens(Box<Type>, Box<Type>),
+    /// Traversal over zero or more `B`s within an `A`.
+    Traversal(Box<Type>, Box<Type>),
+    /// Record type.
+    ///
+    /// `open = true` means at least the listed fields are present (open record
+    /// — the `{k: T, ..}` form). `open = false` means exactly those fields
+    /// (closed record — the `{k: T}` form).
+    Record {
+        fields: BTreeMap<String, Type>,
+        open: bool,
+    },
+    /// Function type: `A -> B`.
+    Function(Box<Type>, Box<Type>),
+    /// Union type: `A | B`.
+    Union(Vec<Type>),
+
+    // ── Variables ────────────────────────────────────────────────────────────
+    /// Type variable (lowercase identifier, e.g. `a`, `b`, `result`).
+    Var(TypeVarId),
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Number => write!(f, "number"),
+            Type::String => write!(f, "string"),
+            Type::Symbol => write!(f, "symbol"),
+            Type::Bool => write!(f, "bool"),
+            Type::Null => write!(f, "null"),
+            Type::DateTime => write!(f, "datetime"),
+            Type::Any => write!(f, "any"),
+            Type::Top => write!(f, "top"),
+            Type::Never => write!(f, "never"),
+            Type::Set => write!(f, "set"),
+            Type::Vec => write!(f, "vec"),
+            Type::Array => write!(f, "array"),
+            Type::Var(v) => write!(f, "{v}"),
+            Type::List(inner) => write!(f, "[{inner}]"),
+            Type::Tuple(elems) => {
+                write!(f, "(")?;
+                match elems.as_slice() {
+                    [] => write!(f, ")")?,
+                    [single] => write!(f, "{single},)")?,
+                    _ => {
+                        let mut iter = elems.iter();
+                        write!(f, "{}", iter.next().unwrap())?;
+                        for t in iter {
+                            write!(f, ", {t}")?;
+                        }
+                        write!(f, ")")?;
+                    }
+                }
+                Ok(())
+            }
+            Type::IO(inner) => write!(f, "IO({inner})"),
+            Type::Lens(a, b) => write!(f, "Lens({a}, {b})"),
+            Type::Traversal(a, b) => write!(f, "Traversal({a}, {b})"),
+            Type::Record { fields, open } => {
+                write!(f, "{{")?;
+                let mut iter = fields.iter();
+                if let Some((k, v)) = iter.next() {
+                    write!(f, "{k}: {v}")?;
+                    for (k, v) in iter {
+                        write!(f, ", {k}: {v}")?;
+                    }
+                }
+                if *open {
+                    if fields.is_empty() {
+                        write!(f, "..")?;
+                    } else {
+                        write!(f, ", ..")?;
+                    }
+                }
+                write!(f, "}}")
+            }
+            Type::Function(a, b) => {
+                // Parenthesise LHS if it is itself a function or a union, to
+                // avoid ambiguity: `(a -> b) -> c` and `(a | b) -> c` must
+                // be distinct from the un-parenthesised forms which parse
+                // differently. Parenthesise RHS if it is a union, because
+                // `a -> b | c` parses as `(a -> b) | c`, not `a -> (b | c)`.
+                let lhs_needs_parens = matches!(a.as_ref(), Type::Function(_, _) | Type::Union(_));
+                let rhs_needs_parens = matches!(b.as_ref(), Type::Union(_));
+                match (lhs_needs_parens, rhs_needs_parens) {
+                    (true, true) => write!(f, "({a}) -> ({b})"),
+                    (true, false) => write!(f, "({a}) -> {b}"),
+                    (false, true) => write!(f, "{a} -> ({b})"),
+                    (false, false) => write!(f, "{a} -> {b}"),
+                }
+            }
+            Type::Union(variants) => {
+                let mut iter = variants.iter();
+                if let Some(first) = iter.next() {
+                    write!(f, "{first}")?;
+                    for t in iter {
+                        write!(f, " | {t}")?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(name: &str) -> Type {
+        Type::Var(TypeVarId(name.to_string()))
+    }
+
+    #[test]
+    fn display_primitives() {
+        assert_eq!(Type::Number.to_string(), "number");
+        assert_eq!(Type::String.to_string(), "string");
+        assert_eq!(Type::Symbol.to_string(), "symbol");
+        assert_eq!(Type::Bool.to_string(), "bool");
+        assert_eq!(Type::Null.to_string(), "null");
+        assert_eq!(Type::DateTime.to_string(), "datetime");
+        assert_eq!(Type::Any.to_string(), "any");
+        assert_eq!(Type::Top.to_string(), "top");
+        assert_eq!(Type::Never.to_string(), "never");
+        assert_eq!(Type::Set.to_string(), "set");
+        assert_eq!(Type::Vec.to_string(), "vec");
+        assert_eq!(Type::Array.to_string(), "array");
+    }
+
+    #[test]
+    fn display_list() {
+        let t = Type::List(Box::new(Type::Number));
+        assert_eq!(t.to_string(), "[number]");
+    }
+
+    #[test]
+    fn display_tuple_1() {
+        let t = Type::Tuple(vec![Type::String]);
+        assert_eq!(t.to_string(), "(string,)");
+    }
+
+    #[test]
+    fn display_tuple_2() {
+        let t = Type::Tuple(vec![Type::Symbol, Type::Any]);
+        assert_eq!(t.to_string(), "(symbol, any)");
+    }
+
+    #[test]
+    fn display_function() {
+        let t = Type::Function(Box::new(var("a")), Box::new(var("b")));
+        assert_eq!(t.to_string(), "a -> b");
+    }
+
+    #[test]
+    fn display_curried_function() {
+        let t = Type::Function(
+            Box::new(Type::Number),
+            Box::new(Type::Function(
+                Box::new(Type::Number),
+                Box::new(Type::Number),
+            )),
+        );
+        assert_eq!(t.to_string(), "number -> number -> number");
+    }
+
+    #[test]
+    fn display_io() {
+        let t = Type::IO(Box::new(Type::String));
+        assert_eq!(t.to_string(), "IO(string)");
+    }
+
+    #[test]
+    fn display_lens() {
+        let t = Type::Lens(
+            Box::new(Type::Record {
+                fields: BTreeMap::new(),
+                open: true,
+            }),
+            Box::new(Type::Any),
+        );
+        assert_eq!(t.to_string(), "Lens({..}, any)");
+    }
+
+    #[test]
+    fn display_closed_record() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::String);
+        fields.insert("age".to_string(), Type::Number);
+        let t = Type::Record {
+            fields,
+            open: false,
+        };
+        // BTreeMap is sorted alphabetically
+        assert_eq!(t.to_string(), "{age: number, name: string}");
+    }
+
+    #[test]
+    fn display_open_record() {
+        let mut fields = BTreeMap::new();
+        fields.insert("name".to_string(), Type::String);
+        let t = Type::Record { fields, open: true };
+        assert_eq!(t.to_string(), "{name: string, ..}");
+    }
+
+    #[test]
+    fn display_union() {
+        let t = Type::Union(vec![Type::Number, Type::String]);
+        assert_eq!(t.to_string(), "number | string");
+    }
+
+    #[test]
+    fn display_type_var() {
+        assert_eq!(var("a").to_string(), "a");
+        assert_eq!(var("result").to_string(), "result");
+    }
+
+    #[test]
+    fn type_scheme_mono() {
+        let s = TypeScheme::mono(Type::Number);
+        assert_eq!(s.to_string(), "number");
+    }
+
+    #[test]
+    fn type_scheme_poly() {
+        let s = TypeScheme::poly(
+            vec![TypeVarId("a".to_string()), TypeVarId("b".to_string())],
+            Type::Function(
+                Box::new(Type::Function(Box::new(var("a")), Box::new(var("b")))),
+                Box::new(Type::Function(
+                    Box::new(Type::List(Box::new(var("a")))),
+                    Box::new(Type::List(Box::new(var("b")))),
+                )),
+            ),
+        );
+        assert_eq!(s.to_string(), "forall a b. (a -> b) -> [a] -> [b]");
+    }
+}

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -1,0 +1,266 @@
+//! Type annotation check command (`eu check`).
+//!
+//! Parses eucalypt source files, extracts `type:` metadata annotations from
+//! all declarations, and reports any annotation strings that fail to parse.
+//!
+//! No actual type checking is performed yet — this phase validates that
+//! annotations are syntactically well-formed according to the type grammar.
+
+use std::fs;
+use std::path::Path;
+
+use crate::core::typecheck::parse;
+use crate::driver::options::EucalyptOptions;
+use crate::syntax::rowan::ast::{self, Block, Declaration, Element, HasSoup};
+use crate::syntax::rowan::parse_unit;
+use rowan::ast::AstNode;
+
+/// A single type annotation found in a source file.
+struct Annotation {
+    /// Byte offset of the annotation string within the source file.
+    source_offset: usize,
+    /// The annotation string value.
+    value: String,
+    /// Name of the declaration the annotation was attached to (for error messages).
+    decl_name: String,
+}
+
+/// Run the `eu check` command.
+pub fn check(opt: &EucalyptOptions) -> Result<i32, String> {
+    let files: Vec<_> = opt.explicit_inputs().iter().collect();
+
+    if files.is_empty() {
+        eprintln!("eu check: no files specified");
+        return Ok(1);
+    }
+
+    let mut total_errors = 0;
+
+    for input in &files {
+        let path_str = input.locator().to_string();
+        let path = Path::new(&path_str);
+
+        if !path.exists() {
+            eprintln!("eu check: file not found: {path_str}");
+            total_errors += 1;
+            continue;
+        }
+
+        let source = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read '{}': {}", path_str, e))?;
+
+        let file_errors = check_source(&path_str, &source, opt.check_strict());
+        total_errors += file_errors;
+    }
+
+    if total_errors == 0 {
+        Ok(0)
+    } else if opt.check_strict() {
+        Ok(1)
+    } else {
+        // Warnings do not cause non-zero exit unless --strict
+        Ok(0)
+    }
+}
+
+/// Check a single source string, reporting type annotation parse errors.
+///
+/// Returns the number of annotation errors found.
+fn check_source(filename: &str, source: &str, strict: bool) -> usize {
+    let parse_result = parse_unit(source);
+
+    // Report any eucalypt syntax errors first (these are real errors regardless of --strict).
+    for err in parse_result.errors() {
+        eprintln!("{filename}: parse error: {err}");
+    }
+
+    let unit = parse_result.tree();
+    let annotations = collect_annotations_from_unit(&unit, source);
+
+    let mut error_count = 0;
+    for ann in annotations {
+        if let Err(e) = parse::parse_type(&ann.value) {
+            let severity = if strict { "error" } else { "warning" };
+            let line_col = byte_offset_to_line_col(source, ann.source_offset);
+            eprintln!(
+                "{filename}:{line_col}: {severity}: invalid type annotation on '{}': {}",
+                ann.decl_name, e
+            );
+            error_count += 1;
+        }
+    }
+
+    error_count
+}
+
+/// Convert a byte offset to a `line:col` string (1-based).
+fn byte_offset_to_line_col(source: &str, offset: usize) -> String {
+    let clamped = offset.min(source.len());
+    let prefix = &source[..clamped];
+    let line = prefix.bytes().filter(|&b| b == b'\n').count() + 1;
+    let col = match prefix.rfind('\n') {
+        Some(last_nl) => clamped - last_nl,
+        None => clamped + 1,
+    };
+    format!("{line}:{col}")
+}
+
+/// Collect all `type:` annotations from a `Unit`.
+fn collect_annotations_from_unit(unit: &ast::Unit, source: &str) -> Vec<Annotation> {
+    let mut result = Vec::new();
+    for decl in unit.declarations() {
+        collect_annotations_from_decl(&decl, source, &mut result);
+    }
+    result
+}
+
+/// Collect `type:` annotations from a declaration (and any nested blocks in its body).
+fn collect_annotations_from_decl(decl: &Declaration, source: &str, out: &mut Vec<Annotation>) {
+    let decl_name = declaration_name(decl);
+
+    // Inspect the declaration's backtick metadata block for a `type:` field.
+    if let Some(meta) = decl.meta() {
+        if let Some(soup) = meta.soup() {
+            let elems: Vec<ast::Element> = soup.elements().collect();
+            if let Some(Element::Block(meta_block)) = elems.first() {
+                if let Some(ann) = extract_type_annotation(meta_block, &decl_name) {
+                    out.push(ann);
+                }
+            }
+        }
+    }
+
+    // Recurse into nested block bodies.
+    if let Some(body) = decl.body() {
+        if let Some(body_soup) = body.soup() {
+            for elem in body_soup.elements() {
+                if let Element::Block(inner_block) = elem {
+                    collect_annotations_from_block(&inner_block, source, out);
+                }
+            }
+        }
+    }
+}
+
+/// Collect `type:` annotations from all declarations within a block.
+fn collect_annotations_from_block(block: &Block, source: &str, out: &mut Vec<Annotation>) {
+    for decl in block.declarations() {
+        collect_annotations_from_decl(&decl, source, out);
+    }
+}
+
+/// Try to extract a `type:` string literal from a metadata block.
+fn extract_type_annotation(meta_block: &Block, decl_name: &str) -> Option<Annotation> {
+    for inner_decl in meta_block.declarations() {
+        let Some(head) = inner_decl.head() else {
+            continue;
+        };
+        let ast::DeclarationKind::Property(prop) = head.classify_declaration() else {
+            continue;
+        };
+        if prop.value() != "type" {
+            continue;
+        }
+
+        // Found a `type:` field — extract its string literal value.
+        let body = inner_decl.body()?;
+        let body_soup = body.soup()?;
+        let body_elems: Vec<ast::Element> = body_soup.elements().collect();
+
+        if let Some(Element::Lit(lit)) = body_elems.first() {
+            if let Some(lit_val) = lit.value() {
+                if let Some(type_str) = lit_val.string_value() {
+                    // Find the byte offset of this literal in the source.
+                    let node_offset = usize::from(lit.syntax().text_range().start());
+                    return Some(Annotation {
+                        source_offset: node_offset,
+                        value: type_str.to_string(),
+                        decl_name: decl_name.to_string(),
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Attempt to extract a human-readable name from a declaration head.
+fn declaration_name(decl: &Declaration) -> String {
+    let Some(head) = decl.head() else {
+        return "<unknown>".to_string();
+    };
+    match head.classify_declaration() {
+        ast::DeclarationKind::Property(id) => id.value().to_string(),
+        ast::DeclarationKind::Function(name, _) => name.value().to_string(),
+        _ => "<unknown>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_errors_for_valid_annotations() {
+        let src = r#"
+` { type: "number -> number" }
+double(x): x * 2
+"#;
+        assert_eq!(check_source("<test>", src, false), 0);
+    }
+
+    #[test]
+    fn reports_invalid_annotation() {
+        let src = r#"
+` { type: "number ->" }
+bad(x): x
+"#;
+        assert_eq!(check_source("<test>", src, false), 1);
+    }
+
+    #[test]
+    fn ignores_declarations_without_type_annotation() {
+        let src = r#"
+` { doc: "just a doc" }
+no_type(x): x
+"#;
+        assert_eq!(check_source("<test>", src, false), 0);
+    }
+
+    #[test]
+    fn multiple_valid_annotations() {
+        let src = r#"
+` { type: "(a -> b) -> [a] -> [b]" }
+map(f, xs): __MAP
+
+` { type: "(a -> bool) -> [a] -> [a]" }
+filter(p, xs): __FILTER
+"#;
+        assert_eq!(check_source("<test>", src, false), 0);
+    }
+
+    #[test]
+    fn multiple_annotations_one_bad() {
+        let src = r#"
+` { type: "(a -> b) -> [a] -> [b]" }
+map(f, xs): __MAP
+
+` { type: "number ->" }
+bad(x): x
+"#;
+        assert_eq!(check_source("<test>", src, false), 1);
+    }
+
+    #[test]
+    fn byte_offset_line_col_first_line() {
+        let src = "hello world";
+        assert_eq!(byte_offset_to_line_col(src, 0), "1:1");
+        assert_eq!(byte_offset_to_line_col(src, 5), "1:6");
+    }
+
+    #[test]
+    fn byte_offset_line_col_second_line() {
+        let src = "line1\nline2";
+        assert_eq!(byte_offset_to_line_col(src, 6), "2:1");
+    }
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod check;
 pub mod error;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod eval;

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -109,6 +109,19 @@ pub enum Commands {
     Fmt(FmtArgs),
     /// Start the Language Server Protocol server
     Lsp,
+    /// Check type annotations in eucalypt source files
+    Check(CheckArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CheckArgs {
+    /// Treat type annotation warnings as errors
+    #[arg(long = "strict")]
+    pub strict: bool,
+
+    /// Files to type-check
+    #[arg(value_name = "FILES")]
+    pub files: Vec<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -342,6 +355,10 @@ pub struct EucalyptOptions {
     // LSP mode
     pub lsp: bool,
 
+    // Check mode
+    pub check: bool,
+    pub check_strict: bool,
+
     // Format command options
     pub format: bool,
     pub format_width: usize,
@@ -389,6 +406,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             Some(Commands::ListTargets(args)) => &args.files,
             Some(Commands::Fmt(args)) => &args.files,
             Some(Commands::Version) | Some(Commands::Lsp) => &cli.files,
+            Some(Commands::Check(args)) => &args.files,
             None => &cli.files,
         };
 
@@ -552,6 +570,12 @@ impl From<EucalyptCli> for EucalyptOptions {
         // Extract LSP mode
         let lsp = matches!(cli.command, Some(Commands::Lsp));
 
+        // Extract check mode
+        let (check, check_strict) = match &cli.command {
+            Some(Commands::Check(args)) => (true, args.strict),
+            _ => (false, false),
+        };
+
         // Extract heap limit and no-dce from Run command
         // 0 means unbounded; any other value is the limit in MiB
         let heap_limit_mib = match &cli.command {
@@ -625,6 +649,8 @@ impl From<EucalyptCli> for EucalyptOptions {
             dump_stg,
             dump_runtime,
             lsp,
+            check,
+            check_strict,
             format,
             format_width,
             format_write,
@@ -668,6 +694,7 @@ impl EucalyptCli {
             "list-targets",
             "fmt",
             "lsp",
+            "check",
             "help",
         ];
         // Rewrite --version/-V to the version subcommand so the
@@ -783,6 +810,14 @@ impl EucalyptOptions {
         self.lsp
     }
 
+    pub fn check(&self) -> bool {
+        self.check
+    }
+
+    pub fn check_strict(&self) -> bool {
+        self.check_strict
+    }
+
     pub fn no_dce(&self) -> bool {
         self.no_dce
     }
@@ -800,6 +835,7 @@ impl EucalyptOptions {
             && !self.dump_runtime
             && !self.format
             && !self.lsp
+            && !self.check
     }
 
     pub fn target(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary

- Adds `src/core/typecheck/` module with the foundational type system for eucalypt's gradual typing (bead eu-ps21)
- Implements `eu check <file>` CLI subcommand that validates type annotation syntax

## What's included

### `src/core/typecheck/types.rs`
`Type` enum covering all forms from the spec: primitives (`Number`, `String`, `Symbol`, `Bool`, `Null`, `DateTime`), special types (`Any`, `Top`, `Never`), composites (`List`, `Tuple`, `Set`, `Vec`, `Array`, `IO`, `Lens`, `Traversal`, `Record { fields, open }`, `Function`, `Union`), and `Var(TypeVarId)`. Plus `TypeScheme` (forall-quantified), `Constraint` (reserved/empty for now), and `Display` implementations.

### `src/core/typecheck/parse.rs`
Hand-written recursive descent parser for type annotation strings from spec section 4. Right-associative `->`, union `|`, open/closed records `{k: T, ..}`, tuples `(A, B)` vs grouping `(A -> B)`, IO/Lens/Traversal constructors. Returns `ParseError` with byte-offset positions for good error messages.

### `src/core/typecheck/env.rs`
Scoped `TypeEnv` (stack of frames) with push/pop for block/let scope entry/exit.

### `src/driver/check.rs` + CLI wiring
`eu check <file>` subcommand: parses source files, walks declarations to find `type:` metadata annotations, parses each annotation string, reports failures. Warnings by default; `--strict` promotes to errors.

## Test plan

- [x] `cargo test --lib` — 707 tests pass (including all new type parser tests, round-trip tests, error cases, spec examples)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)