### PR TITLE
fix: make @ operator left-associative

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -313,7 +313,7 @@ From highest (tightest) to lowest binding:
 | 35 | bool-prod | left | `&&`, `∧` | Logical AND |
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
-| 10 | apply | right | `@` | Function application |
+| 10 | apply | left | `@` | Function application |
 | 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
 
 **Named precedence levels** for use in operator metadata: `:lookup`,

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1138,7 +1138,7 @@ compose(f, g, x): x g f
 ` { doc: "(l @ r) - function application operator, for reversing catentation args and eliding parentheses"
     type: "(a → b) → a → b"
     export: :suppress
-    associates: :right
+    associates: :left
     precedence: :apply }
 (l @ r): l(r)
 

--- a/tests/harness/152_at_operator.eu
+++ b/tests/harness/152_at_operator.eu
@@ -1,0 +1,13 @@
+f(a, b, c): a + b + c
+
+tests: {
+  # basic usage
+  basic: f(1) @ 2 @ 3
+
+  # left-associative: f(1) @ 2 @ 3 should parse as (f(1) @ 2) @ 3
+  left-assoc: f(10, 20) @ 30
+
+  pass: [basic = 6, left-assoc = 60] all-true?
+}
+
+RESULT: if(tests.pass, :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1603,6 +1603,11 @@ pub fn test_harness_151() {
 }
 
 #[test]
+pub fn test_harness_152() {
+    run_test(&opts("152_at_operator.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary
- Changed `@` operator from right-associative to left-associative in `lib/prelude.eu`
- `f(1) @ 2 @ 3` now parses as `(f(1) @ 2) @ 3`, enabling successive partial application
- No existing code uses `@` (verified: only the definition itself mentions it)
- Updated `docs/reference/agent-reference.md` precedence table

## Test plan
- [x] New harness test `152_at_operator` verifies left-associative chaining
- [x] Full test suite passes (315 tests)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)