### PR TITLE
fix(errors): add source location to BitwiseIntegerRequired errors

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -709,8 +709,8 @@ pub enum ExecutionError {
     ExpectedClosure,
     #[error("array bounds error: index {index} out of bounds for array of length {length}")]
     ArrayBoundsError { index: usize, length: usize },
-    #[error("bitwise operations require integer arguments ({0})")]
-    BitwiseIntegerRequired(String),
+    #[error("bitwise operations require integer arguments ({1})")]
+    BitwiseIntegerRequired(Smid, String),
     #[error("array index out of bounds: coordinates {1:?} are outside the array bounds")]
     ArrayNdIndexOutOfBounds(Smid, Vec<usize>),
     #[error("array shape mismatch: {1}")]
@@ -813,6 +813,7 @@ impl HasSmid for ExecutionError {
             ExecutionError::NumericRangeError(s, _, _) => *s,
             ExecutionError::DivisionByZero(s, _) => *s,
             ExecutionError::BadDateTimeComponents(s, _, _, _, _, _, _, _) => *s,
+            ExecutionError::BitwiseIntegerRequired(s, _) => *s,
             _ => Smid::default(),
         }
     }

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -993,25 +993,28 @@ impl CallGlobal2 for Rem {}
 
 /// Extract an i64 from a Number, accepting integer-valued floats
 /// (which arise from intrinsics like `sort-nums` that convert via f64).
-fn require_i64(n: &Number) -> Result<i64, ExecutionError> {
+fn require_i64(n: &Number, smid: crate::common::sourcemap::Smid) -> Result<i64, ExecutionError> {
     if let Some(i) = n.as_i64() {
         Ok(i)
     } else if let Some(u) = n.as_u64() {
         i64::try_from(u).map_err(|_| {
-            ExecutionError::BitwiseIntegerRequired(format!(
-                "{u} is out of the i64 range for bitwise operations"
-            ))
+            ExecutionError::BitwiseIntegerRequired(
+                smid,
+                format!("{u} is out of the i64 range for bitwise operations"),
+            )
         })
     } else if let Some(f) = n.as_f64() {
         if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
             Ok(f as i64)
         } else {
-            Err(ExecutionError::BitwiseIntegerRequired(format!(
-                "got {f}, which is not a whole number"
-            )))
+            Err(ExecutionError::BitwiseIntegerRequired(
+                smid,
+                format!("got {f}, which is not a whole number"),
+            ))
         }
     } else {
         Err(ExecutionError::BitwiseIntegerRequired(
+            smid,
             "value cannot be represented as an integer".to_string(),
         ))
     }
@@ -1034,7 +1037,8 @@ impl StgIntrinsic for BitAnd {
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
-        let result = require_i64(&x)? & require_i64(&y)?;
+        let smid = machine.annotation();
+        let result = require_i64(&x, smid)? & require_i64(&y, smid)?;
         machine_return_num(machine, view, Number::from(result))
     }
 }
@@ -1058,7 +1062,8 @@ impl StgIntrinsic for BitOr {
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
-        let result = require_i64(&x)? | require_i64(&y)?;
+        let smid = machine.annotation();
+        let result = require_i64(&x, smid)? | require_i64(&y, smid)?;
         machine_return_num(machine, view, Number::from(result))
     }
 }
@@ -1082,7 +1087,8 @@ impl StgIntrinsic for BitXor {
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
-        let result = require_i64(&x)? ^ require_i64(&y)?;
+        let smid = machine.annotation();
+        let result = require_i64(&x, smid)? ^ require_i64(&y, smid)?;
         machine_return_num(machine, view, Number::from(result))
     }
 }
@@ -1105,7 +1111,8 @@ impl StgIntrinsic for BitNot {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
-        let result = !require_i64(&x)?;
+        let smid = machine.annotation();
+        let result = !require_i64(&x, smid)?;
         machine_return_num(machine, view, Number::from(result))
     }
 }
@@ -1129,10 +1136,11 @@ impl StgIntrinsic for Shl {
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
-        let n = require_i64(&x)?;
-        let k = require_i64(&y)?;
+        let smid = machine.annotation();
+        let n = require_i64(&x, smid)?;
+        let k = require_i64(&y, smid)?;
         if !(0..64).contains(&k) {
-            return Err(ExecutionError::BitshiftRangeError(machine.annotation(), k));
+            return Err(ExecutionError::BitshiftRangeError(smid, k));
         }
         let result = n << k;
         machine_return_num(machine, view, Number::from(result))
@@ -1158,10 +1166,11 @@ impl StgIntrinsic for Shr {
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
         let y = num_arg(machine, view, &args[1])?;
-        let n = require_i64(&x)?;
-        let k = require_i64(&y)?;
+        let smid = machine.annotation();
+        let n = require_i64(&x, smid)?;
+        let k = require_i64(&y, smid)?;
         if !(0..64).contains(&k) {
-            return Err(ExecutionError::BitshiftRangeError(machine.annotation(), k));
+            return Err(ExecutionError::BitshiftRangeError(smid, k));
         }
         let result = n >> k;
         machine_return_num(machine, view, Number::from(result))
@@ -1186,7 +1195,7 @@ impl StgIntrinsic for PopCount {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
-        let n = require_i64(&x)?;
+        let n = require_i64(&x, machine.annotation())?;
         let result = n.count_ones() as i64;
         machine_return_num(machine, view, Number::from(result))
     }
@@ -1210,7 +1219,7 @@ impl StgIntrinsic for Ctz {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
-        let n = require_i64(&x)?;
+        let n = require_i64(&x, machine.annotation())?;
         let result = n.trailing_zeros() as i64;
         machine_return_num(machine, view, Number::from(result))
     }
@@ -1234,7 +1243,7 @@ impl StgIntrinsic for Clz {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let x = num_arg(machine, view, &args[0])?;
-        let n = require_i64(&x)?;
+        let n = require_i64(&x, machine.annotation())?;
         let result = n.leading_zeros() as i64;
         machine_return_num(machine, view, Number::from(result))
     }

--- a/tests/harness/errors/143_bitwise_float.eu
+++ b/tests/harness/errors/143_bitwise_float.eu
@@ -1,0 +1,3 @@
+# Bitwise AND on a non-integer float should produce a BitwiseIntegerRequired
+# error with a source location pointing to the call site.
+result: 1.5 bit.and(2)

--- a/tests/harness/errors/143_bitwise_float.eu.expect
+++ b/tests/harness/errors/143_bitwise_float.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "bitwise operations require integer arguments"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1538,6 +1538,11 @@ pub fn test_error_140() {
 }
 
 #[test]
+pub fn test_error_143() {
+    run_error_test(&error_opts("143_bitwise_float.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `BitwiseIntegerRequired(String)` had no `Smid` field, so bitwise errors produced no source location in diagnostics
- Changed to `BitwiseIntegerRequired(Smid, String)` and added the `HasSmid` arm
- Updated `require_i64()` helper to accept a `Smid` parameter
- All call sites in `arith.rs` pass `machine.annotation()` so the error points to the user's code

## Test plan

- [ ] `cargo test test_error_143` passes (new harness test: `143_bitwise_float.eu`)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` applied

Closes eu-olsx.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)