### PR TITLE
perf(memory): skip zero-init in RawArray backing allocations

### DIFF
--- a/src/eval/memory/alloc.rs
+++ b/src/eval/memory/alloc.rs
@@ -23,8 +23,13 @@ pub trait Allocator {
     where
         T: StgObject;
 
-    /// Allocate a region of bytes
+    /// Allocate a region of bytes (zero-initialised)
     fn alloc_bytes(&self, size_bytes: usize) -> Result<NonNull<u8>, HeapError>;
+
+    /// Allocate a region of bytes without zero-initialisation.
+    ///
+    /// Callers must ensure every byte is written before it is read.
+    fn alloc_bytes_uninit(&self, size_bytes: usize) -> Result<NonNull<u8>, HeapError>;
 
     /// Get header from object
     fn get_header<T>(&self, object: NonNull<T>) -> NonNull<AllocHeader>;
@@ -82,6 +87,14 @@ pub trait ScopedAllocator<'guard> {
     where
         T: StgObject;
 
-    /// Allocate a region of bytes
+    /// Allocate a region of bytes (zero-initialised)
     fn alloc_bytes(&self, size_bytes: usize) -> Result<NonNull<u8>, ExecutionError>;
+
+    /// Allocate a region of bytes without zero-initialisation.
+    ///
+    /// Callers must ensure every byte is written before it is read.
+    /// The default implementation falls back to the zeroing path.
+    fn alloc_bytes_uninit(&self, size_bytes: usize) -> Result<NonNull<u8>, ExecutionError> {
+        self.alloc_bytes(size_bytes)
+    }
 }

--- a/src/eval/memory/array.rs
+++ b/src/eval/memory/array.rs
@@ -128,7 +128,7 @@ impl<T: Sized> RawArray<T> {
                 .checked_mul(size_of::<T>())
                 .ok_or(ExecutionError::AllocationError)?;
             Ok(RefPtr::new(
-                mem.alloc_bytes(capacity_bytes)?.as_ptr() as *mut T
+                mem.alloc_bytes_uninit(capacity_bytes)?.as_ptr() as *mut T
             ))
         }
     }

--- a/src/eval/memory/array.rs
+++ b/src/eval/memory/array.rs
@@ -128,7 +128,7 @@ impl<T: Sized> RawArray<T> {
                 .checked_mul(size_of::<T>())
                 .ok_or(ExecutionError::AllocationError)?;
             Ok(RefPtr::new(
-                mem.alloc_bytes_uninit(capacity_bytes)?.as_ptr() as *mut T
+                mem.alloc_bytes_uninit(capacity_bytes)?.as_ptr() as *mut T,
             ))
         }
     }

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -2293,6 +2293,41 @@ impl Allocator for Heap {
         }
     }
 
+    /// Allocate a region of bytes without zero-initialisation.
+    ///
+    /// Callers must ensure every byte is written before it is read.  The GC
+    /// never scans beyond the `length` field stored in the owning `Array<T>`,
+    /// so capacity bytes beyond `length` are never traversed, making it safe to
+    /// leave them uninitialised.
+    fn alloc_bytes_uninit(&self, size_bytes: usize) -> Result<NonNull<u8>, HeapError> {
+        if size_bytes > u32::MAX as usize {
+            return Err(HeapError::InvalidAllocationSize {
+                requested_size: size_bytes,
+                max_size: u32::MAX as usize,
+            });
+        }
+
+        let header_size = size_of::<AllocHeader>();
+        let alloc_size = Self::alloc_size_of(header_size + size_bytes);
+        let size_class = SizeClass::for_size(alloc_size);
+
+        let space = self.find_space(alloc_size)?;
+
+        let header = AllocHeader::new_with_mark_state(size_bytes as u32, self.mark_state());
+
+        // Update allocation metrics (lightweight - just counters)
+        self.update_allocation_counters_fast(alloc_size, size_class);
+
+        // SAFETY: Memory layout is the same as alloc_bytes.  No zero-fill is
+        // performed; the caller is responsible for initialising all bytes it
+        // will subsequently read.
+        unsafe {
+            write(space as *mut AllocHeader, header);
+            let array_space = space.add(header_size);
+            Ok(NonNull::new_unchecked(array_space as *mut u8))
+        }
+    }
+
     /// Get header from object pointer
     fn get_header<T>(&self, object: NonNull<T>) -> NonNull<AllocHeader> {
         // SAFETY: Pointer arithmetic is valid because:

--- a/src/eval/memory/mutator.rs
+++ b/src/eval/memory/mutator.rs
@@ -131,6 +131,16 @@ impl<'guard> ScopedAllocator<'guard> for MutatorHeapView<'guard> {
     fn alloc_bytes(&self, size_bytes: usize) -> Result<std::ptr::NonNull<u8>, ExecutionError> {
         self.heap_ref().alloc_bytes(size_bytes).map_err(Into::into)
     }
+
+    /// Allocate a region of bytes without zero-initialisation
+    fn alloc_bytes_uninit(
+        &self,
+        size_bytes: usize,
+    ) -> Result<std::ptr::NonNull<u8>, ExecutionError> {
+        self.heap_ref()
+            .alloc_bytes_uninit(size_bytes)
+            .map_err(Into::into)
+    }
 }
 
 /// Build an indexed branch table from tagged branch pairs


### PR DESCRIPTION
## Performance: skip zero-initialisation of Array backing buffers

### Hypothesis
`alloc_bytes` zero-initialises every byte of newly allocated backing buffers for `Array<T>`.
This is unnecessary: the GC only ever scans indices `[0, length)`, and all callers either
copy full data over the allocation immediately (`with_data`) or push elements incrementally,
advancing `length` only after writing each slot (`push`).
Removing the zero-fill should save proportional allocation cost, most visible in GC-heavy
workloads that create many small arrays.

### Change
- Added `alloc_bytes_uninit` to `Heap` (no zero-fill loop), `Allocator` trait, and
  `ScopedAllocator` trait (default implementation falls back to the zeroing path, keeping future
  implementors safe).
- Overrode `alloc_bytes_uninit` in `MutatorHeapView` to delegate to `Heap::alloc_bytes_uninit`.
- Changed `RawArray::alloc` (the sole `alloc_bytes` caller via `ScopedAllocator`) to use
  `alloc_bytes_uninit`.

Safety invariant documented on `alloc_bytes_uninit`: *callers must ensure every byte is written
before it is read.*  Both call paths satisfy this:
- `with_data` copies `data.len()` elements immediately after allocation.
- `with_capacity` / `push` only increments `length` after writing the element; the GC scans
  `[0, length)` only.

Recycled heap blocks are not zeroed between GC cycles, so `alloc_bytes` was re-zeroing memory
that had simply been in use — this was the main source of overhead.

### Results
Criterion micro-benchmarks (absolute times, 100 samples each):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| gc_alloc_then_collect/256 | 24.36 µs | 21.77 µs | **−10.6%** |
| gc_alloc_then_collect/1024 | 95.05 µs | 85.51 µs | **−10.0%** |
| gc_alloc_then_collect/4096 | 376.9 µs | 338.8 µs | **−10.1%** |
| create_partially_apply_and_saturate_lambda | 442 ns | 432 ns | −2.3% |
| alloc_letrec | 140 ns | 140 ns | no change |

End-to-end wall-clock benchmarks show ~1% improvement, diluted by the fixed ~40 ms pipeline
compilation cost that dominates short programmes.

### Regression check
Full harness suite: 359 tests, 0 failures.

### Risks
- Uninitialized memory beyond `length` is never read, but a future caller of `alloc_bytes_uninit`
  that forgets to initialise could cause undefined behaviour. Mitigated by: the safe default
  implementation on `ScopedAllocator`, and the documented safety invariant on both the trait
  method and `Heap::alloc_bytes_uninit`.
- The `EU_GC_POISON=1` debug mode already detected use-after-free before this change. It
  continues to work: poisoning happens on reclaim, not on allocation, so the uninit path has no
  interaction with the poison check.