### PR TITLE
perf(bench): isolate alloc benchmarks to separate heaps

### DIFF
--- a/benches/alloc.rs
+++ b/benches/alloc.rs
@@ -1,4 +1,10 @@
 //! STG allocation benchmarks
+//!
+//! Each benchmark group gets its own fresh `Heap` so that GC pressure from one
+//! group cannot contaminate the measurements of another.  Previously all
+//! benchmarks shared a single heap: as `alloc_let` filled it, `alloc_letrec`
+//! ran against a heap with higher occupancy, causing phantom regressions of
+//! ±30–80% in criterion comparisons.
 
 use std::iter;
 
@@ -59,7 +65,7 @@ fn fake_env_stack(
     base
 }
 
-/// Allocate a letrec of identify function bindings
+/// Allocate a let frame of identity function bindings
 fn alloc_let(
     view: MutatorHeapView,
     empty: RefPtr<EnvFrame>,
@@ -68,7 +74,7 @@ fn alloc_let(
     view.from_let(bindings, empty, Smid::default()).unwrap()
 }
 
-/// Allocate a letrec of identify function bindings
+/// Allocate a letrec frame of identity function bindings
 fn alloc_letrec(
     view: MutatorHeapView,
     empty: RefPtr<EnvFrame>,
@@ -100,7 +106,7 @@ fn create_and_saturate_lambda(view: MutatorHeapView, empty: RefPtr<EnvFrame>) {
     view.saturate(&lambda, args.as_slice()).unwrap();
 }
 
-/// Create an identity lambda and saturate it
+/// Create a two-argument lambda, partially apply it, then saturate
 fn create_partially_apply_and_saturate_lambda(view: MutatorHeapView, empty: RefPtr<EnvFrame>) {
     let lambda = SynClosure::close(
         &LambdaForm::new(2, view.atom(Ref::L(0)).unwrap().as_ptr(), Smid::default()),
@@ -114,30 +120,55 @@ fn create_partially_apply_and_saturate_lambda(view: MutatorHeapView, empty: RefP
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let heap = Heap::new();
-    let view = MutatorHeapView::new(&heap);
-    let empty = view.alloc(EnvFrame::default()).unwrap().as_ptr();
-    let bindings = fake_bindings(view, 10);
-    let env_stack = fake_env_stack(view, empty, 20, 4);
-    c.bench_function("alloc_let", |b| {
-        b.iter(|| alloc_let(view, empty, &bindings))
-    });
-    c.bench_function("alloc_letrec", |b| {
-        b.iter(|| alloc_letrec(view, empty, &bindings))
-    });
-    c.bench_function("deep_env_access", |b| {
-        b.iter(|| access(view, env_stack, black_box(73)))
-    });
-    c.bench_function("deep_env_update", |b| {
-        b.iter(|| update(view, empty, env_stack, black_box(73)))
-    });
+    // alloc_let — isolated heap so its GC pressure does not affect alloc_letrec.
+    {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let empty = view.alloc(EnvFrame::default()).unwrap().as_ptr();
+        let bindings = fake_bindings(view, 10);
+        c.bench_function("alloc_let", |b| {
+            b.iter(|| black_box(alloc_let(view, empty, &bindings)))
+        });
+    }
 
-    c.bench_function("create_and_saturate_lambda", |b| {
-        b.iter(|| create_and_saturate_lambda(view, empty))
-    });
-    c.bench_function("create_partially_apply_and_saturate_lambda", |b| {
-        b.iter(|| create_partially_apply_and_saturate_lambda(view, empty))
-    });
+    // alloc_letrec — fresh heap, GC state independent of alloc_let run above.
+    {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let empty = view.alloc(EnvFrame::default()).unwrap().as_ptr();
+        let bindings = fake_bindings(view, 10);
+        c.bench_function("alloc_letrec", |b| {
+            b.iter(|| black_box(alloc_letrec(view, empty, &bindings)))
+        });
+    }
+
+    // deep env access / update — share one heap; env_stack is read-only for
+    // access, and update only writes within the existing allocation.
+    {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let empty = view.alloc(EnvFrame::default()).unwrap().as_ptr();
+        let env_stack = fake_env_stack(view, empty, 20, 4);
+        c.bench_function("deep_env_access", |b| {
+            b.iter(|| access(view, env_stack, black_box(73)))
+        });
+        c.bench_function("deep_env_update", |b| {
+            b.iter(|| update(view, empty, env_stack, black_box(73)))
+        });
+    }
+
+    // lambda construction — isolated heap.
+    {
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let empty = view.alloc(EnvFrame::default()).unwrap().as_ptr();
+        c.bench_function("create_and_saturate_lambda", |b| {
+            b.iter(|| create_and_saturate_lambda(view, empty))
+        });
+        c.bench_function("create_partially_apply_and_saturate_lambda", |b| {
+            b.iter(|| create_partially_apply_and_saturate_lambda(view, empty))
+        });
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
## Summary

- Each `alloc_let`, `alloc_letrec`, deep-env, and lambda benchmark group now gets its own fresh `Heap` instance
- Adds `black_box()` around `alloc_let`/`alloc_letrec` return values to prevent dead-computation elision

## Problem

Previously all alloc benchmarks shared a single heap. As `alloc_let` filled it during its measurement window, `alloc_letrec` ran against a heap with higher occupancy and higher GC trigger frequency. This cross-contamination produced phantom ±30–80% regressions in criterion comparisons — the +78% `alloc_letrec` regression flagged in the 0.7.0 regression check was this effect, not a real performance change.

## Before/after benchmark stability (same machine, 3 consecutive runs)

**Before (shared heap):**
```
alloc_letrec  change: +22%  (run 1)
alloc_letrec  change: −30%  (run 2)
alloc_letrec  change: −10%  (run 3)
```

**After (isolated heaps):**
```
alloc_letrec  change: No change in performance detected  (run 1)
alloc_letrec  change: No change in performance detected  (run 2)
alloc_letrec  change: No change in performance detected  (run 3)
```

Absolute times: `alloc_let` ~133–200 ns, `alloc_letrec` ~154–248 ns (1.15–1.35× overhead expected from the two-pass back-patch construction).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` 973 tests pass
- [x] Benchmarks compile and run (`cargo bench --bench benches -- alloc`)
- [x] Three consecutive benchmark runs show "No change detected" (vs ±80% before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)