### PR TITLE
docs: Phase 2 follow-up for A1+A2 — Dict, row-poly, brace escaping

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -457,6 +457,56 @@ The wrong pattern causes a compiler error because only the first
 block is unit metadata — the second becomes an anonymous block
 declaration catenated into the metadata expression.
 
+## Type Annotation String Escaping
+
+### Record Braces in Type Strings Require `{{` Escaping
+
+Type annotation values (`type:`, `types:`) are ordinary eucalypt strings.
+`{` inside a eucalypt string starts string interpolation — it does
+**not** produce a literal `{` for the type parser.
+
+Any record type written in a type annotation string must escape braces
+with `{{` and `}}`:
+
+```eu,notest
+# WRONG — {..r} triggers string interpolation
+` { type: "{..r} -> {..r}" }
+pass-through(x): x
+
+# RIGHT — use {{ and }} for literal braces
+` { type: "{{..r}} -> {{..r}}" }
+pass-through(x): x
+
+# WRONG — {name: string} triggers interpolation
+` { type: "{name: string, age: number, ..} -> string" }
+greet(p): "Hello, {p.name}!"
+
+# RIGHT
+` { type: "{{name: string, age: number, ..}} -> string" }
+greet(p): "Hello, {p.name}!"
+```
+
+The same applies to `types:` unit metadata values:
+
+```eu,notest
+# RIGHT — escape braces in types: values too
+{ types: { Person: "{{name: string, age: number}}" } }
+```
+
+**When escaping is NOT needed**: type strings that contain no `{` at all
+never need escaping. Simple function types and built-in type constructors
+are fine as-is:
+
+```eu,notest
+` { type: "number -> number" }           # fine — no braces
+` { type: "[a] -> a" }                   # fine
+` { type: "IO(block)" }                  # fine — parens, not braces
+` { type: "Lens(a, b) -> a -> b" }       # fine
+` { type-def: "Point" }                  # fine — just a name, no braces
+```
+
+---
+
 ## Future Improvements
 
 These gotchas highlight areas where the language could benefit from:

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -147,7 +147,7 @@ Records describe the shape of blocks:
 | `block`          | any block (no known shape)                        |
 
 ```eu,notest
-` { type: "{name: string, age: number, ..} -> string" }
+` { type: "{{name: string, age: number, ..}} -> string" }
 greet-person(p): "Hello, {p.name}!"
 ```
 
@@ -368,8 +368,8 @@ using unit metadata:
 
 ```eu,notest
 { import: "data.eu"
-  types: { Person: "{name: string, age: number, email: string | null, ..}"
-           Response: "{status: number, body: string | null}" } }
+  types: { Person: "{{name: string, age: number, email: string | null, ..}}"
+           Response: "{{status: number, body: string | null}}" } }
 
 ` { type: "[Person] -> [string]" }
 names: map(_.name)
@@ -395,7 +395,7 @@ Combine `type:` and `type-def:` to override inference:
 
 ```eu,notest
 ` { type-def: "Person"
-    type: "{name: string, age: number, email: string | null, ..}" }
+    type: "{{name: string, age: number, email: string | null, ..}}" }
 nobody: { name: "", age: 0, email: null }
 ```
 
@@ -406,7 +406,7 @@ nobody: { name: "", age: 0, email: null }
 Consider a small data processing pipeline with type annotations:
 
 ```eu,notest
-{ types: { Record: "{id: number, name: string, active: bool, ..}" } }
+{ types: { Record: "{{id: number, name: string, active: bool, ..}}" } }
 
 ` { type: "[Record] -> [Record]" }
 active-records: filter(_.active)
@@ -442,11 +442,11 @@ typically have variable shapes:
 
 ```eu,notest
 # Open: works with any block that has a .name field
-` { type: "{name: string, ..} -> string" }
+` { type: "{{name: string, ..}} -> string" }
 get-name(b): b.name
 
 # Closed: only works with blocks of exactly this shape
-` { type: "{name: string}" }
+` { type: "{{name: string}}" }
 exact-block: { name: "Alice" }
 ```
 

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -146,16 +146,23 @@ origin: { x: 0, y: 0 }
 | `any`              | gradual/unknown — no type errors       |
 | `[T]`              | list of T                              |
 | `(A, B)`           | tuple                                  |
-| `{k: T, ..}`       | open record (at least k: T)            |
-| `{k: T, ..r}`      | named row variable (extra fields in r) |
-| `{k: T}`           | closed record                          |
-| `block`            | any block                              |
+| `{{k: T, ..}}`     | open record (at least k: T)            |
+| `{{k: T, ..r}}`    | named row variable (extra fields in r) |
+| `{{..r, ..s}}`     | row concatenation (union of r and s)   |
+| `{{k: T}}`         | closed record                          |
+| `block`            | any block (no known shape)             |
+| `Dict(T)`          | homogeneous block — all values type T  |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
 | `a`, `b`           | type variable                          |
 | `IO(T)`            | IO action producing T                  |
 | `Lens(a, b)`       | lens                                   |
 | `Traversal(a, b)`  | traversal                              |
+
+**Important**: record braces (`{`) in type strings trigger eucalypt
+string interpolation. Always escape with `{{` and `}}`:
+`"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
+Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
 
 See [Type Checking](../guide/type-checking.md) for the full guide.
 


### PR DESCRIPTION
## Summary

Phase 2 documentation follow-up triggered by Quill's PR #711 (A1+A2 — Dict and row polymorphism).

Three changes across three files:

**`docs/appendices/syntax-gotchas.md`** — new section "Record Braces in Type Strings Require `{{` Escaping"
- Explains that `{` inside `type:` / `types:` annotation strings starts eucalypt string interpolation
- Shows wrong/right examples for row variables (`{..r}` → `{{..r}}`), open records, and closed records
- Notes that simple types without braces (`"number -> number"`, `"IO(T)"`) need no escaping

**`docs/reference/agent-reference.md`** — type forms table updates
- Added `Dict(T)` (homogeneous block) and `{{..r, ..s}}` (row concatenation)
- Updated existing rows to show correct `{{` escaping
- Added bold warning note about brace escaping

**`docs/guide/type-checking.md`** — fix pre-existing wrong examples
- 5 existing record-type code examples used single braces (never tested — `eu,notest` blocks)
- Corrected to `{{name: string, ..}}` etc. to match actual required syntax

Closes eu-v6b8 and eu-h024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)