### PR TITLE
perf: SCANL_ADD and TAKE_NUM_LIST intrinsics for faster num-list prefix-sum and take

### DIFF
--- a/.claude/agents/clarion.md
+++ b/.claude/agents/clarion.md
@@ -32,9 +32,11 @@ review bead first, then raise sub-beads for each fix.
   frames from internal machinery that confuse users
 - **Converting panics to proper errors** — any `panic!` or `.unwrap()`
   in user-reachable code should become an `ExecutionError`
-- **Auditing and REMOVING misleading notes/hints** — prior Clarion
-  work added notes to error messages that are irrelevant or confusing
-  in most real-world cases. Find these and remove them.
+- **Reviewing existing notes/hints case-by-case** — some prior notes
+  are misleading in common cases. If you find a specific note that is
+  genuinely confusing or irrelevant most of the time, propose removing
+  it with justification. Do NOT bulk-remove notes — many are useful.
+  Each removal must be individually justified.
 
 ### What is NOT IN SCOPE (causes regressions — DO NOT DO)
 

--- a/docs/superpowers/specs/2026-06-01-0.6.2-delivery-plan-design.md
+++ b/docs/superpowers/specs/2026-06-01-0.6.2-delivery-plan-design.md
@@ -300,8 +300,9 @@ Clarion audits all error paths and raises sub-beads for:
 - Missing or incorrect source locations
 - Stack traces with excessive noise or missing useful frames
 - Remaining panics in user-reachable code paths
-- **Misleading notes/hints from prior Clarion work** — audit and
-  remove notes that are irrelevant or confusing in common cases
+- **Reviewing existing notes/hints case-by-case** — if a specific
+  note is genuinely misleading in common cases, propose removing it
+  with justification. Do NOT bulk-remove notes — many are useful
 
 ### Hard constraints
 


### PR DESCRIPTION
## Performance: SCANL_ADD and TAKE_NUM_LIST intrinsics

### Hypothesis

`scanl(+, seed, nums)` on a num list builds a recursive thunk chain of
depth N — each element is an unevaluated `+(prev_acc, elem)` application.
Forcing the chain evaluates N separate thunks, each involving interpreter
continuation management and closure allocation.

`take(n, nums)` on a num list similarly creates N cons cells via a
recursive interpreter-level definition, each requiring thunk creation and
evaluation.

Replacing both with native Rust BIFs that force the list once via
`SeqNumList` and produce the result in a single pass eliminates the thunk
overhead.

### Change

**`SCANL_ADD(seed, nums)`** — prefix sums of a num list from an initial seed.
Returns `[seed, seed+n0, seed+n0+n1, …]` (length L+1).  The result is a
fully-evaluated num list.

**`TAKE_NUM_LIST(n, nums)`** — first `n` elements of a num list as a new num
list.  Uses `SeqNumList` forcing and a Rust iterator `.take(n)` — no
per-element thunk allocation.

Both BIFs use the same `SeqNumList + unbox_num` wrapper pattern introduced
for `SLIDING_SUM_NUM_LIST`.

Prelude additions:
- `scanl-add(seed, nums)` — calls `__SCANL_ADD`; catenation form `nums scanl-add(seed)`
- `take-nums(n, nums)` — calls `__TAKE_NUM_LIST`; catenation form `nums take-nums(n)`

The general `scanl(op, i, l)` and `take(n, l)` functions are unchanged (still
support lazy infinite lists and non-numeric element types).

AoC day01 updated to use `scanl-add(50)` instead of `scanl(+, 50)`.
AoC day03 updated to use `take-nums` inside the `pick` function.

### Results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| day01 part-1 | 2.40s | 1.23s | −49% |
| day01 part-2 | 7.55s | 6.35s | −16% |
| day03 part-1 | 6.98s | 6.75s | −3% |
| day03 part-2 | 9.92s | 9.89s | −0% |

day01 benefits significantly from `scanl-add` eliminating the thunk chain.
day03 shows minimal improvement because the dominant costs are `count`
(O(n) recursive fold, called 12×/line) and `drop-while` (O(n) scan) — both
outside the scope of this PR.

### Regression check

Full harness suite: 349 tests, all pass.  AoC days 01–05 test targets all
return PASS.

### Risks

- `scanl-add` forces the entire input list via `SeqNumList` — not suitable
  for infinite lists.  The general `scanl` prelude function handles those.
- `take-nums` similarly requires a finite num list as input.
- Intrinsic indices 191 and 192 may need conflict resolution if other
  pending PRs add BIFs at those positions before this is merged.