### PR TITLE
feat: symbol metadata shortcut for targets

### DIFF
--- a/docs/guide/blocks-and-declarations.md
+++ b/docs/guide/blocks-and-declarations.md
@@ -207,20 +207,33 @@ A bare string is shorthand for documentation metadata.
 Some metadata keys activate special behaviour:
 
 - `:suppress` -- hides the declaration from output
-- `:target` -- marks the declaration as an export target
 - `:main` -- marks the default target
+
+Any other bare symbol becomes a **target shortcut**:
 
 ```eu
 ` :suppress
 helper(x): x + 1
 
-` { target: :my-output }
+` :my-output
 output: {
   result: helper(41)
 }
 ```
 
 Running `eu file.eu -t my-output` renders only the `output` block.
+
+The symbol `:target` uses the declaration's own name:
+
+```eu
+` :target
+report: { total: 42 }
+```
+
+This is equivalent to `` ` { target: :report } ``.
+
+The block form `` ` { target: :name } `` is still supported for when
+you need to combine target with other metadata fields.
 
 ## Block and Unit Metadata
 

--- a/docs/guide/blocks-and-declarations.md
+++ b/docs/guide/blocks-and-declarations.md
@@ -207,8 +207,8 @@ A bare string is shorthand for documentation metadata.
 Some metadata keys activate special behaviour:
 
 - `:suppress` -- hides the declaration from output
+- `:target` -- marks the declaration as an export target
 - `:main` -- marks the default target
-- `:target` -- marks a target using the declaration's own name
 - Any other bare symbol -- marks a named target
 
 ```eu

--- a/docs/guide/blocks-and-declarations.md
+++ b/docs/guide/blocks-and-declarations.md
@@ -208,14 +208,13 @@ Some metadata keys activate special behaviour:
 
 - `:suppress` -- hides the declaration from output
 - `:main` -- marks the default target
-
-Any other bare symbol becomes a **target shortcut**:
+- Any other bare symbol -- marks a named target
 
 ```eu
 ` :suppress
 helper(x): x + 1
 
-` :my-output
+` { target: :my-output }
 output: {
   result: helper(41)
 }
@@ -223,17 +222,15 @@ output: {
 
 Running `eu file.eu -t my-output` renders only the `output` block.
 
-The symbol `:target` uses the declaration's own name:
+Bare symbols are a shortcut for target metadata — `` ` :my-output ``
+is equivalent to `` ` { target: :my-output } ``.  The special symbol
+`:target` uses the declaration's own name:
 
 ```eu
 ` :target
 report: { total: 42 }
+# equivalent to ` { target: :report }
 ```
-
-This is equivalent to `` ` { target: :report } ``.
-
-The block form `` ` { target: :name } `` is still supported for when
-you need to combine target with other metadata fields.
 
 ## Block and Unit Metadata
 

--- a/docs/guide/blocks-and-declarations.md
+++ b/docs/guide/blocks-and-declarations.md
@@ -208,6 +208,7 @@ Some metadata keys activate special behaviour:
 
 - `:suppress` -- hides the declaration from output
 - `:main` -- marks the default target
+- `:target` -- marks a target using the declaration's own name
 - Any other bare symbol -- marks a named target
 
 ```eu

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -2462,7 +2462,7 @@ fn rowan_declaration_to_binding(
     // Process metadata for desugar-phase information
     let (core_meta, metadata) = match components.metadata {
         Some(m) => {
-            let mut core_meta = normalise_metadata(&m);
+            let mut core_meta = normalise_metadata(&m, Some(&name));
             let metadata: DesugarPhaseDeclarationMetadata =
                 core_meta.read_metadata().unwrap_or_default();
             (Some(core_meta), metadata)
@@ -2615,7 +2615,7 @@ impl Desugarable for rowan_ast::Block {
         // Transform metadata for attachment later
         let mut metadata = if let Some(meta) = self.meta() {
             if let Some(meta_soup) = meta.soup() {
-                Some(normalise_metadata(&meta_soup.desugar(desugarer)?))
+                Some(normalise_metadata(&meta_soup.desugar(desugarer)?, None))
             } else {
                 None
             }
@@ -2758,7 +2758,7 @@ impl Desugarable for rowan_ast::Unit {
         // Transform metadata for attachment later
         let mut metadata = if let Some(meta) = self.meta() {
             if let Some(meta_soup) = meta.soup() {
-                Some(normalise_metadata(&meta_soup.desugar(desugarer)?))
+                Some(normalise_metadata(&meta_soup.desugar(desugarer)?, None))
             } else {
                 None
             }

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -30,11 +30,12 @@ fn extract_function_name(expr: &RcExpr) -> Option<String> {
     None
 }
 
-/// Support a few shortcuts for metadata
+/// Support shortcuts for metadata symbols.
 ///
-/// Strings are values for :doc. :main is a target. :suppress is an
-/// export specifier.
-pub fn normalise_metadata(expr: &RcExpr) -> RcExpr {
+/// Strings are values for `:doc`.  `:suppress` is an export specifier.
+/// `:main` is a target.  `:target` uses the declaration's own name as
+/// the target.  Any other unrecognised symbol becomes a target shortcut.
+pub fn normalise_metadata(expr: &RcExpr, decl_name: Option<&str>) -> RcExpr {
     match &*expr.inner {
         Expr::Literal(smid, prim) => match prim {
             Primitive::Str(_) => {
@@ -45,10 +46,22 @@ pub fn normalise_metadata(expr: &RcExpr) -> RcExpr {
                     *smid,
                     [("export".to_string(), expr.clone())].iter().cloned(),
                 ),
-                "main" => core::block(
-                    *smid,
-                    [("target".to_string(), expr.clone())].iter().cloned(),
-                ),
+                "target" => {
+                    if let Some(name) = decl_name {
+                        let target_sym = core::sym(*smid, name);
+                        core::block(*smid, [("target".to_string(), target_sym)].iter().cloned())
+                    } else {
+                        // Unit-level :target — no declaration name, pass through
+                        expr.clone()
+                    }
+                }
+                _ if decl_name.is_some() => {
+                    // Unrecognised symbol on a declaration → target shortcut
+                    core::block(
+                        *smid,
+                        [("target".to_string(), expr.clone())].iter().cloned(),
+                    )
+                }
                 _ => expr.clone(),
             },
             _ => expr.clone(),

--- a/tests/harness/148_symbol_target_shortcut.eu
+++ b/tests/harness/148_symbol_target_shortcut.eu
@@ -1,0 +1,21 @@
+"Symbol metadata target shortcuts. Bare symbols become targets. :target uses the declaration name."
+
+` :alpha
+alpha-target: 1
+
+` :beta
+beta-target: 2
+
+` :target
+self-named: 3
+
+` :suppress
+hidden: 99
+
+` :main
+tests: {
+  ` "symbol shortcut targets"
+  shortcut-alpha: alpha-target //= 1
+  shortcut-beta: beta-target //= 2
+  self-target: self-named //= 3
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1582,6 +1582,11 @@ pub fn test_harness_147() {
     run_test(&opts("147_type_annotations.eu"));
 }
 
+#[test]
+pub fn test_harness_148() {
+    run_test(&opts("148_symbol_target_shortcut.eu"));
+}
+
 // ── Type check message tests ──────────────────────────────────────────────────
 
 #[test]

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1587,6 +1587,61 @@ pub fn test_harness_148() {
     run_test(&opts("148_symbol_target_shortcut.eu"));
 }
 
+#[test]
+pub fn test_target_symbol_shortcut_alpha() {
+    let output = std::process::Command::new(eu_binary())
+        .args([
+            "-B",
+            "-t",
+            "alpha",
+            "tests/harness/148_symbol_target_shortcut.eu",
+        ])
+        .output()
+        .expect("failed to run eu");
+    assert_eq!(output.status.code(), Some(0), "eu -t alpha should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('1'),
+        "alpha target should render 1, got: {stdout}"
+    );
+}
+
+#[test]
+pub fn test_target_symbol_shortcut_self_named() {
+    let output = std::process::Command::new(eu_binary())
+        .args([
+            "-B",
+            "-t",
+            "self-named",
+            "tests/harness/148_symbol_target_shortcut.eu",
+        ])
+        .output()
+        .expect("failed to run eu");
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "eu -t self-named should succeed"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('3'),
+        "self-named target should render 3, got: {stdout}"
+    );
+}
+
+#[test]
+pub fn test_target_symbol_suppress_still_works() {
+    let output = std::process::Command::new(eu_binary())
+        .args(["-B", "tests/harness/148_symbol_target_shortcut.eu"])
+        .output()
+        .expect("failed to run eu");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("hidden"),
+        ":suppress should suppress 'hidden' from output, got: {stdout}"
+    );
+}
+
 // ── Type check message tests ──────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Bare symbols in declaration metadata become target definitions: `` ` :test `` on a declaration is equivalent to `` ` { target: :test } ``
- The special symbol `:target` uses the declaration's own name as the target name
- Only applies to declaration-level metadata — block-internal metadata (`:monad`, etc.) passes through unchanged
- Known shortcuts (`:suppress`) continue to work as before

Implements eu-7a84.

## Test plan

- [x] `` ` :test `` → `eu -t test` renders the declaration
- [x] `` ` :target `` on `my-output` → `eu -t my-output` renders it
- [x] `:suppress` still works as export suppression
- [x] `:main` still works as main target
- [x] `:target` on unit-level metadata → ignored (no crash)
- [x] `:monad` in block bodies → unchanged (no regression)
- [x] New harness test 148 passes
- [x] All 295 harness tests pass
- [x] `eu check lib/prelude.eu` — zero warnings
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)