### PR TITLE
docs: add Random/State type constructors and monad() to quick-reference

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -144,13 +144,13 @@ block) as `.name`, `.(expr)`, or `.[list]`.
 
 **Built-in monadic namespaces:**
 
-| Tag | Monad | Result type |
-|-----|-------|-------------|
-| `:io` | IO effects | IO action |
-| `:random` | Random state | Random action |
-| `:state` | Block state (import `state.eu`) | State action |
-| `:let` | Identity (sequential bindings) | Value |
-| `:for` | List (comprehensions) | List |
+| Tag | Monad | Action type | Element type |
+|-----|-------|-------------|--------------|
+| `:io` | IO effects | `IO(a)` | `a` |
+| `:random` | Random state | `Random(a)` | `a` |
+| `:state` | Block state (import `state.eu`) | `State(a)` | `a` |
+| `:let` | Identity (sequential bindings) | any | same |
+| `:for` | List (comprehensions) | `[a]` | `a` |
 
 ```eu,notest
 # List comprehension: cartesian product with filter
@@ -542,8 +542,18 @@ origin: { x: 0, y: 0 }
 | `forall a. T`      | explicit quantification (kind-`*`)     |
 | `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
+| `Random(T)`        | random action producing T              |
+| `State(T)`         | state action producing T               |
 | `Lens(a, b)`       | lens focusing on b within a            |
 | `Traversal(a, b)`  | traversal over b's within a            |
 | `set`              | ordered set of primitives              |
 | `vec`              | flat vector of primitives              |
 | `array`            | n-dimensional number array             |
+
+### User-defined monads
+
+`monad({ bind(m,f): ..., return(v): ... })` derives the standard
+combinators (`map`, `then`, `and-then`, `join`, `sequence`, `map-m`,
+`filter-m`) annotated with `forall (m :: * -> *)` types.  The type
+checker understands them polymorphically — passing a non-function to
+`my-monad.map` triggers a warning.

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -162,8 +162,21 @@ origin: { x: 0, y: 0 }
 | `forall a. T`      | explicit quantification over kind-`*` variable |
 | `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
+| `Random(T)`        | random action producing T              |
+| `State(T)`         | state action producing T               |
 | `Lens(a, b)`       | lens                                   |
 | `Traversal(a, b)`  | traversal                              |
+
+**User-defined monads**: `monad({ bind(m,f): ..., return(v): ... })`
+derives the standard combinators (`map`, `then`, `and-then`, `join`,
+`sequence`, `map-m`, `filter-m`) and annotates them with
+`forall (m :: * -> *)` types.  The type checker understands them
+polymorphically, so passing the wrong type triggers a warning:
+
+```eu,notest
+my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
+[1, 2, 3] my-for.map(true)   # warning: expected a → b, found bool
+```
 
 **Important**: record braces (`{`) in type strings trigger eucalypt
 string interpolation. Always escape with `{{` and `}}`:


### PR DESCRIPTION
## Summary

Follow-up to PR #757 (B8 — HKT monad namespaces, eu-gqxz).

PR #757 added `Random` and `State` as `* -> *` type constructors and
documented `monad()` with `forall (m :: * -> *)` types in
`type-checking.md`, but the quick-reference tables were not updated.

- **agent-reference.md**: add `Random(T)` and `State(T)` to type forms table; add `monad()` user-defined monad note with example
- **cheat-sheet.md**: same type forms additions; expand built-in monadic namespaces table with action and element type columns; add `monad()` subsection

## Test plan

- [x] Docs-only change — no code changes
- [x] `Random(T)` and `State(T)` now appear alongside `IO(T)` in both quick-reference docs
- [x] `monad()` HKT behaviour documented with example warning

Closes eu-gqxz

🤖 Generated with [Claude Code](https://claude.ai/claude-code)