### PR TITLE
fix: code review findings — humanise vars, block keyword, tests, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ Eucalypt is a Rust-based tool and language for generating, templating, rendering
 - `cargo run` - Run the eucalypt binary
 - `cargo install --path .` - Install local `eu` binary
 
+### Type Checking
+- `eu check file.eu` - Type-check a file (report warnings)
+- `eu check --strict file.eu` - Type-check with warnings as errors
+- `eu --type-check file.eu` - Type-check then evaluate (warnings to stderr)
+
 ### Testing
 - `cargo test` - Run all tests including the comprehensive harness test suite
 - `cargo test test_harness_001` - Run a specific harness test (e.g., test 001)
@@ -41,6 +46,7 @@ Eucalypt is a Rust-based tool and language for generating, templating, rendering
 - `simplify/` - Expression simplification and optimization
 - `transform/` - Various AST transformations
 - `inline/` - Inlining and reduction passes
+- `typecheck/` - Gradual type system: type representation, parser, subtyping, bidirectional checker, polymorphic instantiation
 
 **Evaluation (`src/eval/`)**:
 - `machine/` - Virtual machine implementation with garbage collection

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -719,9 +719,10 @@ impl Checker {
     // ── Warning emission ─────────────────────────────────────────────────────
 
     fn emit_type_mismatch(&mut self, smid: Smid, expected: &Type, found: &Type, message: &str) {
+        use super::types::humanise;
         let warning = TypeWarning::new(message)
             .at(smid)
-            .with_types(expected.to_string(), found.to_string());
+            .with_types(humanise(expected).to_string(), humanise(found).to_string());
         self.warnings.push(warning);
     }
 }

--- a/src/core/typecheck/error.rs
+++ b/src/core/typecheck/error.rs
@@ -9,7 +9,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 ///
 /// Type issues are reported as warnings so that they never prevent evaluation.
 /// The `--strict` flag in `eu check` can promote these to errors.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeWarning {
     /// Human-readable description of the warning.
     pub message: String,

--- a/src/core/typecheck/parse.rs
+++ b/src/core/typecheck/parse.rs
@@ -79,6 +79,7 @@ enum Token {
     Set,
     Vec,
     Array,
+    Block,
     // Type constructors
     Io,
     Lens,
@@ -226,6 +227,7 @@ impl<'a> Lexer<'a> {
                     "set" => Token::Set,
                     "vec" => Token::Vec,
                     "array" => Token::Array,
+                    "block" => Token::Block,
                     "IO" => Token::Io,
                     "Lens" => Token::Lens,
                     "Traversal" => Token::Traversal,
@@ -356,6 +358,10 @@ impl<'a> Parser<'a> {
             Token::Set => Ok(Type::Set),
             Token::Vec => Ok(Type::Vec),
             Token::Array => Ok(Type::Array),
+            Token::Block => Ok(Type::Record {
+                fields: BTreeMap::new(),
+                open: true,
+            }),
             Token::Ident(name) => {
                 // Type variable (lowercase) or type alias reference (uppercase).
                 //
@@ -629,6 +635,18 @@ mod tests {
         assert_eq!(parse_type("set").unwrap(), Type::Set);
         assert_eq!(parse_type("vec").unwrap(), Type::Vec);
         assert_eq!(parse_type("array").unwrap(), Type::Array);
+        // `block` is shorthand for open empty record `{..}`
+        assert_eq!(
+            parse_type("block").unwrap(),
+            Type::Record {
+                fields: BTreeMap::new(),
+                open: true
+            }
+        );
+        assert_eq!(
+            parse_type("symbol → block → any").unwrap(),
+            parse_type("symbol → {..} → any").unwrap(),
+        );
     }
 
     // ── Type variables ──────────────────────────────────────────────────────

--- a/src/core/typecheck/types.rs
+++ b/src/core/typecheck/types.rs
@@ -217,6 +217,99 @@ impl fmt::Display for Type {
     }
 }
 
+/// Replace internal unification variables (`_t0`, `_t1`, etc.) with
+/// user-friendly names (`a`, `b`, `c`, ...) for display in diagnostics.
+///
+/// Named type variables (e.g. from annotations) are left unchanged.
+/// Only variables whose name starts with `_t` are replaced.
+pub fn humanise(ty: &Type) -> Type {
+    use std::collections::HashMap;
+
+    fn collect_fresh_vars(ty: &Type, seen: &mut Vec<String>) {
+        match ty {
+            Type::Var(v) if v.0.starts_with("_t") && !seen.contains(&v.0) => {
+                seen.push(v.0.clone());
+            }
+            Type::List(inner) | Type::IO(inner) => collect_fresh_vars(inner, seen),
+            Type::Tuple(elems) => {
+                for e in elems {
+                    collect_fresh_vars(e, seen);
+                }
+            }
+            Type::Function(a, b) | Type::Lens(a, b) | Type::Traversal(a, b) => {
+                collect_fresh_vars(a, seen);
+                collect_fresh_vars(b, seen);
+            }
+            Type::Record { fields, .. } => {
+                for v in fields.values() {
+                    collect_fresh_vars(v, seen);
+                }
+            }
+            Type::Union(variants) => {
+                for v in variants {
+                    collect_fresh_vars(v, seen);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn replace(ty: &Type, mapping: &HashMap<String, String>) -> Type {
+        match ty {
+            Type::Var(v) => {
+                if let Some(replacement) = mapping.get(&v.0) {
+                    Type::Var(TypeVarId(replacement.clone()))
+                } else {
+                    ty.clone()
+                }
+            }
+            Type::List(inner) => Type::List(Box::new(replace(inner, mapping))),
+            Type::IO(inner) => Type::IO(Box::new(replace(inner, mapping))),
+            Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| replace(e, mapping)).collect()),
+            Type::Function(a, b) => {
+                Type::Function(Box::new(replace(a, mapping)), Box::new(replace(b, mapping)))
+            }
+            Type::Lens(a, b) => {
+                Type::Lens(Box::new(replace(a, mapping)), Box::new(replace(b, mapping)))
+            }
+            Type::Traversal(a, b) => {
+                Type::Traversal(Box::new(replace(a, mapping)), Box::new(replace(b, mapping)))
+            }
+            Type::Record { fields, open } => Type::Record {
+                fields: fields
+                    .iter()
+                    .map(|(k, v)| (k.clone(), replace(v, mapping)))
+                    .collect(),
+                open: *open,
+            },
+            Type::Union(variants) => {
+                Type::Union(variants.iter().map(|v| replace(v, mapping)).collect())
+            }
+            _ => ty.clone(),
+        }
+    }
+
+    let mut fresh_vars = Vec::new();
+    collect_fresh_vars(ty, &mut fresh_vars);
+
+    if fresh_vars.is_empty() {
+        return ty.clone();
+    }
+
+    let mut mapping = HashMap::new();
+    for (i, var_name) in fresh_vars.iter().enumerate() {
+        let letter = (b'a' + (i as u8 % 26)) as char;
+        let name = if i < 26 {
+            letter.to_string()
+        } else {
+            format!("{letter}{}", i / 26)
+        };
+        mapping.insert(var_name.clone(), name);
+    }
+
+    replace(ty, &mapping)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -347,5 +440,40 @@ mod tests {
             ),
         );
         assert_eq!(s.to_string(), "forall a b. (a → b) → [a] → [b]");
+    }
+
+    #[test]
+    fn humanise_replaces_fresh_vars() {
+        let ty = Type::Function(
+            Box::new(var("_t0")),
+            Box::new(Type::List(Box::new(var("_t1")))),
+        );
+        let h = humanise(&ty);
+        assert_eq!(h.to_string(), "a → [b]");
+    }
+
+    #[test]
+    fn humanise_preserves_named_vars() {
+        let ty = Type::Function(Box::new(var("x")), Box::new(var("y")));
+        let h = humanise(&ty);
+        assert_eq!(h.to_string(), "x → y");
+    }
+
+    #[test]
+    fn humanise_mixed_vars() {
+        let ty = Type::Function(
+            Box::new(var("_t5")),
+            Box::new(Type::Function(Box::new(var("x")), Box::new(var("_t5")))),
+        );
+        let h = humanise(&ty);
+        // _t5 becomes 'a', x stays 'x', second _t5 also becomes 'a'
+        assert_eq!(h.to_string(), "a → x → a");
+    }
+
+    #[test]
+    fn humanise_no_change_for_concrete() {
+        let ty = Type::Function(Box::new(Type::Number), Box::new(Type::String));
+        let h = humanise(&ty);
+        assert_eq!(h.to_string(), "number → string");
     }
 }

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -167,12 +167,17 @@ pub struct PathCheckResult {
 /// Run the type checker on a single eucalypt source file, returning both
 /// warnings and the inferred type environment.
 ///
-/// Returns an empty result if the pipeline fails.
+/// If the pipeline fails at any stage, returns a single warning
+/// explaining which stage failed rather than silently producing no
+/// results.
 pub fn type_check_path_full(path: &Path) -> PathCheckResult {
+    use crate::core::typecheck::error::TypeWarning;
     use crate::syntax::input::{Input, Locator};
 
-    let empty = PathCheckResult {
-        warnings: vec![],
+    let pipeline_error = |stage: &str, err: &dyn std::fmt::Display| PathCheckResult {
+        warnings: vec![TypeWarning::new(format!(
+            "type checking unavailable: {stage} failed: {err}"
+        ))],
         types: std::collections::HashMap::new(),
         source_map: crate::common::sourcemap::SourceMap::new(),
     };
@@ -184,23 +189,23 @@ pub fn type_check_path_full(path: &Path) -> PathCheckResult {
     let mut loader = SourceLoader::new(vec![]);
 
     for input in &inputs {
-        if loader.load(input).is_err() {
-            return empty;
+        if let Err(e) = loader.load(input) {
+            return pipeline_error("load", &e);
         }
     }
     for input in &inputs {
-        if loader.translate(input).is_err() {
-            return empty;
+        if let Err(e) = loader.translate(input) {
+            return pipeline_error("desugar", &e);
         }
     }
-    if loader.merge_units(&inputs).is_err() {
-        return empty;
+    if let Err(e) = loader.merge_units(&inputs) {
+        return pipeline_error("merge", &e);
     }
-    if loader.cook().is_err() {
-        return empty;
+    if let Err(e) = loader.cook() {
+        return pipeline_error("cook", &e);
     }
-    if loader.eliminate().is_err() {
-        return empty;
+    if let Err(e) = loader.eliminate() {
+        return pipeline_error("eliminate", &e);
     }
 
     let core_expr = loader.core().expr.clone();
@@ -305,16 +310,16 @@ fn byte_offset_to_line_col(source: &str, offset: usize) -> String {
 }
 
 /// Collect all `type:` annotations from a `Unit`.
-fn collect_annotations_from_unit(unit: &ast::Unit, source: &str) -> Vec<Annotation> {
+fn collect_annotations_from_unit(unit: &ast::Unit, _source: &str) -> Vec<Annotation> {
     let mut result = Vec::new();
     for decl in unit.declarations() {
-        collect_annotations_from_decl(&decl, source, &mut result);
+        collect_annotations_from_decl(&decl, &mut result);
     }
     result
 }
 
 /// Collect `type:` annotations from a declaration (and any nested blocks in its body).
-fn collect_annotations_from_decl(decl: &Declaration, source: &str, out: &mut Vec<Annotation>) {
+fn collect_annotations_from_decl(decl: &Declaration, out: &mut Vec<Annotation>) {
     let decl_name = declaration_name(decl);
 
     // Inspect the declaration's backtick metadata block for a `type:` field.
@@ -334,7 +339,7 @@ fn collect_annotations_from_decl(decl: &Declaration, source: &str, out: &mut Vec
         if let Some(body_soup) = body.soup() {
             for elem in body_soup.elements() {
                 if let Element::Block(inner_block) = elem {
-                    collect_annotations_from_block(&inner_block, source, out);
+                    collect_annotations_from_block(&inner_block, out);
                 }
             }
         }
@@ -342,9 +347,9 @@ fn collect_annotations_from_decl(decl: &Declaration, source: &str, out: &mut Vec
 }
 
 /// Collect `type:` annotations from all declarations within a block.
-fn collect_annotations_from_block(block: &Block, source: &str, out: &mut Vec<Annotation>) {
+fn collect_annotations_from_block(block: &Block, out: &mut Vec<Annotation>) {
     for decl in block.declarations() {
-        collect_annotations_from_decl(&decl, source, out);
+        collect_annotations_from_decl(&decl, out);
     }
 }
 

--- a/tests/harness/147_type_annotations.eu
+++ b/tests/harness/147_type_annotations.eu
@@ -1,0 +1,13 @@
+# Type annotation smoke test
+#
+# Verifies that type annotations in metadata are inert — they do not
+# affect evaluation.
+
+` { type: "number → number" }
+double(x): x * 2
+
+` { type: "(a → b) → [a] → [b]" }
+my-map: map
+
+a: double(21) //= 42
+b: [1, 2, 3] my-map(double) //= [2, 4, 6]

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1475,3 +1475,8 @@ pub fn test_harness_144() {
 pub fn test_harness_145() {
     run_test(&opts("145_list_monad.eu"));
 }
+
+#[test]
+pub fn test_harness_147() {
+    run_test(&opts("147_type_annotations.eu"));
+}


### PR DESCRIPTION
## Summary

Addresses findings from the code review of integration/0.6:

### Critical
- **C3**: Internal unification variables (`_t0`, `_t15`) no longer leak into user-facing warnings. New `humanise()` function replaces them with sequential letters (`a`, `b`, `c`, ...) before display.

### Important
- **I3**: `block` is now a proper type parser keyword, equivalent to `{..}` (open empty record). Avoids confusion with it being treated as a type variable.
- **I4**: CLAUDE.md updated with type checking commands (`eu check`, `eu --type-check`) and `typecheck/` in architecture section.
- **I2/M8**: New harness test 147 verifying type annotations are inert during evaluation.

### Minor
- **M5**: `TypeWarning` now derives `PartialEq`/`Eq` for easier test assertions.
- **M7**: Removed unused `source` parameter from annotation collection functions.

## Test plan
- [x] 838 lib tests pass (4 new: humanise, block keyword)
- [x] Harness test 147 passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)