### PR TITLE
docs: fix inaccurate prelude references, cheat-sheet corrections, type snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ For specific topics, also consult:
 4. **Each `_` creates a new param**: `_ + _` means `_0 + _1` (two params). Use `_0 * _0` to reference the same param twice.
 5. **Backtick is metadata, not comment**: `` ` "text" `` attaches to the NEXT declaration. Use `#` for comments.
 6. **`/` is floor division**: Use `÷` for exact division.
-7. **Many "obvious" functions don't exist**: No `str.replace`, `str.trim`, `str.contains?`, `flatten`, `abs`, `even?`. Check agent-reference.md section 5.11.
+7. **Many "obvious" functions don't exist**: No `str.trim`, `flatten`, `even?`, `odd?`. Check agent-reference.md section 5.11. Note: `str.replace`, `str.contains?`, `str.starts-with?`, `str.ends-with?`, and `abs` **do** exist.
 8. **`has` takes a symbol, not a string**: `has(:key)` not `has("key")`.
 9. **`str.split-on` uses regex**: `"a.b" str.split-on(".")` matches any char. Use `"[.]"`.
 10. **No whitespace before `(`**: `f(x)` is a call, `f (x)` is catenation.

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -238,11 +238,11 @@ From highest to lowest binding:
 | 95 | -- | prefix | `↑` | Tight prefix (head) |
 | 90 | lookup | left | `.` | Field access / lookup |
 | 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
-| 85 | exp | right | `!!` | Indexing (`xs !! 0`, arrays use list: `a !! [r,c]`) |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
 | 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
 | 88 | -- | right/left | `∘`, `;` | Composition (right-to-left, left-to-right) |
 | 85 | exp | right | `^` | Power |
+| 85 | exp | right | `!!` | Indexing (`xs !! 0`, arrays use list: `a !! [r,c]`) |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |
 | 55 | -- | right | `‖` | List cons (prepend element) |
@@ -393,7 +393,6 @@ Formats for `parse-as`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jso
 | `negate` | Negate number |
 | `inc` / `dec` | Increment / decrement |
 | `max(a, b)` / `min(a, b)` | Maximum / minimum |
-| `even?` / `odd?` | Parity predicates |
 | `zero?` / `pos?` / `neg?` | Sign predicates |
 | `floor` / `ceiling` / `⌊n⌋` / `⌈n⌉` | Rounding (no `round`) |
 | `even?` / `odd?` | Do **not** exist — use `x % 2 = 0` / `x % 2 = 1` |

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -237,9 +237,12 @@ From highest to lowest binding:
 |------|------|-------|-----------|-------------|
 | 95 | -- | prefix | `↑` | Tight prefix (head) |
 | 90 | lookup | left | `.` | Field access / lookup |
+| 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
+| 85 | exp | right | `!!` | Indexing (`xs !! 0`, arrays use list: `a !! [r,c]`) |
 | 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
 | 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
-| 85 | exp | right | `^`, `∘`, `;` | Power, composition |
+| 88 | -- | right/left | `∘`, `;` | Composition (right-to-left, left-to-right) |
+| 85 | exp | right | `^` | Power |
 | 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
 | 75 | sum | left | `+`, `-` | Addition, subtraction |
 | 55 | -- | right | `‖` | List cons (prepend element) |
@@ -340,16 +343,21 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | Function | Description |
 |----------|-------------|
 | `str.len(s)` | String length |
-| `str.upper(s)` | Upper case |
-| `str.lower(s)` | Lower case |
-| `str.starts-with?(prefix)` | Starts with prefix? |
-| `str.ends-with?(suffix)` | Ends with suffix? |
-| `str.contains?(sub)` | Contains substring? |
-| `str.matches?(regex)` | Matches regex? |
-| `str.split(sep)` | Split by separator |
-| `str.join(sep)` | Join list with separator |
-| `str.replace(from, to)` | Replace occurrences |
-| `str.trim` | Remove surrounding whitespace |
+| `str.to-upper(s)` | Upper case |
+| `str.to-lower(s)` | Lower case |
+| `str.starts-with?(re, s)` | Starts with regex match? |
+| `str.ends-with?(re, s)` | Ends with regex match? |
+| `str.contains?(re, s)` | Contains regex match? |
+| `str.matches?(re, s)` | Matches full regex? |
+| `str.split-on(re, s)` | Split by regex (pipeline-friendly) |
+| `str.join-on(sep, l)` | Join list with separator (pipeline-friendly) |
+| `str.replace(re, rep, s)` | Replace all regex matches |
+| `str.prefix(b, a)` | Prepend `b` onto `a` |
+| `str.suffix(b, a)` | Append `b` onto `a` |
+
+**All str regex functions treat the pattern argument as a regular expression.**
+`str.split-on` and `str.contains?` are pipeline-friendly (data is last arg).
+Note: `str.trim` does **not** exist — strip leading/trailing manually with `str.replace`.
 
 ### Serialisation and Parsing
 
@@ -388,6 +396,7 @@ Formats for `parse-as`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jso
 | `even?` / `odd?` | Parity predicates |
 | `zero?` / `pos?` / `neg?` | Sign predicates |
 | `floor` / `ceiling` / `⌊n⌋` / `⌈n⌉` | Rounding (no `round`) |
+| `even?` / `odd?` | Do **not** exist — use `x % 2 = 0` / `x % 2 = 1` |
 
 ### Arrays (`arr` namespace)
 

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -894,18 +894,22 @@ generalised lookup.
 
 The following are commonly assumed but are **not** in the prelude:
 
-- `str.replace` — does not exist
 - `str.trim` — does not exist
-- `str.starts-with?` — does not exist
-- `str.ends-with?` — does not exist
-- `str.contains?` — does not exist
 - `flatten` — use `concat` (flattens one level)
 - `unique` — does not exist in prelude
-- `abs` — does not exist (use `if(x < 0, negate(x), x)`)
 - `even?` / `odd?` — do not exist (use `x % 2 = 0`)
 - `round` / `ceil` — use `floor` and `ceiling` (or bracket notation `⌊n⌋` and `⌈n⌉`)
 - `select` / `dissoc` — do not exist (use `filter-items` with
   `by-key`)
+
+These **do exist** and are commonly available:
+
+- `str.replace(pattern, replacement, s)` — replaces all regex matches
+- `str.contains?(pattern, s)` — true if `s` contains a match for regex `pattern`
+- `str.starts-with?(re, s)` — true if `s` starts with regex match
+- `str.ends-with?(re, s)` — true if `s` ends with regex match
+- `abs(n)` — absolute value
+- `str.to-upper(s)` / `str.to-lower(s)` — case conversion (not `str.upper` / `str.lower`)
 
 ### 5.12 str.split-on Uses Regex, Not Literal Strings
 

--- a/editors/vscode/snippets/eucalypt.code-snippets
+++ b/editors/vscode/snippets/eucalypt.code-snippets
@@ -96,5 +96,37 @@
     "prefix": "pipe",
     "body": ["${1:value} ${2:f} ${3:g}"],
     "description": "Value pipeline (catenation)"
+  },
+  "Typed function declaration": {
+    "prefix": "tfn",
+    "body": [
+      "` { doc: \"`${1:name}(${2:x})` - ${3:description}.\"",
+      "    type: \"${4:number} -> ${5:number}\" }",
+      "${1:name}(${2:x}): ${6:${2:x}}"
+    ],
+    "description": "Function declaration with type annotation"
+  },
+  "Type alias in unit metadata": {
+    "prefix": "types",
+    "body": [
+      "{ types: { ${1:Name}: \"{${2:key}: ${3:type}, ..}\" } }"
+    ],
+    "description": "Type alias definitions in unit metadata"
+  },
+  "Type-def declaration": {
+    "prefix": "typedef",
+    "body": [
+      "` { type-def: \"${1:TypeName}\" }",
+      "${2:canonical-value}: ${3:{ key: value }}"
+    ],
+    "description": "Derive type alias from canonical instance"
+  },
+  "IO typed binding": {
+    "prefix": "iobind",
+    "body": [
+      "` { type: \"IO(${1:block})\" }",
+      "${2:action}: io.shell(\"${3:command}\")"
+    ],
+    "description": "IO action with type annotation"
   }
 }


### PR DESCRIPTION
## Summary

- **Agent-reference §5.11 corrected**: `str.replace`, `str.contains?`, `str.starts-with?`, `str.ends-with?`, and `abs` all verified to exist in `lib/prelude.eu` — remove false negatives and add a positive clarification list
- **CLAUDE.md rule 7 corrected** to match verified prelude state
- **Cheat-sheet str namespace fixed**: correct function names (`str.to-upper` not `str.upper`, `str.split-on` not `str.split`), remove nonexistent `str.trim`, document regex-based signatures, add `str.prefix`/`str.suffix`; note `even?`/`odd?` don't exist
- **Cheat-sheet precedence table fixed**: `∘` and `;` correctly placed at 88 (not 85 alongside `^`); added missing `~` safe-lookup (90) and `!!` indexing (85)
- **VS Code snippets**: add `tfn` (typed function), `types` (type aliases), `typedef` (type-def), `iobind` (IO action) for type-checking workflow

Resolves beads: eu-z43g, eu-6g15, eu-bthd, eu-xb8t (partial), eu-1w2e, eu-uo4c

## Test plan

- [ ] Review docs changes for accuracy against `lib/prelude.eu`
- [ ] Verify VS Code snippets have correct syntax by inspection
- [ ] Confirm precedence values against `src/core/metadata.rs` `named_precedence`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)