### PR TITLE
docs: fix cheat sheet errors and add cond/=> coverage

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -312,14 +312,14 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | `drop(n)` | Remove first n |
 | `zip` | Pair elements from two lists |
 | `zip-with(f)` | Combine elements with function |
-| `flatten` | Flatten nested lists one level |
+| `concat` | Flatten nested lists one level (use `concat`, not `flatten` — does not exist) |
 | `reverse` | Reverse a list |
 | `count` | Number of elements |
 | `range(a, b)` | Integers from a to b-1 |
 | `nil?` | Is the list empty? |
-| `any?(p?)` | Does any element match? |
-| `all?(p?)` | Do all elements match? |
-| `unique` | Remove duplicates |
+| `any(p?)` | Does any element match? |
+| `all(p?)` | Do all elements match? |
+| `nub-by(f)` | Deduplicate by key function (no `unique` in prelude) |
 
 ### Blocks
 
@@ -333,8 +333,7 @@ Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
 | `elements` | List of `{key, value}` pairs |
 | `map-keys(f)` | Transform keys |
 | `map-values(f)` | Transform values |
-| `select(keys)` | Keep only listed keys |
-| `dissoc(keys)` | Remove listed keys |
+| `filter-items(p?)` | Keep entries matching predicate (use with `by-key`, `by-value`) |
 | `merge(b)` | Shallow merge |
 | `deep-merge(b)` | Deep recursive merge |
 | `sort-keys` | Sort by key name |

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -26,6 +26,7 @@ The precedence hierarchy (highest to lowest):
 | 35         | bool-prod    | `∧` (and)                    |
 | 30         | bool-sum     | `∨` (or)                     |
 | 20         | cat          | catenation (juxtaposition)   |
+| 15         | clause       | `=>`, `⇒` (cond clause)      |
 | 10         | apply        |                              |
 | 5          | meta         | `` ` `` (metadata)           |
 

--- a/docs/eucalypt-style.md
+++ b/docs/eucalypt-style.md
@@ -29,6 +29,29 @@ Don't mix idioms on the same context. If you use `second(xs)`, use `first(xs)` n
   }.(ok ∧ result > 0)
   ```
 
+### Multi-way conditionals: `cond`
+
+Use `cond` for three or more branches instead of nesting `if`. The `=>`
+operator (precedence 15, right-associative; Unicode alias `⇒`) builds a
+clause pair. The last list element is the default:
+
+```eu,notest
+# Prefer: cond for multi-way dispatch
+classify(n): cond[n < 0 => "negative", n > 100 => "huge", "normal"]
+
+# Avoid: nested if
+classify(n): if(n < 0, "negative", if(n > 100, "huge", "normal"))
+```
+
+Rules:
+- Use `cond` when there are **three or more branches**.
+- Use `if` or `then` for a single two-way test.
+- Use `when` for a **conditional transform** (pass-through if condition is false).
+- `cond` integrates with the type checker's flow-sensitive narrowing: each
+  clause condition narrows the variable's type within that branch.
+- The `⇒` Unicode alias is accepted everywhere `=>` is (input via `>>` in
+  the eucalypt input method).
+
 ## Catenation precedence
 
 Catenation (juxtaposition / pipeline application) has the **lowest** operator precedence (20). ALL infix operators bind tighter, including `∧` (35), `∨` (30), `=` (40), `+` (75), etc. This means infix operators steal adjacent atoms from catenation pipelines:

--- a/docs/eucalypt-style.md
+++ b/docs/eucalypt-style.md
@@ -32,7 +32,7 @@ Don't mix idioms on the same context. If you use `second(xs)`, use `first(xs)` n
 ### Multi-way conditionals: `cond`
 
 Use `cond` for three or more branches instead of nesting `if`. The `=>`
-operator (precedence 15, right-associative; Unicode alias `⇒`) builds a
+operator (precedence 15, left-associative; Unicode alias `⇒`) builds a
 clause pair. The last list element is the default:
 
 ```eu,notest

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -339,7 +339,7 @@ From highest (tightest) to lowest binding:
 | 35 | bool-prod | left | `&&`, `∧` | Logical AND |
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
-| 15 | clause | right | `=>`, `⇒` | Cond clause builder (`condition => result`) |
+| 15 | clause | left | `=>`, `⇒` | Cond clause builder (`condition => result`) |
 | 10 | apply | left | `@` | Function application |
 | 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
 

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -339,6 +339,7 @@ From highest (tightest) to lowest binding:
 | 35 | bool-prod | left | `&&`, `∧` | Logical AND |
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
+| 15 | clause | right | `=>`, `⇒` | Cond clause builder (`condition => result`) |
 | 10 | apply | left | `@` | Function application |
 | 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
 


### PR DESCRIPTION
## Summary

- **cheat-sheet**: Remove four non-existent prelude functions (`flatten`, `unique`, `select`, `dissoc`) and replace with correct alternatives (`concat`, `any`/`all`, `nub-by`, `filter-items`). These were contradicting agent-reference.md §5.11, causing agent confusion.
- **agent-reference**: Add missing `=>` / `⇒` clause operator at precedence 15 to the operator precedence table. The cheat sheet had it; agent-reference did not.
- **syntax-gotchas**: Add `=>` / `⇒` at precedence 15 to the simplified overview table.
- **eucalypt-style**: Add `cond` / `=>` multi-way conditional style section under Conditionals, covering when to prefer `cond` over nested `if`, type-checker narrowing integration, and the `⇒` Unicode alias.

Closes eu-0rb9.4, eu-0rb9.5, eu-0rb9.6, eu-0rb9.8

## Test plan

- [ ] Docs-only change — verify no broken markdown links or formatting issues
- [ ] Check that the cheat sheet no longer lists `flatten`, `unique`, `select`, `dissoc`
- [ ] Confirm `=>` appears at precedence 15 in both agent-reference and syntax-gotchas tables
- [ ] Confirm new `cond` style section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)