### PR TITLE
fix(errors): convert set type panics to TypeMismatch errors (issues 6+7)

### DIFF
--- a/src/eval/stg/set.rs
+++ b/src/eval/stg/set.rs
@@ -130,7 +130,11 @@ impl StgIntrinsic for SetFromList {
             match &*code {
                 HeapSyn::Atom { evaluand } => {
                     let native = item_closure.navigate_local_native(&view, evaluand.clone());
-                    primitives.push(native_to_set_primitive(view, &native)?);
+                    primitives.push(native_to_set_primitive(
+                        machine.annotation(),
+                        view,
+                        &native,
+                    )?);
                 }
                 HeapSyn::Cons {
                     tag: _,
@@ -144,7 +148,11 @@ impl StgIntrinsic for SetFromList {
                         )
                     })?;
                     let native = item_closure.navigate_local_native(&view, inner_ref.clone());
-                    primitives.push(native_to_set_primitive(view, &native)?);
+                    primitives.push(native_to_set_primitive(
+                        machine.annotation(),
+                        view,
+                        &native,
+                    )?);
                 }
                 _ => {
                     return Err(ExecutionError::Panic(
@@ -264,7 +272,7 @@ impl StgIntrinsic for SetAdd {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let native = resolve_native_unboxing(machine, view, &args[0])?;
-        let prim = native_to_set_primitive(view, &native)?;
+        let prim = native_to_set_primitive(machine.annotation(), view, &native)?;
         let set = set_arg(machine, view, &args[1])?;
         machine_return_set(machine, view, set.with_added(prim))
     }
@@ -292,7 +300,7 @@ impl StgIntrinsic for SetRemove {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         let native = resolve_native_unboxing(machine, view, &args[0])?;
-        let prim = native_to_set_primitive(view, &native)?;
+        let prim = native_to_set_primitive(machine.annotation(), view, &native)?;
         let set = set_arg(machine, view, &args[1])?;
         machine_return_set(machine, view, set.with_removed(&prim))
     }
@@ -328,7 +336,7 @@ impl StgIntrinsic for SetContains {
             Ok(n) => n,
             Err(_) => return machine_return_bool(machine, view, false),
         };
-        let prim = match native_to_set_primitive(view, &native) {
+        let prim = match native_to_set_primitive(machine.annotation(), view, &native) {
             Ok(p) => p,
             Err(_) => return machine_return_bool(machine, view, false),
         };

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -65,9 +65,8 @@ fn native_type(native: &Native) -> IntrinsicType {
         Native::Zdt(_) => IntrinsicType::ZonedDateTime,
         Native::NdArray(_) => IntrinsicType::Array,
         Native::Vec(_) => IntrinsicType::Vec,
-        Native::Index(_) | Native::Set(_) | Native::Prng(_) | Native::Producer(_) => {
-            IntrinsicType::Unknown
-        }
+        Native::Set(_) => IntrinsicType::Set,
+        Native::Index(_) | Native::Prng(_) | Native::Producer(_) => IntrinsicType::Unknown,
     }
 }
 
@@ -519,6 +518,7 @@ pub fn resolve_native_unboxing(
 
 /// Convert a Native value to a set Primitive
 pub fn native_to_set_primitive(
+    smid: Smid,
     view: MutatorHeapView,
     native: &Native,
 ) -> Result<crate::eval::memory::set::Primitive, ExecutionError> {
@@ -527,9 +527,11 @@ pub fn native_to_set_primitive(
         Native::Num(n) => Ok(SetPrim::from_number(n)),
         Native::Str(s) => Ok(SetPrim::Str(view.scoped(*s).as_str().to_string())),
         Native::Sym(id) => Ok(SetPrim::Sym(*id)),
-        _ => Err(ExecutionError::Panic(
-            Smid::default(),
-            "only numbers, strings, and symbols can be set elements".to_string(),
+        _ => Err(ExecutionError::TypeMismatch(
+            smid,
+            Box::new(crate::eval::types::IntrinsicType::Set),
+            Box::new(native_type(native)),
+            None,
         )),
     }
 }
@@ -561,13 +563,15 @@ pub fn set_arg<'guard>(
     view: MutatorHeapView<'guard>,
     arg: &Ref,
 ) -> Result<ScopedPtr<'guard, HeapSet>, ExecutionError> {
-    let native = machine.nav(view).resolve_native(arg)?;
+    let native = resolve_native_unboxing(machine, view, arg)?;
     if let Native::Set(ptr) = native {
         Ok(view.scoped(ptr))
     } else {
-        Err(ExecutionError::Panic(
-            Smid::default(),
-            "expected set argument".to_string(),
+        Err(ExecutionError::TypeMismatch(
+            machine.annotation(),
+            Box::new(crate::eval::types::IntrinsicType::Set),
+            Box::new(native_type(&native)),
+            describe_native(&native, machine, view),
         ))
     }
 }

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -65,14 +65,15 @@ fn resolve_list_ref(
 /// boxed constructor closures (`Cons { BoxedNumber | BoxedString | … }`).
 fn extract_primitive(
     item_closure: &SynClosure,
-    _machine: &mut dyn IntrinsicMachine,
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
 ) -> Result<Primitive, ExecutionError> {
+    let smid = machine.annotation();
     let code = view.scoped(item_closure.code());
     match &*code {
         HeapSyn::Atom { evaluand } => {
             let native = item_closure.navigate_local_native(&view, evaluand.clone());
-            native_to_set_primitive(view, &native)
+            native_to_set_primitive(smid, view, &native)
         }
         HeapSyn::Cons { args: cargs, .. } => {
             // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol, BoxedZdt)
@@ -80,7 +81,7 @@ fn extract_primitive(
                 ExecutionError::Panic(Smid::default(), "empty boxed value in vec".to_string())
             })?;
             let native = item_closure.navigate_local_native(&view, inner_ref.clone());
-            native_to_set_primitive(view, &native)
+            native_to_set_primitive(smid, view, &native)
         }
         _ => Err(ExecutionError::Panic(
             Smid::default(),

--- a/src/eval/types.rs
+++ b/src/eval/types.rs
@@ -15,6 +15,7 @@ pub enum IntrinsicType {
     ZonedDateTime,
     Array,
     Vec,
+    Set,
     List(Box<IntrinsicType>),
     Function(Box<IntrinsicType>, Box<IntrinsicType>),
     Record(HashMap<String, IntrinsicType>),
@@ -33,6 +34,7 @@ impl fmt::Display for IntrinsicType {
             IntrinsicType::ZonedDateTime => write!(f, "datetime"),
             IntrinsicType::Array => write!(f, "array"),
             IntrinsicType::Vec => write!(f, "vec"),
+            IntrinsicType::Set => write!(f, "set"),
             IntrinsicType::List(t) => write!(f, "list of {}", *t),
             IntrinsicType::Function(i, o) => write!(f, "{i} -> {o}"),
             IntrinsicType::Record(hm) => {
@@ -163,6 +165,10 @@ pub fn arr() -> Box<IntrinsicType> {
 
 pub fn vec_type() -> Box<IntrinsicType> {
     Box::new(IntrinsicType::Vec)
+}
+
+pub fn set_type() -> Box<IntrinsicType> {
+    Box::new(IntrinsicType::Set)
 }
 
 pub fn block() -> Box<IntrinsicType> {

--- a/tests/harness/errors/151_set_add_non_set.eu
+++ b/tests/harness/errors/151_set_add_non_set.eu
@@ -1,0 +1,1 @@
+result: "hello" set.add("world")

--- a/tests/harness/errors/151_set_add_non_set.eu.expect
+++ b/tests/harness/errors/151_set_add_non_set.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch: expected set, found string"

--- a/tests/harness/errors/152_set_element_type_mismatch.eu
+++ b/tests/harness/errors/152_set_element_type_mismatch.eu
@@ -1,0 +1,1 @@
+result: ∅ set.add([1, 2, 3] set.from-list)

--- a/tests/harness/errors/152_set_element_type_mismatch.eu.expect
+++ b/tests/harness/errors/152_set_element_type_mismatch.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1553,6 +1553,16 @@ pub fn test_error_143() {
 }
 
 #[test]
+pub fn test_error_151() {
+    run_error_test(&error_opts("151_set_add_non_set.eu"));
+}
+
+#[test]
+pub fn test_error_152() {
+    run_error_test(&error_opts("152_set_element_type_mismatch.eu"));
+}
+
+#[test]
 pub fn test_error_135() {
     run_error_test(&error_opts("135_head_empty_list.eu"));
 }


### PR DESCRIPTION
## Summary

- `native_to_set_primitive`: replace `Panic` with `TypeMismatch` when a non-primitive native (ZonedDateTime, Set, Block, etc.) is used as a set element; add `smid` parameter so the source location is propagated to the error
- `set_arg`: replace `Panic` with `TypeMismatch(set, actual_type)` when a non-set value is passed where a set is expected; switch to `resolve_native_unboxing` so boxed string/number/symbol values produce a `TypeMismatch` instead of the confusing `NotValue` error
- Add `IntrinsicType::Set` variant and map `Native::Set` to it in `native_type()` for accurate type names in error messages
- Update all call sites in `set.rs` and `vec.rs` to pass `machine.annotation()` as the smid

## Tests

- `151_set_add_non_set.eu`: passing a string as the set argument gives `type mismatch: expected set, found string`
- `152_set_element_type_mismatch.eu`: passing a set as a set element gives `type mismatch` (previously panicked)

## Checklist

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test test_error_15` passes
- [x] `cargo test test_harness_074` (existing set tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)