### PR TITLE
fix: row variable binding inherits closedness correctly

### DIFF
--- a/src/core/typecheck/unify.rs
+++ b/src/core/typecheck/unify.rs
@@ -218,9 +218,15 @@ pub fn unify(t1: &Type, t2: &Type, subst: &mut Substitution) -> Result<(), Unify
                         .filter(|(k, _)| !f1.contains_key(*k))
                         .map(|(k, v)| (k.clone(), apply_subst(v, subst)))
                         .collect();
+                    // The row var captures exactly the extra fields.  If the
+                    // other side has a row var, propagate it (the result stays
+                    // open with a named row).  Otherwise the captured record
+                    // is closed — the anonymous openness of synthesised blocks
+                    // reflects runtime uncertainty, not a structural guarantee
+                    // that should propagate through row variable bindings.
                     let extra_ty = Type::Record {
                         fields: extra,
-                        open: open2,
+                        open: row2.is_some(),
                         row: row2.clone(),
                     };
                     if !occurs(r1, &extra_ty) {
@@ -238,7 +244,7 @@ pub fn unify(t1: &Type, t2: &Type, subst: &mut Substitution) -> Result<(), Unify
                         .collect();
                     let extra_ty = Type::Record {
                         fields: extra,
-                        open: open1,
+                        open: row1.is_some(),
                         row: row1.clone(),
                     };
                     if !occurs(r2, &extra_ty) {

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1780,7 +1780,6 @@ pub fn test_typecheck_021_row_var_block_app_preserves_field() {
 // to the declared return type, so the result is treated as open and `result.w`
 // produces no warning.  This test documents the desired end state.
 #[test]
-#[ignore = "row var return-type substitution not yet implemented in synthesise_app"]
 pub fn test_typecheck_022_row_var_block_app_absent_field_warns() {
     run_typecheck_test("022_row_var_block_app_absent_field_warns.eu");
 }


### PR DESCRIPTION
## Summary

When unifying `{x: number, ..r}` against `{x: number}`, the row variable `r` was bound to an open empty record (because synthesised blocks are always open). This meant the result type stayed open and the checker couldn't detect absent fields.

Fix: row variable absorption uses `row.is_some()` for openness instead of the other side's anonymous openness. Only propagate openness when the other side has a named row variable (the extra fields are genuinely unknown). Anonymous openness reflects runtime uncertainty, not a structural guarantee.

Enables test 022 (previously `#[ignore]`d) which verifies that `result.w` warns "field 'w' not found in closed record type" when the row variable is bound to empty.

Fixes eu-z9zz.11.

## Test plan

- [x] Test 022 un-ignored and passes
- [x] All 310 harness tests pass, 0 ignored
- [x] `eu check lib/prelude.eu` — zero warnings
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)