### PR TITLE
fix(errors): show user-code location as primary error site, deduplicate stack trace cycles

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -97,6 +97,11 @@ pub struct SourceInfo {
 #[derive(Default)]
 pub struct SourceMap {
     source: Vec<SourceInfo>,
+    /// File IDs that correspond to resources (e.g. prelude, stdlib) rather
+    /// than user-authored files.  Used by `is_user_file` so that diagnostic
+    /// code can prefer user locations over resource locations when building
+    /// error labels.
+    resource_file_ids: std::collections::HashSet<usize>,
 }
 
 impl SourceMap {
@@ -238,6 +243,19 @@ impl SourceMap {
         }
     }
 
+    /// Mark a file ID as belonging to a resource (e.g. the prelude, a stdlib
+    /// module).  Diagnostics can use `is_user_file` to avoid showing resource
+    /// locations as the primary error site.
+    pub fn mark_resource_file(&mut self, file_id: usize) {
+        self.resource_file_ids.insert(file_id);
+    }
+
+    /// Returns `true` when `file_id` belongs to a user-authored file, i.e. it
+    /// has *not* been marked as a resource file.
+    pub fn is_user_file(&self, file_id: usize) -> bool {
+        !self.resource_file_ids.contains(&file_id)
+    }
+
     /// Find the first Smid in a trace slice that has a concrete file/span location.
     ///
     /// Used as a fallback when an error's own Smid is synthetic (e.g. an
@@ -247,6 +265,25 @@ impl SourceMap {
         trace.iter().copied().find(|smid| {
             if let Some(info) = self.source_info_for_smid(*smid) {
                 info.file.is_some() && info.span.is_some()
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Find the first Smid in a trace slice that has a concrete location in a
+    /// *user* file (i.e. not a prelude / resource file).
+    ///
+    /// Used to surface user-code call sites as the primary error location when
+    /// the error itself originated inside a library function.
+    pub fn first_user_source_smid(&self, trace: &[Smid]) -> Option<Smid> {
+        trace.iter().copied().find(|smid| {
+            if let Some(info) = self.source_info_for_smid(*smid) {
+                if let Some(fid) = info.file {
+                    info.span.is_some() && self.is_user_file(fid)
+                } else {
+                    false
+                }
             } else {
                 false
             }
@@ -324,8 +361,69 @@ impl SourceMap {
         // Reverse to read outermost-first (matches conventional stack trace order)
         elements.reverse();
 
+        // Compress repeated cycles (e.g. mutual recursion between foldl and +)
+        let elements = compress_trace_cycles(elements);
+
         elements.as_slice().join("\n")
     }
+}
+
+/// Detect and compress repeating cycles in a formatted stack trace.
+///
+/// Scans the elements list for the smallest repeating prefix and, when the
+/// same pattern of frames appears two or more times consecutively, emits the
+/// pattern once followed by a `  ... N frames elided (M× repetition)` line.
+/// The remaining non-repeating tail is appended unchanged.
+///
+/// Only patterns of length ≤ 8 are considered to keep the algorithm efficient.
+fn compress_trace_cycles(elements: Vec<String>) -> Vec<String> {
+    let n = elements.len();
+    if n < 2 {
+        return elements;
+    }
+
+    let mut result = Vec::with_capacity(n);
+    let mut i = 0;
+
+    while i < n {
+        let remaining = n - i;
+        let max_pat = (remaining / 2).min(8);
+        let mut compressed = false;
+
+        // Try shortest patterns first so we find the smallest repeating unit
+        for pat_len in 1..=max_pat {
+            let pattern = &elements[i..i + pat_len];
+            let mut count = 1usize;
+            let mut j = i + pat_len;
+
+            while j + pat_len <= n && elements[j..j + pat_len] == *pattern {
+                count += 1;
+                j += pat_len;
+            }
+
+            if count >= 2 {
+                // Emit the pattern once
+                result.extend_from_slice(pattern);
+                let elided = (count - 1) * pat_len;
+                result.push(format!(
+                    "  ... {} frame{} elided ({}× repetition)",
+                    elided,
+                    if elided == 1 { "" } else { "s" },
+                    count
+                ));
+                i = j;
+                compressed = true;
+                break;
+            }
+        }
+
+        if !compressed {
+            result.push(elements[i].clone());
+            i += 1;
+        }
+    }
+
+    result
 }
 
 /// Map internal intrinsic names to user-facing display names.

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -349,6 +349,12 @@ impl SourceLoader {
                 // store text and map locator to fileid
                 let id = self.files.add(locator.to_string(), source);
                 self.locators.insert(locator.clone(), id);
+                // Resources (prelude, stdlib) are not user files; mark them so
+                // that diagnostics can prefer user-code locations as the primary
+                // error site rather than showing prelude internals.
+                if matches!(locator, Locator::Resource(_)) {
+                    self.source_map.mark_resource_file(id);
+                }
                 Ok(id)
             }
         }

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -788,28 +788,53 @@ impl ExecutionError {
             other => (other, [].as_slice(), [].as_slice()),
         };
 
-        // If the error's own Smid has no file location (e.g. it points to a
-        // synthetic intrinsic label), try to find a source location from the
-        // environment trace.  The env trace contains annotations from the let
-        // frames that were live at the time of the error, including any Ann
-        // nodes the compiler injected at call sites.
-        let has_source_label = source_map
-            .source_info(inner)
-            .map(|info| info.file.is_some())
+        // Determine the best primary source location:
+        // - Prefer a user-file location (the call site in user code) over a
+        //   prelude/resource location (the site of the failure inside a library).
+        // - If the error's own Smid already points to a user file, use that.
+        // - Otherwise, search the environment trace (innermost call annotations)
+        //   then the stack trace for the first user-file Smid.
+        // - As a last resort, fall back to any Smid with a file location.
+        let error_info = source_map.source_info(inner);
+        let error_has_user_file = error_info
+            .and_then(|info| info.file)
+            .map(|fid| source_map.is_user_file(fid))
             .unwrap_or(false);
 
-        if !has_source_label {
-            // Prefer the env trace (innermost call site) over the stack trace
-            let fallback_smid = source_map
-                .first_source_smid(env_trace)
-                .or_else(|| source_map.first_source_smid(stack_trace));
-            if let Some(smid) = fallback_smid {
-                if let Some(info) = source_map.source_info_for_smid(smid) {
-                    if let (Some(file), Some(span)) = (info.file, info.span) {
-                        diag = diag.with_labels(vec![Label::primary(file, span)]);
-                    }
-                }
+        let primary_file_span: Option<(usize, codespan::Span)> = if error_has_user_file {
+            error_info.and_then(|info| info.file.zip(info.span))
+        } else {
+            // Try to find a user-file location in the traces
+            let user_smid = source_map
+                .first_user_source_smid(env_trace)
+                .or_else(|| source_map.first_user_source_smid(stack_trace));
+
+            if let Some(smid) = user_smid {
+                source_map
+                    .source_info_for_smid(smid)
+                    .and_then(|info| info.file.zip(info.span))
+            } else {
+                // No user-file location; fall back to the error's own Smid or
+                // any location in the traces (handles rare all-library scenarios).
+                error_info
+                    .and_then(|info| info.file.zip(info.span))
+                    .or_else(|| {
+                        let smid = source_map
+                            .first_source_smid(env_trace)
+                            .or_else(|| source_map.first_source_smid(stack_trace))?;
+                        source_map
+                            .source_info_for_smid(smid)
+                            .and_then(|info| info.file.zip(info.span))
+                    })
             }
+        };
+
+        // Apply the primary label.  We clear any label that source_map.diagnostic()
+        // may have set (which could be a prelude location) and replace it with the
+        // best location determined above.
+        if let Some((file, span)) = primary_file_span {
+            diag.labels.clear();
+            diag.labels.push(Label::primary(file, span));
         }
 
         // Add secondary labels from the env trace for call-chain context.
@@ -818,18 +843,6 @@ impl ExecutionError {
         // from the primary label (to avoid redundant markers).  Limited to 3
         // secondary labels to keep output readable.
         {
-            // Determine the primary span (from error's own Smid or fallback)
-            let primary_file_span = source_map
-                .source_info(inner)
-                .and_then(|info| info.file.zip(info.span))
-                .or_else(|| {
-                    let smid = source_map
-                        .first_source_smid(env_trace)
-                        .or_else(|| source_map.first_source_smid(stack_trace))?;
-                    let info = source_map.source_info_for_smid(smid)?;
-                    info.file.zip(info.span)
-                });
-
             let mut secondary_labels: Vec<Label<usize>> = vec![];
             let mut seen_spans: Vec<(usize, codespan::Span)> = vec![];
 
@@ -893,8 +906,12 @@ impl ExecutionError {
                 Self::format_smid_detail(error_smid, source_map)
             ));
 
-            // vm.annotation (same as error smid for most errors)
-            dump.push(format!("has_source_label: {has_source_label}"));
+            // Whether the error's own Smid points to a user file
+            dump.push(format!("error_has_user_file: {error_has_user_file}"));
+            dump.push(format!(
+                "primary_file_span: {:?}",
+                primary_file_span.map(|(f, s)| (f, s.start(), s.end()))
+            ));
 
             // Environment trace
             if env_trace.is_empty() {

--- a/src/wasm_pipeline.rs
+++ b/src/wasm_pipeline.rs
@@ -116,6 +116,7 @@ fn run_pipeline(source: &str, format: &str, mode: ParseMode) -> Result<String, P
         .expect("prelude is embedded")
         .clone();
     let prelude_file_id = files.add("prelude".to_string(), prelude_text.clone());
+    source_map.mark_resource_file(prelude_file_id);
     let prelude_parse = rowan::parse_unit(&prelude_text);
     if !prelude_parse.errors().is_empty() {
         return Err(PipelineError {

--- a/tests/harness/errors/131_map_user_location.eu
+++ b/tests/harness/errors/131_map_user_location.eu
@@ -1,0 +1,4 @@
+# Error through prelude map() should show user's call site as primary location,
+# not the prelude's map internals.
+data: [1, 2, 3]
+result: data map(+ "hello")

--- a/tests/harness/errors/131_map_user_location.eu.expect
+++ b/tests/harness/errors/131_map_user_location.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "131_map_user_location.eu:4"

--- a/tests/harness/errors/132_foldl_user_location.eu
+++ b/tests/harness/errors/132_foldl_user_location.eu
@@ -1,0 +1,3 @@
+# Error through prelude foldl() should show user's call site as primary location,
+# not the prelude's foldl internals.
+result: [1, 2, 3] foldl(+, "zero")

--- a/tests/harness/errors/132_foldl_user_location.eu.expect
+++ b/tests/harness/errors/132_foldl_user_location.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "132_foldl_user_location.eu:3"

--- a/tests/harness/errors/133_stack_trace_cycle_dedup.eu
+++ b/tests/harness/errors/133_stack_trace_cycle_dedup.eu
@@ -1,0 +1,3 @@
+# Stack traces with cycles (e.g. mutual recursion through prelude foldl and +)
+# should be deduplicated rather than showing the same frames repeatedly.
+result: [1, 2, 3] foldl(+, "zero")

--- a/tests/harness/errors/133_stack_trace_cycle_dedup.eu.expect
+++ b/tests/harness/errors/133_stack_trace_cycle_dedup.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "frames elided"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1508,6 +1508,21 @@ pub fn test_error_130() {
 }
 
 #[test]
+pub fn test_error_131() {
+    run_error_test(&error_opts("131_map_user_location.eu"));
+}
+
+#[test]
+pub fn test_error_132() {
+    run_error_test(&error_opts("132_foldl_user_location.eu"));
+}
+
+#[test]
+pub fn test_error_133() {
+    run_error_test(&error_opts("133_stack_trace_cycle_dedup.eu"));
+}
+
+#[test]
 pub fn test_harness_142() {
     run_test(&opts("142_consecutive_metadata_blocks.eu"));
 }


### PR DESCRIPTION
## Summary

- **Primary error location**: When an error occurs inside a prelude/library function, the primary label now points to the user's call site rather than the prelude internals
- **Stack trace cycle deduplication**: Repeating patterns in stack traces (e.g. mutual recursion between `foldl` and `+`) are now compressed

## Before / After

### Before
```
error: type mismatch: expected number, found string "hello"
   ┌─ [prelude]:1408:33          ← prelude shown as PRIMARY
   │
1408 │ map(f, l): if(l nil?, l, cons(l head f, l tail map(f)))
   │                                 ^^^^
   ┌─ /tmp/err-test.eu:2:14      ← user code shown as secondary
   │
   2 │ result: data map(+ "hello")
   │              --- - called from here
```

### After
```
error: type mismatch: expected number, found string "hello"
     ┌─ err-test.eu:2:18         ← user code shown as PRIMARY
   │
   2 │ result: data map(+ "hello")
   │              --- ^
   ┌─ [prelude]:1408:33          ← prelude shown as secondary
```

Stack trace (before): 4 identical cyclic frames repeated  
Stack trace (after): `... 2 frames elided (2× repetition)`

## Implementation

- `SourceMap::mark_resource_file(file_id)` — marks a file ID as belonging to a resource (prelude, stdlib)
- `SourceMap::is_user_file(file_id)` — returns `true` for user-authored files
- `SourceMap::first_user_source_smid(trace)` — finds first Smid from a user file in a trace
- `SourceLoader::load_source()` — calls `mark_resource_file()` when loading `Locator::Resource` files
- `ExecutionError::to_diagnostic()` — prefers user-file location as primary; falls back to resource location only when no user location is found
- `compress_trace_cycles()` — new function that detects and compresses repeating patterns in formatted stack traces

## Tests

- `131_map_user_location` — error through `map()` shows user file as primary
- `132_foldl_user_location` — error through `foldl()` shows user file as primary  
- `133_stack_trace_cycle_dedup` — stack trace cycles produce `frames elided` output

All 282 harness tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)