### PR TITLE
feat: arr.unit-arrays(shape)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -2045,6 +2045,13 @@ arr: {
       type: "array → [number] → [[number]] → [number]" }
   neighbours(a, coords, offsets): __ARRAY_NEIGHBOURS(coords, offsets concat, a arr.rank, a)
 
+  ` :suppress
+  basis-array(shape, coords): arr.zeros(shape) arr.set(coords, 1)
+
+  ` { doc: "arr.unit-arrays(shape) - list of arrays with a single 1 at each coordinate position."
+      type: "[number] → [array]" }
+  unit-arrays(shape): basis-array(shape) <$> (arr.zeros(shape) arr.indices)
+
 }
 
 ` "`is-array?(x)` - true if `x` is an n-dimensional array."

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -2045,12 +2045,11 @@ arr: {
       type: "array → [number] → [[number]] → [number]" }
   neighbours(a, coords, offsets): __ARRAY_NEIGHBOURS(coords, offsets concat, a arr.rank, a)
 
-  ` :suppress
-  basis-array(shape, coords): arr.zeros(shape) arr.set(coords, 1)
-
   ` { doc: "arr.unit-arrays(shape) - list of arrays with a single 1 at each coordinate position."
       type: "[number] → [array]" }
-  unit-arrays(shape): basis-array(shape) <$> (arr.zeros(shape) arr.indices)
+  unit-arrays(shape): {
+    basis(coords): zeros(shape) set(coords, 1)
+  }.(basis <$> (zeros(shape) indices))
 
 }
 


### PR DESCRIPTION
## Summary

Add `arr.unit-arrays(shape)` — returns a list of arrays of the given shape, each with a single 1 at a different coordinate position.

```eu,notest
arr.unit-arrays([3]) map(arr.to-list)
# [[1, 0, 0], [0, 1, 0], [0, 0, 1]]

arr.unit-arrays([2, 2]) map(arr.to-list)
# [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
```

## Test plan
- [x] 279 harness tests pass
- [x] `eu check lib/prelude.eu` — zero warnings
- [x] Manual verification for 1D and 2D shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)