### PR TITLE
docs: fix stale type-def: reference in cheat-sheet type alias row

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -531,7 +531,7 @@ origin: { x: 0, y: 0 }
 | `{..r, ..s}`       | row concatenation (in string: `{{..r, ..s}}`)   |
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
-| `Name` (capitalised) | recursive alias — resolved from `type-def:` |
+| `Name` (capitalised) | type alias — defined via `types: { Name: "..." }` |
 | `"value"`          | literal string type (subtype of `string`); in annotation string: `\"value\"` |
 | `:name`            | literal symbol type (subtype of `symbol`)      |
 | `A -> B`           | function                               |


### PR DESCRIPTION
One-line fix: the `Name (capitalised)` row in the cheat-sheet type syntax table incorrectly cited `type-def:` as the way to define named type aliases. The correct mechanism is `types: { Name: "..." }` metadata — the same error that was fixed in `type-checking.md` by PR #718.

Flagged as non-blocking pre-existing issue by Wicket in PR #721 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)