### PR TITLE
feat(typecheck): add asserted record type annotations to monad namespaces (eu-meir)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -26,7 +26,8 @@ eu: {
 }
 
 ` { doc: "IO related declarations. The io namespace is a monad: io.bind, io.return, io.sequence, io.map-m, io.filter-m, io.then, io.join are derived automatically."
-    monad: "IO(a)" }
+    monad: "IO(a)"
+    type: "!{{bind: IO(a) → (a → IO(b)) → IO(b), return: a → IO(a), map: (a → b) → IO(a) → IO(b), then: IO(a) → IO(b) → IO(b), and-then: (a → IO(b)) → IO(a) → IO(b), join: IO(IO(a)) → IO(a), sequence: [IO(a)] → IO([a]), map-m: (a → IO(b)) → [a] → IO([b]), filter-m: (a → IO(bool)) → [a] → IO([a]), ..}}" }
 io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
   ` { doc: "Read access to environment variables at time of launch."
       type: "{{..}}" }
@@ -147,7 +148,8 @@ random-bind(m, f, stream): {
 }
 
 ` { doc: "Monadic random: namespace. Each operation is a state-monad action: a function from stream to a value/rest block. Use random.stream(seed) to create the initial stream, then run actions by calling them with the stream."
-    monad: "stream → {{value: a, rest: stream}}" }
+    monad: "stream → {{value: a, rest: stream}}"
+    type: "!{{bind: (stream → {{value: a, rest: stream}}) → (a → stream → {{value: b, rest: stream}}) → stream → {{value: b, rest: stream}}, return: a → stream → {{value: a, rest: stream}}, ..}}" }
 random: monad{bind: random-bind, return: random-ret} {
   ` { doc: "random.stream(seed) - create an opaque PRNG stream from integer seed."
       type: "number → any" }
@@ -2098,7 +2100,8 @@ let: monad({bind(m, f): f(m), return: identity})
 ##
 
 ` { doc: "List monad for list comprehensions. Each binding draws from a list; subsequent bindings can depend on earlier ones. Use [x] filter(pred?) for guards."
-    monad: "[a]" }
+    monad: "[a]"
+    type: "!{{bind: [a] → (a → [b]) → [b], return: a → [a], map: (a → b) → [a] → [b], then: [a] → [b] → [b], and-then: (a → [b]) → [a] → [b], join: [[a]] → [a], sequence: [[a]] → [[a]], map-m: (a → [b]) → [a] → [[b]], filter-m: (a → [bool]) → [a] → [[a]]}}" }
 for: monad({bind(m, f): m mapcat(f), return(v): [v]})
 
 ##

--- a/lib/state.eu
+++ b/lib/state.eu
@@ -50,7 +50,8 @@ mod-at(lens, f, s): { value: null, state: over(lens, f, s) }
 # ─── Namespace (enables { :state ... } blocks) ───────────────────────────────
 
 ` { doc: "State monad namespace.  Each declaration in a colon-state block is a monadic bind step."
-    monad: "state → {{value: a, state: state}}" }
+    monad: "state → {{value: a, state: state}}"
+    type: "!{{bind: ({{..}} → {{value: a, state: {{..}}}}) → (a → {{..}} → {{value: b, state: {{..}}}}) → {{..}} → {{value: b, state: {{..}}}}, return: a → {{..}} → {{value: a, state: {{..}}}}, ..}}" }
 state: monad{bind: state-bind, return: state-ret} {
 
   ` "state.get - action returning the whole state as the value."


### PR DESCRIPTION
## Summary

- Adds `type:` metadata with `!` asserted record types to the `for`, `io`, `random`, and `state` namespace declarations
- Uses `!` prefix since `monad()` returns `{..}` and the checker cannot verify the body
- `for`: closed record with all 9 monad combinators (bind, return, map, then, and-then, join, sequence, map-m, filter-m)
- `io`: open record (`..`) with all 9 combinators plus room for IO-specific fields
- `random`: open record with bind and return typed explicitly (full combinators + stream/int/float extra fields)
- `state` (lib/state.eu): open record with bind and return typed explicitly

## Verification

- `eu check lib/prelude.eu` — zero warnings
- `eu check lib/state.eu` — zero warnings
- `cargo test --lib` — 855 tests pass
- `cargo clippy --all-targets -- -D warnings` — clean

## Bead

Closes eu-meir.