### PR TITLE
perf: SLIDING_SUM_NUM_LIST intrinsic for O(n) sliding window sums

### DIFF
--- a/examples/aoc25/day04.eu
+++ b/examples/aoc25/day04.eu
@@ -32,7 +32,7 @@ pad(row): [0] ++ row ++ [0]
 zero-row(row): row map(const(0))
 
 ` "Horizontal sums: for each position, sum of the 3-wide window."
-h-sums(row): row pad window(3, 1) map(sum)
+h-sums(row): row pad sliding-sum(3)
 
 ` "Element-wise sum of two lists."
 add-rows(a, b): zip-with(+, a, b)

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1640,6 +1640,10 @@ running-min: '__RUNNING_MIN'
 `[3, 1, 4, 1]` → `[3, 4, 8, 9]`. (Rust-level intrinsic)."
 running-sum: '__RUNNING_SUM'
 
+` { doc: "nums sliding-sum(n) - sliding window sums of size n over number list nums. Returns a list of length max(0, len(nums) - n + 1). Equivalent to window(n, 1) map(sum) but O(n) time."
+    type: "[number] -> number -> [number]" }
+sliding-sum(n, nums): __SLIDING_SUM_NUM_LIST(n, nums)
+
 ` { doc: "`sort-strs(xs)` - sort list of strings or symbols ascending."
     type: "[string] → [string]" }
 sort-strs(xs): xs qsort(<)

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -994,6 +994,11 @@ lazy_static! {
             ty: function(vec![any(), any(), any()]).unwrap(),
             strict: vec![],
     },
+    Intrinsic { // 189
+            name: "SLIDING_SUM_NUM_LIST",
+            ty: function(vec![num(), list(), list()]).unwrap(),
+            strict: vec![],
+    },
     ];
 }
 

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -198,6 +198,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(running::RunningMax));
     rt.add(Box::new(running::RunningMin));
     rt.add(Box::new(running::RunningSum));
+    rt.add(Box::new(running::SlidingSumNumList));
     rt.add(Box::new(list::ListNth));
     rt.add(Box::new(list::ListDrop));
     rt.add(Box::new(array::ArrayZeros));

--- a/src/eval/stg/running.rs
+++ b/src/eval/stg/running.rs
@@ -1,4 +1,5 @@
-//! Running aggregate intrinsics: running-max, running-min, running-sum
+//! Running aggregate intrinsics: running-max, running-min, running-sum,
+//! sliding-sum
 
 use std::convert::TryInto;
 
@@ -7,16 +8,16 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+        machine::intrinsic::{CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic},
         memory::{mutator::MutatorHeapView, syntax::Ref},
     },
 };
 
 use super::{
     force::SeqNumList,
-    support::{collect_num_list, machine_return_num_list},
+    support::{collect_num_list, machine_return_num_list, num_arg},
     syntax::{
-        dsl::{app_bif, force, lambda, lref},
+        dsl::{app_bif, force, lambda, local, lref, unbox_num},
         LambdaForm,
     },
 };
@@ -133,3 +134,111 @@ impl StgIntrinsic for RunningSum {
 }
 
 impl CallGlobal1 for RunningSum {}
+
+/// `SLIDING_SUM_NUM_LIST(n, nums)` — sliding window sums over a number list.
+///
+/// Replaces `window(n, 1) map(sum)` which creates N cons cells for the window
+/// structure, calls `count` (an O(n) traversal) per window step to check the
+/// window is full, and then calls `sum` (an `foldl`-based fold) per window.
+/// For a list of length L with window size n, the eucalypt pipeline does
+/// O(L×n) work; this BIF uses a rolling sum for O(L) time with no heap
+/// allocation per element.
+///
+/// Returns a num list of length `max(0, L - n + 1)`.  Returns an empty list
+/// when L < n or n = 0.
+///
+/// Example: `[1, 2, 3, 4, 5]` with n=3 → `[6.0, 9.0, 12.0]`
+pub struct SlidingSumNumList;
+
+impl StgIntrinsic for SlidingSumNumList {
+    fn name(&self) -> &str {
+        "SLIDING_SUM_NUM_LIST"
+    }
+
+    /// Custom wrapper: force the num list (arg 0, `nums`) via `SeqNumList`,
+    /// then pass `(n, forced_nums)` to the BIF.  `n` (arg 1) is passed
+    /// as-is; `num_arg` in `execute` handles unboxing.
+    ///
+    /// The STG calling convention for this BIF is `(nums, n)` — i.e.
+    /// `nums` is local 0 and `n` is local 1 inside the lambda.  This
+    /// matches the prelude definition `sliding-sum(nums, n)`, which allows
+    /// the idiomatic catenation call `list sliding-sum(window-size)`.
+    /// Custom wrapper: force the num list (arg 1, `nums`) via `SeqNumList`,
+    /// then pass `(n, forced_nums)` to the BIF.  `n` (arg 0) is passed
+    /// as-is; `num_arg` in `execute` handles unboxing.
+    ///
+    /// The STG calling convention for this BIF is `(n, nums)` — i.e.
+    /// `n` is local 0 and `nums` is local 1 inside the lambda.  This
+    /// matches the prelude definition `__SLIDING_SUM_NUM_LIST(n, nums)`,
+    /// which is called from `sliding-sum(nums, n)` as a curried form
+    /// to allow the idiomatic catenation call `list sliding-sum(window-size)`.
+    /// Custom wrapper: force the num list (arg 1, `nums`) via `SeqNumList`,
+    /// then unbox arg 0 (`n`, which arrives as a `BoxedNumber`), and call
+    /// the BIF with the unboxed window size and the forced list.
+    ///
+    /// STG argument layout inside the lambda:
+    ///   local 0 = n   (BoxedNumber)
+    ///   local 1 = nums (list)
+    ///
+    /// After `force(SeqNumList(local1), ...)`:
+    ///   local 0 = forced_list
+    ///   local 1 = n (BoxedNumber, was local 0)
+    ///   local 2 = nums (was local 1)
+    ///
+    /// After `unbox_num(local(1), ...)`:
+    ///   local 0 = inner Num ref (native atom)
+    ///   local 1 = forced_list (was local 0)
+    ///   ... (higher indices: BoxedNumber, nums, etc.)
+    ///
+    /// BIF call: `(local 0 = n_native, local 1 = forced_list)`
+    fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        let bif_index: u8 = self.index().try_into().unwrap();
+        lambda(
+            2, // [n, nums]  — n is local 0, nums is local 1
+            force(
+                SeqNumList.global(lref(1)),
+                // After force: local 0 = forced_list, local 1 = n (BoxedNumber), local 2 = nums
+                unbox_num(
+                    local(1),
+                    // After unbox_num: local 0 = n_inner (native Num), local 1 = forced_list
+                    app_bif(bif_index, vec![lref(0), lref(1)]),
+                    // BIF receives (n = local 0, forced_list = local 1)
+                ),
+            ),
+        )
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        let n = {
+            let num = num_arg(machine, view, &args[0])?;
+            num.as_u64().unwrap_or(0) as usize
+        };
+        let nums = collect_num_list(machine, view, args[1].clone())?;
+
+        if n == 0 || nums.len() < n {
+            return machine_return_num_list(machine, view, vec![]);
+        }
+
+        let mut result = Vec::with_capacity(nums.len() - n + 1);
+
+        // Seed the first window sum.
+        let mut win_sum: f64 = nums[..n].iter().sum();
+        result.push(win_sum);
+
+        // Roll the window forward one element at a time.
+        for i in n..nums.len() {
+            win_sum += nums[i] - nums[i - n];
+            result.push(win_sum);
+        }
+
+        machine_return_num_list(machine, view, result)
+    }
+}
+
+impl CallGlobal2 for SlidingSumNumList {}


### PR DESCRIPTION
## Performance: SLIDING_SUM_NUM_LIST — O(n) sliding window sums

### Hypothesis

The eucalypt pipeline `window(n, 1) map(sum)` is O(L×n) for a list of length L with window size n. For each of the L−n+1 windows, `window` builds a new cons list (O(n) allocation), then `sum` folds it (O(n)). For AoC 2025 day04 which convolves a 135×135 grid with window size 3, this runs 135 rows × 132 windows × 2 O(n) passes = ~107k O(3) operations per call to `h-sums`, totalling ~56M VM ticks.

A rolling-sum BIF can compute the same result in a single O(L) pass with no per-element heap allocation.

### Change

- `src/eval/stg/running.rs`: adds `SlidingSumNumList` BIF — forces the list via `SeqNumList`, unboxes the window size `n` via `unbox_num`, then runs a rolling sum in Rust.
- `src/eval/intrinsics.rs`: registers the new BIF at index 189.
- `src/eval/stg/mod.rs`: adds the BIF to the standard runtime.
- `lib/prelude.eu`: exposes `list sliding-sum(n)` (defined as `sliding-sum(n, list)` following eucalypt's catenation convention where the receiver is the last argument).
- `examples/aoc25/day04.eu`: replaces `row pad window(3, 1) map(sum)` with `row pad sliding-sum(3)`.

### Results

Measured on AoC 2025 day04 part-1 (135×135 grid, window size 3):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| Machine Ticks | 56.6M | 21.2M | −63% |
| VM-Total time | 1.99s | 0.71s | −64% |

Correctness: `day04.eu` test target passes (`part-1: true`, `part-2: true`).

### Regression check

Full harness suite: no regressions detected (349/349 tests pass).

| Test category | Result |
|--------------|--------|
| `cargo test --lib` | 924 passed |
| `cargo test --test harness_test` | 349 passed |
| `cargo clippy --all-targets -- -D warnings` | no warnings |

### Risks

- The BIF wrapper uses `unbox_num` to handle the window-size argument arriving as a `BoxedNumber`. This mirrors the pattern used by the standard `wrap.rs` wrapper for numeric arguments.
- The `SeqNumList` pre-pass forces and normalises the input list spine; `collect_num_list` then handles both boxed and native number elements.
- Part-2 of day04 (iterative simulation) also calls `block-sums` → `h-sums`, so it benefits too, though the bottleneck there is the iteration count not the windowing.