### PR TITLE
docs: mark git imports as not currently implemented

### DIFF
--- a/docs/guide/imports-and-modules.md
+++ b/docs/guide/imports-and-modules.md
@@ -181,6 +181,12 @@ projects that rely on `-L` continue to work without modification.
 
 ## Git Imports
 
+> **Note — not currently implemented.** Git imports were available in the
+> original (Haskell) eucalypt but are **not yet supported** by the current
+> implementation: a `{ git: … }` import block is presently ignored rather than
+> fetched. Restoration is planned and prioritised; the form below documents the
+> intended design.
+
 Import eucalypt code directly from a git repository. This is useful
 for sharing libraries without manually managing local copies:
 

--- a/docs/reference/import-formats.md
+++ b/docs/reference/import-formats.md
@@ -86,6 +86,11 @@ it has already been specified in the command line or another unit.
 
 ### Git imports
 
+> **Note — not currently implemented.** Git imports were available in the
+> original (Haskell) eucalypt but are **not yet supported** by the current
+> implementation; a `{ git: … }` import block is presently ignored. The format
+> below documents the intended design, pending restoration.
+
 Git imports allow you to import eucalypt direct from a git repository
 at a specified commit, combining the convenience of not having to
 explicitly manage a git working copy and a library path with the


### PR DESCRIPTION
Git imports (`{ import: { git:, commit:, import: } }`) are documented in the guide and the import-format reference, but the feature was dropped in the Haskell→Rust rewrite and never re-ported. A `{ git: … }` import block is **silently ignored** today (the import scraper handles only string/list forms), so the import simply doesn't happen and the user gets a downstream "unbound name" rather than a clear error.

This adds a **"not currently implemented"** note to both sections so users aren't misled, keeping the intended design visible pending restoration:

- `docs/guide/imports-and-modules.md` — *Git Imports* section
- `docs/reference/import-formats.md` — *Git imports* section

Docs-only; no code change.

Background: git imports worked in the original Haskell eucalypt (PR #115, 2019) and were removed with the Haskell implementation in 2021.

https://claude.ai/code/session_013RyQUwQLvA9GsSBCpUcfE4

---
_Generated by [Claude Code](https://claude.ai/code/session_013RyQUwQLvA9GsSBCpUcfE4)_