### PR TITLE
perf(lsp): cache parse errors to avoid re-parsing in apply_pipeline_result

### DIFF
--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -46,6 +46,7 @@ use lsp_types::{
 
 use crate::common::sourcemap::SourceMap;
 use crate::core::typecheck::types::Type;
+use crate::syntax::rowan::ParseError;
 
 use self::symbol_table::{SymbolSource, SymbolTable};
 
@@ -251,6 +252,11 @@ struct ServerState {
     /// Green node from the last parse per document, for change detection.
     last_green: HashMap<Url, rowan::GreenNode>,
 
+    /// Parse errors from the most recent parse per document.
+    /// Cached so that `apply_pipeline_result` can include them without
+    /// re-parsing the document.
+    last_parse_errors: HashMap<Url, Vec<ParseError>>,
+
     /// Channel for receiving pipeline results from background threads.
     pipeline_rx: mpsc::Receiver<PipelineResult>,
 
@@ -271,6 +277,7 @@ impl ServerState {
             prelude_table: symbol_table::prelude_symbols(&prelude_uri),
             cached: HashMap::new(),
             last_green: HashMap::new(),
+            last_parse_errors: HashMap::new(),
             pipeline_rx,
             pipeline_tx,
             cancel: HashMap::new(),
@@ -334,9 +341,12 @@ impl ServerState {
                     &cached.warnings,
                     &cached.source_map,
                 );
-                // Re-parse to get parse errors too (we must include them).
-                let parse = crate::syntax::rowan::parse_unit(&text);
-                let mut diags = diagnostics::diagnostics_from_parse_errors(&text, parse.errors());
+                // Use cached parse errors from the most recent parse rather
+                // than re-parsing the document.
+                let cached_errors = self.last_parse_errors.get(&uri);
+                let empty = vec![];
+                let parse_errors = cached_errors.unwrap_or(&empty);
+                let mut diags = diagnostics::diagnostics_from_parse_errors(&text, parse_errors);
                 diags.extend(type_diags);
 
                 let params = PublishDiagnosticsParams {
@@ -356,11 +366,13 @@ impl ServerState {
                 eprintln!("pipeline error for {uri}: {err}");
                 // Remove stale cached result so we don't serve outdated
                 // type information. Re-publish diagnostics with only parse
-                // errors (no type warnings).
+                // errors (no type warnings), using the cached parse errors.
                 self.cached.remove(&uri);
                 let text = self.store.get(&uri).unwrap_or_default().to_string();
-                let parse = crate::syntax::rowan::parse_unit(&text);
-                let diags = diagnostics::diagnostics_from_parse_errors(&text, parse.errors());
+                let cached_errors = self.last_parse_errors.get(&uri);
+                let empty = vec![];
+                let parse_errors = cached_errors.unwrap_or(&empty);
+                let diags = diagnostics::diagnostics_from_parse_errors(&text, parse_errors);
                 let params = PublishDiagnosticsParams {
                     uri: uri.clone(),
                     diagnostics: diags,
@@ -625,6 +637,7 @@ fn on_document_close(state: &mut ServerState, params: lsp_types::DidCloseTextDoc
     state.store.close(&uri);
     state.cached.remove(&uri);
     state.last_green.remove(&uri);
+    state.last_parse_errors.remove(&uri);
     if let Some(cancel) = state.cancel.remove(&uri) {
         cancel.store(true, Ordering::SeqCst);
     }
@@ -651,8 +664,11 @@ fn on_document_changed(
         return Ok(());
     }
 
-    // Update cached green node.
+    // Update cached green node and parse errors.
     state.last_green.insert(uri.clone(), new_green);
+    state
+        .last_parse_errors
+        .insert(uri.clone(), parse.errors().clone());
 
     // Publish parse-error diagnostics immediately.
     let diags = diagnostics::diagnostics_from_parse_errors(text, parse.errors());

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -19,7 +19,7 @@ use super::hover;
 use super::inlay_hints;
 use super::symbol_table::{self, SymbolSource, SymbolTable};
 use super::{apply_content_change, CachedPipeline, PipelineResult, TypeEnv};
-use crate::syntax::rowan::parse_unit;
+use crate::syntax::rowan::{parse_unit, ParseError};
 
 /// An in-process LSP editing session for testing.
 ///
@@ -35,6 +35,8 @@ pub struct LspTestSession {
     pipeline_tx: mpsc::Sender<PipelineResult>,
     cancel: Arc<AtomicBool>,
     last_green: Option<rowan::GreenNode>,
+    /// Parse errors from the most recent parse, cached to avoid re-parsing.
+    last_parse_errors: Vec<ParseError>,
 }
 
 impl LspTestSession {
@@ -52,6 +54,7 @@ impl LspTestSession {
             pipeline_tx,
             cancel: Arc::new(AtomicBool::new(false)),
             last_green: None,
+            last_parse_errors: Vec::new(),
         }
     }
 
@@ -305,6 +308,7 @@ impl LspTestSession {
             return;
         }
         self.last_green = Some(new_green);
+        self.last_parse_errors = parse.errors().clone();
 
         // Cancel any in-flight run.
         self.cancel.store(true, Ordering::SeqCst);


### PR DESCRIPTION
## Summary

When the background pipeline result arrives, `apply_pipeline_result` previously called `parse_unit` a second time solely to get the parse-error list. The document had already been parsed in `on_document_changed` and nothing had changed in between.

- Adds `last_parse_errors` map to `ServerState` (and field to `LspTestSession`)
- Stores parse errors alongside the green node on every parse
- Removes the two redundant `parse_unit` calls from `apply_pipeline_result`
- Cleans up on `didClose`

The diagnostics published are identical; only the redundant parse is eliminated.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test lsp_test` — 58 tests pass

Closes eu-4toi.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)