### PR TITLE
docs: add monadic block type-checking section

### DIFF
--- a/docs/guide/monads.md
+++ b/docs/guide/monads.md
@@ -483,6 +483,23 @@ ok:     maybe.bind(safe-head([42]), inc) # => 43
 
 ---
 
+## Type checking in monadic blocks
+
+`eu check` understands monadic blocks. When a namespace has a known
+element type (e.g. `io` uses `IO(a)`, `for` uses `[a]`), the checker
+infers the types of bound variables automatically and warns if a binding
+RHS has the wrong type.
+
+```sh
+eu check file.eu          # reports type warnings in monadic blocks
+eu check file.eu --strict # treats type warnings as errors
+```
+
+See [Type Checking — Monadic block binding types](type-checking.md#monadic-block-binding-types)
+for examples and a full explanation.
+
+---
+
 ## Key concepts
 
 - `monad(m)` takes `{bind, return}` and returns a block with `bind`,

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -237,6 +237,89 @@ values from leaking into pure data.
 
 ---
 
+## Monadic block binding types
+
+When `eu check` encounters a monadic block, it uses the monad's element
+type to infer the types of bound variables. Each binding in a `{ :ns
+... }` block should be an action in that monad; the checker unwraps the
+monad layer and gives the bound name the result type.
+
+### The list monad: `{ :for ... }`
+
+The `for` namespace is the list monad. Binding a name draws elements
+from a list, so the bound variable gets the list's element type:
+
+```eu,notest
+{ :for x: [1, 2, 3] }.(x * 2)   # x : number  ✓
+{ :for s: ["a", "b"] }.(s)       # s : string  ✓
+```
+
+If you bind a non-list, `eu check` warns:
+
+```eu,notest
+{ :for x: 42 }.(x)   # warning: binding in :for block must be [a], got number
+```
+
+### The IO monad: `{ :io ... }`
+
+The `io` namespace is typed with `IO(a)`. Each binding must be an IO
+action; the bound variable gets the inner type:
+
+```eu,notest
+{ :io
+  r: io.shell("echo hello")   # r : block  (IO(block) unwrapped)
+  _: io.check(r)
+}.(r.stdout)                  # stdout lookup on block  ✓
+```
+
+The most common mistake the checker catches is binding a plain value
+instead of an IO action:
+
+```eu,notest
+{ :io
+  cmd: 42                     # warning: expected IO(a), got number
+}.(cmd)
+```
+
+### The state monad: `{ :random ... }` and `{ :state ... }`
+
+State monads wrap actions as functions of a state value. The checker
+validates that each binding is a valid monadic action for that namespace.
+Bound variables receive the result type (the `value` component):
+
+```eu,notest
+{ :random
+  d6:  random.int(6)     # d6  : number
+  d20: random.int(20)    # d20 : number
+}.[d6, d20]
+```
+
+### The identity monad: `{ :let ... }`
+
+`{ :let ... }` blocks use the identity monad — every binding is a plain
+value, so bound variables keep their inferred types directly:
+
+```eu,notest
+{ :let
+  x: 1 + 1               # x : number
+  s: str.of(x)           # s : string
+}.(x + 1)                # number + number  ✓
+```
+
+### What the checker validates
+
+`eu check` reports a warning when:
+
+- A binding's RHS type is inconsistent with the monad's expected action
+  type (e.g. `number` in an `:io` block instead of `IO(a)`)
+- A bound variable is used in a way inconsistent with its unwrapped type
+  (e.g. calling `.stdout` on a `number`)
+
+The checker does **not** require annotations — it infers binding types
+from the monad's known type signature and the RHS expression type.
+
+---
+
 ## Lens and traversal types
 
 The lens library is typed with two opaque type constructors:


### PR DESCRIPTION
## Summary

- Adds a new **"Monadic block binding types"** section to `docs/guide/type-checking.md`, covering how `eu check` infers bound variable types in `:for`, `:io`, `:random`/`:state`, and `:let` monadic blocks
- Adds a brief cross-reference note to `docs/guide/monads.md` pointing readers to the type-checking guide

## Details

The type-checking guide previously covered the `IO(T)` type constructor in isolation but never explained how the checker validates bindings *inside* monadic blocks. The new section:

- Shows that `:for x: [1,2,3]` gives `x : number`
- Shows that `:io cmd: 42` warns (expected `IO(a)`, got `number`)
- Covers `:random`, `:state` (result type unwrapping), and `:let` (identity, plain types)
- Explains what the checker does and does not validate

Closes eu-5wrq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)