### PR TITLE
docs: add T? and ExecutionError to agent-reference type forms

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -157,6 +157,8 @@ origin: { x: 0, y: 0 }
 | `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
+| `T?`               | partial — sugar for `T \| ExecutionError` |
+| `ExecutionError`   | the type of a raised runtime error     |
 | `a`, `b`           | type variable (kind `*`)               |
 | `m a`              | constructor application (`m` of kind `* -> *` applied to `a`) |
 | `forall a. T`      | explicit quantification over kind-`*` variable |
@@ -183,6 +185,25 @@ string interpolation. Always escape with `{{` and `}}`:
 `"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
 Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
 Literal string types (`"value"`) need `\"` escaping inside annotation strings.
+
+**Partial functions**: functions that may raise a runtime error use the
+`T?` postfix sugar — equivalent to `T | ExecutionError`.  Several
+prelude functions are partial by nature:
+
+```
+nth      : number → [a] → a?         # out-of-range index
+parse-as : symbol → string → any?    # invalid input format
+lookup   : symbol → Dict(a) → a?     # key not found
+```
+
+A partial result flowing into `any` (unannotated code) is **silent** —
+a warning fires only when the receiving position is explicitly annotated
+as total:
+
+```eu,notest
+` { type: "number" }
+result: [1, 2, 3] nth(0)   # warning: expected number, found number?
+```
 
 **Flow-sensitive narrowing**: when a type-predicate test (`number?`,
 `string?`, `bool?`, `null?`, `list?`, `block?`, `symbol?`) on an


### PR DESCRIPTION
## Summary

Follow-up to PR #762 (B5 — Partial(T)/T? opaque type, eu-c87i).

PR #762 added `T?` and `ExecutionError` to `cheat-sheet.md` and
`type-checking.md` but `agent-reference.md` was not updated.

- **agent-reference.md**: add `T?` and `ExecutionError` rows to the type forms table
- **agent-reference.md**: add partial functions note with `nth`/`parse-as`/`lookup` examples and the gradual self-limiting rule (partial flows into `any` silently; warns only at explicitly-annotated-total positions)

## Test plan

- [x] Docs-only change — no code changes
- [x] `T?` and `ExecutionError` now appear in agent-reference type forms table
- [x] Partial types behaviour documented with concrete examples

Closes eu-c87i

🤖 Generated with [Claude Code](https://claude.ai/claude-code)