### PR TITLE
fix(errors): dedicated HeadOfNonList/TailOfNonList error variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -687,6 +687,10 @@ pub enum ExecutionError {
     ArrayNegativeIndex(Smid, f64),
     #[error("list index out of bounds: index {1} is beyond the end of the list")]
     ListIndexOutOfBounds(Smid, usize),
+    #[error("head requires a list, found {1}")]
+    HeadOfNonList(Smid, String),
+    #[error("tail requires a list, found {1}")]
+    TailOfNonList(Smid, String),
 }
 
 impl From<bump::AllocError> for ExecutionError {
@@ -754,6 +758,8 @@ impl HasSmid for ExecutionError {
             ExecutionError::IoTimeout(s, _) => *s,
             ExecutionError::IoCommandError(s, _) => *s,
             ExecutionError::ListIndexOutOfBounds(s, _) => *s,
+            ExecutionError::HeadOfNonList(s, _) => *s,
+            ExecutionError::TailOfNonList(s, _) => *s,
             ExecutionError::BadDateTimeString(s, _) => *s,
             ExecutionError::BadRegex(s, _, _) => *s,
             ExecutionError::BadFormatString(s, _) => *s,
@@ -1015,6 +1021,37 @@ impl ExecutionError {
                      to handle empty or short lists safely"
                         .to_string(),
                 ]
+            }
+            ExecutionError::HeadOfNonList(_, found) => {
+                let mut notes = vec![
+                    "head and tail require a list (e.g. [1, 2, 3]) as their argument".to_string(),
+                ];
+                if found.starts_with('"') {
+                    notes.push(
+                        "to concatenate strings, use string interpolation (e.g. \"{a}{b}\") \
+                         or 'str.join-on', not '++' (which is for list append)"
+                            .to_string(),
+                    );
+                    notes.push(
+                        "to get individual characters of a string, use 'str.letters'".to_string(),
+                    );
+                } else if found == "number" || found.parse::<f64>().is_ok() {
+                    notes.push("to create a list from a number, wrap it: '[n]'".to_string());
+                }
+                notes
+            }
+            ExecutionError::TailOfNonList(_, found) => {
+                let mut notes = vec![
+                    "head and tail require a list (e.g. [1, 2, 3]) as their argument".to_string(),
+                ];
+                if found.starts_with('"') {
+                    notes.push(
+                        "to concatenate strings, use string interpolation (e.g. \"{a}{b}\") \
+                         or 'str.join-on', not '++' (which is for list append)"
+                            .to_string(),
+                    );
+                }
+                notes
             }
             ExecutionError::BadDateTimeComponents(_, _, _, _, _, _, _, _) => {
                 vec![

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -100,10 +100,7 @@ impl StgIntrinsic for Tail {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let repr = super::debug::render_debug_repr(machine, view, &args[0]);
-        Err(ExecutionError::Panic(
-            machine.annotation(),
-            format!("tail requires a list argument, got {repr}"),
-        ))
+        Err(ExecutionError::TailOfNonList(machine.annotation(), repr))
     }
 }
 
@@ -146,10 +143,7 @@ impl StgIntrinsic for Head {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let repr = super::debug::render_debug_repr(machine, view, &args[0]);
-        Err(ExecutionError::Panic(
-            machine.annotation(),
-            format!("head requires a list argument, got {repr}"),
-        ))
+        Err(ExecutionError::HeadOfNonList(machine.annotation(), repr))
     }
 }
 

--- a/tests/harness/errors/042_map_non_list.eu.expect
+++ b/tests/harness/errors/042_map_non_list.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "requires a list argument"
+stderr: "requires a list"

--- a/tests/harness/errors/047_str_plus_plus.eu.expect
+++ b/tests/harness/errors/047_str_plus_plus.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "requires a list argument"
+stderr: "requires a list"

--- a/tests/harness/errors/129_head_tail_not_list.eu.expect
+++ b/tests/harness/errors/129_head_tail_not_list.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "head requires a list argument, got 42"
+stderr: "head requires a list, found 42"


### PR DESCRIPTION
## Summary

When `head` or `tail` was called on a non-list value (string, number, block, etc.), the error was `Panic` with message `"head requires a list argument, got X"`. This was prefixed with `"panic:"` and had no helpful notes.

Added `HeadOfNonList(Smid, String)` and `TailOfNonList(Smid, String)` error variants with context-sensitive notes.

## Before / After

**`"hello" ++ " world"` (string appended with list operator `++`):**

Before:
```
error: panic: head requires a list argument, got "hello"
     ┌─ [prelude]:1356:37
```

After:
```
error: head requires a list, found "hello"
     ┌─ [prelude]:1356:37
  = head and tail require a list (e.g. [1, 2, 3]) as their argument
  = to concatenate strings, use string interpolation (e.g. "{a}{b}") or 'str.join-on', not '++' (which is for list append)
  = to get individual characters of a string, use 'str.letters'
```

**`{a: 1} map((+ 1))` (map on a block):**

Before:
```
error: panic: head requires a list argument, got {block}
```

After:
```
error: head requires a list, found {block}
  = head and tail require a list (e.g. [1, 2, 3]) as their argument
```

## Test plan

- [x] `cargo build` — clean build
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --test harness_test` — all 279 tests pass
- [x] Updated 3 `.expect` files to match new message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)