### PR TITLE
fix: show help when run with no inputs and terminal stdin

### DIFF
--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -3,6 +3,8 @@ extern crate eucalypt;
 use std::process;
 use std::thread;
 
+use std::io::IsTerminal;
+
 use eucalypt::driver::check;
 use eucalypt::driver::format;
 use eucalypt::driver::lsp;
@@ -87,6 +89,16 @@ fn run() -> i32 {
                 return 2;
             }
         }
+    }
+
+    // No files, no -e, and stdin is a terminal — show help.
+    if opt.explicit_inputs.is_empty() && opt.evaluate.is_none() && std::io::stdin().is_terminal() {
+        use clap::CommandFactory;
+        eucalypt::driver::options::EucalyptCli::command()
+            .print_help()
+            .ok();
+        println!();
+        return 0;
     }
 
     // Anything else is going to involve reading the inputs


### PR DESCRIPTION
## Summary

- `eu` with no files, no `-e`, and terminal stdin crashed with "expected scalar value" — the prelude's PRNG stream object was being rendered as output
- Now shows clap help text instead, matching standard CLI behaviour
- When stdin is a pipe, existing behaviour (read from stdin) is preserved

Fixes eu-4l91.

## Test plan

- [x] `eu` with terminal stdin → shows help (can only test interactively)
- [x] `eu -B` with piped stdin → `{}` (unchanged)
- [x] `eu -B -e '42'` → `42` (unchanged)
- [x] All 862 lib tests pass
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)