### PR TITLE
fix(errors): use UnknownRenderFormat instead of Panic for render-as

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -91,12 +91,18 @@ pub struct SourceInfo {
     pub span: Option<Span>,
     /// Text annotation (e.g. global name)
     pub annotation: Option<String>,
+    /// Whether this location is in a library/resource file (e.g. the prelude).
+    /// Library locations are skipped when searching for user-code source labels.
+    pub is_lib: bool,
 }
 
 /// Store all source info...
 #[derive(Default)]
 pub struct SourceMap {
     source: Vec<SourceInfo>,
+    /// File IDs that belong to library/resource units (e.g. the prelude).
+    /// Smids registered for these files are tagged `is_lib = true`.
+    lib_files: std::collections::HashSet<usize>,
 }
 
 impl SourceMap {
@@ -105,13 +111,23 @@ impl SourceMap {
         SourceMap::default()
     }
 
+    /// Register a file ID as belonging to a library/resource unit (e.g. the
+    /// prelude).  Smids subsequently added for this file will have
+    /// `is_lib = true`, causing them to be skipped when searching for
+    /// user-code source locations during diagnostic rendering.
+    pub fn register_lib_file(&mut self, file_id: usize) {
+        self.lib_files.insert(file_id);
+    }
+
     /// Add a new source info and get a SMID referencing it
     pub fn add(&mut self, file: usize, span: Span) -> Smid {
         let smid = Smid::new(self.source.len());
+        let is_lib = self.lib_files.contains(&file);
         self.source.push(SourceInfo {
             file: Some(file),
             span: Some(span),
             annotation: None,
+            is_lib,
         });
         smid
     }
@@ -119,10 +135,12 @@ impl SourceMap {
     /// Add a new source info and get a SMID referencing it
     pub fn add_annotated<T: AsRef<str>>(&mut self, file: usize, span: Span, annotation: T) -> Smid {
         let smid = Smid::new(self.source.len());
+        let is_lib = self.lib_files.contains(&file);
         self.source.push(SourceInfo {
             file: Some(file),
             span: Some(span),
             annotation: Some(annotation.as_ref().to_string()),
+            is_lib,
         });
         smid
     }
@@ -134,6 +152,7 @@ impl SourceMap {
             file: None,
             span: None,
             annotation: Some(annotation.as_ref().to_string()),
+            is_lib: false,
         });
         smid
     }
@@ -152,6 +171,7 @@ impl SourceMap {
                 file: None,
                 span: None,
                 annotation: Some(annotation),
+                is_lib: false,
             }
         };
         self.source.push(new_info);
@@ -253,6 +273,21 @@ impl SourceMap {
         })
     }
 
+    /// Find the first Smid in a trace slice that has a concrete file/span location
+    /// in user code (i.e. not a library/prelude file).
+    ///
+    /// Skips entries marked `is_lib = true` so that diagnostics don't point
+    /// into prelude internals when only library smids are available in the trace.
+    pub fn first_user_source_smid(&self, trace: &[Smid]) -> Option<Smid> {
+        trace.iter().copied().find(|smid| {
+            if let Some(info) = self.source_info_for_smid(*smid) {
+                !info.is_lib && info.file.is_some() && info.span.is_some()
+            } else {
+                false
+            }
+        })
+    }
+
     /// Format a stack / environment trace
     ///
     /// Produces source-level references where file locations are
@@ -266,6 +301,11 @@ impl SourceMap {
             .iter()
             .filter_map(|smid| {
                 let info = self.source.get(smid.get())?;
+                // Skip library/prelude locations — they clutter the trace with
+                // internal implementation details rather than user call sites.
+                if info.is_lib {
+                    return None;
+                }
 
                 // Determine the display name: prefer intrinsic display name,
                 // then annotation (function name), then source snippet

--- a/src/core/analyse/testplan.rs
+++ b/src/core/analyse/testplan.rs
@@ -41,6 +41,8 @@ pub struct ErrorExpectation {
     exit: Option<i32>,
     /// Regex pattern to match against stderr
     stderr_pattern: Option<String>,
+    /// Regex pattern that must NOT match stderr
+    stderr_not_pattern: Option<String>,
 }
 
 impl ErrorExpectation {
@@ -73,6 +75,15 @@ impl ErrorExpectation {
                 ));
             }
         }
+        if let Some(ref pattern) = self.stderr_not_pattern {
+            let re = Regex::new(pattern)
+                .map_err(|e| format!("invalid stderr_not regex pattern '{pattern}': {e}"))?;
+            if re.is_match(actual_stderr) {
+                return Err(format!(
+                    "stderr matched forbidden pattern '{pattern}'\nactual stderr:\n{actual_stderr}"
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -86,6 +97,7 @@ impl ErrorExpectation {
     pub fn parse(content: &str) -> Result<Self, String> {
         let mut exit = None;
         let mut stderr_pattern = None;
+        let mut stderr_not_pattern = None;
 
         for line in content.lines() {
             let line = line.trim();
@@ -99,6 +111,13 @@ impl ErrorExpectation {
                         .parse::<i32>()
                         .map_err(|e| format!("invalid exit code '{value}': {e}"))?,
                 );
+            } else if let Some(value) = line.strip_prefix("stderr_not:") {
+                let value = value.trim();
+                let value = value
+                    .strip_prefix('"')
+                    .and_then(|v| v.strip_suffix('"'))
+                    .unwrap_or(value);
+                stderr_not_pattern = Some(value.to_string());
             } else if let Some(value) = line.strip_prefix("stderr:") {
                 let value = value.trim();
                 // Strip surrounding quotes if present
@@ -110,13 +129,17 @@ impl ErrorExpectation {
             }
         }
 
-        if exit.is_none() && stderr_pattern.is_none() {
-            return Err("sidecar must specify at least one of 'exit' or 'stderr'".to_string());
+        if exit.is_none() && stderr_pattern.is_none() && stderr_not_pattern.is_none() {
+            return Err(
+                "sidecar must specify at least one of 'exit', 'stderr', or 'stderr_not'"
+                    .to_string(),
+            );
         }
 
         Ok(ErrorExpectation {
             exit,
             stderr_pattern,
+            stderr_not_pattern,
         })
     }
 
@@ -415,6 +438,7 @@ pub mod tests {
         let exp = ErrorExpectation {
             exit: Some(1),
             stderr_pattern: Some("division by zero".to_string()),
+            stderr_not_pattern: None,
         };
         assert!(exp.validate(1, "error: division by zero at line 5").is_ok());
     }
@@ -424,6 +448,7 @@ pub mod tests {
         let exp = ErrorExpectation {
             exit: Some(1),
             stderr_pattern: None,
+            stderr_not_pattern: None,
         };
         let result = exp.validate(0, "");
         assert!(result.is_err());
@@ -435,6 +460,7 @@ pub mod tests {
         let exp = ErrorExpectation {
             exit: None,
             stderr_pattern: Some("expected pattern".to_string()),
+            stderr_not_pattern: None,
         };
         let result = exp.validate(1, "something else entirely");
         assert!(result.is_err());
@@ -446,6 +472,7 @@ pub mod tests {
         let exp = ErrorExpectation {
             exit: None,
             stderr_pattern: Some(r"line \d+".to_string()),
+            stderr_not_pattern: None,
         };
         assert!(exp.validate(1, "error at line 42").is_ok());
         assert!(exp.validate(1, "error at line XY").is_err());

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -349,6 +349,12 @@ impl SourceLoader {
                 // store text and map locator to fileid
                 let id = self.files.add(locator.to_string(), source);
                 self.locators.insert(locator.clone(), id);
+                // Mark resource files (e.g. the prelude) as library files so
+                // that diagnostics skip their source locations when searching
+                // for user-code call sites.
+                if matches!(locator, Locator::Resource(_)) {
+                    self.source_map.register_lib_file(id);
+                }
                 Ok(id)
             }
         }

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -799,10 +799,12 @@ impl ExecutionError {
             .unwrap_or(false);
 
         if !has_source_label {
-            // Prefer the env trace (innermost call site) over the stack trace
+            // Prefer user-code locations (non-library) from the env trace, then
+            // the stack trace.  Fall back to any location only if no user smid
+            // is found (this avoids pointing into prelude internals).
             let fallback_smid = source_map
-                .first_source_smid(env_trace)
-                .or_else(|| source_map.first_source_smid(stack_trace));
+                .first_user_source_smid(env_trace)
+                .or_else(|| source_map.first_user_source_smid(stack_trace));
             if let Some(smid) = fallback_smid {
                 if let Some(info) = source_map.source_info_for_smid(smid) {
                     if let (Some(file), Some(span)) = (info.file, info.span) {
@@ -824,8 +826,8 @@ impl ExecutionError {
                 .and_then(|info| info.file.zip(info.span))
                 .or_else(|| {
                     let smid = source_map
-                        .first_source_smid(env_trace)
-                        .or_else(|| source_map.first_source_smid(stack_trace))?;
+                        .first_user_source_smid(env_trace)
+                        .or_else(|| source_map.first_user_source_smid(stack_trace))?;
                     let info = source_map.source_info_for_smid(smid)?;
                     info.file.zip(info.span)
                 });
@@ -842,6 +844,10 @@ impl ExecutionError {
                     Some(i) => i,
                     None => continue,
                 };
+                // Skip library/prelude locations — only show user-code context
+                if info.is_lib {
+                    continue;
+                }
                 let (file, span) = match (info.file, info.span) {
                     (Some(f), Some(s)) => (f, s),
                     _ => continue,

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1283,10 +1283,15 @@ fn evaluate_to_whnf_impl(
         }
         // Capture lifecycle inside sub-evaluation (needed if sub-eval uses render-as).
         if let Some(fmt) = state.pending_capture_start.take() {
-            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
-                &fmt,
-                state.annotation,
-            )?;
+            let view = MutatorHeapView::new(&core.heap);
+            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&fmt)
+                .map_err(|e| {
+                    ExecutionError::Traced(
+                        Box::new(e),
+                        state.nav(view).env_trace(),
+                        state.stack_trace(&view),
+                    )
+                })?;
             cap.stream_start();
             // We have no capture_emitters stack in this context; this is a limitation
             // of BIF-level sub-evaluation.  Nested render-as inside evaluate_to_whnf
@@ -1656,11 +1661,20 @@ impl<'a> Machine<'a> {
         // Handle capture lifecycle from the step just executed.
 
         // If a capture start was requested, push the capture emitter.
+        // Wrap any format error in Traced so to_diagnostic() can fall back to
+        // the env/stack trace to locate the user's render-as call site.
         if let Some(format) = self.state.pending_capture_start.take() {
-            let mut capture = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
-                &format,
-                self.state.annotation,
-            )?;
+            let mut capture = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&format)
+                .map_err(|e| {
+                    ExecutionError::Traced(
+                        Box::new(e),
+                        self.state
+                            .nav(MutatorHeapView::new(&self.core.heap))
+                            .env_trace(),
+                        self.state
+                            .stack_trace(&MutatorHeapView::new(&self.core.heap)),
+                    )
+                })?;
             capture.stream_start();
             self.capture_emitters.push(capture);
         }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1283,7 +1283,10 @@ fn evaluate_to_whnf_impl(
         }
         // Capture lifecycle inside sub-evaluation (needed if sub-eval uses render-as).
         if let Some(fmt) = state.pending_capture_start.take() {
-            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&fmt)?;
+            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
+                &fmt,
+                state.annotation,
+            )?;
             cap.stream_start();
             // We have no capture_emitters stack in this context; this is a limitation
             // of BIF-level sub-evaluation.  Nested render-as inside evaluate_to_whnf
@@ -1654,8 +1657,10 @@ impl<'a> Machine<'a> {
 
         // If a capture start was requested, push the capture emitter.
         if let Some(format) = self.state.pending_capture_start.take() {
-            let mut capture =
-                crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&format)?;
+            let mut capture = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
+                &format,
+                self.state.annotation,
+            )?;
             capture.stream_start();
             self.capture_emitters.push(capture);
         }

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -59,10 +59,11 @@ impl OwnedCaptureEmitter {
     /// Create a new capture emitter for the given format (e.g. "json",
     /// "yaml", "text").
     ///
-    /// `annotation` is the source location from the machine at the point of
-    /// the `render-as` call; it is used to produce a source-located diagnostic
-    /// when the format name is not recognised.
-    pub fn new(format: &str, annotation: Smid) -> Result<Self, ExecutionError> {
+    /// Returns `UnknownRenderFormat` with `Smid::default()` (no source
+    /// location) if the format is not recognised.  The caller in vm.rs
+    /// wraps this error in `Traced` so that `to_diagnostic()` can fall
+    /// back to the env/stack trace to find the user's call-site location.
+    pub fn new(format: &str) -> Result<Self, ExecutionError> {
         #[allow(clippy::box_default)]
         let mut buffer: Box<Vec<u8>> = Box::new(Vec::new());
         // SAFETY: We take a raw pointer to the boxed buffer.  The Box
@@ -71,8 +72,10 @@ impl OwnedCaptureEmitter {
         // before the buffer (field declaration order), so the borrow is
         // valid for the emitter's entire lifetime.
         let buf_ptr: *mut Vec<u8> = &mut *buffer;
-        let emitter = export::create_emitter(format, unsafe { &mut *buf_ptr })
-            .ok_or_else(|| ExecutionError::UnknownRenderFormat(annotation, format.to_string()))?;
+        let emitter =
+            export::create_emitter(format, unsafe { &mut *buf_ptr }).ok_or_else(|| {
+                ExecutionError::UnknownRenderFormat(Smid::default(), format.to_string())
+            })?;
         // SAFETY: The lifetime erasure is sound because format-specific emitters
         // created by `create_emitter` only write through the `&mut dyn Write`
         // trait object and never capture the lifetime parameter. The `buffer`

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -58,7 +58,11 @@ pub struct OwnedCaptureEmitter {
 impl OwnedCaptureEmitter {
     /// Create a new capture emitter for the given format (e.g. "json",
     /// "yaml", "text").
-    pub fn new(format: &str) -> Result<Self, ExecutionError> {
+    ///
+    /// `annotation` is the source location from the machine at the point of
+    /// the `render-as` call; it is used to produce a source-located diagnostic
+    /// when the format name is not recognised.
+    pub fn new(format: &str, annotation: Smid) -> Result<Self, ExecutionError> {
         #[allow(clippy::box_default)]
         let mut buffer: Box<Vec<u8>> = Box::new(Vec::new());
         // SAFETY: We take a raw pointer to the boxed buffer.  The Box
@@ -67,10 +71,8 @@ impl OwnedCaptureEmitter {
         // before the buffer (field declaration order), so the borrow is
         // valid for the emitter's entire lifetime.
         let buf_ptr: *mut Vec<u8> = &mut *buffer;
-        let emitter =
-            export::create_emitter(format, unsafe { &mut *buf_ptr }).ok_or_else(|| {
-                ExecutionError::Panic(Smid::default(), format!("unknown render format: {format}"))
-            })?;
+        let emitter = export::create_emitter(format, unsafe { &mut *buf_ptr })
+            .ok_or_else(|| ExecutionError::UnknownRenderFormat(annotation, format.to_string()))?;
         // SAFETY: The lifetime erasure is sound because format-specific emitters
         // created by `create_emitter` only write through the `&mut dyn Write`
         // trait object and never capture the lifetime parameter. The `buffer`

--- a/tests/harness/errors/131_render_as_unknown_format.eu
+++ b/tests/harness/errors/131_render_as_unknown_format.eu
@@ -1,0 +1,6 @@
+# Error test: render-as with an unrecognised format symbol.
+# Should produce 'unknown render format' with a helpful list of valid formats,
+# not a bare 'panic:' message.
+data: { x: 1 }
+result: data render-as(:not_a_format)
+RESULT: result

--- a/tests/harness/errors/131_render_as_unknown_format.eu.expect
+++ b/tests/harness/errors/131_render_as_unknown_format.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "unknown render format 'not_a_format'"

--- a/tests/harness/errors/131_render_as_unknown_format.eu.expect
+++ b/tests/harness/errors/131_render_as_unknown_format.eu.expect
@@ -1,2 +1,3 @@
 exit: 1
 stderr: "unknown render format 'not_a_format'"
+stderr_not: "\\[prelude\\]"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1508,6 +1508,11 @@ pub fn test_error_130() {
 }
 
 #[test]
+pub fn test_error_131() {
+    run_error_test(&error_opts("131_render_as_unknown_format.eu"));
+}
+
+#[test]
 pub fn test_harness_142() {
     run_test(&opts("142_consecutive_metadata_blocks.eu"));
 }


### PR DESCRIPTION
## Problem

`render-as(:invalid_format)` was showing a source location pointing at `[prelude]:1072-1074` — the internal prelude definition of `render-as` — instead of the user's call site.

## Root cause

At error-raise time, the `env_trace` and `stack_trace` contain only prelude smids. The user's call-site annotation is set transiently by an `Ann` node, then immediately overridden by the prelude function's `annotated_lambda` when the closure is entered. There is no way to recover the user's smid from the trace.

## Fix

Add `is_lib: bool` to `SourceInfo` and `register_lib_file(file_id)` to `SourceMap`. When `source.rs` loads a `Resource` locator (the prelude), it registers that file ID as a library file. All subsequent smids added for that file are tagged `is_lib = true`.

The diagnostic fallback in `to_diagnostic()` now uses `first_user_source_smid()` (skips `is_lib` entries) instead of `first_source_smid()`. Secondary labels and `format_trace()` also skip lib entries.

Result: no source label is shown (rather than a misleading prelude location).

Also wrap `OwnedCaptureEmitter::new` errors in `Traced` at both call sites in `vm.rs` so that `to_diagnostic()` has env/stack traces available for the fallback path.

## Before

```
error: unknown render format 'invalid_format'
  help: supported formats for render-as are: :yaml, :json, :toml, :text, :edn, :html
     ┌─ [prelude]:1072:1
     │  
1072 │ ╭ ` { doc: "render-as(fmt, value) - ..."
1073 │ │     type: "symbol → any → string" }
1074 │ │ render-as(fmt, value): __RENDER_TO_STRING(value, fmt)
     │ │                        ------------------ called from here
     │ ╰─────────────────────────────────────────────────────' called from here
     │  
     = stack trace:
       - render-as at [prelude]:1074:24
```

## After

```
error: unknown render format 'invalid_format'
  help: supported formats for render-as are: :yaml, :json, :toml, :text, :edn, :html
```

No misleading prelude location shown.

## New test infrastructure

Added `stderr_not:` field to the `.expect` sidecar format. Allows tests to assert that a pattern does NOT appear in stderr. Test 131 now verifies `[prelude]` is absent from the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)