### PR TITLE
feat: desugarer type hint injection (eu-dh2k)

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -1385,9 +1385,25 @@ impl Desugarable for Element {
                     ));
                 };
 
-                let bracket_fn_name = RcExpr::from(Expr::Name(smid, pair_name));
+                let bracket_fn_name = RcExpr::from(Expr::Name(smid, pair_name.clone()));
                 let bracket_fn = desugarer.varify(bracket_fn_name);
-                Ok(RcExpr::from(Expr::App(smid, bracket_fn, vec![inner])))
+                let app = RcExpr::from(Expr::App(smid, bracket_fn, vec![inner]));
+
+                // Inject a type hint for lens path brackets (‹›).
+                //
+                // ‹ :items 0 :meta › desugars to a composed lens over
+                // at-lenses (Lens({..}, any)) and ix-lenses (Lens([any], any)).
+                // The result is always a Lens, so we attach a general
+                // Lens(any, any) hint to guide the type checker without
+                // having to re-infer through the foldr(∘, identity)
+                // implementation.
+                if pair_name == "\u{2039}\u{203A}" {
+                    let hint = core::str(smid, "Lens(any, any)");
+                    let meta = core::block(smid, [("__type_hint".to_string(), hint)]);
+                    Ok(core::meta(smid, app, meta))
+                } else {
+                    Ok(app)
+                }
             }
             Element::BracketBlock(bracket) => {
                 // BracketBlock element appearing in isolation (single-element soup, no .expr).


### PR DESCRIPTION
## Summary

- Injects `{__type_hint: "Lens(any, any)"}` as `Expr::Meta` around the desugared `App` node for `‹›`-bracketed lens expressions in `src/core/desugar/rowan_ast.rs`
- Uses the existing `Expr::Meta` mechanism with reserved key `__type_hint` — no new AST variants required
- Hints are inert metadata: the current evaluation pipeline ignores them completely; they are available for the forthcoming type checker

## Design

The `‹›` bracket pair desugars to `foldr(∘, identity)` over a list of at/ix-lenses. The result is always a `Lens`, but re-inferring that from the implementation would require the type checker to understand `∘` and `foldr`. Attaching `Lens(any, any)` at the desugar site gives a direct signal with no runtime cost.

The `__type_hint` key is a reserved metadata key (established in eu-dh2k spec). Other metadata consumers strip it via `strip_desugar_phase_metadata` or ignore it.

## Test plan

- [x] `cargo build --release` — compiles cleanly
- [x] `cargo test --test harness_test` — 269/269 pass (hints are inert)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)