### PR TITLE
perf(vm): avoid HeapSyn clone on every instruction dispatch

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -376,8 +376,19 @@ impl MachineState {
         _intrinsics: &[&'guard dyn StgIntrinsic],
         metrics: &mut Metrics,
     ) -> Result<(), ExecutionError> {
-        // Load "op code"
-        let code = (*view.scoped(self.closure.code())).clone();
+        // Load "op code" as a reference to avoid cloning 56 bytes of HeapSyn on every tick.
+        //
+        // SAFETY:
+        // - `self.closure.code()` is a `NonNull<HeapSyn>` pointing into the GC-managed heap.
+        // - GC can only run between ticks (in the main `run()` loop before each call to
+        //   `handle_instruction`), never *during* `handle_instruction`.  No allocation path
+        //   reachable from here triggers an inline collection.
+        // - `scan_and_update()` updates `self.closure.code()` before every tick, so the pointer
+        //   is always current when we enter this function.
+        // - The HeapSyn object is immutable once compiled; no mutation occurs to it here or in
+        //   any function called from this scope.
+        // - The reference lifetime is bounded to this function call.
+        let code: &HeapSyn = unsafe { &*self.closure.code().as_ptr() };
         let environment = self.closure.env();
         let remaining_arity = self.closure.arity();
 
@@ -402,7 +413,7 @@ impl MachineState {
                 let suppress_update = std::mem::replace(&mut self.suppress_next_update, false);
                 match evaluand {
                     Ref::L(i) => {
-                        self.closure = self.nav(view).get(i)?;
+                        self.closure = self.nav(view).get(*i)?;
                         let is_thunk = self.closure.update();
                         let updateable = is_thunk && !suppress_update;
                         // When suppress_update is active but the loaded closure is
@@ -427,22 +438,22 @@ impl MachineState {
                             let hole = view.alloc(HeapSyn::BlackHole)?;
                             let black_hole = SynClosure::new(hole.as_ptr(), environment);
                             let cont_env = view.scoped(environment);
-                            cont_env.update(&view, i, black_hole)?;
+                            cont_env.update(&view, *i, black_hole)?;
 
                             self.push(
                                 view,
                                 Continuation::Update {
                                     environment,
-                                    index: i,
+                                    index: *i,
                                 },
                             )?;
                         }
                     }
                     Ref::G(i) => {
-                        self.closure = self.nav(view).global(i)?;
+                        self.closure = self.nav(view).global(*i)?;
                     }
                     Ref::V(v) => {
-                        self.return_native(view, &v)?;
+                        self.return_native(view, v)?;
                     }
                 }
             }
@@ -456,18 +467,18 @@ impl MachineState {
                 self.push(
                     view,
                     Continuation::Branch {
-                        min_tag,
-                        branch_table,
-                        fallback,
+                        min_tag: *min_tag,
+                        branch_table: branch_table.clone(),
+                        fallback: *fallback,
                         environment,
                         annotation: self.annotation,
-                        suppress_update: case_suppress,
+                        suppress_update: *case_suppress,
                     },
                 )?;
-                self.closure = SynClosure::new(scrutinee, environment);
+                self.closure = SynClosure::new(*scrutinee, environment);
             }
             HeapSyn::Cons { tag, args } => {
-                self.return_data(view, tag, args.as_slice())?;
+                self.return_data(view, *tag, args.as_slice())?;
             }
             HeapSyn::App { callable, args } => {
                 let array = view.create_arg_array(args.as_slice(), environment)?;
@@ -478,31 +489,31 @@ impl MachineState {
                         annotation: self.annotation,
                     },
                 )?;
-                self.closure = self.nav(view).resolve_callable(&callable)?;
+                self.closure = self.nav(view).resolve_callable(callable)?;
             }
             HeapSyn::Bif { intrinsic, args } => {
                 // Defer BIF execution to Machine::step() so that the full
                 // Machine is available (needed for evaluate_to_whnf).
                 // Clone the args: Ref is cheap to clone (indices or small natives).
-                self.pending_bif = Some((intrinsic, args.as_slice().to_vec()));
+                self.pending_bif = Some((*intrinsic, args.as_slice().to_vec()));
             }
             HeapSyn::Let { bindings, body } => {
                 metrics.alloc(bindings.len());
                 let new_env = view.from_let(bindings.as_slice(), environment, self.annotation)?;
-                self.closure = SynClosure::new(body, new_env);
+                self.closure = SynClosure::new(*body, new_env);
             }
             HeapSyn::LetRec { bindings, body } => {
                 metrics.alloc(bindings.len());
                 let new_env =
                     view.from_letrec(bindings.as_slice(), environment, self.annotation)?;
-                self.closure = SynClosure::new(body, new_env);
+                self.closure = SynClosure::new(*body, new_env);
             }
             HeapSyn::Ann { smid, body } => {
-                self.annotation = smid;
-                self.closure = SynClosure::new(body, environment);
+                self.annotation = *smid;
+                self.closure = SynClosure::new(*body, environment);
             }
             HeapSyn::Meta { meta, body } => {
-                self.return_meta(view, &meta, &body)?;
+                self.return_meta(view, meta, body)?;
             }
             HeapSyn::DeMeta {
                 scrutinee,
@@ -512,12 +523,12 @@ impl MachineState {
                 self.push(
                     view,
                     Continuation::DeMeta {
-                        handler,
-                        or_else,
+                        handler: *handler,
+                        or_else: *or_else,
                         environment,
                     },
                 )?;
-                self.closure = SynClosure::new(scrutinee, environment);
+                self.closure = SynClosure::new(*scrutinee, environment);
             }
             HeapSyn::BlackHole => return Err(ExecutionError::BlackHole(self.annotation)),
         }


### PR DESCRIPTION
## Performance: avoid 56-byte HeapSyn clone on every VM tick

> ⚠ **OWNER REVIEW REQUIRED** — this PR uses `unsafe` in the core VM dispatch loop and modifies
> GC-heap pointer semantics. Please verify the safety argument before merging.

### Hypothesis
`handle_instruction` cloned 56 bytes of `HeapSyn` on every VM tick:
```rust
let code = (*view.scoped(self.closure.code())).clone();
```
This clone is unnecessary: GC only runs between ticks (in the main `run()` loop, before each
`handle_instruction` call), never during it. The `HeapSyn` pointer is safe to dereference
throughout the function.

For compute-intensive programs (e.g. `fib(30)` → 134M ticks), this amounts to 134M × 56 bytes =
7.5 GB of avoided data movement.

### Change
Replace the clone with an unsafe reference:
```rust
// SAFETY: GC runs between ticks, not during handle_instruction.
// scan_and_update() keeps self.closure.code() current before every tick.
// HeapSyn objects are immutable once compiled.
let code: &HeapSyn = unsafe { &*self.closure.code().as_ptr() };
```

Match arms updated to handle reference field bindings:
- Copy fields (`Tag`, `RefPtr<T>`, `bool`, `Smid`, `u8`) are dereferenced with `*`
- `Array<T>` fields are cloned (cheap: 24 bytes = 2 usizes + pointer)
- `&Ref` fields pass directly to functions already accepting `&Ref` (`resolve_callable`,
  `return_native`, `return_meta`)

### Safety argument
1. **GC timing**: The garbage collector runs exclusively in the main loop (`run()`, `run2()`) at
   a `gc_countdown` boundary, always *before* `handle_instruction`. No allocation in any code path
   reachable from `handle_instruction` triggers an inline collection.
2. **Pointer validity**: `scan_and_update()` updates `self.closure.code()` before every tick, so
   the pointer is always current on entry to this function.
3. **Immutability**: `HeapSyn` objects are compiled once and never mutated. The reference does not
   alias any mutable path.
4. **Lifetime**: The reference is stack-local and dropped before `handle_instruction` returns.
5. **Verified**: `EU_GC_POISON=1 EU_GC_VERIFY=1` detects no GC violations. 134M-tick `fib(30)`
   completes correctly.

### Results
| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| 001_naive_fib (fib(30), 134M ticks) | 12.69s ± 0.45s | 11.56s ± 0.09s | **−8.9%** |
| gc_alloc_then_collect/256 | 24.36 µs | 23.84 µs | −2.1% |
| gc_alloc_then_collect/1024 | 95.05 µs | 93.37 µs | −1.8% |
| gc_alloc_then_collect/4096 | 376.9 µs | 369.5 µs | −2.0% |

End-to-end benchmarks that are pipeline-dominated (parse/translate/cook) show <1% improvement
since VM execution is a small fraction of total time.

### Regression check
Full harness suite: 362 tests, 0 failures.  
`EU_GC_POISON=1 EU_GC_VERIFY=1` run: no GC violations.

### Risks
- **Unsafe pointer dereference in the hot dispatch loop**: if the safety invariant were violated
  (e.g. by a future change that triggers GC inside `handle_instruction`), this would be
  unsound. The code includes a detailed safety comment. A future audit should check any new
  allocation calls added to this function.
- The `branch_table` clone in the `Case` arm (24 bytes) is retained because
  `Continuation::Branch` needs an owned `Array<Option<RefPtr<HeapSyn>>>`. This is a shallow
  copy of the metadata (length + backing pointer), not a deep clone.