### PR TITLE
feat: monadic block bound variable type hinting in LSP

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -1069,8 +1069,11 @@ fn desugar_monadic_block(
         .map(|name| desugarer.env().get(name).unwrap().clone())
         .collect();
 
-    // Desugar all declaration bodies (in order) with bind names in scope
-    let mut name_value_pairs: Vec<(String, RcExpr)> = Vec::with_capacity(decls.len());
+    // Desugar all declaration bodies (in order) with bind names in scope.
+    // Each entry carries (name, value, smid) — the smid is from the
+    // individual declaration's span so that lambdas in the bind chain
+    // have unique source locations.
+    let mut name_value_pairs: Vec<(String, RcExpr, Smid)> = Vec::with_capacity(decls.len());
     for (i, decl) in decls.iter().enumerate() {
         let decl_name = bind_names[i].clone();
         let span = text_range_to_span(decl.syntax().text_range());
@@ -1096,8 +1099,9 @@ fn desugar_monadic_block(
                 desugarer.new_smid(span),
             ));
         };
-        let value = wrap_with_type_hint(value, monad_type, desugarer.new_smid(span));
-        name_value_pairs.push((decl_name, value));
+        let decl_smid = desugarer.new_smid(span);
+        let value = wrap_with_type_hint(value, monad_type, decl_smid);
+        name_value_pairs.push((decl_name, value, decl_smid));
     }
 
     // Desugar the return expression (potentially a dot chain) now that
@@ -1129,9 +1133,11 @@ fn desugar_monadic_block(
         }
     };
 
-    // Build bind chain from right-to-left using all pairs
-    for ((_, value), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
-        let lambda = core::lam(smid, vec![bind_var], result);
+    // Build bind chain from right-to-left using all pairs.
+    // Each lambda gets the individual declaration's Smid so that
+    // lambda_params in the type checker can be keyed uniquely.
+    for ((_, value, decl_smid), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
+        let lambda = core::lam(decl_smid, vec![bind_var], result);
         result = match spec {
             MonadSpec::Explicit { bind_name, .. } => {
                 let bind_fn = desugarer.varify(RcExpr::from(Expr::Name(smid, bind_name.clone())));
@@ -1191,7 +1197,7 @@ fn desugar_monadic_block_implicit(
         .collect();
 
     // Desugar all declaration bodies.
-    let mut name_value_pairs: Vec<(String, RcExpr)> = Vec::with_capacity(decls.len());
+    let mut name_value_pairs: Vec<(String, RcExpr, Smid)> = Vec::with_capacity(decls.len());
     for (i, decl) in decls.iter().enumerate() {
         let decl_name = bind_names[i].clone();
         let span = text_range_to_span(decl.syntax().text_range());
@@ -1217,8 +1223,9 @@ fn desugar_monadic_block_implicit(
                 desugarer.new_smid(span),
             ));
         };
-        let value = wrap_with_type_hint(value, monad_type, desugarer.new_smid(span));
-        name_value_pairs.push((decl_name, value));
+        let decl_smid = desugarer.new_smid(span);
+        let value = wrap_with_type_hint(value, monad_type, decl_smid);
+        name_value_pairs.push((decl_name, value, decl_smid));
     }
 
     // Synthesise the implicit return block from all non-underscore bind names.
@@ -1304,8 +1311,8 @@ fn desugar_monadic_block_implicit(
         }
     };
 
-    for ((_, value), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
-        let lambda = core::lam(smid, vec![bind_var], result);
+    for ((_, value, decl_smid), bind_var) in name_value_pairs.into_iter().zip(bind_vars).rev() {
+        let lambda = core::lam(decl_smid, vec![bind_var], result);
         result = match spec {
             MonadSpec::Explicit { bind_name, .. } => {
                 let bind_fn = desugarer.varify(RcExpr::from(Expr::Name(smid, bind_name.clone())));

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -103,6 +103,15 @@ pub struct Checker {
     /// checker walks the expression tree.  Used in `extract_annotation` to
     /// resolve alias references before erasing type variables.
     aliases: AliasMap,
+
+    /// Lambda parameter types inferred during `check_lambda`.
+    ///
+    /// Maps parameter name → inferred type.  These are accumulated as
+    /// the checker walks the expression tree and survive scope pops,
+    /// making them available for LSP features (hover, inlay hints on
+    /// monadic block bound variables).  Later bindings with the same
+    /// name overwrite earlier ones.
+    lambda_params: HashMap<String, Type>,
 }
 
 impl Default for Checker {
@@ -119,6 +128,7 @@ impl Checker {
             var_counter: 0,
             warnings: Vec::new(),
             aliases: AliasMap::new(),
+            lambda_params: HashMap::new(),
         }
     }
 
@@ -149,6 +159,7 @@ impl Checker {
         TypeCheckResult {
             warnings: self.warnings,
             types: type_env,
+            lambda_params: self.lambda_params,
         }
     }
 
@@ -336,16 +347,23 @@ impl Checker {
     /// and whether it was asserted (prefixed with `!`).
     ///
     /// Asserted annotations are trusted without body verification.
-    fn extract_annotation(&self, meta: &RcExpr) -> Option<(Type, bool)> {
+    /// Extract a type annotation from metadata.
+    ///
+    /// Returns `(type, asserted, is_hint)`:
+    /// - `asserted`: `!` prefix — body not verified
+    /// - `is_hint`: came from `__type_hint` (monad binding) — the
+    ///   annotation is for checking only, not for overriding the
+    ///   synthesised type
+    fn extract_annotation(&self, meta: &RcExpr) -> Option<(Type, bool, bool)> {
         let block = match &*meta.inner {
             Expr::Block(_, b) => b,
             _ => return None,
         };
 
-        let type_str: String = if let Some(e) = block.get("type") {
-            extract_string_literal(e)?
+        let (type_str, is_hint): (String, bool) = if let Some(e) = block.get("type") {
+            (extract_string_literal(e)?, false)
         } else if let Some(e) = block.get("__type_hint") {
-            extract_string_literal(e)?
+            (extract_string_literal(e)?, true)
         } else {
             return None;
         };
@@ -358,7 +376,7 @@ impl Checker {
         };
 
         let parsed = parse::parse_type(&type_str).ok()?;
-        Some((self.resolve_aliases_in_type(parsed), asserted))
+        Some((self.resolve_aliases_in_type(parsed), asserted, is_hint))
     }
 
     /// Try to extract a `TypeScheme` from a binding value's `Meta` wrapper.
@@ -370,7 +388,7 @@ impl Checker {
     fn annotation_scheme_of(&self, value: &RcExpr) -> Option<TypeScheme> {
         if let Expr::Meta(_, _, meta) = &*value.inner {
             self.extract_annotation(meta)
-                .map(|(ty, _asserted)| infer_scheme(ty))
+                .map(|(ty, _asserted, _is_hint)| infer_scheme(ty))
         } else {
             None
         }
@@ -450,7 +468,7 @@ impl Checker {
                         // Use the explicit `type:` annotation if given; otherwise
                         // the synthesised type (inferred from the value shape).
                         let alias_ty = if let Expr::Meta(_, _, meta) = &*value.inner {
-                            self.extract_annotation(meta).map(|(ty, _)| ty)
+                            self.extract_annotation(meta).map(|(ty, _, _)| ty)
                         } else {
                             None
                         }
@@ -518,7 +536,7 @@ impl Checker {
         // the annotation itself can reference freshly-declared aliases.
         self.register_aliases_from_meta(meta);
 
-        if let Some((annotated_type, asserted)) = self.extract_annotation(meta) {
+        if let Some((annotated_type, asserted, is_hint)) = self.extract_annotation(meta) {
             let scheme = infer_scheme(annotated_type);
             let working_type = freshen(&scheme, &mut self.var_counter);
             // Asserted annotations (prefixed with `!`) are trusted without
@@ -527,7 +545,31 @@ impl Checker {
             if !asserted {
                 self.check_against(inner, &working_type, smid);
             }
-            working_type
+            if is_hint {
+                // For __type_hint (monad bindings), the hint is for checking
+                // only — return the value's synthesised type so downstream
+                // type inference (e.g. for.bind arg unification) sees the
+                // concrete type, not the hint's type variables.
+                //
+                // Small list literals synthesise as tuples (e.g. [1,2,3] →
+                // (number, number, number)) which don't unify with the
+                // wrapper's list type [a].  Convert tuples to their common
+                // element type as a list.
+                let inner_type = self.synthesise(inner);
+                if is_informative(&inner_type) {
+                    match &inner_type {
+                        Type::Tuple(elems) if !elems.is_empty() => {
+                            // Use the first element's type as representative
+                            Type::List(Box::new(elems[0].clone()))
+                        }
+                        _ => inner_type,
+                    }
+                } else {
+                    working_type
+                }
+            } else {
+                working_type
+            }
         } else {
             self.synthesise(inner)
         }
@@ -671,6 +713,32 @@ impl Checker {
                             }
                             return apply_subst(&result_type, subst);
                         }
+                    }
+                }
+
+                // When the argument is a lambda and the parameter type is a
+                // known function type, use check_against so that check_lambda
+                // fires — this infers parameter types for the lambda's bound
+                // variables (needed for LSP inlay hints on monadic bindings).
+                if let Expr::Lam(_, _, scope) = &*arg.inner {
+                    if matches!(&param_applied, Type::Function(_, _))
+                        && is_informative(&param_applied)
+                    {
+                        self.check_against(arg, &param_applied, smid);
+                        // Record resolved lambda parameter types for LSP.
+                        // Only record when substitution resolves to concrete
+                        // types (no unresolved type variables).
+                        let mut remaining = param_applied.clone();
+                        for param in &scope.pattern {
+                            if let Type::Function(p, r) = remaining {
+                                let resolved = apply_subst(&p, subst);
+                                if is_informative(&resolved) && !matches!(&resolved, Type::Var(_)) {
+                                    self.lambda_params.insert(param.clone(), resolved);
+                                }
+                                remaining = *r;
+                            }
+                        }
+                        return apply_subst(&result_type, subst);
                     }
                 }
 
@@ -1024,6 +1092,11 @@ pub struct TypeCheckResult {
     pub warnings: Vec<TypeWarning>,
     /// Flattened type environment mapping binding names to their inferred types.
     pub types: HashMap<String, Type>,
+    /// Lambda parameter types inferred during type checking.
+    ///
+    /// Maps parameter name → inferred type.  Available for LSP features
+    /// like hover and inlay hints on monadic block bound variables.
+    pub lambda_params: HashMap<String, Type>,
 }
 
 /// Run the type checker over `expr` and return all warnings found.

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -551,16 +551,28 @@ impl Checker {
                 // type inference (e.g. for.bind arg unification) sees the
                 // concrete type, not the hint's type variables.
                 //
+                // We synthesise the inner expression to get its concrete type.
+                // check_against above already validated the value against the
+                // wrapper type; this second synthesis is just to extract the
+                // type for the return value.
+                //
                 // Small list literals synthesise as tuples (e.g. [1,2,3] →
                 // (number, number, number)) which don't unify with the
-                // wrapper's list type [a].  Convert tuples to their common
-                // element type as a list.
+                // wrapper's list type [a].  Convert homogeneous tuples to
+                // lists; heterogeneous tuples fall back to the wrapper type.
                 let inner_type = self.synthesise(inner);
                 if is_informative(&inner_type) {
                     match &inner_type {
                         Type::Tuple(elems) if !elems.is_empty() => {
-                            // Use the first element's type as representative
-                            Type::List(Box::new(elems[0].clone()))
+                            let first = &elems[0];
+                            if elems.iter().all(|e| e == first) {
+                                Type::List(Box::new(first.clone()))
+                            } else {
+                                // Heterogeneous tuple — can't reduce to a
+                                // single list element type; fall back to
+                                // wrapper type.
+                                working_type
+                            }
                         }
                         _ => inner_type,
                     }

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -104,14 +104,12 @@ pub struct Checker {
     /// resolve alias references before erasing type variables.
     aliases: AliasMap,
 
-    /// Lambda parameter types inferred during `check_lambda`.
+    /// Lambda parameter types inferred during function argument checking.
     ///
-    /// Maps parameter name → inferred type.  These are accumulated as
-    /// the checker walks the expression tree and survive scope pops,
-    /// making them available for LSP features (hover, inlay hints on
-    /// monadic block bound variables).  Later bindings with the same
-    /// name overwrite earlier ones.
-    lambda_params: HashMap<String, Type>,
+    /// Maps `Smid` (source location of the lambda) → parameter types.
+    /// Used by LSP features (inlay hints on monadic block bound
+    /// variables) to show the unwrapped element type.
+    lambda_params: HashMap<Smid, Vec<(String, Type)>>,
 }
 
 impl Default for Checker {
@@ -542,36 +540,55 @@ impl Checker {
             // Asserted annotations (prefixed with `!`) are trusted without
             // checking the body.  Used when the body has type-level assumptions
             // the checker cannot verify (e.g. dependent-length lists as tuples).
-            if !asserted {
-                self.check_against(inner, &working_type, smid);
-            }
             if is_hint {
-                // For __type_hint (monad bindings), the hint is for checking
-                // only — return the value's synthesised type so downstream
-                // type inference (e.g. for.bind arg unification) sees the
-                // concrete type, not the hint's type variables.
-                //
-                // We synthesise the inner expression to get its concrete type.
-                // check_against above already validated the value against the
-                // wrapper type; this second synthesis is just to extract the
-                // type for the return value.
-                //
+                // For __type_hint (monad bindings), synthesise the inner
+                // expression ONCE, emit a warning if it doesn't match the
+                // hint type, then return the synthesised type (not the hint)
+                // so downstream unification sees concrete types.
+                let inner_type = self.synthesise(inner);
+
+                // Check consistency and warn (replicates check_against logic
+                // without double-synthesising).
+                if !asserted
+                    && is_informative(&inner_type)
+                    && is_informative(&working_type)
+                    && !is_consistent(&inner_type, &working_type)
+                {
+                    self.emit_type_mismatch(
+                        smid,
+                        &working_type,
+                        &inner_type,
+                        "expression type does not match annotation",
+                    );
+                }
+
                 // Small list literals synthesise as tuples (e.g. [1,2,3] →
                 // (number, number, number)) which don't unify with the
                 // wrapper's list type [a].  Convert homogeneous tuples to
                 // lists; heterogeneous tuples fall back to the wrapper type.
-                let inner_type = self.synthesise(inner);
                 if is_informative(&inner_type) {
                     match &inner_type {
                         Type::Tuple(elems) if !elems.is_empty() => {
                             let first = &elems[0];
                             if elems.iter().all(|e| e == first) {
+                                // Homogeneous tuple → list of element type
                                 Type::List(Box::new(first.clone()))
                             } else {
-                                // Heterogeneous tuple — can't reduce to a
-                                // single list element type; fall back to
-                                // wrapper type.
-                                working_type
+                                // Heterogeneous tuple → list of union
+                                let mut seen = std::collections::BTreeSet::new();
+                                let mut unique = Vec::new();
+                                for e in elems {
+                                    let s = format!("{e}");
+                                    if seen.insert(s) {
+                                        unique.push(e.clone());
+                                    }
+                                }
+                                let elem_type = if unique.len() == 1 {
+                                    unique.into_iter().next().unwrap()
+                                } else {
+                                    Type::Union(unique)
+                                };
+                                Type::List(Box::new(elem_type))
                             }
                         }
                         _ => inner_type,
@@ -579,6 +596,9 @@ impl Checker {
                 } else {
                     working_type
                 }
+            } else if !asserted {
+                self.check_against(inner, &working_type, smid);
+                working_type
             } else {
                 working_type
             }
@@ -732,23 +752,28 @@ impl Checker {
                 // known function type, use check_against so that check_lambda
                 // fires — this infers parameter types for the lambda's bound
                 // variables (needed for LSP inlay hints on monadic bindings).
-                if let Expr::Lam(_, _, scope) = &*arg.inner {
+                if let Expr::Lam(lam_smid, _, scope) = &*arg.inner {
                     if matches!(&param_applied, Type::Function(_, _))
                         && is_informative(&param_applied)
                     {
                         self.check_against(arg, &param_applied, smid);
-                        // Record resolved lambda parameter types for LSP.
-                        // Only record when substitution resolves to concrete
-                        // types (no unresolved type variables).
+                        // Record resolved lambda parameter types for LSP,
+                        // keyed by the lambda's Smid (source location) to
+                        // avoid name collisions between different monadic
+                        // blocks using the same binding name.
+                        let mut params = Vec::new();
                         let mut remaining = param_applied.clone();
                         for param in &scope.pattern {
                             if let Type::Function(p, r) = remaining {
                                 let resolved = apply_subst(&p, subst);
                                 if is_informative(&resolved) && !matches!(&resolved, Type::Var(_)) {
-                                    self.lambda_params.insert(param.clone(), resolved);
+                                    params.push((param.clone(), resolved));
                                 }
                                 remaining = *r;
                             }
+                        }
+                        if !params.is_empty() {
+                            self.lambda_params.insert(*lam_smid, params);
                         }
                         return apply_subst(&result_type, subst);
                     }
@@ -1106,9 +1131,11 @@ pub struct TypeCheckResult {
     pub types: HashMap<String, Type>,
     /// Lambda parameter types inferred during type checking.
     ///
-    /// Maps parameter name → inferred type.  Available for LSP features
-    /// like hover and inlay hints on monadic block bound variables.
-    pub lambda_params: HashMap<String, Type>,
+    /// Maps `Smid` (source location of the lambda) → list of
+    /// `(param_name, inferred_type)` pairs.  Keyed by Smid to avoid
+    /// name collisions between different lambdas with the same param
+    /// names.
+    pub lambda_params: HashMap<Smid, Vec<(String, Type)>>,
 }
 
 /// Run the type checker over `expr` and return all warnings found.

--- a/src/driver/lsp/inlay_hints.rs
+++ b/src/driver/lsp/inlay_hints.rs
@@ -25,7 +25,7 @@ pub fn inlay_hints(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
-    lambda_params: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<(String, u32), Type>>,
 ) -> Vec<InlayHint> {
     let mut hints = Vec::new();
 
@@ -52,7 +52,7 @@ fn collect_hints_from_unit(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
-    lambda_params: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<(String, u32), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     for decl in unit.declarations() {
@@ -120,7 +120,7 @@ fn collect_monadic_binding_hints(
     block: &ast::Block,
     range: &Range,
     table: &SymbolTable,
-    lambda_params: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<(String, u32), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -157,15 +157,16 @@ fn collect_monadic_binding_hints(
                 DeclarationKind::Function(id, _) => (id.syntax().clone(), id.text().to_string()),
                 _ => continue,
             };
+            let token_range = text_range_to_lsp_range(source, name_token.text_range());
+            let line = token_range.start.line;
             // Prefer the inferred element type from the pipeline's
             // lambda_params (e.g. x: number) over the raw wrapper
-            // type (e.g. x: [a]).
+            // type (e.g. x: [a]).  Keyed by (name, line) to avoid
+            // collisions between different monadic blocks.
             let hint_type = lambda_params
-                .and_then(|params| params.get(&decl_name))
+                .and_then(|params| params.get(&(decl_name.clone(), line)))
                 .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
                 .unwrap_or_else(|| monad_type.clone());
-
-            let token_range = text_range_to_lsp_range(source, name_token.text_range());
             hints.push(InlayHint {
                 position: token_range.end,
                 label: InlayHintLabel::String(format!(": {hint_type}")),
@@ -191,7 +192,7 @@ fn collect_bracket_block_binding_hints(
     block: &ast::BracketBlock,
     range: &Range,
     table: &SymbolTable,
-    lambda_params: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<(String, u32), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -224,11 +225,12 @@ fn collect_bracket_block_binding_hints(
                 DeclarationKind::Function(id, _) => (id.syntax().clone(), id.text().to_string()),
                 _ => continue,
             };
+            let token_range = text_range_to_lsp_range(source, name_token.text_range());
+            let line = token_range.start.line;
             let hint_type = lambda_params
-                .and_then(|params| params.get(&decl_name))
+                .and_then(|params| params.get(&(decl_name.clone(), line)))
                 .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
                 .unwrap_or_else(|| monad_type.clone());
-            let token_range = text_range_to_lsp_range(source, name_token.text_range());
             hints.push(InlayHint {
                 position: token_range.end,
                 label: InlayHintLabel::String(format!(": {hint_type}")),

--- a/src/driver/lsp/inlay_hints.rs
+++ b/src/driver/lsp/inlay_hints.rs
@@ -25,7 +25,7 @@ pub fn inlay_hints(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
-    lambda_params: Option<&HashMap<(String, u32), Type>>,
+    lambda_params: Option<&HashMap<(u32, u32, String), Type>>,
 ) -> Vec<InlayHint> {
     let mut hints = Vec::new();
 
@@ -52,7 +52,7 @@ fn collect_hints_from_unit(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
-    lambda_params: Option<&HashMap<(String, u32), Type>>,
+    lambda_params: Option<&HashMap<(u32, u32, String), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     for decl in unit.declarations() {
@@ -120,7 +120,7 @@ fn collect_monadic_binding_hints(
     block: &ast::Block,
     range: &Range,
     table: &SymbolTable,
-    lambda_params: Option<&HashMap<(String, u32), Type>>,
+    lambda_params: Option<&HashMap<(u32, u32, String), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -158,13 +158,17 @@ fn collect_monadic_binding_hints(
                 _ => continue,
             };
             let token_range = text_range_to_lsp_range(source, name_token.text_range());
-            let line = token_range.start.line;
+
             // Prefer the inferred element type from the pipeline's
             // lambda_params (e.g. x: number) over the raw wrapper
             // type (e.g. x: [a]).  Keyed by (name, line) to avoid
             // collisions between different monadic blocks.
             let hint_type = lambda_params
-                .and_then(|params| params.get(&(decl_name.clone(), line)))
+                .and_then(|params| {
+                    let line = token_range.start.line;
+                    let col = token_range.start.character;
+                    params.get(&(line, col, decl_name.clone()))
+                })
                 .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
                 .unwrap_or_else(|| monad_type.clone());
             hints.push(InlayHint {
@@ -192,7 +196,7 @@ fn collect_bracket_block_binding_hints(
     block: &ast::BracketBlock,
     range: &Range,
     table: &SymbolTable,
-    lambda_params: Option<&HashMap<(String, u32), Type>>,
+    lambda_params: Option<&HashMap<(u32, u32, String), Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -226,9 +230,13 @@ fn collect_bracket_block_binding_hints(
                 _ => continue,
             };
             let token_range = text_range_to_lsp_range(source, name_token.text_range());
-            let line = token_range.start.line;
+
             let hint_type = lambda_params
-                .and_then(|params| params.get(&(decl_name.clone(), line)))
+                .and_then(|params| {
+                    let line = token_range.start.line;
+                    let col = token_range.start.character;
+                    params.get(&(line, col, decl_name.clone()))
+                })
                 .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
                 .unwrap_or_else(|| monad_type.clone());
             hints.push(InlayHint {

--- a/src/driver/lsp/inlay_hints.rs
+++ b/src/driver/lsp/inlay_hints.rs
@@ -25,12 +25,21 @@ pub fn inlay_hints(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<String, Type>>,
 ) -> Vec<InlayHint> {
     let mut hints = Vec::new();
 
     // Walk declarations for operator fixity hints and parameter hints in call sites
     if let Some(unit) = ast::Unit::cast(root.clone()) {
-        collect_hints_from_unit(source, &unit, range, table, type_env, &mut hints);
+        collect_hints_from_unit(
+            source,
+            &unit,
+            range,
+            table,
+            type_env,
+            lambda_params,
+            &mut hints,
+        );
     }
 
     hints
@@ -43,6 +52,7 @@ fn collect_hints_from_unit(
     range: &Range,
     table: &SymbolTable,
     type_env: Option<&HashMap<String, Type>>,
+    lambda_params: Option<&HashMap<String, Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     for decl in unit.declarations() {
@@ -75,11 +85,23 @@ fn collect_hints_from_unit(
                 for element in soup.elements() {
                     match element {
                         ast::Element::Block(block) => {
-                            collect_monadic_binding_hints(source, &block, range, table, hints);
+                            collect_monadic_binding_hints(
+                                source,
+                                &block,
+                                range,
+                                table,
+                                lambda_params,
+                                hints,
+                            );
                         }
                         ast::Element::BracketBlock(block) => {
                             collect_bracket_block_binding_hints(
-                                source, &block, range, table, hints,
+                                source,
+                                &block,
+                                range,
+                                table,
+                                lambda_params,
+                                hints,
                             );
                         }
                         _ => {}
@@ -98,6 +120,7 @@ fn collect_monadic_binding_hints(
     block: &ast::Block,
     range: &Range,
     table: &SymbolTable,
+    lambda_params: Option<&HashMap<String, Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -123,19 +146,29 @@ fn collect_monadic_binding_hints(
         None => return,
     };
 
-    // Add type hints on each binding declaration
+    // Add type hints on each binding declaration.
+    // When the pipeline has inferred an element type for the bound
+    // variable (via check_lambda), show that instead of the raw wrapper.
     for decl in block.declarations() {
         if let Some(head) = decl.head() {
             let kind = head.classify_declaration();
-            let name_token = match &kind {
-                DeclarationKind::Property(id) => id.syntax().clone(),
-                DeclarationKind::Function(id, _) => id.syntax().clone(),
+            let (name_token, decl_name) = match &kind {
+                DeclarationKind::Property(id) => (id.syntax().clone(), id.text().to_string()),
+                DeclarationKind::Function(id, _) => (id.syntax().clone(), id.text().to_string()),
                 _ => continue,
             };
+            // Prefer the inferred element type from the pipeline's
+            // lambda_params (e.g. x: number) over the raw wrapper
+            // type (e.g. x: [a]).
+            let hint_type = lambda_params
+                .and_then(|params| params.get(&decl_name))
+                .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
+                .unwrap_or_else(|| monad_type.clone());
+
             let token_range = text_range_to_lsp_range(source, name_token.text_range());
             hints.push(InlayHint {
                 position: token_range.end,
-                label: InlayHintLabel::String(format!(": {monad_type}")),
+                label: InlayHintLabel::String(format!(": {hint_type}")),
                 kind: Some(InlayHintKind::TYPE),
                 text_edits: None,
                 tooltip: Some(lsp_types::InlayHintTooltip::String(format!(
@@ -158,6 +191,7 @@ fn collect_bracket_block_binding_hints(
     block: &ast::BracketBlock,
     range: &Range,
     table: &SymbolTable,
+    lambda_params: Option<&HashMap<String, Type>>,
     hints: &mut Vec<InlayHint>,
 ) {
     let block_range = text_range_to_lsp_range(source, block.syntax().text_range());
@@ -185,15 +219,19 @@ fn collect_bracket_block_binding_hints(
     for decl in block.declarations() {
         if let Some(head) = decl.head() {
             let kind = head.classify_declaration();
-            let name_token = match &kind {
-                DeclarationKind::Property(id) => id.syntax().clone(),
-                DeclarationKind::Function(id, _) => id.syntax().clone(),
+            let (name_token, decl_name) = match &kind {
+                DeclarationKind::Property(id) => (id.syntax().clone(), id.text().to_string()),
+                DeclarationKind::Function(id, _) => (id.syntax().clone(), id.text().to_string()),
                 _ => continue,
             };
+            let hint_type = lambda_params
+                .and_then(|params| params.get(&decl_name))
+                .map(|ty| crate::core::typecheck::types::humanise(ty).to_string())
+                .unwrap_or_else(|| monad_type.clone());
             let token_range = text_range_to_lsp_range(source, name_token.text_range());
             hints.push(InlayHint {
                 position: token_range.end,
-                label: InlayHintLabel::String(format!(": {monad_type}")),
+                label: InlayHintLabel::String(format!(": {hint_type}")),
                 kind: Some(InlayHintKind::TYPE),
                 text_edits: None,
                 tooltip: Some(lsp_types::InlayHintTooltip::String(format!(
@@ -399,7 +437,7 @@ mod tests {
         let parse = parse_unit(source);
         let root = parse.syntax_node();
         let table = SymbolTable::new();
-        let hints = inlay_hints(source, &root, &full_range(), &table, None);
+        let hints = inlay_hints(source, &root, &full_range(), &table, None, None);
         assert!(hints.is_empty());
     }
 
@@ -409,7 +447,7 @@ mod tests {
         let parse = parse_unit(source);
         let root = parse.syntax_node();
         let table = make_table(source);
-        let hints = inlay_hints(source, &root, &full_range(), &table, None);
+        let hints = inlay_hints(source, &root, &full_range(), &table, None, None);
         let fixity_hints: Vec<_> = hints
             .iter()
             .filter(|h| h.kind == Some(InlayHintKind::TYPE))
@@ -429,7 +467,7 @@ mod tests {
         let parse = parse_unit(source);
         let root = parse.syntax_node();
         let table = make_table(source);
-        let hints = inlay_hints(source, &root, &full_range(), &table, None);
+        let hints = inlay_hints(source, &root, &full_range(), &table, None, None);
         let param_hints: Vec<_> = hints
             .iter()
             .filter(|h| h.kind == Some(InlayHintKind::PARAMETER))
@@ -446,7 +484,7 @@ mod tests {
         let parse = parse_unit(source);
         let root = parse.syntax_node();
         let table = make_table(source);
-        let hints = inlay_hints(source, &root, &full_range(), &table, None);
+        let hints = inlay_hints(source, &root, &full_range(), &table, None, None);
         let param_hints: Vec<_> = hints
             .iter()
             .filter(|h| h.kind == Some(InlayHintKind::PARAMETER))
@@ -509,7 +547,7 @@ mod tests {
         let parse = parse_unit(source);
         let root = parse.syntax_node();
 
-        let hints = inlay_hints(source, &root, &full_range(), &table, None);
+        let hints = inlay_hints(source, &root, &full_range(), &table, None, None);
         let type_hints: Vec<_> = hints
             .iter()
             .filter(|h| matches!(&h.label, InlayHintLabel::String(s) if s.contains("[a]")))

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -65,9 +65,12 @@ struct ImportedFile {
 struct CachedPipeline {
     uri: Url,
     type_env: TypeEnv,
-    /// Lambda parameter types inferred by the type checker (e.g.
-    /// monadic block bound variable types).
-    lambda_params: HashMap<String, Type>,
+    /// Lambda parameter types inferred by the type checker.
+    ///
+    /// Keyed by `(param_name, line)` to avoid collisions between
+    /// different monadic blocks using the same binding name on different
+    /// lines.
+    lambda_params: HashMap<(String, u32), Type>,
     warnings: Vec<crate::core::typecheck::error::TypeWarning>,
     source_map: SourceMap,
     /// Imported files resolved by the pipeline, for building symbol
@@ -327,7 +330,7 @@ impl ServerState {
     }
 
     /// Look up lambda parameter types from the cached pipeline.
-    fn lambda_params_for(&self, uri: &Url) -> Option<&HashMap<String, Type>> {
+    fn lambda_params_for(&self, uri: &Url) -> Option<&HashMap<(String, u32), Type>> {
         self.cached.get(uri).map(|c| &c.lambda_params)
     }
 
@@ -1174,12 +1177,33 @@ fn run_pipeline(
         })
         .collect();
 
+    // Flatten the Smid-keyed lambda_params into (name, line) keys
+    // so the LSP inlay hints can look up by declaration position.
+    let mut lambda_params = HashMap::new();
+    {
+        use codespan_reporting::files::Files;
+        let files = loader.files();
+        let sm = loader.source_map();
+        for (smid, params) in &result.lambda_params {
+            if let Some(info) = sm.source_info_for_smid(*smid) {
+                if let (Some(file_id), Some(span)) = (info.file, info.span) {
+                    if let Ok(loc) = files.location(file_id, span.start().into()) {
+                        let line = (loc.line_number - 1) as u32;
+                        for (name, ty) in params {
+                            lambda_params.insert((name.clone(), line), ty.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let (_, source_map, _) = loader.complete();
 
     Ok(CachedPipeline {
         uri: uri.clone(),
         type_env,
-        lambda_params: result.lambda_params,
+        lambda_params,
         warnings: result.warnings,
         source_map,
         imports,

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -67,10 +67,10 @@ struct CachedPipeline {
     type_env: TypeEnv,
     /// Lambda parameter types inferred by the type checker.
     ///
-    /// Keyed by `(param_name, line)` to avoid collisions between
-    /// different monadic blocks using the same binding name on different
-    /// lines.
-    lambda_params: HashMap<(String, u32), Type>,
+    /// Lambda parameter types keyed by `(line, column, param_name)`.
+    /// The line/column come from the lambda's Smid resolved via the
+    /// source map, giving a unique key per binding declaration.
+    lambda_params: HashMap<(u32, u32, String), Type>,
     warnings: Vec<crate::core::typecheck::error::TypeWarning>,
     source_map: SourceMap,
     /// Imported files resolved by the pipeline, for building symbol
@@ -330,7 +330,7 @@ impl ServerState {
     }
 
     /// Look up lambda parameter types from the cached pipeline.
-    fn lambda_params_for(&self, uri: &Url) -> Option<&HashMap<(String, u32), Type>> {
+    fn lambda_params_for(&self, uri: &Url) -> Option<&HashMap<(u32, u32, String), Type>> {
         self.cached.get(uri).map(|c| &c.lambda_params)
     }
 
@@ -1179,6 +1179,8 @@ fn run_pipeline(
 
     // Flatten the Smid-keyed lambda_params into (name, line) keys
     // so the LSP inlay hints can look up by declaration position.
+    // Flatten the Smid-keyed lambda_params into (line, col, name) keys
+    // using the source map for position resolution.
     let mut lambda_params = HashMap::new();
     {
         use codespan_reporting::files::Files;
@@ -1189,8 +1191,9 @@ fn run_pipeline(
                 if let (Some(file_id), Some(span)) = (info.file, info.span) {
                     if let Ok(loc) = files.location(file_id, span.start().into()) {
                         let line = (loc.line_number - 1) as u32;
+                        let col = (loc.column_number - 1) as u32;
                         for (name, ty) in params {
-                            lambda_params.insert((name.clone(), line), ty.clone());
+                            lambda_params.insert((line, col, name.clone()), ty.clone());
                         }
                     }
                 }

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -65,6 +65,9 @@ struct ImportedFile {
 struct CachedPipeline {
     uri: Url,
     type_env: TypeEnv,
+    /// Lambda parameter types inferred by the type checker (e.g.
+    /// monadic block bound variable types).
+    lambda_params: HashMap<String, Type>,
     warnings: Vec<crate::core::typecheck::error::TypeWarning>,
     source_map: SourceMap,
     /// Imported files resolved by the pipeline, for building symbol
@@ -321,6 +324,11 @@ impl ServerState {
     /// Look up the type env for a URI from the cached pipeline result.
     fn type_env_for(&self, uri: &Url) -> Option<&TypeEnv> {
         self.cached.get(uri).map(|c| &c.type_env)
+    }
+
+    /// Look up lambda parameter types from the cached pipeline.
+    fn lambda_params_for(&self, uri: &Url) -> Option<&HashMap<String, Type>> {
+        self.cached.get(uri).map(|c| &c.lambda_params)
     }
 
     /// Build a symbol table for a document from AST, prelude, and
@@ -936,7 +944,9 @@ fn on_inlay_hint(
     let root = parse.syntax_node();
     let table = state.build_symbol_table(uri, text);
     let type_env = state.type_env_for(uri);
-    let hints = inlay_hints::inlay_hints(text, &root, &params.range, &table, type_env);
+    let lambda_params = state.lambda_params_for(uri);
+    let hints =
+        inlay_hints::inlay_hints(text, &root, &params.range, &table, type_env, lambda_params);
     Some(hints)
 }
 
@@ -1169,6 +1179,7 @@ fn run_pipeline(
     Ok(CachedPipeline {
         uri: uri.clone(),
         type_env,
+        lambda_params: result.lambda_params,
         warnings: result.warnings,
         source_map,
         imports,

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -5,9 +5,12 @@
 //! JSON-RPC transport.  Used for integration tests that exercise LSP
 //! features against realistic editing scenarios.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
+
+use crate::core::typecheck::types::Type;
 
 use lsp_types::{
     CompletionItem, CompletionResponse, DocumentHighlight, GotoDefinitionResponse, Hover,
@@ -181,9 +184,17 @@ impl LspTestSession {
         let root = parse.syntax_node();
         let table = self.build_symbol_table();
         let type_env = self.type_env();
+        let lambda_params = self.lambda_params();
 
         let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, 0));
-        inlay_hints::inlay_hints(&self.content, &root, &range, &table, type_env)
+        inlay_hints::inlay_hints(
+            &self.content,
+            &root,
+            &range,
+            &table,
+            type_env,
+            lambda_params,
+        )
     }
 
     /// Get the completion labels as strings (convenience for assertions).
@@ -246,6 +257,20 @@ impl LspTestSession {
     /// Return the current document content.
     pub fn content(&self) -> &str {
         &self.content
+    }
+
+    /// Lambda param names and types in the cached pipeline (for debugging).
+    pub fn lambda_param_names(&self) -> Vec<(String, String)> {
+        self.cached.as_ref().map_or(vec![], |c| {
+            c.lambda_params
+                .iter()
+                .map(|(k, v)| (k.clone(), format!("{v}")))
+                .collect()
+        })
+    }
+
+    fn lambda_params(&self) -> Option<&HashMap<String, Type>> {
+        self.cached.as_ref().map(|c| &c.lambda_params)
     }
 
     /// Return the last pipeline error, if any.

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -264,12 +264,12 @@ impl LspTestSession {
         self.cached.as_ref().map_or(vec![], |c| {
             c.lambda_params
                 .iter()
-                .map(|((name, _line), v)| (name.clone(), format!("{v}")))
+                .map(|((_line, _col, name), v)| (name.clone(), format!("{v}")))
                 .collect()
         })
     }
 
-    fn lambda_params(&self) -> Option<&HashMap<(String, u32), Type>> {
+    fn lambda_params(&self) -> Option<&HashMap<(u32, u32, String), Type>> {
         self.cached.as_ref().map(|c| &c.lambda_params)
     }
 

--- a/src/driver/lsp/testing.rs
+++ b/src/driver/lsp/testing.rs
@@ -264,12 +264,12 @@ impl LspTestSession {
         self.cached.as_ref().map_or(vec![], |c| {
             c.lambda_params
                 .iter()
-                .map(|(k, v)| (k.clone(), format!("{v}")))
+                .map(|((name, _line), v)| (name.clone(), format!("{v}")))
                 .collect()
         })
     }
 
-    fn lambda_params(&self) -> Option<&HashMap<String, Type>> {
+    fn lambda_params(&self) -> Option<&HashMap<(String, u32), Type>> {
         self.cached.as_ref().map(|c| &c.lambda_params)
     }
 

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -506,6 +506,35 @@ fn inlay_hints_on_monadic_binding() {
     );
 }
 
+// ── Feature: monadic bound variable type hinting ─────────────────────────────
+
+#[test]
+fn inlay_hint_shows_element_type_after_pipeline() {
+    let mut s = LspTestSession::new();
+    // After the pipeline runs, the type checker infers x: number
+    // from for.bind([1,2,3], λx. ...) where bind: [a] → (a → [b]) → [b]
+    // and a unifies with number.
+    s.run_pipeline("main: { :for x: [1,2,3] }.(x)");
+    let hints = s.inlay_hints();
+    let type_hints: Vec<_> = hints
+        .iter()
+        .filter(
+            |h| matches!(&h.label, lsp_types::InlayHintLabel::String(s) if s.contains("number")),
+        )
+        .collect();
+    assert!(
+        !type_hints.is_empty(),
+        "after pipeline, should show element type 'number' not wrapper '[a]', got: {:?}",
+        hints
+            .iter()
+            .filter_map(|h| match &h.label {
+                lsp_types::InlayHintLabel::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    );
+}
+
 // ── Feature: import resolution ───────────────────────────────────────────────
 
 #[test]

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -535,6 +535,42 @@ fn inlay_hint_shows_element_type_after_pipeline() {
     );
 }
 
+#[test]
+fn inlay_hint_let_monad_shows_wrapper_not_element() {
+    let mut s = LspTestSession::new();
+    // :let is untyped (monad: true) — no element type inference
+    s.run_pipeline("main: { :let x: 42 }.(x)");
+    let hints = s.inlay_hints();
+    // Should NOT show a resolved element type — :let has no typed wrapper
+    let number_hints: Vec<_> = hints
+        .iter()
+        .filter(
+            |h| matches!(&h.label, lsp_types::InlayHintLabel::String(s) if s.contains("number")),
+        )
+        .collect();
+    assert!(
+        number_hints.is_empty(),
+        ":let monad should not show element type hints, got: {:?}",
+        hints
+            .iter()
+            .filter_map(|h| match &h.label {
+                lsp_types::InlayHintLabel::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn inlay_hint_element_type_does_not_crash_on_incomplete() {
+    let mut s = LspTestSession::new();
+    // Incomplete monadic block value — pipeline may fail, must not crash
+    s.open("main: { :for x: }.(x)");
+    let _ = s.inlay_hints();
+    s.open("main: { :for x: [1, }.(x)");
+    let _ = s.inlay_hints();
+}
+
 // ── Feature: import resolution ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Inlay hints on monadic block bindings now show the unwrapped element type instead of the raw monad wrapper type:

- Before: `{ :for x: [1,2,3] }` shows `x: [a]`
- After: `{ :for x: [1,2,3] }` shows `x: number`

This works by extending the type checker to record lambda parameter types inferred during `check_lambda`, then threading those through the cached pipeline to the LSP inlay hints provider.

**Key changes:**
- `Checker.lambda_params` accumulates parameter→type mappings
- `apply_one_with_subst` records resolved param types when processing lambda args with known function types
- `synthesise_meta` for `__type_hint` returns the inner value's type (not the hint's type variables), with tuple→list coercion for small list literals
- `extract_annotation` returns `is_hint` flag to distinguish `type:` (authoritative) from `__type_hint:` (checking only)

Fixes eu-z9zz.10.

## Test plan

- [x] New test: `inlay_hint_shows_element_type_after_pipeline` verifies `number` not `[a]`
- [x] All 82 LSP tests pass
- [x] All 24 typecheck harness tests pass
- [x] clippy clean, rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)