### PR TITLE
fix(errors): separate user panic() from internal runtime errors

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -659,8 +659,18 @@ pub enum ExecutionError {
     NoBranchForNative(Smid, String),
     #[error("{}", format_cannot_return_fun(.1))]
     CannotReturnFunToCase(Smid, Vec<u8>),
-    #[error("panic: {1}")]
+    /// Internal runtime error — shown as-is, without any "panic:" prefix.
+    ///
+    /// Use `UserPanic` when the error originates from the user's `panic()`
+    /// function so that the "panic:" label appears in the diagnostic.
+    #[error("{1}")]
     Panic(Smid, String),
+    /// Error raised by the user's `panic("msg")` call.
+    ///
+    /// Displays with the "panic: " prefix so the user sees their explicit
+    /// call to `panic()` reflected in the error message.
+    #[error("panic: {1}")]
+    UserPanic(Smid, String),
     #[error("parse-as({1}): {2}")]
     ParseError(Smid, String, String),
     #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
@@ -767,6 +777,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::CannotReturnFunToCase(s, _) => *s,
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::Panic(s, _) => *s,
+            ExecutionError::UserPanic(s, _) => *s,
             ExecutionError::ParseError(s, _, _) => *s,
             ExecutionError::VersionRequirementFailed(s, _, _) => *s,
             ExecutionError::InvalidBase64(s, _) => *s,

--- a/src/eval/stg/panic.rs
+++ b/src/eval/stg/panic.rs
@@ -24,7 +24,7 @@ impl StgIntrinsic for Panic {
         args: &[Ref],
     ) -> Result<(), crate::eval::error::ExecutionError> {
         let message = str_arg(machine, view, &args[0])?;
-        Err(ExecutionError::Panic(machine.annotation(), message))
+        Err(ExecutionError::UserPanic(machine.annotation(), message))
     }
 }
 

--- a/tests/harness/errors/137_user_panic.eu
+++ b/tests/harness/errors/137_user_panic.eu
@@ -1,0 +1,1 @@
+result: panic("deliberate failure")

--- a/tests/harness/errors/137_user_panic.eu.expect
+++ b/tests/harness/errors/137_user_panic.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "panic: deliberate failure"

--- a/tests/harness/errors/138_internal_no_panic_prefix.eu
+++ b/tests/harness/errors/138_internal_no_panic_prefix.eu
@@ -1,0 +1,1 @@
+result: "hello" head

--- a/tests/harness/errors/138_internal_no_panic_prefix.eu.expect
+++ b/tests/harness/errors/138_internal_no_panic_prefix.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "head requires a list"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1543,6 +1543,16 @@ pub fn test_error_136() {
 }
 
 #[test]
+pub fn test_error_137() {
+    run_error_test(&error_opts("137_user_panic.eu"));
+}
+
+#[test]
+pub fn test_error_138() {
+    run_error_test(&error_opts("138_internal_no_panic_prefix.eu"));
+}
+
+#[test]
 pub fn test_harness_142() {
     run_test(&opts("142_consecutive_metadata_blocks.eu"));
 }


### PR DESCRIPTION
## Summary

- All internal errors using `Panic(Smid, String)` previously showed `error: panic: <msg>`, which made runtime type errors look like internal crashes
- Added `UserPanic(Smid, String)` variant (shown as `panic: <msg>`) used exclusively by the PANIC intrinsic (the user's `panic()` function)
- Changed `Panic(Smid, String)` format to `"{msg}"` (no prefix) for internal errors

## Before / After

**Calling head on a non-list:**

Before:
```
error: panic: head requires a list argument, got 42
```

After:
```
error: head requires a list argument, got 42
```

**User `panic()` call (unchanged):**
```
error: panic: stop here
```

## Impact

All internal `Panic` messages throughout the codebase now lose the confusing `panic:` prefix:
- `head requires a list argument, got X`
- `tail requires a list argument, got X`
- Various I/O and machine errors (malformed cons cell, etc.)

## Test plan

- [x] All 279 harness tests pass
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Test `009_panic` (user panic) still expects and receives `"panic: ..."` prefix
- [x] `head 42` no longer shows `panic:` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)