### PR TITLE
chore: 0.6.0 release — version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to eucalypt are documented here.
 
+## [0.6.0] - 2026-04-21
+
+### Added
+
+- **Gradual type system** — optional, structural type checking for eucalypt. Types are never required; all existing code continues to work unchanged.
+  - `eu check file.eu` — type-check a file, report warnings
+  - `eu check --strict file.eu` — treat warnings as errors
+  - `eu --type-check file.eu` — type-check then evaluate (warnings to stderr)
+- **Type annotation syntax** — `type:` metadata on declarations: `` ` { type: "number → number" } ``
+  - Primitives: `number`, `string`, `symbol`, `bool`, `null`, `datetime`
+  - Composites: `[T]` lists, `(A, B)` tuples, `{k: T, ..}` open records, `A → B` functions, `A | B` unions
+  - Special types: `any` (gradual), `top`, `never`, `set`, `vec`, `array`
+  - Type constructors: `IO(T)`, `Lens(A, B)`, `Traversal(A, B)`
+  - Type variables: `a`, `b`, etc. for polymorphic functions
+  - `→` (U+2192) as alternative to `->` in type strings
+  - `block` keyword as shorthand for `{..}` (open empty record)
+  - Asserted annotations: `type: "!T"` prefix trusts the type without verifying the body
+- **Literal symbol types** — `:name` in type annotations as singleton types matching specific symbols. `:active | :inactive` for discriminated unions
+- **Type aliases** — `type-def:` metadata derives an alias from a declaration's value; `types:` in unit metadata for standalone aliases
+- **Prelude type annotations** — ~200 functions annotated with `type:` metadata covering arithmetic, comparison, string, list, block, IO, lens, set, vec, arr, random, and monad operations
+- **Bidirectional type checker** — synthesis for literals, lists, blocks, variables, applications; checking mode for annotated functions; catenation/pipeline type flow; polymorphic instantiation via unification; union overload resolution with subtype fallback
+- **LSP type integration** — hover shows type annotations and inferred types; completion from record field types; inlay hints for inferred types; type warnings as `DiagnosticSeverity::WARNING`
+- **Warning diagnostic infrastructure** — `Diagnostic::warning()` in CLI (codespan-reporting) and `DiagnosticSeverity::WARNING` in LSP; warnings don't cause non-zero exit; `--strict` promotes to errors
+- **Desugarer type hints** — lens bracket expressions `‹ :items 0 :meta ›` carry `Lens(any, any)` type hints via `Expr::Meta`
+- **`arr.unit-arrays(shape)`** — list of arrays with a single 1 at each coordinate position (standard basis vectors for 1D, elementary matrices for 2D)
+- **Type check message tests** — integration tests for `eu check --strict` validating exit codes and stderr message content
+
+### Changed
+
+- **`arr.slice` and `arr.neighbours` parameter order** — reordered via prelude wrappers for pipeline style: `a arr.slice(axis, idx)`, `a arr.neighbours(coords, offsets)`
+
 ## [0.5.4] - 2026-04-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eucalypt"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 

--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -122,6 +122,11 @@ fn run() -> i32 {
         if opt.statistics() {
             statistics.timings_mut().record("type-check", elapsed);
         }
+
+        // --strict: abort before evaluation if there are type warnings
+        if opt.check_strict() && !warnings.is_empty() {
+            return exit_code(&opt, 1, &statistics);
+        }
     }
 
     if opt.run() || opt.dump_stg() || opt.dump_runtime() {

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -186,6 +186,10 @@ pub struct RunArgs {
     #[arg(long = "type-check")]
     pub type_check: bool,
 
+    /// With --type-check: treat type warnings as errors and abort before evaluation
+    #[arg(long = "strict")]
+    pub strict: bool,
+
     /// Disable dead code elimination (for debugging)
     #[arg(long = "no-dce")]
     pub no_dce: bool,
@@ -584,6 +588,7 @@ impl From<EucalyptCli> for EucalyptOptions {
         // Extract check mode
         let (check, check_strict) = match &cli.command {
             Some(Commands::Check(args)) => (true, args.strict),
+            Some(Commands::Run(run_args)) => (false, run_args.strict),
             _ => (false, false),
         };
 


### PR DESCRIPTION
## Summary

Version bump to 0.6.0, comprehensive changelog, and `--strict` flag for `--type-check`.

### Changes
- Cargo.toml version: 0.5.4 → 0.6.0
- CHANGELOG.md: full 0.6.0 entry covering the gradual typing system
- `--strict` flag added to `--type-check` mode: `eu --type-check --strict file.eu` aborts before evaluation if there are type warnings

### CLI modes
```sh
eu check file.eu                # type-check only, report warnings, exit 0
eu check --strict file.eu       # type-check only, exit 1 on warnings (for CI)
eu --type-check file.eu         # type-check then evaluate, warnings to stderr
eu --type-check --strict file.eu # abort before evaluation on type warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)