### PR TITLE
perf: native COUNT intrinsic with SeqSpine (×50 speedup, element-lazy)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1423,7 +1423,7 @@ range(b, e): ints-from(b) take(e - b)
 
 ` { doc: "`count(l)` - return count of items in list `l`."
     type: "[a] → number" }
-count(l): foldl({ n: • el: •}.(n inc), 0, l)
+count: __COUNT
 
 ` { doc: "`last(l)` - return last element of list `l`."
     type: "[a] → a" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -984,6 +984,16 @@ lazy_static! {
             ty: function(vec![unk()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 187
+            name: "seqSpine",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 188
+            name: "COUNT",
+            ty: function(vec![list(), num()]).unwrap(),
+            strict: vec![],
+    },
     ];
 }
 

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -185,6 +185,53 @@ impl StgIntrinsic for SeqList {
 
 impl CallGlobal1 for SeqList {}
 
+/// `SeqSpine` — force the spine (cons/nil structure) of a list without
+/// touching the elements.
+///
+/// Unlike `SeqNumList` / `SeqStrList` / `SeqList`, this does **not** evaluate
+/// list elements.  It only forces each cons cell constructor so that the
+/// resulting list is traversable by `DataIterator` without further thunk
+/// evaluation.  Element closures are preserved as-is.
+///
+/// This gives the same semantics as `foldl` over the list: the cons/nil
+/// structure is forced lazily (element by element) but the values themselves
+/// are never evaluated.
+pub struct SeqSpine;
+
+impl StgIntrinsic for SeqSpine {
+    fn name(&self) -> &str {
+        "seqSpine"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        // switch(xs)
+        //   NIL → NIL (spine is already terminal)
+        //   CONS [h t] →
+        //     force SeqSpine(t)     -- [stail, h, t, xs]
+        //     data CONS(h, stail)   -- rebuild with unforced head, forced tail
+        lambda(
+            1,
+            switch(
+                local(0),
+                vec![
+                    (DataConstructor::ListNil.tag(), local(0)),
+                    (
+                        DataConstructor::ListCons.tag(),
+                        // env after switch: [h=0, t=1, xs=2]
+                        force(
+                            SeqSpine.global(lref(1)), // SeqSpine(t)
+                            // env after force: [stail=0, h=1, t=2, xs=3]
+                            data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+                        ),
+                    ),
+                ],
+            ),
+        )
+    }
+}
+
+impl CallGlobal1 for SeqSpine {}
+
 /// `__FORCE_WHNF` — force a thunk to weak head normal form from within an intrinsic.
 ///
 /// Unlike the STG-level `force` DSL combinator (which is woven into the

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -17,10 +17,13 @@ use crate::{
     },
 };
 
+use serde_json::Number;
+
 use super::{
-    force::SeqNumList,
+    force::{SeqNumList, SeqSpine},
     support::{
-        collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
+        collect_num_list, data_list_arg, machine_return_bool, machine_return_num,
+        machine_return_num_list, num_arg,
     },
     syntax::{
         dsl::{app_bif, case, data, force, lambda, local, lref, value},
@@ -488,3 +491,47 @@ impl StgIntrinsic for ListDrop {
 }
 
 impl CallGlobal2 for ListDrop {}
+
+/// `COUNT(list)` — count the elements of a list in Rust.
+///
+/// Replaces `count(l): foldl({n: • el: •}.(n inc), 0, l)` which allocates
+/// a block-lambda closure per element.  The wrapper forces the cons/nil
+/// spine via `SeqSpine` (without touching element values — elements remain
+/// lazy) and the execute body simply increments a Rust counter.
+pub struct NativeCount;
+
+impl StgIntrinsic for NativeCount {
+    fn name(&self) -> &str {
+        "COUNT"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        lambda(
+            1,
+            force(
+                SeqSpine.global(lref(0)),
+                // [spine_list] [xs]
+                app_bif(bif_index, vec![lref(0)]),
+            ),
+        )
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let iter = data_list_arg(machine, view, args[0].clone())?;
+        let mut count = 0i64;
+        for item in iter {
+            item?;
+            count += 1;
+        }
+        machine_return_num(machine, view, Number::from(count))
+    }
+}
+
+impl CallGlobal1 for NativeCount {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -180,6 +180,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(block::LookupFail));
     rt.add(Box::new(force::SeqNumList));
     rt.add(Box::new(force::SeqList));
+    rt.add(Box::new(force::SeqSpine));
+    rt.add(Box::new(list::NativeCount));
     rt.add(Box::new(list::SortNumList));
     rt.add(Box::new(graph::GraphUnionFind));
     rt.add(Box::new(graph::GraphTopoSort));


### PR DESCRIPTION
## Performance: native COUNT intrinsic

### Hypothesis

`count(l): foldl({n: • el: •}.(n inc), 0, l)` allocates a block-lambda closure
on every element.  For each element this requires:

1. Allocating a two-parameter block lambda `{n: •, el: •}`
2. An env-frame extension to bind `n` and `el`
3. A block-dot `.` lookup to extract `n`
4. Calling `inc` (one more dispatch)
5. A recursive `foldl` call

For a k-element list this is O(k) heap allocations just to count cons cells.

A native intrinsic can traverse the spine directly, incrementing a Rust counter
with zero per-element allocation.

### Change

**New intrinsic: `SeqSpine`** (`src/eval/stg/force.rs`)

Forces only the cons/nil spine of a list without touching element values.
Unlike `SeqList`, elements remain lazy — semantics match the original `foldl`
which also never forces elements.  Implementation: recursive case match on
cons/nil constructors, rebuilding the forced cons cells with the original
head closures and the recursively-forced tail.

**New intrinsic: `COUNT`** (`src/eval/stg/list.rs`)

Wrapper uses `SeqSpine` to force the spine, then `execute` traverses the
`DataIterator` counting elements.

**Prelude change:**
`count(l): foldl({n: • el: •}.(n inc), 0, l)` → `count: __COUNT`

### Results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `repeat(1) take(10000) count` (ticks) | 51.8 M | 1.1 M | −98% |
| `repeat(1) take(10000) count` (STG time) | 2065 ms | 41 ms | ×50 |
| `range(1,1001) map(range(1)) map(count)` (wall) | 16.7 s | 5.1 s | ×3.3 |
| bench-008 (contains one `count` on 200-el list) | 3.93 M ticks | 3.86 M ticks | −1.7% |

### Regression check

Full harness suite (332 tests): no regressions.

### Risks

- **Semantic note**: `SeqSpine` forces cons/nil constructors but not element
  values, matching the original `count` semantics. The implementation
  reconstructs the cons cells with the same element closure references,
  so lazy elements remain lazy after spine-forcing.
- The `DataIterator` yields element closures which are immediately discarded
  (only the count matters), so element laziness is preserved end-to-end.