### PR TITLE
fix: surface LSP pipeline errors as visible diagnostics

### DIFF
--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -71,10 +71,24 @@ struct CachedPipeline {
     imports: Vec<ImportedFile>,
 }
 
+/// A pipeline error with a message and optional source location.
+pub struct PipelineError {
+    /// The error message.
+    pub message: String,
+    /// Source location of the error, if available.
+    pub range: Option<lsp_types::Range>,
+}
+
+impl std::fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
 /// Result sent from the background pipeline thread.
 struct PipelineResult {
     uri: Url,
-    result: Result<CachedPipeline, String>,
+    result: Result<CachedPipeline, PipelineError>,
 }
 
 /// Run the LSP server on stdio.
@@ -363,16 +377,25 @@ impl ServerState {
                 self.cached.insert(uri.clone(), cached);
             }
             Err(err) => {
-                eprintln!("pipeline error for {uri}: {err}");
+                eprintln!("pipeline error for {}: {}", uri, err.message);
                 // Remove stale cached result so we don't serve outdated
-                // type information. Re-publish diagnostics with only parse
-                // errors (no type warnings), using the cached parse errors.
+                // type information. Re-publish diagnostics with parse
+                // errors plus the pipeline error as a visible warning.
                 self.cached.remove(&uri);
                 let text = self.store.get(&uri).unwrap_or_default().to_string();
                 let cached_errors = self.last_parse_errors.get(&uri);
                 let empty = vec![];
                 let parse_errors = cached_errors.unwrap_or(&empty);
-                let diags = diagnostics::diagnostics_from_parse_errors(&text, parse_errors);
+                let mut diags = diagnostics::diagnostics_from_parse_errors(&text, parse_errors);
+                // Surface the pipeline error as a diagnostic so the user
+                // can see why type checking and import resolution failed.
+                diags.push(lsp_types::Diagnostic {
+                    range: err.range.unwrap_or_default(),
+                    severity: Some(lsp_types::DiagnosticSeverity::WARNING),
+                    source: Some("eucalypt-pipeline".to_string()),
+                    message: err.message,
+                    ..Default::default()
+                });
                 let params = PublishDiagnosticsParams {
                     uri: uri.clone(),
                     diagnostics: diags,
@@ -972,11 +995,40 @@ fn spawn_pipeline(
 /// editor content is type-checked without requiring a save to disk.
 /// Returns extracted data (type env, warnings, source map) since
 /// `SourceLoader` is not `Send`.
+/// Convert a `EucalyptError` into a `PipelineError` with source location
+/// extracted from the loader's source map and file store.
+fn make_pipeline_error(
+    loader: &crate::driver::source::SourceLoader,
+    e: &crate::driver::error::EucalyptError,
+) -> PipelineError {
+    use codespan_reporting::files::Files;
+    let diag = e.to_diagnostic(loader.source_map());
+    let range = diag.labels.first().and_then(|label| {
+        let files = loader.files();
+        let start = files.location(label.file_id, label.range.start).ok()?;
+        let end = files.location(label.file_id, label.range.end).ok()?;
+        Some(lsp_types::Range {
+            start: lsp_types::Position {
+                line: (start.line_number - 1) as u32,
+                character: (start.column_number - 1) as u32,
+            },
+            end: lsp_types::Position {
+                line: (end.line_number - 1) as u32,
+                character: (end.column_number - 1) as u32,
+            },
+        })
+    });
+    PipelineError {
+        message: format!("{e}"),
+        range,
+    }
+}
+
 fn run_pipeline(
     uri: &Url,
     text: &str,
     path: Option<&std::path::Path>,
-) -> Result<CachedPipeline, String> {
+) -> Result<CachedPipeline, PipelineError> {
     use crate::core::typecheck::check::type_check_full;
     use crate::driver::source::SourceLoader;
     use crate::syntax::input::{Input, Locator};
@@ -1002,24 +1054,30 @@ fn run_pipeline(
     let mut loader = SourceLoader::new(vec![]);
 
     for input in &inputs {
-        loader.load(input).map_err(|e| format!("load: {e}"))?;
+        if let Err(e) = loader.load(input) {
+            return Err(make_pipeline_error(&loader, &e));
+        }
     }
     for input in &inputs {
-        loader
-            .translate(input)
-            .map_err(|e| format!("desugar: {e}"))?;
+        if let Err(e) = loader.translate(input) {
+            return Err(make_pipeline_error(&loader, &e));
+        }
     }
-    loader
-        .merge_units(&inputs)
-        .map_err(|e| format!("merge: {e}"))?;
-    loader.cook().map_err(|e| format!("cook: {e}"))?;
+    if let Err(e) = loader.merge_units(&inputs) {
+        return Err(make_pipeline_error(&loader, &e));
+    }
+    if let Err(e) = loader.cook() {
+        return Err(make_pipeline_error(&loader, &e));
+    }
 
     // Extract all binding names BEFORE dead-code elimination so that
     // completion can offer imported names that aren't yet referenced.
     let mut type_env = TypeEnv::new();
     extract_top_level_bindings(&loader.core().expr, &mut type_env);
 
-    loader.eliminate().map_err(|e| format!("eliminate: {e}"))?;
+    if let Err(e) = loader.eliminate() {
+        return Err(make_pipeline_error(&loader, &e));
+    }
 
     let core_expr = loader.core().expr.clone();
     let result = type_check_full(&core_expr);

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -18,7 +18,7 @@ use super::completion;
 use super::hover;
 use super::inlay_hints;
 use super::symbol_table::{self, SymbolSource, SymbolTable};
-use super::{apply_content_change, CachedPipeline, PipelineResult, TypeEnv};
+use super::{apply_content_change, CachedPipeline, PipelineError, PipelineResult, TypeEnv};
 use crate::syntax::rowan::{parse_unit, ParseError};
 
 /// An in-process LSP editing session for testing.
@@ -37,6 +37,8 @@ pub struct LspTestSession {
     last_green: Option<rowan::GreenNode>,
     /// Parse errors from the most recent parse, cached to avoid re-parsing.
     last_parse_errors: Vec<ParseError>,
+    /// Last pipeline error, if any.
+    last_pipeline_error: Option<PipelineError>,
 }
 
 impl LspTestSession {
@@ -55,6 +57,7 @@ impl LspTestSession {
             cancel: Arc::new(AtomicBool::new(false)),
             last_green: None,
             last_parse_errors: Vec::new(),
+            last_pipeline_error: None,
         }
     }
 
@@ -110,9 +113,12 @@ impl LspTestSession {
             Ok(result) => match result.result {
                 Ok(cached) => {
                     self.cached = Some(cached);
+                    self.last_pipeline_error = None;
                 }
                 Err(err) => {
                     eprintln!("pipeline error in test: {err}");
+                    self.cached = None;
+                    self.last_pipeline_error = Some(err);
                 }
             },
             Err(e) => {
@@ -216,6 +222,11 @@ impl LspTestSession {
     /// Return the current document content.
     pub fn content(&self) -> &str {
         &self.content
+    }
+
+    /// Return the last pipeline error, if any.
+    pub fn last_pipeline_error(&self) -> Option<&PipelineError> {
+        self.last_pipeline_error.as_ref()
     }
 
     /// Check if a cached pipeline result is available.

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -623,6 +623,11 @@ impl SourceLoader {
         &self.source_map
     }
 
+    /// Access the file store for error location resolution.
+    pub fn files(&self) -> &SimpleFiles<String, String> {
+        &self.files
+    }
+
     /// Print a diagnostic to stderr
     pub fn diagnose_to_stderr(&self, diag: &Diagnostic<usize>) {
         let writer = StandardStream::stderr(ColorChoice::Auto);

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -680,6 +680,63 @@ fn requests_during_pipeline_run_do_not_crash() {
     assert!(s.has_cached());
 }
 
+// ── Pipeline: error diagnostics with source location ─────────────────────────
+
+#[test]
+fn pipeline_error_has_source_location() {
+    let mut s = LspTestSession::new();
+    let test_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/lsp");
+    let test_uri =
+        lsp_types::Url::from_file_path(test_dir.join("pipeline_error.eu")).expect("valid file URI");
+    s.set_uri(test_uri.as_str());
+
+    // Content that will cause a pipeline error (bad import)
+    s.open("{ import: \"nonexistent_file.eu\" }\nmain: 42");
+    s.wait_for_pipeline();
+
+    let err = s.last_pipeline_error();
+    assert!(
+        err.is_some(),
+        "pipeline should have produced an error for missing import"
+    );
+    let err = err.unwrap();
+    assert!(
+        !err.message.is_empty(),
+        "pipeline error should have a message"
+    );
+}
+
+#[test]
+fn pipeline_error_clears_stale_cache() {
+    let mut s = LspTestSession::new();
+
+    // Successful pipeline first
+    s.run_pipeline("x: 1");
+    assert!(s.has_cached(), "should have cached result");
+    assert!(
+        s.last_pipeline_error().is_none(),
+        "should have no error after success"
+    );
+
+    // Now cause a pipeline error
+    let test_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/lsp");
+    let test_uri =
+        lsp_types::Url::from_file_path(test_dir.join("pipeline_error.eu")).expect("valid file URI");
+    s.set_uri(test_uri.as_str());
+    s.open("{ import: \"nonexistent_file.eu\" }\nmain: 42");
+    s.wait_for_pipeline();
+
+    assert!(
+        s.last_pipeline_error().is_some(),
+        "should have pipeline error"
+    );
+    // Stale cache should have been cleared
+    assert!(
+        !s.has_cached(),
+        "stale cached result should be cleared on pipeline error"
+    );
+}
+
 // ── Incremental sync: apply_edit ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Pipeline errors (e.g. invalid monad spec on a bracket pair) were only logged to stderr — the user saw no indication in the editor why type checking and import resolution stopped working.

Now publishes the pipeline error message as a WARNING diagnostic with source `eucalypt-pipeline`, so it appears in the editor's problems panel.

## Test plan

- [x] All 72 LSP tests pass
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)