### PR TITLE
docs: Phase 2 follow-up for A6 — list synthesis, NonEmpty, nil? narrowing

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -524,6 +524,7 @@ origin: { x: 0, y: 0 }
 | `datetime`         | zoned date-time                        |
 | `any`              | gradual/unknown — no type errors       |
 | `[T]`              | homogeneous list of T                  |
+| `NonEmpty([T])`    | non-empty list of T                    |
 | `(A, B)`           | 2-tuple; `(A, B, C)` for triple        |
 | `(A,)`             | 1-tuple                                |
 | `{k: T}`           | closed record                          |

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -550,6 +550,29 @@ The second example does not produce false-positive warnings because
 `always-true` is not narrowing-aware — `x` retains its declared type
 `number | string` throughout the body, which is type-safe here.
 
+## `head` on an Empty List Produces a Type Warning
+
+The type checker tracks list emptiness.  `[]` synthesises as `List(Never)`,
+which means `head []` is flagged as a potential error:
+
+```eu,notest
+# WARNING — [] is List(Never); head on an empty list
+bad: [] head
+
+# OK — non-empty literal is Tuple([number]); head gives number
+ok: [42] head
+```
+
+To use `head` safely on a list of unknown size, guard with `nil?`:
+
+```eu,notest
+` { type: "[number] → number" }
+safe-head(xs): if(xs nil?, 0, xs head)   # xs is NonEmpty([number]) in the false branch
+```
+
+Or annotate the input as `NonEmpty([T])` when the caller guarantees
+non-emptiness.
+
 ---
 
 ## Future Improvements

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -157,6 +157,22 @@ to-strings: map(str.of)
 first: head
 ```
 
+`NonEmpty([T])` is a non-empty list guaranteed to have at least one element.
+`head` and `tail` are safe on `NonEmpty([T])` without type warnings.
+
+#### List literal synthesis
+
+The checker assigns precise types to list literals:
+
+| Literal         | Synthesised type      | Notes                                  |
+|-----------------|-----------------------|----------------------------------------|
+| `[]`            | `List(Never)`         | Empty — `head` on this warns           |
+| `[42]`          | `Tuple([number])`     | 1–16 elements → Tuple with element types |
+| `[42, "hello"]` | `Tuple([number, string])` | Heterogeneous; `head` gives `number` |
+| `[e1..e17, ...]`| `NonEmpty([T])`       | >16 elements → non-empty homogeneous   |
+
+`cons(h, t)` and `h ‖ t` both return `NonEmpty([a])`.
+
 ### Tuples
 
 Tuples use parentheses with commas:
@@ -173,6 +189,14 @@ Tuples appear naturally in lens element types and in functions like
 ```eu,notest
 ` { type: "(a -> bool) -> [a] -> ([a], [a])" }
 discriminate: ...
+```
+
+`head` on a `Tuple([A, B, ...])` returns the precise first-element type `A`
+(not `A | B | ...`). `tail` returns `Tuple([B, ...])`:
+
+```eu,notest
+[42, "hello"] head       # type: number
+[42, "hello"] tail head  # type: string
 ```
 
 ### Records
@@ -610,6 +634,14 @@ describe(x): if(x null?, "nothing", if(x string?, x, str(x)))
 Recognised predicates: `number?`, `string?`, `symbol?`, `bool?`, `list?`,
 `block?`, `nil?`, `null?`, `not-nil?`.
 
+`nil?` narrows a `[T]` to `NonEmpty([T])` in the **false** branch (the
+list is non-empty), enabling `head` without a type warning:
+
+```eu,notest
+` { type: "[number] -> number" }
+safe-head(xs): if(xs nil?, 0, xs head)   # no warning — xs is NonEmpty([number]) in false branch
+```
+
 Recognised branchers: `if` (three-argument), `and`, `or`, `cond`.
 A user-defined brancher that aliases or wraps one of these inherits its
 narrowing — but only if the prelude's `if`/`and`/`or`/`cond` is used,
@@ -652,6 +684,9 @@ checker for flow-sensitive narrowing through each clause.
 | Type variable            | lowercase identifier: `a`, `b`, `s`              |
 | Union type               | `A \| B`                              |
 | NonEmpty list            | `NonEmpty([a])`                       |
+| Empty list literal       | `[]` synthesises as `List(Never)`     |
+| Short list literal       | `[a, b]` synthesises as `Tuple([A, B])` (1–16 elements) |
+| `nil?` false-branch      | `[T]` narrowed to `NonEmpty([T])`     |
 | Type alias (unit meta)   | `{ types: { Name: "..." } }`          |
 | Type alias (declaration) | `` ` { type-def: "Name" } ``          |
 | Cond clause              | `condition => result`                 |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -406,17 +406,25 @@ foldr(++, [], [[1,2],[3,4]])  # [1, 2, 3, 4]
 [10, 20, 30] head            # 10
 ```
 
+The type checker warns if `xs` could be empty (`List(T)` or `List(Never)`).
+Use `nil?` narrowing or annotate as `NonEmpty([T])` to suppress.  On a
+`Tuple([A, B, ...])` literal, `head` synthesises the precise type `A`.
+
 #### `tail(xs)` — all but first (panics if empty)
 
 ```
 [10, 20, 30] tail            # [20, 30]
 ```
 
+On a `Tuple([A, B, C])`, `tail` synthesises `Tuple([B, C])`.
+
 #### `cons(h, t)` — prepend element to list
 
 ```
 cons(0, [1, 2, 3])           # [0, 1, 2, 3]
 ```
+
+`cons` and `‖` return `NonEmpty([a])` — the result is guaranteed non-empty.
 
 #### `reverse(l)` — reverse a list
 


### PR DESCRIPTION
## Summary

Phase 2 follow-up for Quill's A6 bead (eu-2mr2). No docs were added by Quill. Full four-surface update:

**`docs/guide/type-checking.md`**:
- Lists: `NonEmpty([T])` description; list literal synthesis table (`[]` → `List(Never)`, 1–16 → `Tuple`, >16 → `NonEmpty`); `cons`/`‖` return `NonEmpty([a])`
- Tuples: `head`/`tail` precise typing on Tuple literals with examples
- Flow-sensitive narrowing: `nil?` narrows `[T]` → `NonEmpty([T])` in false branch with example
- Summary table: three new rows

**`docs/appendices/cheat-sheet.md`**:
- Type syntax table: `NonEmpty([T])` was missing, added

**`docs/reference/agent-reference.md`**:
- `head`: type warning note for empty lists; precise Tuple typing
- `tail`: `Tuple([B, C])` result type note
- `cons`/`‖`: `NonEmpty([a])` return note

**`docs/appendices/syntax-gotchas.md`**:
- New section: `head` on empty list produces type warning; `nil?` guard pattern

## Test plan

- [ ] List literal synthesis table matches AC1/AC6 test 048
- [ ] nil? narrowing example matches test 049
- [ ] head/tail Tuple typing matches test 050
- [ ] head on empty warns matches test 051
- [ ] NonEmpty([T]) in cheat-sheet type table

Fixes bead eu-v49u.