### PR TITLE
feat: LSP integration test harness

### DIFF
--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -20,6 +20,7 @@ mod selection;
 mod semantic;
 pub mod symbol_table;
 mod symbols;
+pub mod testing;
 
 use std::collections::HashMap;
 

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -1,0 +1,138 @@
+//! In-process LSP test harness.
+//!
+//! Provides `LspTestSession` — a lightweight wrapper around the LSP
+//! handler functions that simulates an editing session without any
+//! JSON-RPC transport.  Used for integration tests that exercise LSP
+//! features against realistic editing scenarios.
+
+use lsp_types::{CompletionItem, CompletionResponse, Hover, InlayHint, Position, Range, Url};
+
+use super::completion;
+use super::hover;
+use super::inlay_hints;
+use super::symbol_table::{self, SymbolSource, SymbolTable};
+use crate::syntax::rowan::parse_unit;
+
+/// An in-process LSP editing session for testing.
+///
+/// Simulates opening, editing, and querying a single document without
+/// the JSON-RPC transport layer.
+pub struct LspTestSession {
+    uri: Url,
+    content: String,
+    prelude_table: SymbolTable,
+}
+
+impl LspTestSession {
+    /// Create a new session with the prelude loaded.
+    pub fn new() -> Self {
+        let uri = Url::parse("file:///test.eu").expect("test URI");
+        let prelude_uri = Url::parse("resource:prelude").expect("prelude URI");
+        Self {
+            uri,
+            content: String::new(),
+            prelude_table: symbol_table::prelude_symbols(&prelude_uri),
+        }
+    }
+
+    /// Open (or replace) the document content.
+    pub fn open(&mut self, content: &str) {
+        self.content = content.to_string();
+    }
+
+    /// Replace the entire document content (alias for `open`).
+    pub fn change(&mut self, content: &str) {
+        self.content = content.to_string();
+    }
+
+    /// Request completion at the given line and character offset.
+    pub fn complete(&self, line: u32, character: u32) -> Vec<CompletionItem> {
+        let parse = parse_unit(&self.content);
+        let root = parse.syntax_node();
+        let table = self.build_symbol_table();
+
+        let response = completion::completions(
+            &self.content,
+            &root,
+            &Position::new(line, character),
+            &table,
+            None,
+        );
+        match response {
+            CompletionResponse::Array(items) => items,
+            CompletionResponse::List(list) => list.items,
+        }
+    }
+
+    /// Request hover information at the given position.
+    pub fn hover(&self, line: u32, character: u32) -> Option<Hover> {
+        let parse = parse_unit(&self.content);
+        let root = parse.syntax_node();
+        let table = self.build_symbol_table();
+
+        hover::hover(
+            &self.content,
+            &root,
+            &Position::new(line, character),
+            &table,
+            None,
+        )
+    }
+
+    /// Request inlay hints for the full document.
+    pub fn inlay_hints(&self) -> Vec<InlayHint> {
+        let parse = parse_unit(&self.content);
+        let root = parse.syntax_node();
+        let table = self.build_symbol_table();
+
+        let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, 0));
+        inlay_hints::inlay_hints(&self.content, &root, &range, &table, None)
+    }
+
+    /// Get the completion labels as strings (convenience for assertions).
+    pub fn complete_labels(&self, line: u32, character: u32) -> Vec<String> {
+        self.complete(line, character)
+            .into_iter()
+            .map(|item| item.label)
+            .collect()
+    }
+
+    /// Get hover content as a plain string (convenience for assertions).
+    pub fn hover_text(&self, line: u32, character: u32) -> Option<String> {
+        self.hover(line, character).map(|h| match h.contents {
+            lsp_types::HoverContents::Markup(m) => m.value,
+            lsp_types::HoverContents::Scalar(s) => match s {
+                lsp_types::MarkedString::String(s) => s,
+                lsp_types::MarkedString::LanguageString(ls) => ls.value,
+            },
+            lsp_types::HoverContents::Array(arr) => arr
+                .into_iter()
+                .map(|s| match s {
+                    lsp_types::MarkedString::String(s) => s,
+                    lsp_types::MarkedString::LanguageString(ls) => ls.value,
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        })
+    }
+
+    fn build_symbol_table(&self) -> SymbolTable {
+        let parse = parse_unit(&self.content);
+        let unit = parse.tree();
+
+        let mut table = SymbolTable::new();
+        table.add_from_unit(&unit, &self.content, &self.uri, SymbolSource::Local);
+
+        for sym in self.prelude_table.all_symbols() {
+            table.add(sym.clone());
+        }
+
+        table
+    }
+}
+
+impl Default for LspTestSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -1,0 +1,144 @@
+//! LSP integration tests using the in-process test harness.
+//!
+//! Each test creates an `LspTestSession`, simulates editing actions,
+//! and asserts on LSP responses.  No JSON-RPC transport is involved.
+
+use eucalypt::driver::lsp::testing::LspTestSession;
+
+// ── Stability: partial input must not panic ────────────────────────────────
+
+#[test]
+fn bare_colon_in_block_does_not_crash() {
+    let mut s = LspTestSession::new();
+    s.open("{ : }");
+    // These should not panic
+    let _ = s.complete(0, 3);
+    let _ = s.hover(0, 3);
+    let _ = s.inlay_hints();
+}
+
+#[test]
+fn empty_document_does_not_crash() {
+    let mut s = LspTestSession::new();
+    s.open("");
+    let _ = s.complete(0, 0);
+    let _ = s.hover(0, 0);
+    let _ = s.inlay_hints();
+}
+
+#[test]
+fn unclosed_block_does_not_crash() {
+    let mut s = LspTestSession::new();
+    s.open("{ x: 1");
+    let _ = s.complete(0, 6);
+    let _ = s.hover(0, 2);
+    let _ = s.inlay_hints();
+}
+
+#[test]
+fn unclosed_string_does_not_crash() {
+    let mut s = LspTestSession::new();
+    s.open("x: \"hello");
+    let _ = s.complete(0, 9);
+    let _ = s.hover(0, 0);
+    let _ = s.inlay_hints();
+}
+
+#[test]
+fn incomplete_declaration_does_not_crash() {
+    let mut s = LspTestSession::new();
+    s.open("x:");
+    let _ = s.complete(0, 2);
+    let _ = s.hover(0, 0);
+    let _ = s.inlay_hints();
+}
+
+#[test]
+fn rapid_edit_sequence_does_not_crash() {
+    let mut s = LspTestSession::new();
+    let edits = [
+        "{", "{ ", "{ x", "{ x:", "{ x: ", "{ x: 1", "{ x: 1 ", "{ x: 1 }",
+    ];
+    for edit in edits {
+        s.change(edit);
+        let _ = s.complete(0, edit.len() as u32);
+    }
+}
+
+// ── Monad tag completion ───────────────────────────────────────────────────
+
+#[test]
+fn monad_tag_completion_after_colon() {
+    let mut s = LspTestSession::new();
+    s.open("main: { :for x: [1,2,3] }.(x)");
+    // Completion at the `:` position inside a block with a known monad tag
+    // should include monad namespaces (requires prelude loaded)
+    s.change("main: { : }");
+    let labels = s.complete_labels(0, 8);
+    // The prelude defines for, io, let, random, state as monads
+    assert!(
+        labels.iter().any(|l| l.contains("for")),
+        "should offer :for in completion, got: {labels:?}"
+    );
+}
+
+// ── Hover ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn hover_on_prelude_function() {
+    let mut s = LspTestSession::new();
+    s.open("main: map(negate, [1,2,3])");
+    let text = s.hover_text(0, 6);
+    assert!(text.is_some(), "hover on 'map' should return something");
+}
+
+// ── Inlay hints ────────────────────────────────────────────────────────────
+
+#[test]
+fn inlay_hints_on_monadic_binding() {
+    let mut s = LspTestSession::new();
+    s.open("main: { :for x: [1,2,3] }.(x)");
+    let hints = s.inlay_hints();
+    let type_hints: Vec<_> = hints
+        .iter()
+        .filter(|h| matches!(&h.label, lsp_types::InlayHintLabel::String(s) if s.contains("[a]")))
+        .collect();
+    assert!(
+        !type_hints.is_empty(),
+        "should show [a] type hint on monadic binding, got: {hints:?}"
+    );
+}
+
+// ── Regression: typing monad tag character by character ─────────────────────
+
+#[test]
+fn typing_monad_tag_keystroke_by_keystroke() {
+    let mut s = LspTestSession::new();
+    let keystrokes = [
+        "main: {",
+        "main: { ",
+        "main: { :",
+        "main: { :f",
+        "main: { :fo",
+        "main: { :for",
+        "main: { :for ",
+        "main: { :for x",
+        "main: { :for x:",
+        "main: { :for x: ",
+        "main: { :for x: [",
+        "main: { :for x: [1",
+        "main: { :for x: [1,",
+        "main: { :for x: [1,2",
+        "main: { :for x: [1,2]",
+        "main: { :for x: [1,2] ",
+        "main: { :for x: [1,2] }",
+        "main: { :for x: [1,2] }.",
+        "main: { :for x: [1,2] }.(x)",
+    ];
+    for keystroke in keystrokes {
+        s.change(keystroke);
+        // All of these must not panic
+        let _ = s.complete(0, keystroke.len() as u32);
+        let _ = s.hover(0, keystroke.len().saturating_sub(1) as u32);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `LspTestSession` in `src/driver/lsp/testing.rs` — an in-process wrapper around LSP handler functions that simulates editing sessions without JSON-RPC transport
- Adds `tests/lsp_test.rs` with 10 initial tests covering stability (partial input, empty docs, unclosed constructs), monad tag completion, hover, inlay hints, and keystroke-by-keystroke regression testing
- Foundation for eu-j4j1 (LSP stability testing) — easy to add more scenarios

Implements eu-51vu.

## Test plan

- [x] All 10 LSP tests pass
- [x] clippy clean, rustfmt clean
- [x] Builds on all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)