### PR TITLE
fix(test): handle bare boolean results in default-expectation

### DIFF
--- a/lib/test.eu
+++ b/lib/test.eu
@@ -22,12 +22,15 @@ validation: {
   ` "By default we expect a RESULT key (PASS/FAIL) or infer from all values being true"
   default-expectation(context): {
     r: context.result
-    has-result: r has(:RESULT)
+    # Handle bare boolean results directly
+    is-block: r block?
+    has-result: if(is-block, r has(:RESULT), false)
     explicit: if(has-result, {
       v: r.RESULT
     }.( if(v = true, :PASS, if(v = false, :FAIL, v)) ), null)
-    auto: r values all(= true) then(:PASS, :FAIL)
-  }.( if(has-result, explicit, auto) )
+    bare: if(r = true, :PASS, if(r = false, :FAIL, null))
+    auto: if(is-block, r values all(= true) then(:PASS, :FAIL), null)
+  }.( if(has-result, explicit, if(is-block, auto, bare)) )
 
   ` "Benchmark targets without explicit validations are report-only and always pass"
   bench-expectation(context): :PASS


### PR DESCRIPTION
## Summary

- Fix crash in `eu test` when a test target evaluates to a bare `true`/`false` rather than a block
- `default-expectation` now guards block operations (`has`, `values`) with `block?`
- Bare `true` → `:PASS`, bare `false` → `:FAIL`

## Reproduction

```eu
` { target: :test }
test-asset: paths("x/y/z").parts //= ["x", "y", "z"]
```

Running `eu test asset.eu` panicked with "elements called on non-block" because `//=` evaluates to `true` (a boolean), not a block.

## Test plan

- [x] 311 harness tests pass
- [x] Manual verification: `./target/release/eu test asset.eu` → `PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)