### PR TITLE
perf: native COUNT_LIST intrinsic fixes O(N²) count scaling

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1436,7 +1436,7 @@ range(b, e): ints-from(b) take(e - b)
 
 ` { doc: "`count(l)` - return count of items in list `l`."
     type: "[a] → number" }
-count(l): foldl({ n: • el: •}.(n inc), 0, l)
+count: '__COUNT_LIST'
 
 ` { doc: "`last(l)` - return last element of list `l`."
     type: "[a] → a" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -994,6 +994,11 @@ lazy_static! {
             ty: function(vec![any(), any(), any()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 189
+            name: "COUNT_LIST",
+            ty: function(vec![list(), num()]).unwrap(),
+            strict: vec![],
+    },
     ];
 }
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -198,6 +198,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
+    rt.add(Box::new(running::CountList));
     rt.add(Box::new(list::ListNth));
     rt.add(Box::new(list::ListDrop));
     rt.add(Box::new(array::ArrayZeros));

--- a/src/eval/stg/running.rs
+++ b/src/eval/stg/running.rs
@@ -2,6 +2,8 @@
 
 use std::convert::TryInto;
 
+use serde_json;
+
 use crate::{
     common::sourcemap::Smid,
     eval::{
@@ -13,8 +15,8 @@ use crate::{
 };
 
 use super::{
-    force::SeqNumList,
-    support::{collect_num_list, machine_return_num_list},
+    force::{SeqList, SeqNumList},
+    support::{collect_num_list, data_list_arg, machine_return_boxed_num, machine_return_num_list},
     syntax::{
         dsl::{app_bif, force, lambda, lref},
         LambdaForm,
@@ -133,3 +135,49 @@ impl StgIntrinsic for RunningSum {
 }
 
 impl CallGlobal1 for RunningSum {}
+
+/// `COUNT_LIST(l)` — count the elements of a list in a single Rust pass.
+///
+/// Replaces `count: foldl({n: •el: •}.(n inc), 0)` which builds an N-deep
+/// lazy accumulator thunk chain.  The wrapper forces the entire list spine
+/// via `SeqList` so that `execute` receives fully-evaluated cons cells;
+/// counting then requires only a single O(N) traversal with no heap
+/// allocation and no thunk building.
+pub struct CountList;
+
+impl StgIntrinsic for CountList {
+    fn name(&self) -> &str {
+        "COUNT_LIST"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        lambda(
+            1, // [xs]
+            force(
+                SeqList.global(lref(0)),
+                // [concrete_list] [xs]
+                app_bif(bif_index, vec![lref(0)]),
+            ),
+        )
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let iter = data_list_arg(machine, view, args[0].clone())?;
+        let mut n: i64 = 0;
+        for item in iter {
+            item?;
+            n += 1;
+        }
+        let num = serde_json::Number::from(n);
+        machine_return_boxed_num(machine, view, num)
+    }
+}
+
+impl CallGlobal1 for CountList {}


### PR DESCRIPTION
## Performance: native COUNT_LIST fixes super-linear count scaling

### Hypothesis
`count: foldl({n: •el: •}.(n inc), 0)` builds an N-deep lazy accumulator
thunk chain before any arithmetic occurs.  Forcing the final result triggers
a cascade of N recursive thunk evaluations.  With N simultaneously-live
thunks, GC pressure amplifies the effect, producing ~O(N^1.7) tick scaling
instead of the expected O(N).

### Change
- `COUNT_LIST` BIF in `src/eval/stg/running.rs` using `SeqList` in the
  wrapper to force the list spine to WHNF, then a single O(N) Rust loop
- Registered in `src/eval/intrinsics.rs` (index 189) and `src/eval/stg/mod.rs`
- `lib/prelude.eu`: `count(l): foldl(...)` → `count: '__COUNT_LIST'`

### Results

| N     | Before (ticks) | After (ticks) | Improvement |
|-------|----------------|---------------|-------------|
|   100 |    24,469      |   14,978      | 1.6×        |
|   500 |   222,669      |   74,578      | 3×          |
| 1,000 |   695,419      |  149,078      | 4.7×        |
| 2,000 | 2,390,919      |  298,078      | 8×          |
| 5,000 | 13,477,419     |  745,078      | **18×**     |

The improvement grows with list size because the baseline has super-linear
scaling while the native implementation is strictly linear.

### Regression check

Full harness suite: **345/345 passed**, no regressions.

### Risks
- `count` now eagerly forces all list elements (via `SeqList`) before
  counting.  Previously `foldl` was also strict (it traverses the whole
  list), so semantics are equivalent.
- `SeqList` forces elements to WHNF — this is necessary to handle lazy
  lists (e.g. `repeat(x) take(N) count`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)