### PR TITLE
perf(list): REVERSE_LIST intrinsic — eliminate O(N²) foldl thunk chain

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1522,7 +1522,7 @@ zip-apply(fs, vs): zip-with(_0(_1), fs, vs)
 
 ` { doc: "`reverse(l)` - reverse list `l`."
     type: "[a] → [a]" }
-reverse(l): foldl(cons flip, [], l)
+reverse: '__REVERSE_LIST'
 
 ` { doc: "`all-true?(l)` - true if and only if all items in list `l` are true."
     type: "[bool] → bool" }

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -994,6 +994,16 @@ lazy_static! {
             ty: function(vec![any(), any(), any()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 189
+            name: "REVERSE_LIST",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![],
+    },
+    Intrinsic { // 190
+            name: "seqListSpine",
+            ty: function(vec![list(), list()]).unwrap(),
+            strict: vec![0],
+    },
     ];
 }
 

--- a/src/eval/stg/force.rs
+++ b/src/eval/stg/force.rs
@@ -185,6 +185,52 @@ impl StgIntrinsic for SeqList {
 
 impl CallGlobal1 for SeqList {}
 
+/// `SeqListSpine` — force only the *spine* of a list, without touching the head elements.
+///
+/// Unlike `SeqList`, this does NOT unbox or force each head element — it only forces
+/// each cons cell's tail pointer to the next cons cell (or nil).  The result has an
+/// identical structure to the input but with a fully-evaluated spine.
+///
+/// Used by `REVERSE_LIST`, which needs `DataIterator` to traverse the list (requiring
+/// a forced spine) but must preserve the original head closures (e.g. `BoxedString`)
+/// so that downstream BIFs such as `str.letters` receive the representation they expect.
+pub struct SeqListSpine;
+
+impl StgIntrinsic for SeqListSpine {
+    fn name(&self) -> &str {
+        "seqListSpine"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        // switch local(0) of
+        //   ListNil  → local(0)                           -- already nil, return as-is
+        //   ListCons → [h, t]                             -- local(0)=h, local(1)=t
+        //     force(SeqListSpine(t),                      -- force the tail spine
+        //       [seq_t, h, t]                             -- local(0)=seq_t, lref(1)=h
+        //       ListCons(lref(1), lref(0))               -- rebuild with original h
+        //     )
+        lambda(
+            1,
+            switch(
+                local(0),
+                vec![
+                    (DataConstructor::ListNil.tag(), local(0)),
+                    (
+                        DataConstructor::ListCons.tag(), // [h t]: local(0)=h, local(1)=t
+                        force(
+                            SeqListSpine.global(lref(1)), // SeqListSpine(t)
+                            // [seq_t] [h t]: local(0)=seq_t, lref(1)=h, lref(2)=t
+                            data(DataConstructor::ListCons.tag(), vec![lref(1), lref(0)]),
+                        ),
+                    ),
+                ],
+            ),
+        )
+    }
+}
+
+impl CallGlobal1 for SeqListSpine {}
+
 /// `__FORCE_WHNF` — force a thunk to weak head normal form from within an intrinsic.
 ///
 /// Unlike the STG-level `force` DSL combinator (which is woven into the

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -18,9 +18,10 @@ use crate::{
 };
 
 use super::{
-    force::SeqNumList,
+    force::{SeqListSpine, SeqNumList},
     support::{
-        collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
+        collect_num_list, data_list_arg, machine_return_bool, machine_return_closure_list,
+        machine_return_num_list, num_arg,
     },
     syntax::{
         dsl::{app_bif, case, data, force, lambda, local, lref, value},
@@ -488,3 +489,48 @@ impl StgIntrinsic for ListDrop {
 }
 
 impl CallGlobal2 for ListDrop {}
+
+/// `REVERSE_LIST(l)` — reverse a list.
+///
+/// Replaces `reverse(l): foldl(cons flip, [], l)` which builds an N-deep
+/// lazy accumulator thunk chain.  The GC must traverse all N thunks each
+/// collection cycle, producing super-linear scaling on large lists.
+///
+/// Uses `SeqListSpine` to force only the list spine (not the head elements),
+/// preserving original head closures (e.g. `BoxedString`) so that downstream
+/// BIFs receive the representation they expect.  Then collects into a `Vec`
+/// and returns the reversed elements in a single pass.
+pub struct ReverseList;
+
+impl StgIntrinsic for ReverseList {
+    fn name(&self) -> &str {
+        "REVERSE_LIST"
+    }
+
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        lambda(
+            1, // [list]
+            force(
+                SeqListSpine.global(lref(0)),
+                // [spine_forced] [list]: spine is in WHNF, heads are unmodified
+                app_bif(bif_index, vec![lref(0)]),
+            ),
+        )
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let iter = data_list_arg(machine, view, args[0].clone())?;
+        let mut items: Vec<_> = iter.collect::<Result<_, _>>()?;
+        items.reverse();
+        machine_return_closure_list(machine, view, items)
+    }
+}
+
+impl CallGlobal1 for ReverseList {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -200,6 +200,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningSum));
     rt.add(Box::new(list::ListNth));
     rt.add(Box::new(list::ListDrop));
+    rt.add(Box::new(list::ReverseList));
+    rt.add(Box::new(force::SeqListSpine));
     rt.add(Box::new(array::ArrayZeros));
     rt.add(Box::new(array::ArrayFill));
     rt.add(Box::new(array::ArrayFromFlat));


### PR DESCRIPTION
## Performance: REVERSE_LIST intrinsic — eliminate O(N²) foldl thunk chain

### Hypothesis

The prelude's `reverse(l): foldl(cons flip, [], l)` builds an N-deep lazy
accumulator thunk chain.  On each GC cycle, the collector must traverse all
N thunks to mark live data.  For long lists this produces super-linear
(O(N²)) GC work.

A native BIF can force only the list spine and collect head closures directly
into a `Vec`, then reverse in a single O(N) pass with no accumulator thunks.

### Change

- **`src/eval/stg/force.rs`**: Add `SeqListSpine` — forces only the list
  spine (each cons cell's tail pointer) without touching head elements.
  Distinct from `SeqList` which strips `BoxedString`/`BoxedNumber`/
  `BoxedSymbol` wrappers and would break downstream BIFs like `str.letters`.

- **`src/eval/stg/list.rs`**: Add `ReverseList` BIF.  Wrapper applies
  `SeqListSpine` to guarantee `DataIterator` can traverse the spine, then
  `execute()` collects the original head closures, reverses, and returns via
  `machine_return_closure_list`.

- **`src/eval/intrinsics.rs`** / **`src/eval/stg/mod.rs`**: Register both
  `SeqListSpine` and `ReverseList`.

- **`lib/prelude.eu`**: Bind `reverse: '__REVERSE_LIST'`.

### Results

Benchmark: `count(reverse(range(1, 30000)))` — hyperfine, 5 runs

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| count(reverse(range(1, 30000))) | 53.3 s ± 0.8 s | 20.9 s ± 0.3 s | **−61% (2.55×)** |
| count(reverse(range(1, 20000))) | 18.5 s | 7.5 s | **−59% (2.5×)** |
| count(reverse(range(1, 10000))) | 4.0 s | 1.76 s | **−56% (2.3×)** |

Note: wall-clock times include prelude parse; absolute times are dominated by
`count`'s own `foldl` accumulator (which has the same thunk-chain issue but
is not addressed here).  Removing `reverse`'s O(N²) contribution gives a
consistent ~2.5× speedup.

N=50000 baseline: exceeds 120 s timeout; new implementation: ~45 s.

### Regression check

Full harness suite: **345/345 passed**, no regressions.

Key tests verified:
- `test_harness_054` (qsort — uses `discriminate` → `reverse`) ✓
- `test_lib_lens` (lens operations using `reverse`) ✓

### Risks

- `SeqListSpine` adds a new recursive STG global.  It is structurally similar
  to `SeqNumList`/`SeqList` and has been validated against the full harness.
- `machine_return_closure_list` stores the original (unstripped) head closures.
  These work correctly with all subsequent operations because `SeqListSpine`
  preserves the original boxed representations.