### PR TITLE
perf: replace nil? prelude lambda with NILP intrinsic

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -306,7 +306,7 @@ head: __HEAD
 
 ` { doc: "`nil?(xs)` - `true` if list `xs` is empty, `false` otherwise."
     type: "[a] → bool" }
-nil?: = []
+nil?: __NILP
 
 ` { doc: "`non-nil?(xs)` - `true` if list `xs` is non-empty, `false` otherwise."
     type: "[a] → bool" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -984,6 +984,11 @@ lazy_static! {
             ty: function(vec![unk()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 187
+            name: "NILP",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -23,7 +23,7 @@ use super::{
         collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
     },
     syntax::{
-        dsl::{app_bif, case, data, force, lambda, local, lref, value},
+        dsl::{app_bif, case, data, f, force, lambda, local, lref, t, value},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -184,6 +184,29 @@ impl StgIntrinsic for TailEmptyErr {
 
 impl CallGlobal0 for HeadEmptyErr {}
 impl CallGlobal0 for TailEmptyErr {}
+
+/// NILP(xs) — test whether a list is empty.
+///
+/// Generates a direct tag check rather than the lambda `λ(x). EQ(x, [])`,
+/// saving a function-call, env-frame creation, and EQ dispatch per call.
+/// The wrapper inlines (via `ProtoInline`) to:
+///   `case xs of Nil → True | _ → False`
+pub struct NilP;
+
+impl StgIntrinsic for NilP {
+    fn name(&self) -> &str {
+        "NILP"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        lambda(
+            1,
+            case(local(0), vec![(DataConstructor::ListNil.tag(), t())], f()),
+        )
+    }
+}
+
+impl CallGlobal1 for NilP {}
 
 /// ISLIST(value)
 ///

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -126,6 +126,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(list::Nil));
     rt.add(Box::new(list::HeadEmptyErr));
     rt.add(Box::new(list::TailEmptyErr));
+    rt.add(Box::new(list::NilP));
     rt.add(Box::new(string::Sym));
     rt.add(Box::new(string::Str));
     rt.add(Box::new(string::Join));


### PR DESCRIPTION
## Performance: replace `nil?` with a NILP intrinsic

### Hypothesis
`nil?` was previously defined in the prelude as `= []` — a partial application of structural equality. Every `nil?` call dispatched through the EQ intrinsic to compare against an empty list. Direct list-termination checks are ubiquitous (used in `foldl`, `take`, `map`, `filter`, `count`, and virtually every recursive function over lists). Replacing this with a direct DataConstructor tag check avoids the EQ dispatch overhead on every call.

### Change
- Added `NilP` struct in `src/eval/stg/list.rs` with a wrapper that generates `case(x, [Nil → True], False)` — a direct tag check with no function call overhead.
- Registered NILP (index 187) in `src/eval/intrinsics.rs`.
- Registered `NilP` in the standard runtime in `src/eval/stg/mod.rs`.
- Changed `nil?` in `lib/prelude.eu` from `= []` to `__NILP`.

### Results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| bench-short-lived (007) | 423.1 ms | 397.0 ms | −6.2% |
| bench-drop-cons (005) | 483.1 ms | 462.5 ms | −4.3% |
| bench-fragmentation (009) | 302.0 ms | 293.1 ms | −2.9% |

### Regression check

Full harness suite (332 tests): no regressions detected. All tests pass.

### Risks
The `nil?` intrinsic skips the EQ code path entirely. Any user code that shadows `nil?` with a custom definition is unaffected (the intrinsic is named differently). No observable behaviour change for conforming code.