### PR TITLE
fix(stg): add native-value fallback to FMT wrapper + audit all intrinsic wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -24,10 +24,7 @@ use super::{
         machine_return_str_list, machine_return_sym, str_arg, str_arg_ref, str_list_arg,
     },
     syntax::{
-        dsl::{
-            atom, box_str, case, data, force, lambda, let_, local, lref, str, switch, unbox_str,
-            value,
-        },
+        dsl::{atom, box_str, case, data, force, lambda, let_, local, lref, str, unbox_str, value},
         LambdaForm,
     },
     tags::DataConstructor,
@@ -325,10 +322,44 @@ impl StgIntrinsic for Fmt {
     }
 
     fn wrapper(&self, _annotation: Smid) -> LambdaForm {
+        // Helper: given unboxed x at local(0) and fmtstring at an offset,
+        // unbox the format string (handling both BoxedString and raw native)
+        // then call the FMT BIF.
+        //
+        // `fmtstring_offset` is the de Bruijn index of the original fmtstring
+        // argument relative to the current environment.
+        //
+        // For a boxed x branch: env is [x_inner] [x fmtstring], so after
+        // force(local(0)) we get [x_raw] [x_inner] [x fmtstring] and
+        // fmtstring is at local(3).
+        //
+        // For the native x fallback: env is [x_native] [x fmtstring] and
+        // fmtstring is at local(2).
+        let unbox_fmt_and_call =
+            |fmtstring_idx: usize, x_raw_idx: usize| -> std::rc::Rc<super::syntax::StgSyn> {
+                // Dispatch on fmtstring: if BoxedString, unbox; if raw native
+                // string, use directly.
+                case(
+                    local(fmtstring_idx),
+                    vec![(
+                        DataConstructor::BoxedString.tag(),
+                        // [fmt_inner] ... env grows by 1
+                        force(
+                            local(0),
+                            // [fmt_raw] [fmt_inner] ...
+                            call::bif::fmt(lref(x_raw_idx + 2), lref(0)),
+                        ),
+                    )],
+                    // Native fallback: fmtstring is already a raw native string.
+                    // case puts the native at local(0), pushing x_raw up by 1.
+                    call::bif::fmt(lref(x_raw_idx + 1), lref(0)),
+                )
+            };
+
         lambda(
             2, // [x fmtstring]
             let_(
-                vec![value(switch(
+                vec![value(case(
                     local(0),
                     vec![
                         (
@@ -337,18 +368,7 @@ impl StgIntrinsic for Fmt {
                             force(
                                 local(0),
                                 // [n'] [n] [x fmtstring]
-                                switch(
-                                    local(3),
-                                    vec![(
-                                        DataConstructor::BoxedString.tag(),
-                                        // [fmt] [n'] [n] [x fmtstring]
-                                        force(
-                                            local(0),
-                                            // [fmt'] [fmt] [n'] [n] [x fmtstring]
-                                            call::bif::fmt(lref(2), lref(0)),
-                                        ),
-                                    )],
-                                ),
+                                unbox_fmt_and_call(3, 0),
                             ),
                         ),
                         (
@@ -357,44 +377,26 @@ impl StgIntrinsic for Fmt {
                             force(
                                 local(0),
                                 // [k'] [k] [x fmtstring]
-                                switch(
-                                    local(3),
-                                    vec![(
-                                        DataConstructor::BoxedString.tag(),
-                                        // [fmt] [k'] [k] [x fmtstring]
-                                        force(
-                                            local(0),
-                                            // [fmt'] [fmt] [k'] [k] [x fmtstring]
-                                            call::bif::fmt(lref(2), lref(0)),
-                                        ),
-                                    )],
-                                ),
+                                unbox_fmt_and_call(3, 0),
                             ),
                         ),
                         (
                             DataConstructor::BoxedString.tag(),
-                            // [k] [x fmtstring]
+                            // [s] [x fmtstring]
                             force(
                                 local(0),
                                 // [s'] [s] [x fmtstring]
-                                switch(
-                                    local(3),
-                                    vec![(
-                                        DataConstructor::BoxedString.tag(),
-                                        // [fmt] [s'] [s] [x fmtstring]
-                                        force(
-                                            local(0),
-                                            // [fmt'] [fmt] [s'] [s] [x fmtstring]
-                                            call::bif::fmt(lref(2), lref(0)),
-                                        ),
-                                    )],
-                                ),
+                                unbox_fmt_and_call(3, 0),
                             ),
                         ),
                         (DataConstructor::BoolFalse.tag(), atom(str("false"))),
                         (DataConstructor::BoolTrue.tag(), atom(str("true"))),
                         (DataConstructor::Unit.tag(), atom(str("null"))),
                     ],
+                    // Native x fallback: x is already a raw native value.
+                    // case puts it at local(0); env is [x_native] [x fmtstring]
+                    // so fmtstring is at local(2).
+                    unbox_fmt_and_call(2, 0),
                 ))],
                 data(DataConstructor::BoxedString.tag(), vec![lref(0)]),
             ),
@@ -580,3 +582,203 @@ impl StgIntrinsic for Trim {
 }
 
 impl CallGlobal1 for Trim {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::{
+        intrinsics,
+        stg::tags::DataConstructor,
+        stg::{arith::Add, panic::Panic, runtime::Runtime, syntax::dsl::*, testing},
+    };
+
+    fn runtime() -> Box<dyn Runtime> {
+        testing::runtime(vec![
+            Box::new(Str),
+            Box::new(Fmt),
+            Box::new(Add),
+            Box::new(Panic),
+        ])
+    }
+
+    // ── STR wrapper tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_str_boxed_num() {
+        // STR called through the wrapper with a boxed number
+        let syntax = letrec_(
+            vec![value(box_num(42))],
+            // STR returns BoxedString; unbox to get the raw string
+            case(
+                Str.global(lref(0)),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("42".to_string()));
+    }
+
+    #[test]
+    fn test_str_native_num() {
+        // STR called through the wrapper with a raw native number
+        // (simulates the result of machine_return_num, e.g. from arithmetic)
+        let syntax = case(
+            Str.global(num(42)),
+            vec![(DataConstructor::BoxedString.tag(), local(0))],
+            unit(),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("42".to_string()));
+    }
+
+    #[test]
+    fn test_str_native_from_arithmetic() {
+        // A number produced by ADD (which uses machine_return_num, yielding
+        // a raw native) is then passed to STR through the wrapper.
+        let syntax = letrec_(
+            vec![
+                // [0]: result of ADD via BIF — raw native num
+                value(app_bif(intrinsics::index_u8("ADD"), vec![num(40), num(2)])),
+            ],
+            case(
+                Str.global(lref(0)),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("42".to_string()));
+    }
+
+    // ── FMT wrapper tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_fmt_boxed_num_boxed_fmtstr() {
+        // FMT with both arguments boxed (the traditional path)
+        let syntax = letrec_(
+            vec![value(box_num(42)), value(box_str("%04d"))],
+            case(
+                Fmt.global(lref(0), lref(1)),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("0042".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_native_num_boxed_fmtstr() {
+        // FMT with a raw native number and a boxed format string.
+        // This is the bug case: the outer switch had no native fallback.
+        let syntax = letrec_(
+            vec![value(box_str("%04d"))],
+            case(
+                Fmt.global(num(42), lref(0)),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("0042".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_boxed_num_native_fmtstr() {
+        // FMT with a boxed number and a raw native format string.
+        // Tests the inner format-string dispatch fallback.
+        let syntax = letrec_(
+            vec![value(box_num(42))],
+            case(
+                Fmt.global(lref(0), str("%04d")),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("0042".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_native_num_native_fmtstr() {
+        // FMT with both arguments as raw natives.
+        // Both the outer and inner fallbacks are exercised.
+        let syntax = case(
+            Fmt.global(num(42), str("%04d")),
+            vec![(DataConstructor::BoxedString.tag(), local(0))],
+            unit(),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("0042".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_arithmetic_result() {
+        // A number produced by ADD (raw native) formatted through FMT wrapper.
+        // This reproduces the real-world scenario from eu-ynhu.
+        let syntax = letrec_(
+            vec![
+                value(app_bif(intrinsics::index_u8("ADD"), vec![num(40), num(2)])),
+                value(box_str("%02d")),
+            ],
+            case(
+                Fmt.global(lref(0), lref(1)),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("42".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_bool_false() {
+        // FMT with a boolean false — returns "false" regardless of format string.
+        let syntax = letrec_(
+            vec![value(f())],
+            case(
+                Fmt.global(lref(0), str("%s")),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("false".to_string()));
+    }
+
+    #[test]
+    fn test_fmt_unit() {
+        // FMT with unit — returns "null".
+        let syntax = letrec_(
+            vec![value(unit())],
+            case(
+                Fmt.global(lref(0), str("%s")),
+                vec![(DataConstructor::BoxedString.tag(), local(0))],
+                unit(),
+            ),
+        );
+        let rt = runtime();
+        let mut m = testing::machine(rt.as_ref(), syntax);
+        m.run(Some(200)).unwrap();
+        assert_eq!(m.string_return(), Some("null".to_string()));
+    }
+}

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -458,7 +458,15 @@ pub mod dsl {
         LambdaForm::value(body)
     }
 
-    /// Case statement, evaluate scrutinee then branch
+    /// Case statement with a native fallback, evaluate scrutinee then branch.
+    ///
+    /// Use `case` when the scrutinee may be a raw native value (e.g. a
+    /// number from `machine_return_num`).  The fallback receives the
+    /// native at `local(0)`.
+    ///
+    /// Use `switch` (no fallback) only when the scrutinee is guaranteed
+    /// to be a data constructor (booleans, list structure, block
+    /// structure, etc.) and never a raw native atom.
     pub fn case(
         scrutinee: Rc<StgSyn>,
         branches: Vec<(Tag, Rc<StgSyn>)>,
@@ -472,7 +480,16 @@ pub mod dsl {
         })
     }
 
-    /// Case statement without default
+    /// Case statement without a native fallback.
+    ///
+    /// **Only safe when the scrutinee is always a data constructor** —
+    /// booleans (`BoolTrue`/`BoolFalse`), list cells (`ListCons`/`ListNil`),
+    /// block structures (`Block`/`BlockPair`/`BlockKvList`), etc.
+    ///
+    /// If the scrutinee could be a raw native value (any user-provided
+    /// number, string, symbol, or datetime), use `case` with a native
+    /// fallback instead.  Missing the fallback causes a
+    /// `NoBranchForDataTag` error at runtime.
     pub fn switch(scrutinee: Rc<StgSyn>, branches: Vec<(Tag, Rc<StgSyn>)>) -> Rc<StgSyn> {
         Rc::new(StgSyn::Case {
             scrutinee,

--- a/tests/harness/154_fmt_lazy_values.eu
+++ b/tests/harness/154_fmt_lazy_values.eu
@@ -1,0 +1,9 @@
+# Regression: FMT on unboxed native values (eu-ynhu)
+# iota returns lazy values via machine_return_num (unboxed natives).
+# FMT wrapper must handle these via case fallback, not switch.
+
+fmt(n): "{n:%02d}"
+
+check: iota(1) take(3) map(fmt)
+
+RESULT: (check = ["01", "02", "03"]) then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1678,6 +1678,11 @@ pub fn test_harness_153() {
 }
 
 #[test]
+pub fn test_harness_154() {
+    run_test(&opts("154_fmt_lazy_values.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

Fixes eu-ynhu: string interpolation with format specifiers (`"{i:%02d}"`) failed on unboxed native values from arithmetic intrinsics.

### Root cause

The FMT wrapper used `switch` (no native fallback) where STR already used `case` (with fallback). PR #720 (`machine_return_num`) changed arithmetic to return unboxed natives and updated STR but missed FMT. Latent since 0.3.0, observable since 0.6.2.

### Changes

- **FMT wrapper fix** — `switch` → `case` with native fallback for both value and format string dispatch
- **Audit** — all other intrinsic wrappers checked; FMT was the only instance
- **Doc comments** — `switch()` and `case()` in `syntax.rs` now document when each is safe
- **10 unit tests** — cover boxed/native combinations for STR and FMT
- **Harness regression test** — `154_fmt_lazy_values.eu`

## Test plan
- [x] Minimal reproduction passes
- [x] `~/dev/test/test.eu` passes
- [x] All existing harness tests pass
- [x] 10 new unit tests for native-value handling
- [ ] CI green