### PR TITLE
docs(lsp): document green node change detection includes token text (eu-4toi.3)

### DIFF
--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -655,6 +655,18 @@ fn on_document_changed(
     let new_green = parse.syntax_node().green().into_owned();
 
     // Check if the green node actually changed.
+    //
+    // Rowan's GreenNode equality compares both tree structure AND token text,
+    // so changing a string literal (e.g. `"hello"` → `"world"`) is detected
+    // as a change and triggers a pipeline re-run.  This is intentional:
+    //
+    // - Import paths are string literals (`{ import: "foo.eu" }`), and
+    //   changing the path must re-run the pipeline to load the new file.
+    // - Eucalypt string values participate in type-checking and can affect
+    //   pipeline output semantically.
+    //
+    // A structural-only comparison (ignoring token text) would incorrectly
+    // suppress re-runs for such changes.  The current approach is correct.
     let changed = match state.last_green.get(&uri) {
         Some(prev_green) => *prev_green != new_green,
         None => true,

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -756,3 +756,43 @@ fn incremental_edit_surrogate_pair_offset() {
     s.apply_edit(0, 5, 0, 6, "c");
     assert_eq!(s.content(), "a \u{1F600} c\n");
 }
+
+// ── Green node change detection: string-only changes ────────────────────────
+
+/// The green node equality comparison includes token text, not just structure.
+/// Changing a string literal must trigger a pipeline re-run because string
+/// values can affect the pipeline (e.g. import paths are string literals).
+#[test]
+fn string_change_triggers_pipeline_run() {
+    let mut s = LspTestSession::new();
+    // First open: pipeline spawned.
+    s.open("x: \"hello\"\n");
+    // Change only the string content.  The tree structure is identical
+    // (same node kinds), but the token text differs.  Change detection
+    // must still report a change and spawn a new pipeline run.
+    s.change("x: \"world\"\n");
+    // Wait for the pipeline spawned by the second change.
+    // If change detection incorrectly skipped the re-run, this would time out.
+    s.wait_for_pipeline();
+    assert!(
+        s.has_cached(),
+        "pipeline should have run after string change"
+    );
+}
+
+#[test]
+fn identical_content_does_not_respawn_pipeline() {
+    let mut s = LspTestSession::new();
+    s.open("x: 1\n");
+    // Simulate an editor sending the same content again (no real change).
+    // The green node is identical so no pipeline should be spawned.
+    // We verify by checking that try_recv returns nothing after a brief wait.
+    s.change("x: 1\n");
+    // Give a short window for any spurious spawn.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let received = s.try_recv_pipeline();
+    assert!(
+        !received,
+        "no pipeline should run when content is unchanged"
+    );
+}


### PR DESCRIPTION
## Summary

Investigation of eu-4toi.3: whether structural-only GreenNode comparison (ignoring token text) is feasible to skip pipeline re-runs when only string literals change.

**Conclusion: the current full equality comparison is correct and should not be weakened.**

Rowan's `GreenToken::eq` compares both `kind` and `text`. Changing `"hello"` → `"world"` produces a different `GreenNode` and triggers a pipeline re-run. This is intentional:

- Import paths are string literals — `{ import: "foo.eu" }` → `{ import: "bar.eu" }` imports a different file, so the pipeline must re-run.
- String values can affect type-checking and pipeline output.

A structural-only comparison would silently suppress re-runs for import-path changes, producing stale type diagnostics.

**Changes:**
- Add an explanatory comment in `on_document_changed` recording the design decision
- Add two integration tests verifying the correct behaviour

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test lsp_test` — 60 tests pass
- [x] `string_change_triggers_pipeline_run` — pipeline re-runs after string change
- [x] `identical_content_does_not_respawn_pipeline` — identical content skips spawn

Closes eu-4toi.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)