### PR TITLE
docs: Phase 2 follow-up for A4 — literal string and symbol types

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -532,6 +532,8 @@ origin: { x: 0, y: 0 }
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
 | `Name` (capitalised) | recursive alias — resolved from `type-def:` |
+| `"value"`          | literal string type (subtype of `string`); in annotation string: `\"value\"` |
+| `:name`            | literal symbol type (subtype of `symbol`)      |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
 | `a`, `b`, `s`      | type variable (lowercase)              |

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -106,6 +106,45 @@ Operators use the same metadata syntax:
 | `datetime` | zoned date-time values             |
 | `any`      | unknown — consistent with all types|
 
+### Literal types
+
+A **literal type** represents exactly one value. Literal types are
+subtypes of their corresponding primitive:
+
+| Type syntax     | Meaning                           | Subtype of |
+|-----------------|-----------------------------------|------------|
+| `"value"`       | the specific string `"value"`     | `string`   |
+| `:name`         | the specific symbol `:name`       | `symbol`   |
+
+Literal types are most useful in **discriminated unions** — type aliases
+where a tag field distinguishes variants:
+
+```eu,notest
+{ types: { Shape: "{{type: \"circle\", radius: number, ..}} | {{type: \"rect\", w: number, h: number, ..}}" } }
+```
+
+Because writing complex union types inline is verbose, defining a `types:`
+alias is the recommended approach.
+
+**Subtyping rules**:
+- `"foo"` is consistent with `string` — a literal satisfies a string parameter
+- `"foo" | string` simplifies to `string` — the specific literal is absorbed
+- `:active` is consistent with `symbol` — same for symbols
+
+**Writing literal types in annotation strings**: the type syntax uses
+`"value"` (double-quoted) for literal strings. Since this appears inside
+a eucalypt string, the inner quotes must be escaped with `\"`:
+
+```eu,notest
+# Literal string type in a type annotation — inner quotes escaped with \"
+` { type: "\"circle\" | \"rect\" -> bool" }
+is-shape-name(s): s match?("circle") or s match?("rect")
+
+# Literal symbol type — no escaping needed (: is not special in strings)
+` { type: ":ok | :err -> bool" }
+ok?(status): status = :ok
+```
+
 ### Lists
 
 `[T]` is a homogeneous list of `T`:
@@ -571,6 +610,8 @@ lookup.
 | IO action                | `IO(T)`                                          |
 | Lens                     | `Lens(a, b)`                                     |
 | Traversal                | `Traversal(a, b)`                                |
+| Literal string type      | `"value"` (`\"value\"` in annotation string)     |
+| Literal symbol type      | `:name`                                           |
 | Type variable            | lowercase identifier: `a`, `b`, `s`              |
 | Union type               | `A \| B`                              |
 | Type alias (unit meta)   | `{ types: { Name: "..." } }`          |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -152,6 +152,8 @@ origin: { x: 0, y: 0 }
 | `{{k: T}}`         | closed record                          |
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
+| `"value"`          | literal string — subtype of `string`; in annotation string: `\"value\"` |
+| `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
 | `a`, `b`           | type variable                          |
@@ -163,6 +165,7 @@ origin: { x: 0, y: 0 }
 string interpolation. Always escape with `{{` and `}}`:
 `"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
 Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
+Literal string types (`"value"`) need `\"` escaping inside annotation strings.
 
 See [Type Checking](../guide/type-checking.md) for the full guide.
 


### PR DESCRIPTION
## Summary

Phase 2 documentation follow-up for Quill PR #719 (A4 literal types). No docs were shipped with A4.

### `docs/guide/type-checking.md`

New "Literal types" section immediately after Primitives:
- `"value"` — literal string type, subtype of `string`
- `:name` — literal symbol type, subtype of `symbol`
- Subtyping rules and union absorption (`"foo" | string = string`)
- Key use-case: discriminated unions with tag fields
- Escaping note: `\"` needed inside eucalypt annotation strings for literal string types
- Two code examples (string literals, symbol literals)
- Two new Summary table rows

### `docs/appendices/cheat-sheet.md`

Two new rows in the type syntax table: `"value"` and `:name`.

### `docs/reference/agent-reference.md`

Two new rows in the type forms table; added `\"` escaping note to the existing brace-escaping warning.

Closes eu-jspj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)