### PR TITLE
perf: replace zero? prelude definition with ZEROP intrinsic

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -748,7 +748,7 @@ abs(n): if(n < 0, 0 - n, n)
 
 ` { doc: "`zero?(n)` - return true if and only if number `n` is 0."
     type: "number → bool" }
-zero?: = 0
+zero?: __ZEROP
 
 ` { doc: "`pos?(n)` - return true if and only if number `n` is strictly positive."
     type: "number → bool" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -984,6 +984,11 @@ lazy_static! {
             ty: function(vec![unk()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 187
+            name: "ZEROP",
+            ty: function(vec![num(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -1251,6 +1251,41 @@ impl StgIntrinsic for Clz {
 
 impl CallGlobal1 for Clz {}
 
+/// ZEROP(n) — test whether a number is zero.
+///
+/// Replaces `zero?:  = 0` in the prelude.  The old definition created a
+/// Let-binding for the literal 0 and then dispatched through the full
+/// polymorphic EQ wrapper on every call.  ZEROP skips all of that:
+/// after unboxing the argument the execute method does a single
+/// integer/float comparison against zero.
+pub struct ZeroP;
+
+impl StgIntrinsic for ZeroP {
+    fn name(&self) -> &str {
+        "ZEROP"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = num_arg(machine, view, &args[0])?;
+        let is_zero = n.as_i64().map_or_else(
+            || {
+                n.as_u64()
+                    .map_or_else(|| n.as_f64() == Some(0.0), |u| u == 0)
+            },
+            |i| i == 0,
+        );
+        machine_return_bool(machine, view, is_zero)
+    }
+}
+
+impl CallGlobal1 for ZeroP {}
+
 #[cfg(test)]
 pub mod tests {
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -193,6 +193,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(arith::PopCount));
     rt.add(Box::new(arith::Ctz));
     rt.add(Box::new(arith::Clz));
+    rt.add(Box::new(arith::ZeroP));
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));


### PR DESCRIPTION
## Performance: replace `zero?` with a ZEROP intrinsic

### Hypothesis
`zero?` was previously defined as `= 0` — a partial application of structural equality. Every call executed the full EQ dispatch wrapper, which allocates an env frame to hold the literal `0` and runs a polymorphic type-dispatch case expression. ZEROP replaces this with a direct BIF that unboxes its argument via the standard numeric wrapper and compares it to zero in Rust.

### Change
- Added `ZeroP` struct in `src/eval/stg/arith.rs` with an execute method comparing the unboxed number to zero.
- Registered ZEROP (index 187) in `src/eval/intrinsics.rs` with `ty: function(vec![num(), bool_()])` and `strict: vec![0]`. The standard `wrap()` machinery generates the numeric unbox wrapper automatically.
- Registered `ZeroP` in the standard runtime in `src/eval/stg/mod.rs`.
- Changed `zero?` in `lib/prelude.eu` from `= 0` to `__ZEROP`.

### Results

| Benchmark | Baseline (user CPU) | ZEROP (user CPU) | Change |
|-----------|---------------------|------------------|--------|
| bench-short-lived (007) | 0.349 s | 0.341 s | −2.3% |
| bench-drop-cons (005) | 0.378 s | 0.368 s | −2.6% |
| bench-thunk-updates (002) | 1.741 s | 1.751 s | +0.6% |

The improvement is modest because `zero?` is called less frequently than `nil?` in most workloads (primarily in `take` and `drop`, once per step vs `nil?` which appears in both `take` and `foldl`). The savings per call — one env frame allocation and a multi-branch EQ dispatch — are real and compound with the NILP optimisation from #724.

### Regression check

Full harness suite (332 tests): no regressions detected. All tests pass.

### Risks
`zero?` now produces a type error for non-numeric inputs rather than silently returning `false`. The prelude documents `zero?` with `type: "number → bool"`, so this is the correct behaviour. All prelude uses of `zero?` pass numeric arguments.