### PR TITLE
fix: LSP go-to-definition on prelude names navigates to real file

### DIFF
--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -285,8 +285,13 @@ struct ServerState {
 
 impl ServerState {
     fn new() -> Self {
-        let prelude_uri = Url::parse("resource:prelude")
-            .unwrap_or_else(|_| Url::parse("file:///prelude.eu").expect("fallback URI"));
+        // Write the embedded prelude to a temp file so go-to-definition
+        // can navigate to real source locations instead of the non-existent
+        // resource:prelude URI.
+        let prelude_uri = Self::write_prelude_to_temp().unwrap_or_else(|| {
+            Url::parse("resource:prelude")
+                .unwrap_or_else(|_| Url::parse("file:///prelude.eu").expect("fallback URI"))
+        });
         let (pipeline_tx, pipeline_rx) = mpsc::channel();
         Self {
             store: DocumentStore::new(),
@@ -298,6 +303,19 @@ impl ServerState {
             pipeline_tx,
             cancel: HashMap::new(),
         }
+    }
+
+    /// Write the embedded prelude source to a temp file and return its
+    /// file URI.  Returns `None` if the write fails.
+    fn write_prelude_to_temp() -> Option<Url> {
+        let prelude_source = crate::driver::resources::Resources::default()
+            .get("prelude")?
+            .clone();
+        let dir = std::env::temp_dir().join("eucalypt-lsp");
+        std::fs::create_dir_all(&dir).ok()?;
+        let path = dir.join("prelude.eu");
+        std::fs::write(&path, &prelude_source).ok()?;
+        Url::from_file_path(&path).ok()
     }
 
     /// Look up the type env for a URI from the cached pipeline result.

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -45,9 +45,13 @@ pub struct LspTestSession {
 
 impl LspTestSession {
     /// Create a new session with the prelude loaded.
+    ///
+    /// Uses the same temp-file prelude as the real server so that
+    /// go-to-definition on prelude names returns a file: URI.
     pub fn new() -> Self {
         let uri = Url::parse("file:///test.eu").expect("test URI");
-        let prelude_uri = Url::parse("resource:prelude").expect("prelude URI");
+        let prelude_uri = super::ServerState::write_prelude_to_temp()
+            .unwrap_or_else(|| Url::parse("resource:prelude").expect("prelude URI"));
         let (pipeline_tx, pipeline_rx) = mpsc::channel();
         Self {
             uri,

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -1009,3 +1009,41 @@ fn goto_definition_bracket_block_binding_jumps_to_pair() {
         "go-to-def on bracket block binding should return a result"
     );
 }
+
+// ── Go-to-definition: prelude names ──────────────────────────────────────────
+
+#[test]
+fn goto_definition_prelude_function_returns_file_uri() {
+    let mut s = LspTestSession::new();
+    // "map" is at column 6 in "main: map(negate, [1])"
+    s.open("main: map(negate, [1])");
+    let def = s.goto_definition(0, 6);
+    assert!(def.is_some(), "go-to-def on 'map' should return a result");
+    // The definition should point to a file: URI (the temp prelude),
+    // not resource:prelude which editors can't navigate to.
+    match def.unwrap() {
+        lsp_types::GotoDefinitionResponse::Scalar(loc) => {
+            assert!(
+                loc.uri.scheme() == "file",
+                "prelude go-to-def should use file: URI, got: {}",
+                loc.uri
+            );
+        }
+        lsp_types::GotoDefinitionResponse::Array(locs) => {
+            assert!(!locs.is_empty());
+            assert!(
+                locs[0].uri.scheme() == "file",
+                "prelude go-to-def should use file: URI, got: {}",
+                locs[0].uri
+            );
+        }
+        lsp_types::GotoDefinitionResponse::Link(links) => {
+            assert!(!links.is_empty());
+            assert!(
+                links[0].target_uri.scheme() == "file",
+                "prelude go-to-def should use file: URI, got: {}",
+                links[0].target_uri
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Go-to-definition on prelude functions (map, foldl, etc.) opened a blank buffer because symbols were registered with a `resource:prelude` URI that editors can't navigate to.

Fix: on server startup, write the embedded prelude source to `/tmp/eucalypt-lsp/prelude.eu` and register symbols with that file URI. Go-to-definition now opens the actual prelude source. Falls back to the resource URI if the temp write fails.

Fixes eu-4toi.6.

## Test plan

- [x] All 80 LSP tests pass
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)