### PR TITLE
docs: add HKT type forms to agent-reference and cheat-sheet

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -537,7 +537,10 @@ origin: { x: 0, y: 0 }
 | `:name`            | literal symbol type (subtype of `symbol`)      |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
-| `a`, `b`, `s`      | type variable (lowercase)              |
+| `a`, `b`, `s`      | type variable, kind `*` (lowercase)    |
+| `m a`              | constructor application (`m :: * -> *` applied to `a`) |
+| `forall a. T`      | explicit quantification (kind-`*`)     |
+| `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
 | `Lens(a, b)`       | lens focusing on b within a            |
 | `Traversal(a, b)`  | traversal over b's within a            |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -157,7 +157,10 @@ origin: { x: 0, y: 0 }
 | `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
-| `a`, `b`           | type variable                          |
+| `a`, `b`           | type variable (kind `*`)               |
+| `m a`              | constructor application (`m` of kind `* -> *` applied to `a`) |
+| `forall a. T`      | explicit quantification over kind-`*` variable |
+| `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
 | `Lens(a, b)`       | lens                                   |
 | `Traversal(a, b)`  | traversal                              |


### PR DESCRIPTION
## Summary

Follow-up to PR #753 (higher-kinded type variables, eu-crbc). The new `forall` / kind annotation / constructor application syntax was documented in `docs/guide/type-checking.md` by Quill, but the quick-reference tables used by agents were not updated.

- **agent-reference.md**: add `m a`, `forall a. T`, `forall (m :: * -> *) a. T` rows to the type forms table in §1.5
- **cheat-sheet.md**: same additions to the Type forms table

Note: no grammar or editor changes needed — `forall` appears only inside `type:` annotation strings, not in eucalypt source syntax.

Closes eu-0rb9.10, eu-0rb9.11

## Test plan

- [ ] Docs-only change — verify markdown renders correctly
- [ ] Confirm `forall` and `m a` rows appear in both tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)