### PR TITLE
perf: native ALL_TRUE_LIST BIF replacing foldl(and, true, l)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1526,7 +1526,7 @@ reverse(l): foldl(cons flip, [], l)
 
 ` { doc: "`all-true?(l)` - true if and only if all items in list `l` are true."
     type: "[bool] → bool" }
-all-true?(l): foldl(and, true, l)
+all-true?: '__ALL_TRUE_LIST'
 
 ` { doc: "`all(p?, l)` - true if and only if all items in list `l` satisfy predicate `p?`."
     type: "(a → bool) → [a] → bool" }
@@ -1534,7 +1534,7 @@ all(p?, l): l map(p?) all-true?
 
 ` { doc: "`any-true?(l)` - true if and only if any items in list `l` are true."
     type: "[bool] → bool" }
-any-true?(l): foldr(or, false, l)
+any-true?: '__ANY_TRUE_LIST'
 
 ` { doc: "`any(p?, l)` - true if and only if any items in list `l` satisfy predicate `p?`."
     type: "(a → bool) → [a] → bool" }

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1534,7 +1534,7 @@ all(p?, l): l map(p?) all-true?
 
 ` { doc: "`any-true?(l)` - true if and only if any items in list `l` are true."
     type: "[bool] → bool" }
-any-true?: '__ANY_TRUE_LIST'
+any-true?(l): foldr(or, false, l)
 
 ` { doc: "`any(p?, l)` - true if and only if any items in list `l` satisfy predicate `p?`."
     type: "(a → bool) → [a] → bool" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -994,6 +994,16 @@ lazy_static! {
             ty: function(vec![any(), any(), any()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 189
+            name: "ALL_TRUE_LIST",
+            ty: function(vec![list(), any()]).unwrap(),
+            strict: vec![],
+    },
+    Intrinsic { // 190
+            name: "ANY_TRUE_LIST",
+            ty: function(vec![list(), any()]).unwrap(),
+            strict: vec![],
+    },
     ];
 }
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -999,11 +999,6 @@ lazy_static! {
             ty: function(vec![list(), any()]).unwrap(),
             strict: vec![],
     },
-    Intrinsic { // 190
-            name: "ANY_TRUE_LIST",
-            ty: function(vec![list(), any()]).unwrap(),
-            strict: vec![],
-    },
     ];
 }
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -198,6 +198,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
+    rt.add(Box::new(running::AllTrueList));
+    rt.add(Box::new(running::AnyTrueList));
     rt.add(Box::new(list::ListNth));
     rt.add(Box::new(list::ListDrop));
     rt.add(Box::new(array::ArrayZeros));

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -199,7 +199,6 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
     rt.add(Box::new(running::AllTrueList));
-    rt.add(Box::new(running::AnyTrueList));
     rt.add(Box::new(list::ListNth));
     rt.add(Box::new(list::ListDrop));
     rt.add(Box::new(array::ArrayZeros));

--- a/src/eval/stg/running.rs
+++ b/src/eval/stg/running.rs
@@ -207,39 +207,3 @@ impl StgIntrinsic for AllTrueList {
 }
 
 impl CallGlobal1 for AllTrueList {}
-
-/// `ANY_TRUE_LIST(bools)` — true iff at least one element of a boolean list is true.
-///
-/// Replaces `any-true?: foldr(or, false)` which builds an N-deep
-/// stack chain.  Uses `SeqList` to force the list upfront, then
-/// traverses in a single O(N) Rust loop.
-pub struct AnyTrueList;
-
-impl StgIntrinsic for AnyTrueList {
-    fn name(&self) -> &str {
-        "ANY_TRUE_LIST"
-    }
-
-    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
-        bool_list_wrapper(self)
-    }
-
-    fn execute(
-        &self,
-        machine: &mut dyn IntrinsicMachine,
-        view: MutatorHeapView<'_>,
-        _emitter: &mut dyn Emitter,
-        args: &[Ref],
-    ) -> Result<(), ExecutionError> {
-        let iter = data_list_arg(machine, view, args[0].clone())?;
-        for item in iter {
-            let closure = item?;
-            if read_bool(&closure, &view)? {
-                return machine_return_bool(machine, view, true);
-            }
-        }
-        machine_return_bool(machine, view, false)
-    }
-}
-
-impl CallGlobal1 for AnyTrueList {}

--- a/src/eval/stg/running.rs
+++ b/src/eval/stg/running.rs
@@ -13,12 +13,13 @@ use crate::{
 };
 
 use super::{
-    force::SeqNumList,
-    support::{collect_num_list, machine_return_num_list},
+    force::{SeqList, SeqNumList},
+    support::{collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list},
     syntax::{
         dsl::{app_bif, force, lambda, lref},
         LambdaForm,
     },
+    tags::DataConstructor,
 };
 
 /// Shared wrapper for single-list intrinsics: force via SeqNumList
@@ -133,3 +134,112 @@ impl StgIntrinsic for RunningSum {
 }
 
 impl CallGlobal1 for RunningSum {}
+
+/// Shared wrapper for boolean-list intrinsics: force via SeqList then call the BIF.
+fn bool_list_wrapper(intrinsic: &dyn StgIntrinsic) -> LambdaForm {
+    let bif_index: u8 = intrinsic.index().try_into().unwrap();
+    lambda(
+        1, // [bools]
+        force(
+            SeqList.global(lref(0)),
+            // [concrete_bools] [bools]
+            app_bif(bif_index, vec![lref(0)]),
+        ),
+    )
+}
+
+/// Extract a bool from a forced element closure.
+///
+/// After `SeqList`, boolean elements are `Cons { tag: BoolTrue/BoolFalse, .. }`.
+fn read_bool(
+    closure: &crate::eval::machine::env::SynClosure,
+    view: &MutatorHeapView<'_>,
+) -> Result<bool, ExecutionError> {
+    let code = view.scoped(closure.code());
+    match &*code {
+        crate::eval::memory::syntax::HeapSyn::Cons { tag, .. } => match (*tag).try_into() {
+            Ok(DataConstructor::BoolTrue) => Ok(true),
+            Ok(DataConstructor::BoolFalse) => Ok(false),
+            _ => Err(ExecutionError::Panic(
+                crate::common::sourcemap::Smid::default(),
+                format!("ALL/ANY_TRUE_LIST: expected boolean, got tag {}", tag),
+            )),
+        },
+        _ => Err(ExecutionError::Panic(
+            crate::common::sourcemap::Smid::default(),
+            "ALL/ANY_TRUE_LIST: expected boolean value".to_string(),
+        )),
+    }
+}
+
+/// `ALL_TRUE_LIST(bools)` — true iff every element of a boolean list is true.
+///
+/// Replaces `all-true?: foldl(and, true)` which builds an N-deep lazy
+/// accumulator thunk chain.  Uses `SeqList` to force the list upfront,
+/// then traverses in a single O(N) Rust loop.
+pub struct AllTrueList;
+
+impl StgIntrinsic for AllTrueList {
+    fn name(&self) -> &str {
+        "ALL_TRUE_LIST"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        bool_list_wrapper(self)
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let iter = data_list_arg(machine, view, args[0].clone())?;
+        for item in iter {
+            let closure = item?;
+            if !read_bool(&closure, &view)? {
+                return machine_return_bool(machine, view, false);
+            }
+        }
+        machine_return_bool(machine, view, true)
+    }
+}
+
+impl CallGlobal1 for AllTrueList {}
+
+/// `ANY_TRUE_LIST(bools)` — true iff at least one element of a boolean list is true.
+///
+/// Replaces `any-true?: foldr(or, false)` which builds an N-deep
+/// stack chain.  Uses `SeqList` to force the list upfront, then
+/// traverses in a single O(N) Rust loop.
+pub struct AnyTrueList;
+
+impl StgIntrinsic for AnyTrueList {
+    fn name(&self) -> &str {
+        "ANY_TRUE_LIST"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        bool_list_wrapper(self)
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let iter = data_list_arg(machine, view, args[0].clone())?;
+        for item in iter {
+            let closure = item?;
+            if read_bool(&closure, &view)? {
+                return machine_return_bool(machine, view, true);
+            }
+        }
+        machine_return_bool(machine, view, false)
+    }
+}
+
+impl CallGlobal1 for AnyTrueList {}


### PR DESCRIPTION
## Performance: native `all-true?` BIF

### Hypothesis

`all-true?(l)` was implemented as `foldl(and, true, l)`.  `foldl` builds
a left-spine lazy accumulator thunk chain `and(and(and(true, h1), h2), h3)…`.
All N thunks exist simultaneously on the heap; the GC must traverse the
entire chain on each collection cycle, producing super-linear scaling.

Converting to a native BIF that uses `SeqList` to force the list upfront
then traverses it in a single O(N) Rust loop eliminates the thunk chain
entirely.

### Change

- Added `AllTrueList` intrinsic (BIF index 189) in `src/eval/stg/running.rs`
- Registered in `src/eval/stg/mod.rs` and `src/eval/intrinsics.rs`
- `all-true?` in `lib/prelude.eu` changed to `'__ALL_TRUE_LIST'`
- `any-true?` left as `foldr(or, false, l)` — `foldr` already short-circuits
  lazily from the left; a `SeqList`-based BIF would force the entire list
  before checking and would regress the common early-exit case (~28× slower
  when the first element matches)

### Results

Measured with `hyperfine` on `all-true?(range(1,N) map(_ > 0))`:

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| N=1 000 (all-true) | 162 ms | 123 ms | −24% |
| N=5 000 (all-true) | 2.62 s | 1.55 s | −41% |

Known trade-off: `all-true?` with an early-false result is ~40% slower
(SeqList forces all elements before the Rust loop can short-circuit).
This is acceptable because `all-true?` is typically used in the
all-passing case (e.g. validating conditions) where the improvement
applies.

### Regression check

Full harness suite (345 tests): no regressions detected.

### Risks

`any-true?` is explicitly kept on its prelude `foldr` implementation —
any future attempt to native-BIF it must account for the short-circuit
regression demonstrated during development of this PR.