### PR TITLE
fix(errors): cal.zdt panics on out-of-range year

### DIFF
--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -128,16 +128,16 @@ impl StgIntrinsic for Zdt {
             sec.as_u64(),
         ) {
             let date = NaiveDate::from_ymd_opt(
-                yy.try_into().expect("year must fit in i32"),
-                mm.try_into().expect("month must fit in u32"),
-                dd.try_into().expect("day must fit in u32"),
+                yy.try_into().ok().ok_or_else(err)?,
+                mm.try_into().ok().ok_or_else(err)?,
+                dd.try_into().ok().ok_or_else(err)?,
             )
             .ok_or_else(err)?;
 
             let time = NaiveTime::from_hms_opt(
-                hours.try_into().expect("hours must fit in u32"),
-                mins.try_into().expect("minutes must fit in u32"),
-                secs.try_into().expect("seconds must fit in u32"),
+                hours.try_into().ok().ok_or_else(err)?,
+                mins.try_into().ok().ok_or_else(err)?,
+                secs.try_into().ok().ok_or_else(err)?,
             )
             .ok_or_else(err)?;
 

--- a/tests/harness/errors/141_calzdt_year_overflow.eu
+++ b/tests/harness/errors/141_calzdt_year_overflow.eu
@@ -1,0 +1,3 @@
+# cal.zdt with a year too large for a 32-bit integer should return a proper
+# BadDateTimeComponents error, not a panic.
+result: cal.zdt(3000000000, 1, 1, 0, 0, 0, "UTC")

--- a/tests/harness/errors/141_calzdt_year_overflow.eu.expect
+++ b/tests/harness/errors/141_calzdt_year_overflow.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "invalid date/time components"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1538,6 +1538,11 @@ pub fn test_error_140() {
 }
 
 #[test]
+pub fn test_error_141() {
+    run_error_test(&error_opts("141_calzdt_year_overflow.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `cal.zdt(3000000000, 1, 1, 0, 0, 0, "UTC")` previously panicked because `.try_into().expect()` on the year overflowed `i32` after a successful `i64` parse
- Replace all six `.try_into().expect()` calls in `src/eval/stg/time.rs` with `.try_into().ok().ok_or_else(err)?`
- Out-of-range components now produce a proper `BadDateTimeComponents` error with the component values shown

## Test plan

- [ ] `cargo test test_error_141` passes (new harness test: `141_calzdt_year_overflow.eu`)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied

Closes eu-5yya.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)