### PR TITLE
fix(errors): add source location to NumericDomainError and BadTimeZone

### DIFF
--- a/src/eval/stg/arith.rs
+++ b/src/eval/stg/arith.rs
@@ -522,18 +522,17 @@ fn arithmetic_wrapper(index: usize) -> LambdaForm {
 /// Ordering comparison between two numbers, trying i64, u64, then f64
 /// representations. Returns the `std::cmp::Ordering` or an error if
 /// the numbers cannot be compared.
-fn num_ord(x: &Number, y: &Number) -> Result<std::cmp::Ordering, ExecutionError> {
+fn num_ord(smid: Smid, x: &Number, y: &Number) -> Result<std::cmp::Ordering, ExecutionError> {
     if let (Some(l), Some(r)) = (x.as_i64(), y.as_i64()) {
         Ok(l.cmp(&r))
     } else if let (Some(l), Some(r)) = (x.as_u64(), y.as_u64()) {
         Ok(l.cmp(&r))
     } else if let (Some(l), Some(r)) = (x.as_f64(), y.as_f64()) {
-        l.partial_cmp(&r).ok_or_else(|| {
-            ExecutionError::NumericDomainError(Smid::default(), x.clone(), y.clone())
-        })
+        l.partial_cmp(&r)
+            .ok_or_else(|| ExecutionError::NumericDomainError(smid, x.clone(), y.clone()))
     } else {
         Err(ExecutionError::NumericDomainError(
-            Smid::default(),
+            smid,
             x.clone(),
             y.clone(),
         ))
@@ -552,7 +551,9 @@ fn ordered_cmp(
     let x = machine.nav(view).resolve_native(&args[0])?;
     let y = machine.nav(view).resolve_native(&args[1])?;
     match (x, y) {
-        (Native::Num(ref nx), Native::Num(ref ny)) => Ok(pred(num_ord(nx, ny)?)),
+        (Native::Num(ref nx), Native::Num(ref ny)) => {
+            Ok(pred(num_ord(machine.annotation(), nx, ny)?))
+        }
         (Native::Str(sx), Native::Str(sy)) => {
             let ls = &*view.scoped(sx);
             let rs = &*view.scoped(sy);

--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -39,11 +39,11 @@ use super::{
 ///
 /// Accepts: numeric offsets (+02:00, -0500, +01:00:00), "Z" for UTC,
 /// and IANA timezone names (e.g. "UTC", "Europe/London") via chrono-tz.
-fn offset_from_tz_str(tz_str: &str) -> Result<FixedOffset, ExecutionError> {
+fn offset_from_tz_str(smid: Smid, tz_str: &str) -> Result<FixedOffset, ExecutionError> {
     // Try "Z" for UTC
     if tz_str == "Z" {
         return FixedOffset::east_opt(0)
-            .ok_or_else(|| ExecutionError::BadTimeZone(Smid::default(), tz_str.to_string()));
+            .ok_or_else(|| ExecutionError::BadTimeZone(smid, tz_str.to_string()));
     }
 
     // Try parsing as a numeric offset by constructing a dummy datetime
@@ -76,10 +76,7 @@ fn offset_from_tz_str(tz_str: &str) -> Result<FixedOffset, ExecutionError> {
             .fix());
     }
 
-    Err(ExecutionError::BadTimeZone(
-        Smid::default(),
-        tz_str.to_string(),
-    ))
+    Err(ExecutionError::BadTimeZone(smid, tz_str.to_string()))
 }
 
 /// ZDT(y, m, d, h, M, s, Z) - create a zoned date time
@@ -142,7 +139,7 @@ impl StgIntrinsic for Zdt {
             .ok_or_else(err)?;
 
             let datetime = NaiveDateTime::new(date, time);
-            let offset = offset_from_tz_str(&tz)?;
+            let offset = offset_from_tz_str(smid, &tz)?;
             if let LocalResult::Single(zdt) = offset.from_local_datetime(&datetime) {
                 machine_return_zdt(machine, view, zdt)
             } else {
@@ -423,19 +420,19 @@ pub mod tests {
     #[test]
     pub fn test_tz_parse() {
         assert_eq!(
-            offset_from_tz_str("-02:00").unwrap(),
+            offset_from_tz_str(Smid::default(), "-02:00").unwrap(),
             FixedOffset::west_opt(2 * 60 * 60).unwrap()
         );
         assert_eq!(
-            offset_from_tz_str("+02:00").unwrap(),
+            offset_from_tz_str(Smid::default(), "+02:00").unwrap(),
             FixedOffset::east_opt(2 * 60 * 60).unwrap()
         );
         assert_eq!(
-            offset_from_tz_str("UTC").unwrap(),
+            offset_from_tz_str(Smid::default(), "UTC").unwrap(),
             FixedOffset::east_opt(0).unwrap()
         );
         assert_eq!(
-            offset_from_tz_str("Z").unwrap(),
+            offset_from_tz_str(Smid::default(), "Z").unwrap(),
             FixedOffset::east_opt(0).unwrap()
         );
     }

--- a/tests/harness/errors/150_bad_timezone_source_loc.eu
+++ b/tests/harness/errors/150_bad_timezone_source_loc.eu
@@ -1,0 +1,3 @@
+# Error: unrecognised timezone — source location should point to the cal.zdt call
+result: cal.zdt(2024, 1, 15, 10, 30, 0, "NotATimezone")
+RESULT: result

--- a/tests/harness/errors/150_bad_timezone_source_loc.eu.expect
+++ b/tests/harness/errors/150_bad_timezone_source_loc.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "150_bad_timezone_source_loc"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1553,6 +1553,11 @@ pub fn test_error_143() {
 }
 
 #[test]
+pub fn test_error_150() {
+    run_error_test(&error_opts("150_bad_timezone_source_loc.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `num_ord` (arith.rs) raised `NumericDomainError(Smid::default(), ...)` — now takes a `smid` parameter populated from `machine.annotation()` in the caller
- `offset_from_tz_str` (time.rs) raised `BadTimeZone(Smid::default(), ...)` — now takes a `smid` parameter populated from the caller's `machine.annotation()`
- Adds harness test 150 to verify `BadTimeZone` shows the user's source file

## Test plan

- [ ] `cargo test test_error_150` — BadTimeZone: filename in diagnostic
- [ ] `cargo clippy --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)