### PR TITLE
fix(typecheck): correct A3 recursive alias syntax in tests and docs

### DIFF
--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -229,11 +229,11 @@ Overloaded operators use union types:
 
 A **recursive alias** is an alias whose definition refers back to itself.
 The type checker resolves it to an equirecursive `μ`-type automatically —
-no special syntax is needed.
+no special syntax is needed. Define recursive aliases with the `types:`
+metadata key:
 
 ```eu,notest
-` { type-def: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
-unit: {}
+{ types: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
 
 ` { type: "Json → string" }
 describe: str.from
@@ -244,12 +244,14 @@ and any value whose type is a subtype of any variant passes without
 warning.  The type always *displays* as its alias name (`Json`) — never
 as the (infinite) unfolded form.
 
-**Defining recursive aliases** — use `type-def:` metadata at the block
-level, or a `types:` sub-block:
+**Unit metadata** (the bare block at the top of a file, no `` ` ``) is
+the natural place for type aliases shared across a whole file. Declaration
+metadata (with `` ` ``) can also carry a `types:` block to scope aliases
+to a single binding:
 
 ```eu,notest
-` { types: { Tree: "{value: number, children: [Tree]}" } }
-unit: {}
+` { types: { Tree: "{{value: number, children: [Tree]}}" } }
+root: { value: 1, children: [] }
 ```
 
 **Mutual recursion** — aliases that reference each other are handled:

--- a/tests/harness/typecheck/030_recursive_alias_no_hang.eu
+++ b/tests/harness/typecheck/030_recursive_alias_no_hang.eu
@@ -1,6 +1,5 @@
 # A3: Self-referential alias resolves to Mu — does NOT hang.
 # Json = number | string | bool | null | [Json] | Dict(Json)
-` { type-def: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
-unit: {}
+{ types: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
 
 result: 42

--- a/tests/harness/typecheck/031_json_function_no_warning.eu
+++ b/tests/harness/typecheck/031_json_function_no_warning.eu
@@ -1,7 +1,6 @@
 # A3: A function annotated Json → string produces no type warning
 # when given a plain number (number <: Json).
-` { type-def: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
-unit: {}
+{ types: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
 
 ` { type: "Json → string" }
 describe: (_ str.from)

--- a/tests/harness/typecheck/032_nonrecursive_alias_flat.eu
+++ b/tests/harness/typecheck/032_nonrecursive_alias_flat.eu
@@ -1,7 +1,6 @@
 # A3: A non-recursive alias (Name = string) resolves flat — no Mu wrapper,
 # no warning when passing a string.
-` { type-def: { Name: "string" } }
-unit: {}
+{ types: { Name: "string" } }
 
 ` { type: "Name → number" }
 length: str.length

--- a/tests/harness/typecheck/033_json_dict_no_warning.eu
+++ b/tests/harness/typecheck/033_json_dict_no_warning.eu
@@ -1,7 +1,6 @@
 # A3 + A2: Dict(Json) in a recursive type — a closed record of Json values
 # (here numbers, since number <: Json) is consistent with Dict(Json).
-` { type-def: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
-unit: {}
+{ types: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
 
 ` { type: "Dict(Json)" }
 data: { a: 1, b: 2, c: 3 }


### PR DESCRIPTION
## Problem

The A3 harness tests (030–033) and the "Recursive types" section of
`docs/guide/type-checking.md` used `type-def: {Name: "expr"}` (block
form) to define named type aliases. This is silently ignored:
`extract_type_def_name` in `check.rs` only handles string-valued
`type-def:` (via `extract_string_literal`).

The four tests passed because unregistered capitalised names become
free type variables, quantified universally — effectively `any`. No
recursive `Mu` type was ever created or checked. The tests were not
testing A3 at all.

## Fix

Replace `\` { type-def: {…} }` + `unit: {}` with `{ types: {…} }` unit
metadata in all four test files. The `types:` key is processed by
`register_aliases_from_meta`, which correctly registers the alias and
triggers `resolve_aliases_inner`'s cycle detection to produce `Mu`.

Also update `type-checking.md`:
- Remove the wrong `type-def:` block-form example
- Show the correct `{ types: {…} }` unit metadata form
- Add a note about declaration-level `types:` scope
- Fix the Tree example to use `{{` brace escaping

All four tests still pass — now testing genuine recursive type checking.

Closes eu-7ksp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)