### PR TITLE
perf(vm): eliminate intermediate Vec in pap_syn

### DIFF
--- a/src/eval/machine/env_builder.rs
+++ b/src/eval/machine/env_builder.rs
@@ -278,13 +278,12 @@ fn pap_syn(
     supplied: usize,
     pending: usize,
 ) -> Result<RefPtr<HeapSyn>, ExecutionError> {
-    let mut args = Vec::with_capacity(supplied + pending);
+    let mut arg_array = Array::with_capacity(&view, supplied + pending);
     for i in 0..supplied {
-        args.push(Ref::L(pending + i + 1));
+        arg_array.push(&view, Ref::L(pending + i + 1));
     }
     for i in 0..pending {
-        args.push(Ref::L(i));
+        arg_array.push(&view, Ref::L(i));
     }
-    let arg_array = Array::from_slice(&view, args.as_slice());
     Ok(view.app(Ref::L(pending), arg_array)?.as_ptr())
 }


### PR DESCRIPTION
## Performance: eliminate intermediate Vec allocation in pap_syn

### Hypothesis
`pap_syn` builds the argument array for a partial application code object by first constructing
a Rust-heap `Vec<Ref>`, then copying it into a GC-managed `Array<Ref>` via `Array::from_slice`.
This allocates twice (once on the Rust heap, once on the GC heap) and copies once, for every
partial application. Since `Array<Ref>` supports `push`, the intermediate `Vec` can be
eliminated entirely.

### Change
Replace the `Vec::with_capacity` + `push` + `Array::from_slice` pattern in `pap_syn` with
a direct `Array::with_capacity` + `push` sequence. One Rust heap allocation and one copy are
removed per partial application.

Safety:
- The push loop never exceeds the pre-allocated capacity (`supplied + pending`), so `resize` is
  never called during construction.
- GC only runs at VM step boundaries (`step()` in `vm.rs`), so the array is always fully
  initialised before it can be scanned.

### Results
| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| create_partially_apply_and_saturate_lambda | 435.75 ns | 403.03 ns | **−7.5%** |
| gc_alloc_then_collect/256 | 23.82 µs | 23.62 µs | −0.8% (noise) |
| gc_alloc_then_collect/1024 | 93.74 µs | 92.92 µs | −0.9% (noise) |

### Regression check
Full harness suite: 362 tests, 0 failures.

End-to-end wall-clock (004_generations): 534ms vs 541ms — within noise. The partial application
path is not the dominant cost for existing bench tests.

### Risks
None — the change is a straightforward substitution with identical semantics. No new unsafe code
introduced.