### PR TITLE
docs: type checking guide and reference updates

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 - [IO and Shell Commands](guide/io.md)
 - [Monads and the monad() Utility](guide/monads.md)
 - [The State Monad](guide/state-monad.md)
+- [Type Checking](guide/type-checking.md)
 - [Advanced Topics](guide/advanced-topics.md)
 
 # Reference

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -458,4 +458,65 @@ eu -Q file.eu               # Suppress prelude
 eu fmt file.eu              # Format source
 eu dump stg file.eu         # Dump STG syntax
 eu -- arg1 arg2             # Pass arguments (io.args)
+eu check file.eu            # Type-check, report warnings
+eu check --strict file.eu   # Treat type warnings as errors
+eu --type-check file.eu     # Check then evaluate
 ```
+
+## Type Checking
+
+Type annotations live in declaration metadata alongside doc strings.
+All annotations are optional — unannotated code is treated as `any`.
+
+### Annotation syntax
+
+```eu,notest
+` { doc: "`double(x)` - double a number."
+    type: "number -> number" }
+double(x): x * 2
+
+# Operator
+` { doc: "..."
+    type: "a -> (a -> b) -> b"
+    associates: :left
+    precedence: 20 }
+(x |> f): f(x)
+```
+
+### Type aliases
+
+```eu,notest
+# In unit metadata
+{ types: { Person: "{name: string, age: number, ..}" } }
+
+# Via type-def: on a canonical instance
+` { type-def: "Point" }
+origin: { x: 0, y: 0 }
+```
+
+### Type forms
+
+| Syntax             | Meaning                                |
+|--------------------|----------------------------------------|
+| `number`           | number                                 |
+| `string`           | string                                 |
+| `symbol`           | symbol                                 |
+| `bool`             | boolean                                |
+| `null`             | null                                   |
+| `datetime`         | zoned date-time                        |
+| `any`              | gradual/unknown — no type errors       |
+| `[T]`              | homogeneous list of T                  |
+| `(A, B)`           | 2-tuple; `(A, B, C)` for triple        |
+| `(A,)`             | 1-tuple                                |
+| `{k: T}`           | closed record                          |
+| `{k: T, ..}`       | open record (at least k: T)            |
+| `block`            | any block (no known shape)             |
+| `A -> B`           | function                               |
+| `A \| B`           | union                                  |
+| `a`, `b`, `s`      | type variable (lowercase)              |
+| `IO(T)`            | IO action producing T                  |
+| `Lens(a, b)`       | lens focusing on b within a            |
+| `Traversal(a, b)`  | traversal over b's within a            |
+| `set`              | ordered set of primitives              |
+| `vec`              | flat vector of primitives              |
+| `array`            | n-dimensional number array             |

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -1,0 +1,413 @@
+# Type Checking
+
+Eucalypt includes an optional, advisory type checker. It never prevents
+your code from running — all existing code continues to work exactly as
+before. Think of it as a second pair of eyes that can catch common
+mistakes before they become confusing runtime errors.
+
+```sh
+eu check file.eu              # type-check, report warnings
+eu check file.eu --strict     # treat type warnings as errors
+eu --type-check file.eu       # check then evaluate
+```
+
+Type issues are reported as **warnings**, not errors. Your code runs
+regardless.
+
+---
+
+## What type checking catches
+
+The checker is most useful for catching a handful of mistakes that are
+easy to make and hard to debug:
+
+- **Passing an IO action where a plain value is expected.** `io.shell`
+  returns an `IO({..})`, not a block. Accessing `.stdout` on the action
+  itself is a common mistake the checker flags immediately.
+- **Accessing a missing or misspelled field on a block.** If you have
+  a block typed as `{name: string, age: number}`, accessing `.naem` is
+  a warning.
+- **Type mismatches in pipelines.** Piping a `string` into a function
+  expecting `number` produces a clear warning with a source location.
+- **Wrong lens composition.** `Lens(a, b)` composed with
+  `Lens(c, d)` requires `b = c`; the checker catches the mismatch.
+
+The checker works through inference — it does not require any
+annotations in your code. Annotated prelude functions (like `map`,
+`filter`, `str.of`, `io.shell`, `at`, `view`) propagate types through
+your pipelines automatically.
+
+## What type checking does not catch
+
+- **Runtime-dependent values.** If a function returns `any` (because
+  its type depends on a runtime value, like `lookup`), the checker
+  makes no assumptions about the result. This is correct — eucalypt
+  is gradual, not fully statically typed.
+- **Unannotated functions.** Code without `type:` annotations is
+  treated as `any -> any -> ... -> any`. The checker stays silent
+  rather than guessing.
+- **Dynamic block construction.** `block(kvs)` constructs a block
+  from a list of pairs at runtime; the checker cannot know its shape.
+
+---
+
+## Adding type annotations
+
+Annotations live in declaration metadata alongside doc strings:
+
+```eu,notest
+` { doc: "`double(x)` - double a number."
+    type: "number -> number" }
+double(x): x * 2
+```
+
+The `type:` value is a string containing a type expression. You can
+annotate as much or as little as you like. Unannotated declarations
+default to `any`.
+
+### Simple annotations
+
+```eu,notest
+` { type: "number -> number" }
+square(x): x * x
+
+` { type: "string -> string -> string" }
+greet(greeting, name): "{greeting}, {name}!"
+
+` { type: "[number] -> number" }
+total: fold(+, 0)
+```
+
+### Operators
+
+Operators use the same metadata syntax:
+
+```eu,notest
+` { doc: "`x |> f` - pipe x into f."
+    type: "a -> (a -> b) -> b"
+    associates: :left
+    precedence: 20 }
+(x |> f): f(x)
+```
+
+---
+
+## The type language
+
+### Primitives
+
+| Type       | Values                             |
+|------------|------------------------------------|
+| `number`   | integers and floats                |
+| `string`   | strings                            |
+| `symbol`   | symbolic atoms (`:key`, `:name`)   |
+| `bool`     | `true`, `false`                    |
+| `null`     | `null`                             |
+| `datetime` | zoned date-time values             |
+| `any`      | unknown — consistent with all types|
+
+### Lists
+
+`[T]` is a homogeneous list of `T`:
+
+```eu,notest
+` { type: "[number] -> [string]" }
+to-strings: map(str.of)
+
+` { type: "[a] -> a" }
+first: head
+```
+
+### Tuples
+
+Tuples use parentheses with commas:
+
+| Syntax    | Meaning          |
+|-----------|------------------|
+| `(A, B)`  | pair             |
+| `(A, B, C)` | triple         |
+| `(A,)`    | 1-tuple          |
+
+Tuples appear naturally in lens element types and in functions like
+`discriminate` that return pairs:
+
+```eu,notest
+` { type: "(a -> bool) -> [a] -> ([a], [a])" }
+discriminate: ...
+```
+
+### Records
+
+Records describe the shape of blocks:
+
+| Syntax           | Meaning                                           |
+|------------------|---------------------------------------------------|
+| `{k: T}`         | closed record — exactly the key `k` of type `T`  |
+| `{k: T, ..}`     | open record — at least `k: T`, may have more      |
+| `block`          | any block (no known shape)                        |
+
+```eu,notest
+` { type: "{name: string, age: number, ..} -> string" }
+greet-person(p): "Hello, {p.name}!"
+```
+
+Open records are more commonly useful — most block-processing functions
+don't require a specific shape.
+
+### Functions
+
+Arrow `->` is right-associative. Multi-argument functions are curried:
+
+```eu,notest
+# a -> b -> c  means  a -> (b -> c)
+` { type: "a -> b -> a" }
+const(k, _): k
+```
+
+### Unions
+
+`|` expresses "either type". Useful for overloaded functions:
+
+```eu,notest
+` { type: "number -> number | string -> string" }
+to-upper-or-double: ...
+```
+
+Overloaded operators use union types:
+```
++   : number -> number -> number | [a] -> [a] -> [a] | array -> array -> array
+<   : number -> number -> bool | string -> string -> bool | symbol -> symbol -> bool
+```
+
+### Type variables
+
+Lowercase identifiers are type variables, universally quantified at
+the declaration level:
+
+```eu,notest
+` { type: "(a -> b) -> [a] -> [b]" }
+map: ...
+```
+
+At call sites, type variables are instantiated from the argument types.
+`map(str.of, [1, 2])` instantiates `a = number, b = string`, giving
+result type `[string]`.
+
+### Special types
+
+| Type    | Meaning                                               |
+|---------|-------------------------------------------------------|
+| `any`   | gradual/dynamic — no errors involving `any`           |
+| `top`   | supertype of everything — nothing useful can be done with it |
+| `never` | bottom type — unreachable code, empty collections     |
+
+---
+
+## IO actions
+
+`IO(T)` is a proper type constructor, not a block with metadata.
+IO actions have dedicated runtime representations — they are
+genuinely distinct from the values they produce.
+
+This is the type checker's most valuable capability: catching the
+common mistake of treating an IO action as its result:
+
+```eu,notest
+# WRONG: io.shell returns IO(block), not block
+result: io.shell("echo hello")
+name: result.stdout              # warning: IO(block) has no field .stdout
+
+# RIGHT: extract fields inside the monad
+name: io.shell("echo hello") io.map(_.stdout)  # IO(string) ✓
+```
+
+The prelude IO functions are typed:
+
+| Function         | Type                              |
+|------------------|-----------------------------------|
+| `io.shell(cmd)`  | `string -> IO(block)`             |
+| `io.return(a)`   | `a -> IO(a)`                      |
+| `io.bind(a, c)`  | `IO(a) -> (a -> IO(b)) -> IO(b)` |
+| `io.map(f, a)`   | `(a -> b) -> IO(a) -> IO(b)`     |
+| `io.fail(msg)`   | `string -> IO(a)`                 |
+
+`IO(T)` is opaque. The only way to work with the value inside is
+through `io.bind`, `io.map`, or the IO runner. This prevents IO
+values from leaking into pure data.
+
+---
+
+## Lens and traversal types
+
+The lens library is typed with two opaque type constructors:
+
+| Type              | Meaning                                      |
+|-------------------|----------------------------------------------|
+| `Lens(a, b)`      | focuses on a single `b` within an `a`        |
+| `Traversal(a, b)` | focuses on zero or more `b`s within an `a`   |
+
+`Lens(a, b)` is a subtype of `Traversal(a, b)`.
+
+```eu,notest
+` { type: "symbol -> Lens(block, any)" }
+at(key, k): ...
+
+` { type: "number -> Lens([a], a)" }
+ix(n, k): ...
+
+` { type: "Lens(a, b) -> a -> b" }
+view(lens, data): ...
+
+` { type: "Lens(a, b) | Traversal(a, b) -> (b -> b) -> a -> a" }
+over(lens, fn, data): ...
+```
+
+Composition of lenses via `∘` chains optic types:
+- `Lens(a, b) ∘ Lens(b, c)` → `Lens(a, c)`
+- `Lens(a, b) ∘ Traversal(b, c)` → `Traversal(a, c)`
+
+The checker catches broken compositions:
+
+```eu,notest
+# Works: a block → string → number (hypothetical)
+path: at(:name) ∘ at(:length)
+
+# Warning: Lens(block, any) ∘ ix(0) — ix expects [a], not any
+bad-path: at(:name) ∘ ix(0)
+```
+
+---
+
+## Type aliases
+
+For complex or repeated types, define aliases at the top of your file
+using unit metadata:
+
+```eu,notest
+{ import: "data.eu"
+  types: { Person: "{name: string, age: number, email: string | null, ..}"
+           Response: "{status: number, body: string | null}" } }
+
+` { type: "[Person] -> [string]" }
+names: map(_.name)
+
+` { type: "Response -> bool" }
+success?(r): r.status < 400
+```
+
+Alternatively, use `type-def:` on a declaration to name the type of
+a canonical value:
+
+```eu,notest
+` { type-def: "Point" }
+origin: { x: 0, y: 0 }
+# Defines: Point = {x: number, y: number, ..}
+# And: origin : Point
+
+` { type: "Point -> Point -> number" }
+distance(a, b): ((b.x - a.x)^2 + (b.y - a.y)^2) abs
+```
+
+Combine `type:` and `type-def:` to override inference:
+
+```eu,notest
+` { type-def: "Person"
+    type: "{name: string, age: number, email: string | null, ..}" }
+nobody: { name: "", age: 0, email: null }
+```
+
+---
+
+## A worked example
+
+Consider a small data processing pipeline with type annotations:
+
+```eu,notest
+{ types: { Record: "{id: number, name: string, active: bool, ..}" } }
+
+` { type: "[Record] -> [Record]" }
+active-records: filter(_.active)
+
+` { type: "[Record] -> block" }
+index-by-id: group-by(_.id)
+
+` { type: "Record -> string" }
+summary(r): "[{r.id}] {r.name}"
+```
+
+With these annotations in place, the checker can verify downstream
+code:
+
+```eu,notest
+# Warning: filter expects (a -> bool), but str.of has type any -> string
+bad: records filter(str.of)
+
+# Fine: map over active records, produce strings
+ok: records active-records map(summary)
+```
+
+---
+
+## Open vs. closed records
+
+An **open record** `{k: T, ..}` says "has at least this key", allowing
+additional fields. A **closed record** `{k: T}` says "has exactly this
+key".
+
+In practice, open records are more useful because eucalypt blocks
+typically have variable shapes:
+
+```eu,notest
+# Open: works with any block that has a .name field
+` { type: "{name: string, ..} -> string" }
+get-name(b): b.name
+
+# Closed: only works with blocks of exactly this shape
+` { type: "{name: string}" }
+exact-block: { name: "Alice" }
+```
+
+Width subtyping means `{x: number, y: number}` is a subtype of
+`{x: number, ..}` — a more specific block satisfies a less specific
+requirement.
+
+---
+
+## Namespace typing
+
+Functions within namespace blocks (`str`, `arr`, `set`, etc.) are
+annotated in the same way:
+
+```eu,notest
+str: {
+  ` { type: "any -> string" }
+  of: __STR
+
+  ` { type: "string -> number" }
+  len: __STR_LEN
+}
+```
+
+The checker synthesises the block's record type from its members, so
+`str.len` resolves to `string -> number` via standard record field
+lookup.
+
+---
+
+## Summary
+
+| What                     | How                                   |
+|--------------------------|---------------------------------------|
+| Run the checker          | `eu check file.eu`                    |
+| Treat warnings as errors | `eu check file.eu --strict`           |
+| Annotate a declaration   | `` ` { type: "number -> number" } ``  |
+| Any block                | `block`                               |
+| Open record              | `{k: T, ..}`                          |
+| Closed record            | `{k: T}`                              |
+| IO action                | `IO(T)`                               |
+| Lens                     | `Lens(a, b)`                          |
+| Traversal                | `Traversal(a, b)`                     |
+| Type variable            | lowercase identifier: `a`, `b`, `s`   |
+| Union type               | `A \| B`                              |
+| Type alias (unit meta)   | `{ types: { Name: "..." } }`          |
+| Type alias (declaration) | `` ` { type-def: "Name" } ``          |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -108,6 +108,52 @@ main: { result: 42 }
 result: helper(42)
 ```
 
+**Type annotations** (optional, advisory): add `type:` alongside `doc:`
+to annotate declarations for the type checker (`eu check`):
+
+```eu,notest
+` { doc: "`double(x)` - double a number."
+    type: "number -> number" }
+double(x): x * 2
+
+` { doc: "`map(f, xs)` - apply f to each element."
+    type: "(a -> b) -> [a] -> [b]" }
+map: __MAP
+```
+
+**Type aliases**: define reusable type names in unit metadata or via
+`type-def:` on a declaration:
+
+```eu,notest
+# Named aliases in unit metadata
+{ types: { Point: "{x: number, y: number}"
+           Person: "{name: string, age: number, email: string | null, ..}" } }
+
+# Alias derived from a canonical instance
+` { type-def: "Point" }
+origin: { x: 0, y: 0 }
+```
+
+**Common type forms in annotations**:
+
+| Syntax             | Meaning                                |
+|--------------------|----------------------------------------|
+| `number`, `string`, `symbol`, `bool`, `null`, `datetime` | primitives |
+| `any`              | gradual/unknown — no type errors       |
+| `[T]`              | list of T                              |
+| `(A, B)`           | tuple                                  |
+| `{k: T, ..}`       | open record (at least k: T)            |
+| `{k: T}`           | closed record                          |
+| `block`            | any block                              |
+| `A -> B`           | function                               |
+| `A \| B`           | union                                  |
+| `a`, `b`           | type variable                          |
+| `IO(T)`            | IO action producing T                  |
+| `Lens(a, b)`       | lens                                   |
+| `Traversal(a, b)`  | traversal                              |
+
+See [Type Checking](../guide/type-checking.md) for the full guide.
+
 ### 1.6 Function Application
 
 ```eu,notest


### PR DESCRIPTION
## Summary

- New guide chapter `docs/guide/type-checking.md` — practical, example-driven introduction to the gradual type system
- Type checking section added to `docs/appendices/cheat-sheet.md`
- Type annotation format documented in `docs/reference/agent-reference.md`
- New chapter added to `docs/SUMMARY.md` navigation

## New chapter covers

- What `eu check` does (optional, advisory, warnings not errors)
- Adding `type:` annotations to declarations via metadata
- Full type language reference: primitives, lists, tuples, records, functions, unions, type variables, `any`
- Special types: `IO(T)`, `Lens(a, b)`, `Traversal(a, b)`
- What the checker catches (IO/value confusion, missing fields, pipeline mismatches, lens composition errors)
- What it does not catch (runtime-dependent values, unannotated code)
- Type aliases via `types:` unit metadata and `type-def:`
- Open vs. closed records
- Namespace typing (`str`, `arr`, etc.)
- Worked examples with real warnings

## Test plan

- [x] All `eu` code blocks use `eu,notest` (19/19)
- [x] Links and navigation entries consistent with existing structure
- [x] No behaviour changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)