### PR TITLE
fix: named import diamond deduplication suppresses sibling imports

### DIFF
--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -99,6 +99,11 @@ pub struct Desugarer<'smap> {
     /// direct import of the same file under a *different* name emits an
     /// alias binding `let { new_name = old_name }` instead of re-desugaring.
     import_first_direct: HashMap<usize, String>,
+    /// Nesting depth of named imports.  Incremented when entering a named
+    /// import (`a=a.eu`), decremented on exit.  When > 0, transitive
+    /// imports are "namespaced" — their bindings won't be visible at the
+    /// top level, so they must not suppress later unnamed encounters.
+    named_import_depth: usize,
 }
 
 impl<'smap> Desugarer<'smap> {
@@ -124,6 +129,7 @@ impl<'smap> Desugarer<'smap> {
             import_seen_direct: HashSet::new(),
             import_seen_nested: HashSet::new(),
             import_first_direct: HashMap::new(),
+            named_import_depth: 0,
         }
     }
 
@@ -298,6 +304,10 @@ impl<'smap> Desugarer<'smap> {
 
             // Suppress if already seen transitively, OR if already seen
             // directly and we're now inside a nested import.
+            // However, do NOT suppress if the previous encounter was inside
+            // a named import chain — those bindings are namespaced and not
+            // visible to the current scope.
+            let inside_named = self.named_import_depth > 0;
             if self.import_seen_nested.contains(&guard_key)
                 || (is_nested && self.import_seen_direct.contains(&guard_key))
             {
@@ -305,8 +315,13 @@ impl<'smap> Desugarer<'smap> {
             }
 
             // Record this import in the appropriate guard set.
+            // Only record nested imports when NOT inside a named import
+            // chain, since namespaced bindings don't satisfy other
+            // importers' need for the same file at the top level.
             if is_nested {
-                self.import_seen_nested.insert(guard_key);
+                if !inside_named {
+                    self.import_seen_nested.insert(guard_key);
+                }
             } else {
                 self.import_seen_direct.insert(guard_key);
                 // Record the first direct named import for Rule 3 alias resolution.
@@ -319,6 +334,13 @@ impl<'smap> Desugarer<'smap> {
 
             self.file.push(file_id);
 
+            // Track whether we're inside a named import chain so that
+            // transitive imports know their bindings will be namespaced.
+            let is_named = import.name().is_some();
+            if is_named {
+                self.named_import_depth += 1;
+            }
+
             // Snapshot targets before desugaring the import so we can
             // identify which targets were added by the imported file.
             let targets_before = self.targets.clone();
@@ -330,8 +352,9 @@ impl<'smap> Desugarer<'smap> {
             let newly_added = self.targets.difference(&targets_before).cloned();
             self.imported_targets.extend(newly_added);
 
-            if let Some(name) = import.name() {
-                expr = expr.apply_name(smid, name);
+            if is_named {
+                self.named_import_depth -= 1;
+                expr = expr.apply_name(smid, import.name().as_ref().unwrap());
             }
 
             self.file.pop();

--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -304,10 +304,6 @@ impl<'smap> Desugarer<'smap> {
 
             // Suppress if already seen transitively, OR if already seen
             // directly and we're now inside a nested import.
-            // However, do NOT suppress if the previous encounter was inside
-            // a named import chain — those bindings are namespaced and not
-            // visible to the current scope.
-            let inside_named = self.named_import_depth > 0;
             if self.import_seen_nested.contains(&guard_key)
                 || (is_nested && self.import_seen_direct.contains(&guard_key))
             {
@@ -316,10 +312,11 @@ impl<'smap> Desugarer<'smap> {
 
             // Record this import in the appropriate guard set.
             // Only record nested imports when NOT inside a named import
-            // chain, since namespaced bindings don't satisfy other
-            // importers' need for the same file at the top level.
+            // chain — namespaced bindings are invisible to sibling
+            // importers, so recording would incorrectly suppress later
+            // unnamed encounters of the same file.
             if is_nested {
-                if !inside_named {
+                if self.named_import_depth == 0 {
                     self.import_seen_nested.insert(guard_key);
                 }
             } else {
@@ -334,10 +331,9 @@ impl<'smap> Desugarer<'smap> {
 
             self.file.push(file_id);
 
-            // Track whether we're inside a named import chain so that
-            // transitive imports know their bindings will be namespaced.
-            let is_named = import.name().is_some();
-            if is_named {
+            // Track named import depth so transitive imports know their
+            // bindings will be namespaced.
+            if import.name().is_some() {
                 self.named_import_depth += 1;
             }
 
@@ -352,9 +348,9 @@ impl<'smap> Desugarer<'smap> {
             let newly_added = self.targets.difference(&targets_before).cloned();
             self.imported_targets.extend(newly_added);
 
-            if is_named {
+            if let Some(name) = import.name() {
                 self.named_import_depth -= 1;
-                expr = expr.apply_name(smid, import.name().as_ref().unwrap());
+                expr = expr.apply_name(smid, name);
             }
 
             self.file.pop();

--- a/tests/harness/150_named_diamond_import.eu
+++ b/tests/harness/150_named_diamond_import.eu
@@ -1,0 +1,16 @@
+"150 named import diamond deduplication"
+
+# When a named import (a=diamond_a.eu) and an unnamed import
+# (diamond_b.eu) both transitively import diamond_common.eu,
+# diamond_b.eu must still be able to resolve names from
+# diamond_common.eu — even though diamond_common.eu was first
+# desugared inside the named import chain.
+
+` { import: ["a=testdata/diamond_a.eu", "testdata/diamond_b.eu"], target: :test }
+test: {
+  # b-val should resolve common-val from diamond_common.eu
+  b-accessible: b-val //= 11
+
+  # a-val is namespaced under 'a'
+  a-accessible: a.a-val //= 110
+}

--- a/tests/harness/151_nested_named_diamond.eu
+++ b/tests/harness/151_nested_named_diamond.eu
@@ -1,0 +1,18 @@
+"151 nested named import diamond deduplication"
+
+# Multi-level named import nesting: this file imports
+# a=diamond_a_nested.eu (which imports m=diamond_mid.eu, which
+# imports diamond_common.eu) alongside diamond_b.eu (which also
+# imports diamond_common.eu unnamed).
+#
+# diamond_common.eu is first seen two named-import levels deep.
+# diamond_b.eu must still resolve common-val from diamond_common.eu.
+
+` { import: ["a=testdata/diamond_a_nested.eu", "testdata/diamond_b.eu"], target: :test }
+test: {
+  # b-val depends on common-val from diamond_common.eu
+  b-accessible: b-val //= 11
+
+  # a.a-nested-val depends on m.mid-val which depends on common-val
+  a-accessible: a.a-nested-val //= 61
+}

--- a/tests/harness/testdata/diamond_a.eu
+++ b/tests/harness/testdata/diamond_a.eu
@@ -1,0 +1,2 @@
+` { import: "diamond_common.eu" }
+a-val: common-val + 100

--- a/tests/harness/testdata/diamond_a_nested.eu
+++ b/tests/harness/testdata/diamond_a_nested.eu
@@ -1,0 +1,2 @@
+` { import: "m=diamond_mid.eu" }
+a-nested-val: m.mid-val + 1

--- a/tests/harness/testdata/diamond_mid.eu
+++ b/tests/harness/testdata/diamond_mid.eu
@@ -1,0 +1,2 @@
+` { import: "diamond_common.eu" }
+mid-val: common-val + 50

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1598,6 +1598,11 @@ pub fn test_harness_150() {
 }
 
 #[test]
+pub fn test_harness_151() {
+    run_test(&opts("151_nested_named_diamond.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1593,6 +1593,11 @@ pub fn test_harness_149() {
 }
 
 #[test]
+pub fn test_harness_150() {
+    run_test(&opts("150_named_diamond_import.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

- Fix `unresolved variable` error when a named import (`a=a.eu`) and unnamed import (`b.eu`) both transitively import the same file (`common.eu`)
- Track `named_import_depth` in the desugarer — transitive imports inside a named chain are not recorded in the dedup guard since their bindings are namespaced and invisible to sibling importers
- Add harness test 150 covering the named diamond import pattern

## Root cause

The import dedup guard recorded `common.eu` as "seen transitively" when it was first desugared inside `a=a.eu`. When `b.eu` later tried to import `common.eu`, it was suppressed. But `common.eu`'s bindings were wrapped in the `a` namespace and not visible to `b.eu`.

## Test plan

- [x] New harness test 150: named diamond import (`a=a.eu` + `b.eu` both import `common.eu`)
- [x] Existing test 137 (unnamed diamond) still passes
- [x] Existing test 139 (alias rule 3) still passes
- [x] All 312 harness tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)