### PR TITLE
fix(errors): generalise list-where-block-expected notes

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -100,7 +100,11 @@ fn data_tag_mismatch_notes(actual: u8, expected: &[u8]) -> Vec<String> {
 
     if is_list && expects_block {
         vec![
-            "the '.' operator performs key lookup on blocks, not lists".to_string(),
+            "a block (structured record, e.g. `{a: 1}`) was expected but a list was passed; \
+             lists and blocks are different types in eucalypt"
+                .to_string(),
+            "block operations like '.', 'merge', 'has', and 'lookup' require a block argument"
+                .to_string(),
             "for lists, use pipeline functions: 'xs count' (length), 'xs head' (first element), \
              'xs tail' (rest), 'xs !! 0' (nth element, 0-indexed)"
                 .to_string(),


### PR DESCRIPTION
## Summary

The note for 'type mismatch: expected block, found list' previously said 'the . operator performs key lookup on blocks, not lists'. This was correct for dot-lookup errors but misleading when the same error was raised by other block operations like `merge`, `has`, and `lookup`.

Updated the note to explain that lists and blocks are different types, and to list all common block operations that require block arguments.

## Before / After

**`merge([1, 2], {a: 1})`:**

Before:
```
error: type mismatch: expected block, found list
  = the '.' operator performs key lookup on blocks, not lists
  = for lists, use pipeline functions: ...
```

After:
```
error: type mismatch: expected block, found list
  = a block (structured record, e.g. `{a: 1}`) was expected but a list was passed; lists and blocks are different types in eucalypt
  = block operations like '.', 'merge', 'has', and 'lookup' require a block argument
  = for lists, use pipeline functions: ...
```

**`xs.length` (list with dot lookup) also benefits** — the new first note is more explicit about the type distinction.

## Test plan

- [x] `cargo build` — clean build
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --test harness_test` — all 279 tests pass
- [x] Manual verification: both `xs.length` and `merge([1,2], block)` show improved notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)