### PR TITLE
test(regression): string interpolation de Bruijn index in blocks (eu-ynhu)

### DIFF
--- a/tests/harness/154_interp_block_debruijn.eu
+++ b/tests/harness/154_interp_block_debruijn.eu
@@ -1,0 +1,77 @@
+"154 string interpolation de Bruijn index — block with 3+ bindings (eu-ynhu regression)"
+
+# Regression test for eu-ynhu: string interpolation in a block body should
+# correctly resolve the interpolated variable regardless of how many bindings
+# precede it in the same block.
+#
+# The bug: compile_block adds Pair/Cons entries to the same LetBinder used by
+# the binding values. With 3+ bindings, the letrec indices for the block
+# structure entries shift past the value entries, causing interpolation
+# variable references (resolved as de Bruijn indices) to point at the wrong
+# letrec entry at runtime.
+
+` { target: :test }
+test: {
+
+  # --- 3-binding case (minimal reproduction from the bug report) ---
+  f-three(pair): {
+    i: pair first
+    x: 42
+    result: "component_{i:%02d}"
+  }.result
+
+  three-ok: f-three([1, "a"]) = "component_01"
+
+  # --- Works via map too ---
+  map-ok: [[1, "a"], [2, "b"]] map(f-three) //= ["component_01", "component_02"]
+
+  # --- 4 bindings: interpolation should still reach the right variable ---
+  f-four(n): {
+    val: n
+    a: 10
+    b: 20
+    label: "item_{val}"
+  }.label
+
+  four-ok: f-four(5) = "item_5"
+  four-map-ok: [7, 8, 9] map(f-four) //= ["item_7", "item_8", "item_9"]
+
+  # --- Interpolation of a later binding (not just the first) ---
+  f-mid(pair): {
+    prefix: "x"
+    idx: pair first
+    suffix: "z"
+    result: "{prefix}_{idx}_{suffix}"
+  }.result
+
+  mid-ok: f-mid([3, "q"]) = "x_3_z"
+
+  # --- Format spec with 3+ bindings ---
+  f-fmt(n): {
+    val: n
+    pad1: 0
+    pad2: 0
+    s: "{val:%03d}"
+  }.s
+
+  fmt-ok: f-fmt(7) = "007"
+  fmt-map-ok: [1, 2, 3] map(f-fmt) //= ["001", "002", "003"]
+
+  # --- 2-binding case still works (baseline) ---
+  f-two(pair): {
+    i: pair first
+    result: "pair_{i}"
+  }.result
+
+  two-ok: f-two([42, "x"]) = "pair_42"
+
+  RESULT: [ three-ok
+          , map-ok
+          , four-ok
+          , four-map-ok
+          , mid-ok
+          , fmt-ok
+          , fmt-map-ok
+          , two-ok
+          ] all-true? then(:PASS, :FAIL)
+}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1678,6 +1678,11 @@ pub fn test_harness_153() {
 }
 
 #[test]
+pub fn test_harness_154() {
+    run_test(&opts("154_interp_block_debruijn.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

- Adds harness test 154 as a regression guard for eu-ynhu: string interpolation variable resolution in block bodies with 3+ bindings
- The bug (de Bruijn index shifted by block structure Pair/Cons entries entering the same letrec) was already correct on `integration/0.7.0`; this PR ensures it stays fixed
- Tests all relevant variants: 3-binding and 4-binding blocks, format specifiers (`%02d`, `%03d`), interpolation of non-first bindings, map-based invocations, and the 2-binding baseline

## Investigation

On `integration/0.7.0`, the STG compiler correctly isolates block structure entries (Pair/Cons) from the value bindings in the letrec. The `var_refs` mapping (core binder index → letrec local index) correctly points each binding's value to its letrec slot regardless of subsequent structure entries. The bead description noted this was pre-existing in 0.6.2, and no changes to `src/eval/stg/compiler.rs` or `src/core/desugar/` have been made since 0.6.2 — indicating the bug may have been fixed in an earlier cycle or the current code never exhibited it on this branch.

## Test plan

- [x] `cargo test test_harness_154` passes
- [x] `cargo test` full suite: 104/104 harness + all unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `timeout 60 eu check lib/prelude.eu` produces no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)