### PR TITLE
fix: bracket pair monad spec supports inline function definitions

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -733,13 +733,24 @@ fn extract_monad_meta(decl: &rowan_ast::Declaration) -> Option<Option<String>> {
 fn extract_monad_spec_from_body(
     body: &RcExpr,
     smid: Smid,
+    pair_name: Option<&str>,
 ) -> Result<Option<super::desugarer::MonadSpec>, CoreError> {
     use super::desugarer::MonadSpec;
     let has_monad_marker = has_monad_block_metadata(body);
     let spec = find_monad_spec_in_bindings(body);
     match (has_monad_marker, spec) {
         (true, Some(spec)) => Ok(Some(spec)),
-        (true, None) => Ok(None),
+        (true, None) => {
+            // Monad marker present but bind/return not extractable as names
+            // (e.g. inline function definitions).  If we have a pair name,
+            // fall back to treating the bracket pair itself as a namespace —
+            // its body block has bind and return as fields.
+            if let Some(name) = pair_name {
+                Ok(Some(MonadSpec::Namespace(name.to_string())))
+            } else {
+                Ok(None)
+            }
+        }
         (
             false,
             Some(MonadSpec::Explicit {
@@ -2512,7 +2523,8 @@ fn rowan_declaration_to_binding(
             rowan_ast::DeclarationKind::BracketBlockDef(_, _)
         ) {
             let spec_smid = desugarer.new_smid(components.span);
-            let spec = extract_monad_spec_from_body(&components.body, spec_smid)?;
+            let spec =
+                extract_monad_spec_from_body(&components.body, spec_smid, Some(&components.name))?;
             if let Some(monad_spec) = spec {
                 desugarer.register_monad_spec(components.name.clone(), monad_spec);
             }

--- a/tests/harness/149_bracket_inline_monad.eu
+++ b/tests/harness/149_bracket_inline_monad.eu
@@ -1,0 +1,23 @@
+"Bracket pairs with inline monad function definitions"
+
+# Identity monad with inline bind and return
+⟦{}⟧: { :monad bind(m, f): f(m)  return(a): a }
+
+# List monad with inline bind and return (uses free variable mapcat)
+⌈{}⌉: { :monad bind(m, f): m mapcat(f)  return(v): [v] }
+
+` :main
+tests: {
+
+  ` "inline identity monad — single binding"
+  id-single: ⟦ r: 42 ⟧.r //= 42
+
+  ` "inline identity monad — two bindings"
+  id-two: ⟦ a: 1  b: a + 1 ⟧.b //= 2
+
+  ` "inline list monad — single binding maps and wraps"
+  list-single: ⌈ x: [1, 2, 3] ⌉.(x * 2) //= [2, 4, 6]
+
+  ` "inline list monad — cartesian product"
+  list-product: ⌈ x: [1, 2]  y: [10, 20] ⌉.(x + y) //= [11, 21, 12, 22]
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1588,6 +1588,11 @@ pub fn test_harness_148() {
 }
 
 #[test]
+pub fn test_harness_149() {
+    run_test(&opts("149_bracket_inline_monad.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

Bracket pair declarations with inline monad functions now work:

```eu
⟦{}⟧: { :monad bind(m, f): f(m)  return(a): a }
```

Previously this failed silently — the monad spec extractor couldn't extract function names from inline lambda definitions, so `⟦ x: 42 ⟧` would error with "no monad spec".

Fix: when the `:monad` marker is present but bind/return names can't be extracted (inline definitions), fall back to treating the bracket pair itself as a namespace monad. The desugarer emits `⟦⟧.bind(value, lambda)` — accessing bind/return as fields on the bracket pair's own body block.

This avoids de Bruijn scope issues because the bracket pair is a regular top-level binding accessed by name — no expression injection needed.

Fixes eu-zgbj.

## Test plan

- [x] Harness test 149: inline identity monad, inline list monad (with free variables like mapcat), cartesian product
- [x] All 310 harness tests pass (1 ignored — eu-z9zz.11)
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)