### PR TITLE
feat: add literal symbol types to the type checker

### DIFF
--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -742,7 +742,7 @@ fn synthesise_primitive(prim: &Primitive) -> Type {
     match prim {
         Primitive::Num(_) => Type::Number,
         Primitive::Str(_) => Type::String,
-        Primitive::Sym(_) => Type::Symbol,
+        Primitive::Sym(name) => Type::LiteralSymbol(name.clone()),
         Primitive::Bool(_) => Type::Bool,
         Primitive::Null => Type::Null,
     }
@@ -877,7 +877,10 @@ mod tests {
     #[test]
     fn synthesise_symbol_literal() {
         let mut c = Checker::new();
-        assert_eq!(c.synthesise(&sym_lit("foo")), Type::Symbol);
+        assert_eq!(
+            c.synthesise(&sym_lit("foo")),
+            Type::LiteralSymbol("foo".to_string())
+        );
     }
 
     #[test]

--- a/src/core/typecheck/parse.rs
+++ b/src/core/typecheck/parse.rs
@@ -412,6 +412,41 @@ impl<'a> Parser<'a> {
                 self.expect(&Token::RParen)?;
                 Ok(Type::Traversal(Box::new(a), Box::new(b)))
             }
+            Token::Colon => {
+                // Literal symbol type: `:ident`
+                //
+                // After `:`, we accept any identifier-like token — including
+                // keywords that the lexer maps to their own token variants
+                // (e.g. `number`, `string`).  These are all valid symbol names
+                // in eucalypt.
+                let (next_tok, next_pos) = self.advance()?;
+                let name = match &next_tok {
+                    Token::Ident(name) => name.clone(),
+                    Token::Number => "number".to_string(),
+                    Token::String => "string".to_string(),
+                    Token::Symbol => "symbol".to_string(),
+                    Token::Bool => "bool".to_string(),
+                    Token::Null => "null".to_string(),
+                    Token::Datetime => "datetime".to_string(),
+                    Token::Any => "any".to_string(),
+                    Token::Top => "top".to_string(),
+                    Token::Never => "never".to_string(),
+                    Token::Set => "set".to_string(),
+                    Token::Vec => "vec".to_string(),
+                    Token::Array => "array".to_string(),
+                    Token::Block => "block".to_string(),
+                    Token::Io => "IO".to_string(),
+                    Token::Lens => "Lens".to_string(),
+                    Token::Traversal => "Traversal".to_string(),
+                    _ => {
+                        return Err(ParseError::new(
+                            next_pos,
+                            format!("expected an identifier after ':' in literal symbol type, got {next_tok:?}"),
+                        ));
+                    }
+                };
+                Ok(Type::LiteralSymbol(name))
+            }
             other => Err(ParseError::new(
                 tok_pos,
                 format!("expected a type, got {other:?}"),
@@ -1064,6 +1099,42 @@ mod tests {
         let err = parse_type("[number").unwrap_err();
         // Position should be non-zero (after `[number`)
         assert!(err.position > 0);
+    }
+
+    // ── Literal symbol types ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_literal_symbol() {
+        assert_eq!(
+            parse_type(":active").unwrap(),
+            Type::LiteralSymbol("active".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_literal_symbol_union() {
+        assert_eq!(
+            parse_type(":active | :inactive").unwrap(),
+            Type::Union(vec![
+                Type::LiteralSymbol("active".to_string()),
+                Type::LiteralSymbol("inactive".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_literal_symbol_keyword_name() {
+        // Symbol names that collide with type keywords should still work
+        assert_eq!(
+            parse_type(":number").unwrap(),
+            Type::LiteralSymbol("number".to_string())
+        );
+    }
+
+    #[test]
+    fn roundtrip_literal_symbol() {
+        roundtrip(":active");
+        roundtrip(":active | :inactive");
     }
 
     // ── Spec examples ───────────────────────────────────────────────────────

--- a/src/core/typecheck/subtype.rs
+++ b/src/core/typecheck/subtype.rs
@@ -59,6 +59,11 @@ pub fn is_subtype(s: &Type, t: &Type) -> bool {
         // Uninstantiated type variables are treated as `any`.
         (Type::Var(_), _) | (_, Type::Var(_)) => true,
 
+        // ── Literal symbol types ─────────────────────────────────────────────
+        // `LiteralSymbol(s) <: LiteralSymbol(t)` iff `s == t` (handled by
+        // reflexivity above).  `LiteralSymbol(_) <: Symbol` always.
+        (Type::LiteralSymbol(_), Type::Symbol) => true,
+
         // ── Primitives — flat, no cross-primitive subtyping ───────────────────
         (Type::Number, Type::Number) => true,
         (Type::String, Type::String) => true,
@@ -173,6 +178,14 @@ pub fn is_consistent(s: &Type, t: &Type) -> bool {
     // `any` is consistent with everything in both directions.
     if matches!(s, Type::Any) || matches!(t, Type::Any) {
         return true;
+    }
+
+    // Literal symbol consistency: `LiteralSymbol(s) ~ Symbol` and vice versa.
+    match (s, t) {
+        (Type::LiteralSymbol(_), Type::Symbol) | (Type::Symbol, Type::LiteralSymbol(_)) => {
+            return true;
+        }
+        _ => {}
     }
 
     // Structural consistency: recurse into composite types so that, e.g.,
@@ -722,6 +735,64 @@ mod tests {
         let u = union(vec![Type::Number, Type::Any]);
         // Any variant consistent with target → union is consistent
         assert!(is_consistent(&u, &Type::String));
+    }
+
+    // ── Literal symbol types ────────────────────────────────────────────
+
+    #[test]
+    fn literal_symbol_subtype_of_symbol() {
+        let ls = Type::LiteralSymbol("x".to_string());
+        assert!(is_subtype(&ls, &Type::Symbol));
+    }
+
+    #[test]
+    fn symbol_not_subtype_of_literal_symbol() {
+        let ls = Type::LiteralSymbol("x".to_string());
+        assert!(!is_subtype(&Type::Symbol, &ls));
+    }
+
+    #[test]
+    fn literal_symbol_equal_subtype() {
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("x".to_string());
+        assert!(is_subtype(&a, &b));
+    }
+
+    #[test]
+    fn literal_symbol_different_not_subtype() {
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("y".to_string());
+        assert!(!is_subtype(&a, &b));
+    }
+
+    #[test]
+    fn literal_symbol_consistent_with_symbol() {
+        let ls = Type::LiteralSymbol("x".to_string());
+        assert!(is_consistent(&ls, &Type::Symbol));
+        assert!(is_consistent(&Type::Symbol, &ls));
+    }
+
+    #[test]
+    fn literal_symbol_consistent_with_same() {
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("x".to_string());
+        assert!(is_consistent(&a, &b));
+    }
+
+    #[test]
+    fn literal_symbol_not_consistent_with_different() {
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("y".to_string());
+        assert!(!is_consistent(&a, &b));
+    }
+
+    #[test]
+    fn literal_symbol_in_union_subtype() {
+        let u = Type::Union(vec![
+            Type::LiteralSymbol("active".to_string()),
+            Type::LiteralSymbol("inactive".to_string()),
+        ]);
+        assert!(is_subtype(&u, &Type::Symbol));
     }
 
     // ── Edge cases ───────────────────────────────────────────────────────────

--- a/src/core/typecheck/types.rs
+++ b/src/core/typecheck/types.rs
@@ -129,6 +129,12 @@ pub enum Type {
     /// Union type: `A | B`.
     Union(Vec<Type>),
 
+    // ── Literal types ────────────────────────────────────────────────────────
+    /// Literal symbol type: a specific symbol value (e.g. `:active`).
+    ///
+    /// `LiteralSymbol(s)` is a subtype of `Symbol`.
+    LiteralSymbol(String),
+
     // ── Variables ────────────────────────────────────────────────────────────
     /// Type variable (lowercase identifier, e.g. `a`, `b`, `result`).
     Var(TypeVarId),
@@ -149,6 +155,7 @@ impl fmt::Display for Type {
             Type::Set => write!(f, "set"),
             Type::Vec => write!(f, "vec"),
             Type::Array => write!(f, "array"),
+            Type::LiteralSymbol(name) => write!(f, ":{name}"),
             Type::Var(v) => write!(f, "{v}"),
             Type::List(inner) => write!(f, "[{inner}]"),
             Type::Tuple(elems) => {
@@ -332,6 +339,15 @@ mod tests {
         assert_eq!(Type::Set.to_string(), "set");
         assert_eq!(Type::Vec.to_string(), "vec");
         assert_eq!(Type::Array.to_string(), "array");
+    }
+
+    #[test]
+    fn display_literal_symbol() {
+        assert_eq!(
+            Type::LiteralSymbol("active".to_string()).to_string(),
+            ":active"
+        );
+        assert_eq!(Type::LiteralSymbol("foo".to_string()).to_string(), ":foo");
     }
 
     #[test]

--- a/src/core/typecheck/unify.rs
+++ b/src/core/typecheck/unify.rs
@@ -80,6 +80,9 @@ pub fn unify(t1: &Type, t2: &Type, subst: &mut Substitution) -> Result<(), Unify
             Ok(())
         }
 
+        // Literal symbol ↔ Symbol: widen to symbol (succeed, no binding).
+        (Type::LiteralSymbol(_), Type::Symbol) | (Type::Symbol, Type::LiteralSymbol(_)) => Ok(()),
+
         // Structural: function types — contravariant in param, covariant in result.
         (Type::Function(a1, b1), Type::Function(a2, b2)) => {
             let (a1, b1, a2, b2) = (a1.clone(), b1.clone(), a2.clone(), b2.clone());
@@ -360,6 +363,49 @@ mod tests {
         let l2 = Type::List(Box::new(Type::Number));
         assert!(unify(&l1, &l2, &mut s).is_ok());
         assert_eq!(s.get(&vid("a")), Some(&Type::Number));
+    }
+
+    #[test]
+    fn unify_literal_symbol_with_symbol() {
+        let mut s = Substitution::new();
+        let ls = Type::LiteralSymbol("active".to_string());
+        assert!(unify(&ls, &Type::Symbol, &mut s).is_ok());
+        assert!(s.is_empty()); // no bindings — just widening
+    }
+
+    #[test]
+    fn unify_symbol_with_literal_symbol() {
+        let mut s = Substitution::new();
+        let ls = Type::LiteralSymbol("active".to_string());
+        assert!(unify(&Type::Symbol, &ls, &mut s).is_ok());
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn unify_literal_symbol_same() {
+        let mut s = Substitution::new();
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("x".to_string());
+        assert!(unify(&a, &b, &mut s).is_ok());
+    }
+
+    #[test]
+    fn unify_literal_symbol_different_fails() {
+        let mut s = Substitution::new();
+        let a = Type::LiteralSymbol("x".to_string());
+        let b = Type::LiteralSymbol("y".to_string());
+        assert!(unify(&a, &b, &mut s).is_err());
+    }
+
+    #[test]
+    fn unify_var_with_literal_symbol() {
+        let mut s = Substitution::new();
+        let ls = Type::LiteralSymbol("active".to_string());
+        assert!(unify(&var("a"), &ls, &mut s).is_ok());
+        assert_eq!(
+            s.get(&vid("a")),
+            Some(&Type::LiteralSymbol("active".to_string()))
+        );
     }
 
     // ── apply_subst ──────────────────────────────────────────────────────────

--- a/tests/harness/typecheck/008_literal_symbol.eu
+++ b/tests/harness/typecheck/008_literal_symbol.eu
@@ -1,0 +1,6 @@
+# Literal symbol types — :active | :inactive
+` { type: "(:active | :inactive) → string" }
+describe(status): if(status = :active, "on", "off")
+
+good: describe(:active)
+bad: describe(:unknown)

--- a/tests/harness/typecheck/008_literal_symbol.eu.expect
+++ b/tests/harness/typecheck/008_literal_symbol.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "expected :active | :inactive, found :unknown"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1568,3 +1568,8 @@ pub fn test_typecheck_005_no_warnings() {
 pub fn test_typecheck_006_polymorphic() {
     run_typecheck_test("006_polymorphic.eu");
 }
+
+#[test]
+pub fn test_typecheck_008_literal_symbol() {
+    run_typecheck_test("008_literal_symbol.eu");
+}


### PR DESCRIPTION
## Summary

- Adds `Type::LiteralSymbol(String)` variant to the type system, representing specific symbol values (e.g. `:active`, `:inactive`)
- Symbol literals now synthesise as their literal type rather than the general `symbol` type, enabling more precise type checking
- Parses `:ident` syntax in type annotations (e.g. `":active | :inactive"`)

## Changes

- **types.rs**: New `LiteralSymbol(String)` variant, displays as `:name`
- **parse.rs**: `:ident` syntax in type expressions (handles keyword names like `:number` too)
- **subtype.rs**: `LiteralSymbol(_) <: Symbol` always; consistency in both directions
- **unify.rs**: `LiteralSymbol` widens to `Symbol` without binding type variables
- **check.rs**: `Primitive::Sym(name)` synthesises as `LiteralSymbol(name)` instead of `Symbol`

## Test plan

- [x] Unit tests for Display, parsing, subtyping, consistency, and unification
- [x] Round-trip parsing tests for literal symbol types
- [x] All 856 lib tests pass
- [x] All 277 harness tests pass
- [x] `eu check lib/prelude.eu` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)