### PR TITLE
fix(errors): render-as with unknown format reports UnknownRenderFormat

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1289,7 +1289,10 @@ fn evaluate_to_whnf_impl(
         }
         // Capture lifecycle inside sub-evaluation (needed if sub-eval uses render-as).
         if let Some(fmt) = state.pending_capture_start.take() {
-            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&fmt)?;
+            let mut cap = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
+                &fmt,
+                state.annotation,
+            )?;
             cap.stream_start();
             // We have no capture_emitters stack in this context; this is a limitation
             // of BIF-level sub-evaluation.  Nested render-as inside evaluate_to_whnf
@@ -1660,8 +1663,10 @@ impl<'a> Machine<'a> {
 
         // If a capture start was requested, push the capture emitter.
         if let Some(format) = self.state.pending_capture_start.take() {
-            let mut capture =
-                crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(&format)?;
+            let mut capture = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
+                &format,
+                self.state.annotation,
+            )?;
             capture.stream_start();
             self.capture_emitters.push(capture);
         }

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -58,7 +58,10 @@ pub struct OwnedCaptureEmitter {
 impl OwnedCaptureEmitter {
     /// Create a new capture emitter for the given format (e.g. "json",
     /// "yaml", "text").
-    pub fn new(format: &str) -> Result<Self, ExecutionError> {
+    ///
+    /// `smid` is the source location of the `render-as` call — used in the
+    /// error diagnostic when an unknown format name is supplied.
+    pub fn new(format: &str, smid: Smid) -> Result<Self, ExecutionError> {
         #[allow(clippy::box_default)]
         let mut buffer: Box<Vec<u8>> = Box::new(Vec::new());
         // SAFETY: We take a raw pointer to the boxed buffer.  The Box
@@ -67,10 +70,8 @@ impl OwnedCaptureEmitter {
         // before the buffer (field declaration order), so the borrow is
         // valid for the emitter's entire lifetime.
         let buf_ptr: *mut Vec<u8> = &mut *buffer;
-        let emitter =
-            export::create_emitter(format, unsafe { &mut *buf_ptr }).ok_or_else(|| {
-                ExecutionError::Panic(Smid::default(), format!("unknown render format: {format}"))
-            })?;
+        let emitter = export::create_emitter(format, unsafe { &mut *buf_ptr })
+            .ok_or_else(|| ExecutionError::UnknownRenderFormat(smid, format.to_string()))?;
         // SAFETY: The lifetime erasure is sound because format-specific emitters
         // created by `create_emitter` only write through the `&mut dyn Write`
         // trait object and never capture the lifetime parameter. The `buffer`

--- a/tests/harness/errors/142_render_unknown_format.eu
+++ b/tests/harness/errors/142_render_unknown_format.eu
@@ -1,0 +1,3 @@
+# render-as with an unknown format symbol should produce an UnknownRenderFormat
+# error, not a generic panic.
+result: "hello" render-as(:badformat)

--- a/tests/harness/errors/142_render_unknown_format.eu.expect
+++ b/tests/harness/errors/142_render_unknown_format.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "unknown render format 'badformat'"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1538,6 +1538,11 @@ pub fn test_error_140() {
 }
 
 #[test]
+pub fn test_error_142() {
+    run_error_test(&error_opts("142_render_unknown_format.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `render-as(:badformat, x)` previously returned `Panic(Smid::default(), "unknown render format: badformat")` — the wrong error type with no source location
- `UnknownRenderFormat(Smid, String)` already exists for exactly this case
- `OwnedCaptureEmitter::new()` now accepts a `Smid` parameter and returns `UnknownRenderFormat(smid, format)`
- Both call sites in `vm.rs` pass `machine.annotation()` (the current source location)

## Test plan

- [ ] `cargo test test_error_142` passes (new harness test: `142_render_unknown_format.eu`)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied

Closes eu-h9e3.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)