### PR TITLE
docs: remove Random(T)/State(T) type constructor forms

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -147,8 +147,8 @@ block) as `.name`, `.(expr)`, or `.[list]`.
 | Tag | Monad | Action type | Element type |
 |-----|-------|-------------|--------------|
 | `:io` | IO effects | `IO(a)` | `a` |
-| `:random` | Random state | `Random(a)` | `a` |
-| `:state` | Block state (import `state.eu`) | `State(a)` | `a` |
+| `:random` | Random state | `stream → {value: a, rest: stream}` | `a` |
+| `:state` | Block state (import `state.eu`) | `state → {value: a, state: state}` | `a` |
 | `:let` | Identity (sequential bindings) | any | same |
 | `:for` | List (comprehensions) | `[a]` | `a` |
 
@@ -544,8 +544,6 @@ origin: { x: 0, y: 0 }
 | `forall a. T`      | explicit quantification (kind-`*`)     |
 | `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
-| `Random(T)`        | random action producing T              |
-| `State(T)`         | state action producing T               |
 | `Lens(a, b)`       | lens focusing on b within a            |
 | `Traversal(a, b)`  | traversal over b's within a            |
 | `set`              | ordered set of primitives              |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -164,8 +164,6 @@ origin: { x: 0, y: 0 }
 | `forall a. T`      | explicit quantification over kind-`*` variable |
 | `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
-| `Random(T)`        | random action producing T              |
-| `State(T)`         | state action producing T               |
 | `Lens(a, b)`       | lens                                   |
 | `Traversal(a, b)`  | traversal                              |
 


### PR DESCRIPTION
## Summary

Corrects PR #759 in light of PR #766 (eu-0rb9.12 — HKT monad rework).

PR #759 added `Random(T)` and `State(T)` as named type forms based on PR #757, but PR #766 removed those constructors from the HKT kind table. This PR removes the now-invalid rows.

- **agent-reference.md**: remove `Random(T)` and `State(T)` from type forms table
- **cheat-sheet.md**: same removal; update monadic namespaces table to show structural action types (`stream → {value: a, rest: stream}` and `state → {value: a, state: state}`) instead of the removed constructor shorthands

## Test plan

- [x] Docs-only change — no code changes
- [x] No references to `Random(T)` or `State(T)` remain in quick-reference docs
- [x] Monadic namespaces table shows correct structural action types per PR #766

🤖 Generated with [Claude Code](https://claude.ai/claude-code)