### PR TITLE
fix(parser): recover from bare colon in block without panic

### DIFF
--- a/src/syntax/rowan/mod.rs
+++ b/src/syntax/rowan/mod.rs
@@ -368,4 +368,25 @@ mod tests {
             panic!("Element should be a StringPattern");
         }
     }
+
+    #[test]
+    fn bare_colon_in_block_does_not_panic() {
+        use crate::syntax::rowan::parse_unit;
+
+        // Typing `{ : }` in the editor (e.g. starting a monad tag) must
+        // not crash the parser.  The LSP completion provider needs to run
+        // on partially-typed input like this.
+        let parse = parse_unit("main: { : }");
+        // Parse should complete without panic — errors are acceptable.
+        let _ = parse.syntax_node();
+    }
+
+    #[test]
+    fn bare_colon_at_block_end_does_not_panic() {
+        use crate::syntax::rowan::parse_unit;
+
+        // Edge case: colon immediately before close brace with no space.
+        let parse = parse_unit("main: {:}");
+        let _ = parse.syntax_node();
+    }
 }

--- a/src/syntax/rowan/parse.rs
+++ b/src/syntax/rowan/parse.rs
@@ -1195,6 +1195,12 @@ impl EventSink for BlockEventSink {
                     self.commit_meta();
                 }
             }
+        } else if self.declaration.is_some() {
+            // Orphaned declaration with empty body (e.g. `{ : }` while
+            // typing a monad tag).  Commit it so all tokens are accounted
+            // for — it will have an empty body which is valid for error
+            // recovery and LSP completion.
+            self.commit_declaration();
         }
         swap(&mut self.committed, &mut ret);
         ret


### PR DESCRIPTION
## Summary

- Parser panicked on `{ : }` input — exactly what happens when a user starts typing a monad tag (`:for`, `:io`) in the editor
- The `BlockEventSink` consumed the COLON into a pending declaration but never committed it when the body was empty, leaving a token unaccounted for and triggering an assertion failure
- Fix: commit orphaned declarations (empty body) in `complete()` so all tokens are emitted
- This was blocking the monad tag completion feature added in PR #671 — completion can't run if the parser crashes first

## Test plan

- [x] `eu -B -e '{ : }'` — clean error, no panic
- [x] `eu -B -e '{:}'` — no panic
- [x] Two new unit tests: `bare_colon_in_block_does_not_panic`, `bare_colon_at_block_end_does_not_panic`
- [x] All 294 harness tests pass
- [x] All 862 lib tests pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)