### PR TITLE
fix(errors): add helpful notes for boolean type mismatches

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -93,6 +93,8 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
     let is_number = actual == DataConstructor::BoxedNumber.tag();
     let is_block = actual == DataConstructor::Block.tag();
     let is_symbol = actual == DataConstructor::BoxedSymbol.tag();
+    let is_bool =
+        actual == DataConstructor::BoolTrue.tag() || actual == DataConstructor::BoolFalse.tag();
     let expects_block = expected.contains(&DataConstructor::Block.tag());
     let expects_number = expected.contains(&DataConstructor::BoxedNumber.tag());
     let expects_string = expected.contains(&DataConstructor::BoxedString.tag());
@@ -189,6 +191,24 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
             "to convert a symbol to a string, use 'str.of', e.g. `str.of(:name)` \
              gives the string `\"name\"`"
                 .to_string(),
+        ]
+    } else if is_bool && expects_number {
+        vec![
+            "eucalypt booleans (`true`/`false`) are not numbers; \
+             use 'if' to branch on a boolean value, e.g. 'if(cond, then_val, else_val)'"
+                .to_string(),
+            "to convert a boolean to a number, use 'if(b, 1, 0)'".to_string(),
+        ]
+    } else if is_bool && expects_string {
+        vec![
+            "to convert a boolean to a string, use string interpolation \
+             e.g. \"{b}\" or 'str.of(b)' — gives \"true\" or \"false\""
+                .to_string(),
+        ]
+    } else if is_bool && expects_block {
+        vec![
+            "booleans do not have fields; the '.' operator is for key lookup on blocks".to_string(),
+            "use 'if(cond, then_val, else_val)' to branch on a boolean value".to_string(),
         ]
     } else {
         vec![]


### PR DESCRIPTION
## Summary

- Add `is_bool` detection in `data_tag_mismatch_notes()` in `src/eval/error.rs`
- Three new cases handled: bool where number expected, bool where string expected, bool where block expected (`.` lookup)

## Before / After

**`1 + true`:**

Before:
```
error: type mismatch: expected number, found true
```

After:
```
error: type mismatch: expected number, found true
  = eucalypt booleans (`true`/`false`) are not numbers; use 'if' to branch on a boolean value, e.g. 'if(cond, then_val, else_val)'
  = to convert a boolean to a number, use 'if(b, 1, 0)'
```

**`true.something`:**

Before:
```
error: type mismatch: expected block, found true
```

After:
```
error: type mismatch: expected block, found true
  = booleans do not have fields; the '.' operator is for key lookup on blocks
  = use 'if(cond, then_val, else_val)' to branch on a boolean value
```

## Test plan

- [x] `cargo build` — clean build
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --test harness_test` — all 279 tests pass
- [x] Manual verification: `1 + true` and `true.something` show helpful notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)