### PR TITLE
test(bench): fix broken bench tests 003 and 010

### DIFF
--- a/tests/harness/bench/003_smarter_fib.eu
+++ b/tests/harness/bench/003_smarter_fib.eu
@@ -2,4 +2,4 @@ f(pair): [second(pair), first(pair) + second(pair)]
 fib(n): if(n = 0, 1, [1, 1] iterate(f) drop(n - 1) first first)
 
 ` { target: :bench-smarter-fib }
-bench-smarter-fib: fib(500)
+bench-smarter-fib: fib(90)

--- a/tests/harness/bench/010_deep_find_perf.eu
+++ b/tests/harness/bench/010_deep_find_perf.eu
@@ -27,10 +27,10 @@ services: {
 # --- deep-find: find all hosts (should be 40: 20 direct + 20 nested) ---
 
 ` :suppress
-all-hosts: deep-find("host", services)
+all-hosts: deep-find(:host, services)
 
 ` :suppress
-host-count: all-hosts foldl(0, {n: •, _: •}.n + 1)
+host-count: all-hosts count
 
 # --- deep-query: find config.host values ---
 
@@ -38,20 +38,20 @@ host-count: all-hosts foldl(0, {n: •, _: •}.n + 1)
 config-hosts: deep-query("config.host", services)
 
 ` :suppress
-config-host-count: config-hosts foldl(0, {n: •, _: •}.n + 1)
+config-host-count: config-hosts count
 
 # --- deep-find-first ---
 
 ` :suppress
-first-host: deep-find-first("host", "none", services)
+first-host: deep-find-first(:host, "none", services)
 
-# --- deep-query with wildcard ---
+# --- deep-query with wildcard (should be 40: ** normalisation descends all blocks, then * expands one level, then :host matches) ---
 
 ` :suppress
 star-hosts: deep-query("*.host", services)
 
 ` :suppress
-star-host-count: star-hosts foldl(0, {n: •, _: •}.n + 1)
+star-host-count: star-hosts count
 
 ` { target: :bench-deep-find-perf }
 bench-deep-find-perf: {
@@ -62,7 +62,7 @@ bench-deep-find-perf: {
   RESULT: if(host-count = 40,
              if(config-host-count = 20,
                 if(first-host = "10.0.0.0",
-                   if(star-host-count = 20, :PASS, :FAIL),
+                   if(star-host-count = 40, :PASS, :FAIL),
                    :FAIL),
                 :FAIL),
              :FAIL)


### PR DESCRIPTION
## Performance: Fix broken benchmark tests

### Hypothesis
Two benchmark tests in `tests/harness/bench/` were failing, preventing them from being used as
performance regression targets:

- **003_smarter_fib**: `fib(500)` overflows i64 arithmetic (fib(92) is the last safe value at
  7,540,113,804,746,346,429). The test silently produced a wrong result or panicked.
- **010_deep_find_perf**: Three bugs caused `RESULT: FAIL`:
  1. `deep-find("host", ...)` passes a string but `deep-find` requires a symbol (`has(k)` and
     `lookup(k)` only accept symbols). Fixed to `deep-find(:host, ...)`.
  2. `foldl(0, fn)` has inverted argument order — `foldl` signature is `foldl(op, init, list)`, so
     `0` was used as the operator and a function as the initial value, causing "tried to call a
     number as a function". Replaced all three occurrences with the `count` prelude function.
  3. `star-host-count` expected 20 but `deep-query("*.host", ...)` returns 40. The prelude
     normalises bare patterns by prepending `**`, so `"*.host"` becomes `["**", "*", "host"]`:
     descend all depths, then expand one wildcard level, then match `:host`. With 20 services each
     having a nested `config.host`, this finds 40 values.

### Change
- `003_smarter_fib.eu`: `fib(500)` → `fib(90)` (result: 2,880,067,194,370,816,120)
- `010_deep_find_perf.eu`: symbol keys, `count` instead of broken `foldl`, expected count corrected to 40

### Results
Both tests now run successfully:

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| 003_smarter_fib | error (integer overflow) | 70.6ms | fixed |
| 010_deep_find_perf | RESULT: FAIL | 100.9ms | fixed |

### Regression check
Full harness suite: 359 tests, 0 failures.

### Risks
None — these are test-only changes with no production code modifications.