### PR TITLE
perf: native atom returns from arithmetic ops (~16% faster fib)

### DIFF
--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     array::array_binop,
-    support::{machine_return_bool, machine_return_boxed_num, machine_return_num, num_arg},
+    support::{machine_return_bool, machine_return_num, num_arg},
     syntax::{
         dsl::{app_bif, case, force, lambda, local, lref},
         LambdaForm, StgSyn,
@@ -110,17 +110,17 @@ impl StgIntrinsic for Add {
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(total))
+            machine_return_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let total = l.checked_add(r).ok_or(ExecutionError::NumericRangeError(
                 machine.annotation(),
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(total))
+            machine_return_num(machine, view, Number::from(total))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l + r) {
-                machine_return_boxed_num(machine, view, ret)
+                machine_return_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(
                     machine.annotation(),
@@ -177,17 +177,17 @@ impl StgIntrinsic for Sub {
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(result))
+            machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let result = l.checked_sub(r).ok_or(ExecutionError::NumericRangeError(
                 machine.annotation(),
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(result))
+            machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l - r) {
-                machine_return_boxed_num(machine, view, ret)
+                machine_return_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(
                     machine.annotation(),
@@ -244,17 +244,17 @@ impl StgIntrinsic for Mul {
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(product))
+            machine_return_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let product = l.checked_mul(r).ok_or(ExecutionError::NumericRangeError(
                 machine.annotation(),
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(product))
+            machine_return_num(machine, view, Number::from(product))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             if let Some(ret) = Number::from_f64(l * r) {
-                machine_return_boxed_num(machine, view, ret)
+                machine_return_num(machine, view, ret)
             } else {
                 Err(ExecutionError::NumericDomainError(
                     machine.annotation(),
@@ -318,18 +318,18 @@ impl StgIntrinsic for Div {
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(result))
+            machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
             let result = l.checked_div(r).ok_or(ExecutionError::NumericRangeError(
                 machine.annotation(),
                 x,
                 y,
             ))?;
-            machine_return_boxed_num(machine, view, Number::from(result))
+            machine_return_num(machine, view, Number::from(result))
         } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
             let result = (l / r).floor();
             if let Some(n) = num_from_floored(result) {
-                machine_return_boxed_num(machine, view, n)
+                machine_return_num(machine, view, n)
             } else {
                 Err(ExecutionError::NumericDomainError(
                     machine.annotation(),
@@ -1277,11 +1277,8 @@ pub mod tests {
 
     #[test]
     pub fn test_unboxed_add() {
-        // ADD with a custom wrapper returns BoxedNumber directly from execute
-        // (the arithmetic_wrapper does not include a boxing step, so execute
-        // must call machine_return_boxed_num). Calling the BIF directly also
-        // produces a BoxedNumber, so we check via terminated() rather than
-        // native_return() (which only works for raw atom results).
+        // ADD called directly (bypassing the wrapper) returns a native atom via
+        // machine_return_num.  native_return() should give Some(Num(4)).
         let syntax = letrec_(
             vec![],
             app_bif(intrinsics::index_u8("ADD"), vec![num(2), num(2)]),
@@ -1290,8 +1287,8 @@ pub mod tests {
         let mut m = testing::machine(rt.as_ref(), syntax);
         m.run(Some(100)).unwrap();
         assert!(m.terminated());
-        // Result is BoxedNumber([Num(4)]) — native_return() returns None for Cons
-        assert_eq!(m.native_return(), None);
+        // Result is a native atom — native_return() should yield Some(Num(4)).
+        assert_eq!(m.native_return(), Some(Native::Num(4.into())));
     }
 
     #[test]

--- a/src/eval/stg/eq.rs
+++ b/src/eval/stg/eq.rs
@@ -47,7 +47,13 @@ fn unary_branch(tag: Tag) -> (Tag, Rc<StgSyn>) {
                 tag, // [y-content] [x-content] [x y]
                 Eq.global(lref(1), lref(0)),
             )],
-            f(),
+            // native y fallback — env: [y_native] [x-content] [x] [y]
+            // Force x-content then compare natively.
+            force(
+                local(1), // x-content
+                // env: [x_native] [y_native] [x-content] [x] [y]
+                app_bif(Eq.index() as u8, vec![lref(0), lref(1)]),
+            ),
         ),
     )
 }
@@ -191,10 +197,52 @@ impl StgIntrinsic for Eq {
                         ),
                     ),
                 ],
-                // native and unknown tags
-                force(
-                    local(2),                                            // [x-eval] [x y]
-                    app_bif(self.index() as u8, vec![lref(0), lref(1)]), // [y-eval] [x-eval] [x y]
+                // native and unknown tags — env: [x-eval] [x] [y]
+                // x is a native atom; unbox y if it is a boxed primitive, then
+                // compare natively via the EQ intrinsic.
+                case(
+                    local(2), // y
+                    vec![
+                        (
+                            DataConstructor::BoxedNumber.tag(),
+                            // [num_field] [x-eval] [x] [y]
+                            force(
+                                local(0), // num_field
+                                // [y-native] [num_field] [x-eval] [x] [y]
+                                app_bif(self.index() as u8, vec![lref(2), lref(0)]),
+                            ),
+                        ),
+                        (
+                            DataConstructor::BoxedString.tag(),
+                            // [str_field] [x-eval] [x] [y]
+                            force(
+                                local(0), // str_field
+                                // [y-native] [str_field] [x-eval] [x] [y]
+                                app_bif(self.index() as u8, vec![lref(2), lref(0)]),
+                            ),
+                        ),
+                        (
+                            DataConstructor::BoxedSymbol.tag(),
+                            // [sym_field] [x-eval] [x] [y]
+                            force(
+                                local(0), // sym_field
+                                // [y-native] [sym_field] [x-eval] [x] [y]
+                                app_bif(self.index() as u8, vec![lref(2), lref(0)]),
+                            ),
+                        ),
+                        (
+                            DataConstructor::BoxedZdt.tag(),
+                            // [zdt_field] [x-eval] [x] [y]
+                            force(
+                                local(0), // zdt_field
+                                // [y-native] [zdt_field] [x-eval] [x] [y]
+                                app_bif(self.index() as u8, vec![lref(2), lref(0)]),
+                            ),
+                        ),
+                    ],
+                    // native y fallback: case puts y-native at local(0)
+                    // [y-native] [x-eval] [x] [y]
+                    app_bif(self.index() as u8, vec![lref(1), lref(0)]),
                 ),
             ),
         )
@@ -207,8 +255,17 @@ impl StgIntrinsic for Eq {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        let x = machine.nav(view).resolve_native(&args[0])?;
-        let y = machine.nav(view).resolve_native(&args[1])?;
+        // The wrapper always unboxes before calling the BIF; if a non-native
+        // arg slips through (e.g. a cross-type comparison in the native-x
+        // fallback), it cannot be equal to a primitive — return false.
+        let x = match machine.nav(view).resolve_native(&args[0]) {
+            Ok(v) => v,
+            Err(_) => return machine_return_bool(machine, view, false),
+        };
+        let y = match machine.nav(view).resolve_native(&args[1]) {
+            Ok(v) => v,
+            Err(_) => return machine_return_bool(machine, view, false),
+        };
         let eq = match (x, y) {
             (Native::Num(ref nx), Native::Num(ref ny)) => num_eq(nx, ny),
             (Native::Str(sx), Native::Str(sy)) => str_eq(view, sx, sy),

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -25,7 +25,8 @@ use super::{
     },
     syntax::{
         dsl::{
-            atom, box_str, data, force, lambda, let_, local, lref, str, switch, unbox_str, value,
+            atom, box_str, case, data, force, lambda, let_, local, lref, str, switch, unbox_str,
+            value,
         },
         LambdaForm,
     },
@@ -89,7 +90,7 @@ impl StgIntrinsic for Str {
         lambda(
             1,
             let_(
-                vec![value(switch(
+                vec![value(case(
                     local(0),
                     vec![
                         (
@@ -105,6 +106,8 @@ impl StgIntrinsic for Str {
                         (DataConstructor::BoolTrue.tag(), atom(str("true"))),
                         (DataConstructor::Unit.tag(), atom(str("null"))),
                     ],
+                    // native atom fallback — from_closure puts native at local(0)
+                    call::bif::str(lref(0)),
                 ))],
                 data(DataConstructor::BoxedString.tag(), vec![lref(0)]),
             ),

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -501,9 +501,16 @@ pub mod dsl {
         case(scrutinee, vec![], then)
     }
 
-    /// Unbox a number
+    /// Unbox a number, accepting native atoms as a passthrough fallback.
+    /// In the BoxedNumber branch `local(0)` holds the inner field (same as
+    /// before); in the native fallback `local(0)` holds the atom closure —
+    /// callers that use `lref(0)` work identically in both cases.
     pub fn unbox_num(scrutinee: Rc<StgSyn>, then: Rc<StgSyn>) -> Rc<StgSyn> {
-        switch(scrutinee, vec![(DataConstructor::BoxedNumber.tag(), then)])
+        case(
+            scrutinee,
+            vec![(DataConstructor::BoxedNumber.tag(), then.clone())],
+            then,
+        )
     }
 
     /// Unbox a string
@@ -516,7 +523,7 @@ pub mod dsl {
         switch(scrutinee, vec![(DataConstructor::BoxedSymbol.tag(), then)])
     }
 
-    /// Unbox a symbol
+    /// Unbox a datetime
     pub fn unbox_zdt(scrutinee: Rc<StgSyn>, then: Rc<StgSyn>) -> Rc<StgSyn> {
         switch(scrutinee, vec![(DataConstructor::BoxedZdt.tag(), then)])
     }


### PR DESCRIPTION
## Performance: eliminate boxing in arithmetic return values

### Hypothesis
ADD, SUB, MUL, DIV each allocate a `BoxedNumber{n}` Cons (2 heap objects: array + cons header) when returning a result. Arithmetic-heavy workloads like `fib(30)` call these billions of times. Returning a native `Atom{Ref::V(Native::Num(n))}` instead costs only 1 alloc.

### Change
- `arith.rs`: `machine_return_boxed_num` → `machine_return_num` in all four arithmetic ops
- `syntax.rs`: `unbox_num` uses `case` with native fallback so single-arg intrinsics (abs, ceiling, etc.) accept results of arithmetic
- `eq.rs`: Eq wrapper fixed to handle (native x, boxed y) and (boxed x, native y) comparisons; `execute` returns false instead of erroring for cross-type native comparisons
- `string.rs`: STR wrapper uses `case` with native fallback so `"{x}"` works when `x` is an arithmetic result

### Results
| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| bench-naive-fib (fib 30) — VM-Total | 6.83s | 5.74s | −16% |
| bench-naive-fib — heap blocks | 248 693 | 203 292 | −18% |
| bench-thunk-updates (fib 15, take 5000) — VM-Total | 0.88s | 0.86s | −2% |
| bench-thunk-updates — heap blocks | 1 566 | 1 360 | −13% |

Baseline measured with system `eu` (integration/0.6.2); "after" with this branch.

### Regression check
Full harness suite: **315 passed, 0 failed** (all harness, error, GC, and bench tests).

### Risks
- The `Eq` changes add extra STG evaluation steps for the (boxed x, native y) path — negligible in practice since the common path is (boxed, boxed) via `unary_branch`.
- `EQ.execute` now returns false instead of `NotValue` error for non-native args. The wrapper design ensures natives are always passed; the change is a safety net for cross-type comparisons that reach the BIF through the native-x fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)