### PR TITLE
feat: LSP type integration — hover, inlay hints, annotation validation (eu-glnv)

### DIFF
--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -270,6 +270,36 @@ fn extract_type_annotation(meta_block: &Block, decl_name: &str) -> Option<Annota
     None
 }
 
+/// Return `(TextRange, error_message)` pairs for invalid `type:` annotations.
+///
+/// Exposed for the LSP diagnostic provider, which uses these to emit
+/// `DiagnosticSeverity::WARNING` diagnostics with accurate source ranges.
+pub fn annotation_syntax_errors(source: &str) -> Vec<(rowan::TextRange, String)> {
+    let parse_result = parse_unit(source);
+    let unit = parse_result.tree();
+    let annotations = collect_annotations_from_unit(&unit, source);
+
+    annotations
+        .into_iter()
+        .filter_map(|ann| {
+            if let Err(e) = parse::parse_type(&ann.value) {
+                // Reconstruct a TextRange covering the annotation string literal.
+                // source_offset is the start of the literal node.
+                let start = rowan::TextSize::from(ann.source_offset as u32);
+                let end = start + rowan::TextSize::from(ann.value.len() as u32 + 2); // +2 for quotes
+                let range = rowan::TextRange::new(start, end);
+                let msg = format!(
+                    "invalid type annotation on '{}': {}",
+                    ann.decl_name, e
+                );
+                Some((range, msg))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Attempt to extract a human-readable name from a declaration head.
 fn declaration_name(decl: &Declaration) -> String {
     let Some(head) = decl.head() else {

--- a/src/driver/lsp/diagnostics.rs
+++ b/src/driver/lsp/diagnostics.rs
@@ -5,9 +5,29 @@
 //! positions by scanning the source text for line breaks.
 
 use crate::core::typecheck::error::TypeWarning;
+use crate::driver::check::annotation_syntax_errors;
 use crate::syntax::rowan::ParseError;
 use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use rowan::TextRange;
+
+/// Validate `type:` annotation syntax in a source file and return LSP diagnostics.
+///
+/// Scans the Rowan AST for `type:` metadata entries and parses their string
+/// values against the type grammar.  Invalid annotations produce
+/// `DiagnosticSeverity::WARNING` diagnostics so that they never block evaluation.
+pub fn diagnostics_from_annotation_syntax(source: &str) -> Vec<Diagnostic> {
+    let line_index = LineIndex::new(source);
+    annotation_syntax_errors(source)
+        .into_iter()
+        .map(|(range, msg)| Diagnostic {
+            range: line_index.range(range),
+            severity: Some(DiagnosticSeverity::WARNING),
+            source: Some("eucalypt-types".to_string()),
+            message: msg,
+            ..Diagnostic::default()
+        })
+        .collect()
+}
 
 /// Convert a collection of parse errors into LSP diagnostics.
 pub fn diagnostics_from_parse_errors(source: &str, errors: &[ParseError]) -> Vec<Diagnostic> {
@@ -486,6 +506,37 @@ mod tests {
         let source = "x: 1\n";
         let files: SimpleFiles<String, String> = SimpleFiles::new();
         let diags = diagnostics_from_type_warnings(source, &[], &files);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn valid_annotation_syntax_gives_no_diagnostic() {
+        let source = "` { type: \"number -> number\" }\nf(x): x\n";
+        let diags = diagnostics_from_annotation_syntax(source);
+        assert!(
+            diags.is_empty(),
+            "valid annotation should produce no diagnostics"
+        );
+    }
+
+    #[test]
+    fn invalid_annotation_syntax_gives_warning() {
+        let source = "` { type: \"number ->\" }\nf(x): x\n";
+        let diags = diagnostics_from_annotation_syntax(source);
+        assert_eq!(diags.len(), 1, "invalid annotation should produce one diagnostic");
+        assert_eq!(diags[0].severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diags[0].source.as_deref(), Some("eucalypt-types"));
+        assert!(
+            diags[0].message.contains("invalid type annotation"),
+            "message should mention invalid annotation, got: {}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn no_annotations_gives_no_diagnostic() {
+        let source = "x: 1\ny: 2\n";
+        let diags = diagnostics_from_annotation_syntax(source);
         assert!(diags.is_empty());
     }
 }

--- a/src/driver/lsp/hover.rs
+++ b/src/driver/lsp/hover.rs
@@ -61,6 +61,11 @@ fn make_hover(sym: &SymbolInfo, qualifier: Option<&str>) -> Hover {
         }
     }
 
+    // Type annotation
+    if let Some(ty) = &sym.type_annotation {
+        lines.push(format!("**Type:** `{}`", ty));
+    }
+
     // Source information
     let uri_str = sym.uri.as_str();
     if uri_str.starts_with("resource:") || uri_str.contains("prelude") {
@@ -170,6 +175,32 @@ mod tests {
         let h = result.unwrap();
         if let HoverContents::Markup(m) = &h.contents {
             assert!(m.value.contains("A helper"), "should include documentation");
+        } else {
+            panic!("expected markup content");
+        }
+    }
+
+    #[test]
+    fn test_hover_with_type_annotation() {
+        let source = "` { type: \"number -> number\" }\nf(x): x\ny: f(1)\n";
+        let (table, _) = setup_table(source);
+        let parse = parse_unit(source);
+        let root = parse.syntax_node();
+
+        let pos = Position {
+            line: 2,
+            character: 3,
+        };
+        let result = hover(source, &root, &pos, &table);
+        assert!(result.is_some());
+        let h = result.unwrap();
+        if let HoverContents::Markup(m) = &h.contents {
+            assert!(
+                m.value.contains("number -> number"),
+                "should include type annotation, got: {}",
+                m.value
+            );
+            assert!(m.value.contains("Type:"), "should label the type");
         } else {
             panic!("expected markup content");
         }

--- a/src/driver/lsp/inlay_hints.rs
+++ b/src/driver/lsp/inlay_hints.rs
@@ -43,6 +43,27 @@ fn collect_hints_from_unit(
             continue;
         }
 
+        // Type annotation inlay hints
+        if let Some(head) = decl.head() {
+            let head_range = text_range_to_lsp_range(source, head.syntax().text_range());
+            if let Some(head_name) = head_name_str(&head) {
+                if let Some(sym) = table.lookup(&head_name).into_iter().next() {
+                    if let Some(ty) = &sym.type_annotation {
+                        hints.push(InlayHint {
+                            position: head_range.end,
+                            label: InlayHintLabel::String(format!(": {ty}")),
+                            kind: Some(InlayHintKind::TYPE),
+                            text_edits: None,
+                            tooltip: None,
+                            padding_left: Some(true),
+                            padding_right: Some(false),
+                            data: None,
+                        });
+                    }
+                }
+            }
+        }
+
         // Operator fixity hints
         if let Some(head) = decl.head() {
             let kind = head.classify_declaration();
@@ -55,6 +76,16 @@ fn collect_hints_from_unit(
                 collect_parameter_hints_from_soup(source, &soup, range, table, hints);
             }
         }
+    }
+}
+
+/// Extract the primary identifier text from a declaration head, for symbol table lookup.
+fn head_name_str(head: &ast::DeclarationHead) -> Option<String> {
+    match head.classify_declaration() {
+        ast::DeclarationKind::Property(id) | ast::DeclarationKind::Function(id, _) => {
+            Some(id.text().to_string())
+        }
+        _ => None,
     }
 }
 
@@ -251,6 +282,54 @@ mod tests {
             param_hints.len(),
             2,
             "should have 2 param hints for f(1, 2)"
+        );
+    }
+
+    #[test]
+    fn type_annotation_hint_shown_on_declaration() {
+        let source = "` { type: \"number -> number\" }\nf(x): x\n";
+        let parse = parse_unit(source);
+        let root = parse.syntax_node();
+        let table = make_table(source);
+        let hints = inlay_hints(source, &root, &full_range(), &table);
+        let type_hints: Vec<_> = hints
+            .iter()
+            .filter(|h| h.kind == Some(InlayHintKind::TYPE))
+            .collect();
+        assert!(
+            !type_hints.is_empty(),
+            "should have a type annotation inlay hint"
+        );
+        match &type_hints[0].label {
+            InlayHintLabel::String(s) => {
+                assert!(
+                    s.contains("number -> number"),
+                    "should show type annotation, got: {s}"
+                );
+            }
+            _ => panic!("expected string label"),
+        }
+    }
+
+    #[test]
+    fn no_type_hint_without_annotation() {
+        let source = "f(x): x\n";
+        let parse = parse_unit(source);
+        let root = parse.syntax_node();
+        let table = make_table(source);
+        let hints = inlay_hints(source, &root, &full_range(), &table);
+        // Only operator hints or param hints — no type annotation hint for f
+        // (f has no type annotation in metadata)
+        let type_hints_for_f: Vec<_> = hints
+            .iter()
+            .filter(|h| {
+                h.kind == Some(InlayHintKind::TYPE)
+                    && matches!(&h.label, InlayHintLabel::String(s) if s.contains("->"))
+            })
+            .collect();
+        assert!(
+            type_hints_for_f.is_empty(),
+            "should not show type hint for unannotated function"
         );
     }
 

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -606,7 +606,11 @@ fn publish_diagnostics(
     let parse = crate::syntax::rowan::parse_unit(text);
     let mut diags = diagnostics::diagnostics_from_parse_errors(text, parse.errors());
 
-    // Merge type warnings (currently none — placeholder for future type checker)
+    // Validate type annotation syntax (Phase 1 check — no pipeline needed).
+    let annotation_diags = diagnostics::diagnostics_from_annotation_syntax(text);
+    diags.extend(annotation_diags);
+
+    // Full bidirectional type check requires the compiled pipeline; not run in LSP yet.
     let files: SimpleFiles<String, String> = SimpleFiles::new();
     let type_warnings = diagnostics::diagnostics_from_type_warnings(text, &[], &files);
     diags.extend(type_warnings);

--- a/src/driver/lsp/symbol_table.rs
+++ b/src/driver/lsp/symbol_table.rs
@@ -56,6 +56,8 @@ pub struct SymbolInfo {
     pub selection_range: lsp_types::Range,
     /// Documentation from `` ` { doc: "..." } `` metadata
     pub documentation: Option<String>,
+    /// Type annotation string from `` ` { type: "..." } `` metadata
+    pub type_annotation: Option<String>,
     /// Parameter names for functions
     pub parameters: Vec<String>,
     /// Child symbols (for namespace blocks)
@@ -242,6 +244,7 @@ fn symbol_from_declaration(
     let range = text_range_to_lsp_range(source_text, decl.syntax().text_range());
     let selection_range = text_range_to_lsp_range(source_text, head.syntax().text_range());
     let documentation = extract_documentation(decl);
+    let type_annotation = extract_type_annotation(decl);
     let children = extract_children(decl, source_text, uri, source);
 
     Some(SymbolInfo {
@@ -252,6 +255,7 @@ fn symbol_from_declaration(
         range,
         selection_range,
         documentation,
+        type_annotation,
         parameters,
         children,
     })
@@ -299,6 +303,42 @@ fn extract_documentation(decl: &Declaration) -> Option<String> {
                 }
             }
             _ => {}
+        }
+    }
+    None
+}
+
+/// Extract a type annotation string from declaration metadata.
+///
+/// Looks for `` ` { type: "..." } `` in the declaration's metadata.
+fn extract_type_annotation(decl: &Declaration) -> Option<String> {
+    let meta = decl.meta()?;
+    let soup = meta.soup()?;
+
+    for element in soup.elements() {
+        if let crate::syntax::rowan::ast::Element::Block(block) = element {
+            for inner_decl in block.declarations() {
+                if let Some(head) = inner_decl.head() {
+                    if let DeclarationKind::Property(prop) = head.classify_declaration() {
+                        if prop.text() == "type" {
+                            if let Some(body) = inner_decl.body() {
+                                if let Some(body_soup) = body.soup() {
+                                    for el in body_soup.elements() {
+                                        if let crate::syntax::rowan::ast::Element::Lit(lit) = el {
+                                            if let Some(
+                                                crate::syntax::rowan::ast::LiteralValue::Str(s),
+                                            ) = lit.value()
+                                            {
+                                                return s.value().map(|v| v.to_string());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
     None
@@ -502,5 +542,61 @@ mod tests {
 
         let filter = table.lookup("filter");
         assert!(!filter.is_empty(), "prelude should contain 'filter'");
+    }
+
+    #[test]
+    fn test_type_annotation_extraction() {
+        let source = "` { type: \"number -> number\" }\nf(x): x\n";
+        let parse = parse_unit(source);
+        let unit = parse.tree();
+        let mut table = SymbolTable::new();
+        table.add_from_unit(&unit, source, &test_uri(), SymbolSource::Local);
+
+        let results = table.lookup("f");
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].type_annotation.as_deref(),
+            Some("number -> number")
+        );
+    }
+
+    #[test]
+    fn test_no_type_annotation_without_metadata() {
+        let source = "f(x): x\n";
+        let parse = parse_unit(source);
+        let unit = parse.tree();
+        let mut table = SymbolTable::new();
+        table.add_from_unit(&unit, source, &test_uri(), SymbolSource::Local);
+
+        let results = table.lookup("f");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].type_annotation.is_none());
+    }
+
+    #[test]
+    fn test_doc_and_type_annotation_together() {
+        let source = "` { doc: \"A helper\" type: \"a -> a\" }\nid(x): x\n";
+        let parse = parse_unit(source);
+        let unit = parse.tree();
+        let mut table = SymbolTable::new();
+        table.add_from_unit(&unit, source, &test_uri(), SymbolSource::Local);
+
+        let results = table.lookup("id");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].documentation.as_deref(), Some("A helper"));
+        assert_eq!(results[0].type_annotation.as_deref(), Some("a -> a"));
+    }
+
+    #[test]
+    fn test_prelude_map_has_type_annotation() {
+        let uri = Url::parse("file:///prelude").unwrap();
+        let table = prelude_symbols(&uri);
+
+        let map = table.lookup("map");
+        assert!(!map.is_empty(), "prelude should contain 'map'");
+        assert!(
+            map[0].type_annotation.is_some(),
+            "map should have a type annotation"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `type_annotation: Option<String>` to `SymbolInfo`, extracted from `` ` { type: "..." } `` metadata at AST parse time
- Displays type annotations in hover popups: **Type:** \`number -> number\`
- Shows type annotation inlay hints on declaration heads for annotated symbols
- Validates `type:` annotation syntax on every document open/change; invalid type strings produce `DiagnosticSeverity::WARNING` diagnostics with accurate source ranges (Phase 1 check, no pipeline required)
- Exposes `annotation_syntax_errors()` from `driver::check` for LSP reuse

## What is not yet included

The full bidirectional type check (Phase 2) requires running the compiled pipeline against the source file. This is architecturally non-trivial in the LSP context (no `EucalyptOptions`, no lib path). The infrastructure (`diagnostics_from_type_warnings`) is already in place; wiring the full pipeline is a follow-up.

## Test plan

- [ ] `cargo test --lib -- lsp` — all 127 tests pass (10 new)
- [ ] Open a `.eu` file with `type:` annotations in a client — hover over annotated symbols shows the type string
- [ ] Write an invalid type annotation (`type: "number ->"`) — should see a yellow warning squiggle on the annotation string
- [ ] Valid annotations produce no diagnostic squiggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)