### PR TITLE
fix(errors): clear diagnostics for bracket content mode mismatches

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -1449,6 +1449,13 @@ impl Desugarable for Element {
                     )
                 })?;
 
+                // If this bracket pair is registered as a monad, soup content is an error.
+                // The colon heuristic found no ':' and parsed as BRACKET_EXPR, but monad
+                // brackets require 'name: value' declarations.
+                if desugarer.monad_spec(&pair_name).is_some() {
+                    return Err(CoreError::SoupContentInMonadBracket(pair_name, smid));
+                }
+
                 // Idiot brackets: desugar inner soup with bracket flag.
                 //
                 // Uses desugar_rowan_soup_bracket which processes elements

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -45,8 +45,13 @@ pub enum CoreError {
     TargetNotFound(String),
     #[error("target {0} could not be referenced")]
     BadTarget(String),
-    #[error("monadic block used without a monad spec — bracket pair '{0}' has no 'bind'/'return' metadata")]
+    #[error("block-style content inside bracket pair '{0}' — this bracket accepts expressions, not declarations")]
     NoMonadSpec(String, Smid),
+    /// Expression content (no colons) was used inside a monad bracket pair that
+    /// requires declarations.  The colon heuristic parsed it as a soup bracket,
+    /// but the bracket is registered as a monad.
+    #[error("expression content inside monad bracket '{0}' — this bracket requires declarations ('name: value' bindings)")]
+    SoupContentInMonadBracket(String, Smid),
     #[error("monadic block must contain at least one declaration")]
     EmptyMonadicBlock(Smid),
     #[error("bracket block definition body must be marked with ':monad' — use '{{ :monad bind: {0} return: {1} }}'")]
@@ -80,6 +85,7 @@ impl HasSmid for CoreError {
             UnresolvedVariable(s, _) => s,
             RedeclaredVariable(s, _) => s,
             NoMonadSpec(_, s) => s,
+            SoupContentInMonadBracket(_, s) => s,
             EmptyMonadicBlock(s) => s,
             MonadSpecMissingMarker(_, _, s) => s,
             InvalidStringInterpolation(s) => s,
@@ -115,6 +121,44 @@ impl CoreError {
                         .to_string(),
                     "if you want a literal brace in a string, escape it by doubling: {{ and }}"
                         .to_string(),
+                ])
+            }
+            CoreError::NoMonadSpec(pair_name, _) => source_map.diagnostic(self).with_notes(vec![
+                format!(
+                    "'{}' is an expression bracket — it accepts soup expressions, not 'name: value' declarations",
+                    pair_name
+                ),
+                "the ':' inside the brackets triggered block-mode parsing".to_string(),
+                format!(
+                    "to pass a block literal as content, wrap it: '{} {{key: value}} {}'",
+                    pair_name.chars().next().unwrap_or('?'),
+                    pair_name.chars().last().unwrap_or('?')
+                ),
+                format!(
+                    "to declare a monad bracket: '{}{{}}{}': {{ :monad bind(m, f): f(m)  return(a): a }}",
+                    pair_name.chars().next().unwrap_or('?'),
+                    pair_name.chars().last().unwrap_or('?')
+                ),
+            ]),
+            CoreError::SoupContentInMonadBracket(pair_name, _) => {
+                source_map.diagnostic(self).with_notes(vec![
+                    format!(
+                        "'{}' is a monad bracket — its content must contain at least one 'name: value' binding",
+                        pair_name
+                    ),
+                    "no ':' colon was found inside the brackets, so the content was parsed as expressions".to_string(),
+                    format!(
+                        "example: '{} x: expr {}'.x, or '{} x: e1  y: x + 1 {}'.y",
+                        pair_name.chars().next().unwrap_or('?'),
+                        pair_name.chars().last().unwrap_or('?'),
+                        pair_name.chars().next().unwrap_or('?'),
+                        pair_name.chars().last().unwrap_or('?')
+                    ),
+                    format!(
+                        "to use expression content, declare without '{{}}': '{} x {}': x",
+                        pair_name.chars().next().unwrap_or('?'),
+                        pair_name.chars().last().unwrap_or('?')
+                    ),
                 ])
             }
             _ => source_map.diagnostic(self),

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -45,7 +45,7 @@ pub enum CoreError {
     TargetNotFound(String),
     #[error("target {0} could not be referenced")]
     BadTarget(String),
-    #[error("block-style content inside bracket pair '{0}' — this bracket accepts expressions, not declarations")]
+    #[error("block-style content inside non-monad bracket pair '{0}' — this bracket accepts expressions, not declarations")]
     NoMonadSpec(String, Smid),
     /// Expression content (no colons) was used inside a monad bracket pair that
     /// requires declarations.  The colon heuristic parsed it as a soup bracket,

--- a/tests/harness/errors/155_block_content_in_soup_bracket.eu
+++ b/tests/harness/errors/155_block_content_in_soup_bracket.eu
@@ -1,0 +1,6 @@
+# Block-style content (declarations with ':') used inside a soup bracket.
+# The colon heuristic parses '⟦ a: 1 ⟧' as a bracket-block (monadic mode),
+# but '⟦ x ⟧: x' declares a soup bracket with no monad spec.
+⟦ x ⟧: x
+
+result: ⟦ a: 1 ⟧

--- a/tests/harness/errors/155_block_content_in_soup_bracket.eu.expect
+++ b/tests/harness/errors/155_block_content_in_soup_bracket.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "block-style content inside bracket pair"

--- a/tests/harness/errors/155_block_content_in_soup_bracket.eu.expect
+++ b/tests/harness/errors/155_block_content_in_soup_bracket.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "block-style content inside bracket pair"
+stderr: "block-style content inside non-monad bracket pair"

--- a/tests/harness/errors/156_soup_content_in_monad_bracket.eu
+++ b/tests/harness/errors/156_soup_content_in_monad_bracket.eu
@@ -1,0 +1,6 @@
+# Expression content (no colons) used inside a monad bracket.
+# The colon heuristic finds no ':' in '⟦ 1 2 3 ⟧' and parses it as soup mode,
+# but '⟦{}⟧' declares a monad bracket that requires 'name: value' declarations.
+⟦{}⟧: { :monad bind(m, f): f(m)  return(a): a }
+
+result: ⟦ 1 2 3 ⟧

--- a/tests/harness/errors/156_soup_content_in_monad_bracket.eu.expect
+++ b/tests/harness/errors/156_soup_content_in_monad_bracket.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "expression content inside monad bracket"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1713,6 +1713,16 @@ pub fn test_error_154() {
 }
 
 #[test]
+pub fn test_error_155() {
+    run_error_test(&error_opts("155_block_content_in_soup_bracket.eu"));
+}
+
+#[test]
+pub fn test_error_156() {
+    run_error_test(&error_opts("156_soup_content_in_monad_bracket.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

- **Case a** (block content in soup bracket): `⟦ a: 1 ⟧` where `⟦ x ⟧: x` is declared. The old error was the opaque "monadic block used without a monad spec". The new error is "block-style content inside bracket pair '⟦⟧'" with notes explaining how to pass a block literal or convert to a monad bracket.

- **Case b** (soup content in monad bracket): `⟦ 1 2 3 ⟧` where `⟦{}⟧` is declared. The old error was a confusing runtime "type mismatch: expected block, found list". The new error is caught at desugar time with "expression content inside monad bracket '⟦⟧'" and notes explaining that the bracket needs `name: value` declarations.

Both errors have source locations pointing to the bracket usage site.

## Changes

- `src/core/error.rs`: Updated `NoMonadSpec` error message and added `SoupContentInMonadBracket` variant with diagnostic notes for both cases
- `src/core/desugar/rowan_ast.rs`: Added monad-spec check in `BracketExpr` desugaring to detect case b at compile time
- `tests/harness/errors/155_block_content_in_soup_bracket.eu` + `.expect`: Error test for case a
- `tests/harness/errors/156_soup_content_in_monad_bracket.eu` + `.expect`: Error test for case b

## Test plan

- [ ] `cargo test test_error_155` — case a produces clear error
- [ ] `cargo test test_error_156` — case b produces clear error
- [ ] `cargo test test_harness_09` — existing soup bracket tests still pass
- [ ] `cargo test test_harness_14` — existing monad bracket tests still pass
- [ ] `cargo clippy --all-targets -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)