### PR TITLE
docs: Phase 2 follow-up for A5 — flow narrowing, cond, NonEmpty

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -505,6 +505,51 @@ are fine as-is:
 ` { type-def: "Point" }                  # fine — just a name, no braces
 ```
 
+## Flow-Sensitive Narrowing and User-Defined Branchers
+
+### `=>` (Clause) vs `//=>` (Assertion)
+
+The `=>` / `⇒` operator (precedence 15) builds a `cond` clause
+(`condition => result`).  It looks similar to the assertion meta-operator
+`//=>` (precedence 5) but has a completely different purpose:
+
+```eu,notest
+# CLAUSE — builds a cond branch; result is a list element
+cond[x > 0 => "positive", "non-positive"]
+
+# ASSERTION — checks a value equals the RHS at meta-evaluation time
+` { result //=> "positive" }
+result: "positive"
+```
+
+Mixing these up produces confusing type or parse errors.
+
+### Non-Structural Brancher Wrappers Disable Narrowing
+
+Flow-sensitive narrowing only applies when the checker can verify that
+a user function is a **structural pass-through** of `if` — i.e. its
+body is exactly `if(condition, true-branch, false-branch)` with
+arguments forwarded in order.  A wrapper that ignores one branch, reorders
+arguments, or adds logic is treated as an opaque function:
+
+```eu,notest
+# STRUCTURAL — recognised as If-shaped; narrowing fires
+my-if(c, t, f): if(c, t, f)
+
+` { type: "(number | string) → number" }
+safe-add(x): my-if(x number?, x + 1, 0)   # no warning
+
+# NON-STRUCTURAL — not a brancher; narrowing does NOT fire
+always-true(c, t, _f): t
+
+` { type: "(number | string) → number" }
+safe2(x): always-true(x number?, x + 1, 0)   # x is still number|string in body
+```
+
+The second example does not produce false-positive warnings because
+`always-true` is not narrowing-aware — `x` retains its declared type
+`number | string` throughout the body, which is type-safe here.
+
 ---
 
 ## Future Improvements

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -145,6 +145,7 @@ origin: { x: 0, y: 0 }
 | `number`, `string`, `symbol`, `bool`, `null`, `datetime` | primitives |
 | `any`              | gradual/unknown — no type errors       |
 | `[T]`              | list of T                              |
+| `NonEmpty([T])`    | non-empty list of T                    |
 | `(A, B)`           | tuple                                  |
 | `{{k: T, ..}}`     | open record (at least k: T)            |
 | `{{k: T, ..r}}`    | named row variable (extra fields in r) |
@@ -166,6 +167,14 @@ string interpolation. Always escape with `{{` and `}}`:
 `"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
 Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
 Literal string types (`"value"`) need `\"` escaping inside annotation strings.
+
+**Flow-sensitive narrowing**: when a type-predicate test (`number?`,
+`string?`, `bool?`, `null?`, `list?`, `block?`, `symbol?`) on an
+annotated variable is used as the condition of `if`, `and`, `or`,
+`cond`, or a structural wrapper (e.g. `then(t,f,c): if(c,t,f)`), the
+checker narrows the variable's type in each branch.  Non-structural
+wrappers (e.g. `my-if(c,t,_f): t`) are not recognised as branchers
+and do not trigger narrowing.
 
 See [Type Checking](../guide/type-checking.md) for the full guide.
 
@@ -566,6 +575,17 @@ Patterns: bare `foo` = `**.foo`; `*` = one level; `**` = any depth.
 See also: `identity(v)`, `const(k, _)`, `compose(f, g, x)`,
 `flip(f, x, y)`, `complement(p?)`, `curry(f, x, y)`,
 `uncurry(f, l)`, `cond(l, d)`.
+
+`cond` takes a list of clauses built with `=>` / `⇒` (precedence 15)
+and a default value.  Each clause is `condition => result`; the first
+true clause wins:
+
+```eu,notest
+classify(n): cond[n < 0 => "negative", n > 100 => "huge", "normal"]
+```
+
+Flow-sensitive narrowing applies inside each `cond` clause when the
+condition is a type-predicate test on an annotated variable.
 
 ### 3.5 Type Predicates
 


### PR DESCRIPTION
## Summary

Phase 2 follow-up for Quill's A5 bead (eu-hj08). Quill's `0fd4f141` only updated `type-checking.md` and `cheat-sheet.md`. Two surfaces were missed:

**`docs/reference/agent-reference.md`**:
- Add `NonEmpty([T])` to type forms table
- Expand `cond` entry in combinators section with clause syntax (`=>` / `⇒`, precedence 15) and example
- Add flow-sensitive narrowing note: recognised predicates, recognised branchers, non-structural wrapper limitation

**`docs/appendices/syntax-gotchas.md`**:
- New section: `=>` (clause) vs `//=>` (assertion) — easy to confuse, completely different operators
- New section: non-structural brancher wrappers disable narrowing (pattern from test 042)

## Test plan

- [ ] Read both changed files and verify prose is accurate and consistent with type-checking.md A5 sections
- [ ] Verify `NonEmpty([T])` is in the type forms table
- [ ] Verify `cond` example matches test 041

Fixes bead eu-xhij.