### PR TITLE
fix(errors): correct misleading lookup notes for existing string functions

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -313,22 +313,23 @@ fn lookup_failure_notes(key: &str, suggestions: &[String]) -> Vec<String> {
              e.g. 'text str.to-lower'"
                 .to_string()]
         }
-        "replace" | "sub" | "gsub" => vec!["eucalypt has no 'replace' function; \
-             use 'str.matches-of(re, s)' to find matches, or construct a replacement \
-             by splitting and re-joining: 's str.split-on(re) str.join-on(replacement)'"
-            .to_string()],
+        "replace" | "sub" | "gsub" => vec![
+            "use 'str.replace(pattern, replacement, s)' to replace all regex matches, \
+             e.g. 'text str.replace(\"foo\", \"bar\")'"
+                .to_string(),
+        ],
         "strip" | "trim" | "rstrip" | "lstrip" => vec!["eucalypt has no 'trim'/'strip' function; \
              to remove surrounding whitespace use a regex: \
              'text str.extract(\"^\\\\s*(.*?)\\\\s*$\")'"
             .to_string()],
         "startswith" | "starts_with" | "startsWith" | "hasPrefix" => vec![
-            "to test if a string starts with a prefix, use 'str.matches?(re, s)' \
-             with an anchored regex, e.g. 'text str.matches?(\"^prefix\")'"
+            "use 'str.starts-with?(re, s)' to test if a string starts with a pattern, \
+             e.g. 'text str.starts-with?(\"prefix\")'"
                 .to_string(),
         ],
         "endswith" | "ends_with" | "endsWith" | "hasSuffix" => vec![
-            "to test if a string ends with a suffix, use 'str.matches?(re, s)' \
-             with an anchored regex, e.g. 'text str.matches?(\"suffix$\")'"
+            "use 'str.ends-with?(re, s)' to test if a string ends with a pattern, \
+             e.g. 'text str.ends-with?(\"suffix\")'"
                 .to_string(),
         ],
         "find" | "index" | "indexOf" | "indexof" => {
@@ -344,17 +345,18 @@ fn lookup_failure_notes(key: &str, suggestions: &[String]) -> Vec<String> {
              e.g. 'str.fmt(x, \"%.2f\")' for two decimal places"
             .to_string()],
         "contains?" | "contains" | "includes?" | "includes" => vec![
-            "to test if a string contains a pattern, use 'str.matches?', \
-             e.g. `text str.matches?(\"pattern\")`"
+            "use 'str.contains?(pattern, s)' to test if a string contains a pattern, \
+             e.g. 'text str.contains?(\"word\")'"
                 .to_string(),
-            "note: 'str.matches?' uses a regular expression, so special \
+            "note: 'str.contains?' uses a regular expression, so special \
              characters like '.', '+', '*' must be escaped with '\\'"
                 .to_string(),
         ],
-        "replace-all" | "substitute" => vec!["eucalypt has no 'replace' function; \
-             use 'str.matches-of(re, s)' to find matches, or construct a replacement \
-             by splitting and re-joining: 's str.split-on(re) str.join-on(replacement)'"
-            .to_string()],
+        "replace-all" | "substitute" => vec![
+            "use 'str.replace(pattern, replacement, s)' to replace all regex matches, \
+             e.g. 'text str.replace(\"foo\", \"bar\")'"
+                .to_string(),
+        ],
         "substring" | "substr" => vec!["eucalypt has no substring function; \
              use 'str.extract(re)' with a capturing regex to extract a portion of a string"
             .to_string()],

--- a/tests/harness/errors/144_str_replace_hint.eu
+++ b/tests/harness/errors/144_str_replace_hint.eu
@@ -1,0 +1,3 @@
+# Error: using Ruby/Python-style 'gsub' — 'str.replace' is the correct eucalypt function
+text: "hello world"
+result: text str.gsub("o", "0")

--- a/tests/harness/errors/144_str_replace_hint.eu.expect
+++ b/tests/harness/errors/144_str_replace_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "str\.replace"

--- a/tests/harness/errors/145_str_starts_with_hint.eu
+++ b/tests/harness/errors/145_str_starts_with_hint.eu
@@ -1,0 +1,3 @@
+# Error: using camelCase 'startsWith' — 'str.starts-with?' is the correct eucalypt function
+text: "hello world"
+result: text str.startsWith("hello")

--- a/tests/harness/errors/145_str_starts_with_hint.eu.expect
+++ b/tests/harness/errors/145_str_starts_with_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "similar keys: 'starts-with\?'"

--- a/tests/harness/errors/146_str_ends_with_hint.eu
+++ b/tests/harness/errors/146_str_ends_with_hint.eu
@@ -1,0 +1,3 @@
+# Error: using camelCase 'endsWith' — 'str.ends-with?' is the correct eucalypt function
+text: "hello world"
+result: text str.endsWith("world")

--- a/tests/harness/errors/146_str_ends_with_hint.eu.expect
+++ b/tests/harness/errors/146_str_ends_with_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "similar keys: 'ends-with\?'"

--- a/tests/harness/errors/147_str_contains_hint.eu
+++ b/tests/harness/errors/147_str_contains_hint.eu
@@ -1,0 +1,3 @@
+# Error: using 'str.includes' — 'str.contains?' is the correct eucalypt function
+text: "hello world"
+result: text str.includes("hello")

--- a/tests/harness/errors/147_str_contains_hint.eu.expect
+++ b/tests/harness/errors/147_str_contains_hint.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "str\.contains\?"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1553,6 +1553,26 @@ pub fn test_error_143() {
 }
 
 #[test]
+pub fn test_error_144() {
+    run_error_test(&error_opts("144_str_replace_hint.eu"));
+}
+
+#[test]
+pub fn test_error_145() {
+    run_error_test(&error_opts("145_str_starts_with_hint.eu"));
+}
+
+#[test]
+pub fn test_error_146() {
+    run_error_test(&error_opts("146_str_ends_with_hint.eu"));
+}
+
+#[test]
+pub fn test_error_147() {
+    run_error_test(&error_opts("147_str_contains_hint.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `lookup_failure_notes` told users that `str.replace`, `str.starts-with?`, `str.ends-with?`, and `str.contains?` do not exist — all four are implemented in the prelude
- Updated the four note bodies to point to the real functions instead of unnecessary workarounds
- Adds harness tests 144–147 to exercise the corrected note text

## Test plan

- [ ] `cargo test test_error_144` — `str.gsub` → hints at `str.replace`
- [ ] `cargo test test_error_145` — `str.startsWith` → fuzzy match suggests `starts-with?`
- [ ] `cargo test test_error_146` — `str.endsWith` → fuzzy match suggests `ends-with?`
- [ ] `cargo test test_error_147` — `str.includes` → hints at `str.contains?`
- [ ] `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)