### PR TITLE
Open 0.8.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to eucalypt are documented here.
 
+## [0.8.0] - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.7.1] - 2026-06-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eucalypt"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 

--- a/docs/superpowers/specs/2026-06-09-conformance-corpus-design.md
+++ b/docs/superpowers/specs/2026-06-09-conformance-corpus-design.md
@@ -1,0 +1,99 @@
+# W5: Conformance Corpus, Property Tests & Fuzzing
+
+**Bead:** eu-yhk0.3
+**Target:** 0.8.0 (begin), 1.0 (bar)
+**Roadmap ref:** W5 (Section 7, ROADMAP.md)
+
+## Problem
+
+The 315+ harness tests are good — dogfooded, written in eucalypt's own
+assertion operators, with `.expect` sidecars for error tests. But the
+harness is an internal regression suite, not yet:
+
+1. A **portable contract** an independent backend could run.
+2. A pin on **rendered output bytes** or the **prelude-v1 freeze**.
+3. Backed by **property-based testing** or **fuzzing** of parsers and
+   the type-DSL.
+
+GC verification runs in only one CI job.
+
+## Design (Three Phases)
+
+### Phase 1 (0.8): Contract doc, golden sidecars, GC CI job
+
+**Document the corpus contract.** Write
+`tests/harness/CONFORMANCE.md` specifying the pass/fail convention:
+the `.eu` files plus their sidecars (`.expect` for error tests,
+`.golden` for output tests) are the contract. Each implementation
+brings its own runner, never privileging one. (Dhall and WebAssembly
+spec tests model.)
+
+**Golden-output `.golden` sidecars.** Add a `.golden` file to a
+curated subset of harness tests — every export format and the
+prelude-v1 frozen set. The harness runner compares rendered output
+byte-for-byte against the `.golden` file. This is the executable form
+of the stability freeze and "what would have caught the `cond` break".
+
+**Sidecar plumbing.** Extend `tests/harness_test.rs` to:
+- Look for `<test>.golden` alongside each test file.
+- If present, run `eu <test> -x <format>` and compare output.
+- Fail on mismatch with a diff.
+- A `--bless` mode regenerates `.golden` files (for intentional
+  changes).
+
+**GC-verified CI job.** Promote `EU_GC_VERIFY=2` + `EU_GC_STRESS=1` +
+`EU_GC_POISON=1` to a **full-harness CI job** on x86-64. Currently
+these flags are available but not run in CI on the full suite.
+
+### Phase 2 (0.9): Property tests
+
+Add `proptest` property tests for:
+
+1. **Round-trip idempotence**: render → parse produces equivalent
+   structure.
+2. **Render determinism**: same input renders identically across runs.
+3. **`eu fmt` idempotence**: formatting a formatted file is a no-op.
+4. **Subtyping reflexivity/transitivity** and the consistency-symmetry
+   property from Section 4.2 of ROADMAP.md (needs `Arbitrary` for
+   `Type` covering `Con`/`App`/`Forall`/`Mu`).
+5. **GC invariants** over generated structures.
+
+### Phase 3 (0.9–1.0): Fuzz targets
+
+Three `cargo-fuzz` targets:
+
+1. **`fuzz_type_dsl`** (highest priority) — the hand-written type
+   parser over untrusted annotation strings
+   (`src/core/typecheck/parse.rs`).
+2. **`fuzz_parser`** — the Rowan parser over arbitrary byte input.
+3. **`fuzz_loader`** — YAML/JSON/TOML/CSV/XML import paths.
+
+Seed corpora from the existing harness tests. Run to exhaustion before
+the 1.0 freeze. Every panic becomes a diagnostic with a regression
+test.
+
+## Testing
+
+Phase 1 is itself a testing deliverable — success is:
+
+- Golden sidecars cover every export format and the frozen prelude set
+- The GC-verified CI job runs the full harness green under
+  `EU_GC_VERIFY=2` + `EU_GC_POISON=1`
+- A future breaking change to prelude-v1 output is caught by a
+  `.golden` mismatch
+
+Phase 2: property suite passes in CI.
+
+Phase 3: **zero panics after a 24-hour fuzz run** on each target.
+
+Ultimate bar (1.0): when the first alternative backend lands it can be
+held to the same corpus with its own runner.
+
+## Scope Exclusions
+
+- No new test *language* features (the `//=`/`//!` operators are
+  sufficient)
+- No cross-backend runner in this deliverable (that arrives with the
+  alternative backend candidate)
+- ASAN as a hard gate is a CI infrastructure decision, not a code
+  change — include if feasible but not gating

--- a/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
@@ -24,11 +24,15 @@ a declaration, re-runs, and sees what arrives.
 | Annotation                    | Entry | Exit | Args forced? |
 |-------------------------------|-------|------|--------------|
 | `` ` :trace ``                | yes   | no   | no           |
+| `` ` { trace: :lazy } ``     | yes   | no   | no           |
 | `` ` { trace: :strict } ``   | yes   | no   | yes          |
 | `` ` { trace: :exit } ``     | yes   | yes  | no           |
 | `` ` { trace: :strict-exit } `` | yes | yes  | yes          |
 
-**Lazy mode** (`:trace`, `:exit`): arguments that have already been
+`` ` :trace `` and `` ` { trace: :lazy } `` are equivalent — the bare
+symbol form is shorthand for the block form.
+
+**Lazy mode** (`:trace`/`:lazy`, `:exit`): arguments that have already been
 evaluated are rendered; unevaluated thunks display as `<thunk>`.
 No forcing occurs — evaluation semantics are unchanged.
 
@@ -77,8 +81,8 @@ Normalisation rules in `normalise_metadata()`:
   the existing symbol-to-target path — this needs special-casing.
   Instead, detect `:trace` before the target fallback and normalise to
   `{ trace: :lazy }`.
-- `{ trace: :strict }`, `{ trace: :exit }`, `{ trace: :strict-exit }`
-  pass through as-is.
+- `{ trace: :lazy }`, `{ trace: :strict }`, `{ trace: :exit }`,
+  `{ trace: :strict-exit }` pass through as-is.
 
 Read the `trace` key via `ReadMetadata` / `Extract` traits, producing
 `Option<TraceSpec>`. Strip the key after extraction (same pattern as

--- a/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
@@ -1,0 +1,225 @@
+# Declaration Trace Metadata
+
+**Bead:** eu-xu3e
+**Target:** 0.8.0
+**Status:** Design
+
+## Problem
+
+Debugging eucalypt programs is difficult. The existing `dbg{}` and `▶`
+operator require manual insertion around expressions and don't
+naturally show what arguments a declaration receives. When a function
+produces unexpected results, there is no quick way to confirm what
+flowed in — you must manually wrap each argument in debug calls, which
+is tedious and error-prone.
+
+## Solution
+
+A `trace` metadata key on declarations that instruments them to print
+entry (and optionally exit) information to stderr. The user annotates
+a declaration, re-runs, and sees what arrives.
+
+## Metadata Forms
+
+| Annotation                    | Entry | Exit | Args forced? |
+|-------------------------------|-------|------|--------------|
+| `` ` :trace ``                | yes   | no   | no           |
+| `` ` { trace: :strict } ``   | yes   | no   | yes          |
+| `` ` { trace: :exit } ``     | yes   | yes  | no           |
+| `` ` { trace: :strict-exit } `` | yes | yes  | yes          |
+
+**Lazy mode** (`:trace`, `:exit`): arguments that have already been
+evaluated are rendered; unevaluated thunks display as `<thunk>`.
+No forcing occurs — evaluation semantics are unchanged.
+
+**Strict mode** (`:strict`, `:strict-exit`): arguments are forced to
+WHNF before rendering. This changes evaluation order; the user opts in
+deliberately.
+
+**Exit tracing** (`:exit`, `:strict-exit`): the result is rendered
+after the body evaluates. In lazy exit mode the result is rendered at
+whatever depth it has reached; in strict exit mode it is forced to
+WHNF first. Exit tracing changes evaluation semantics — it is opt-in.
+
+## Output Format
+
+```
+→ f(x: <thunk>, y: <thunk>)
+→ f(x: 42, y: [1, 2, 3])
+← f: <thunk>
+← f: {result: "hello"}
+```
+
+- `→` for entry, `←` for exit.
+- Flat output, no nesting or indentation.
+- Output goes to stderr.
+- Rendering reuses the existing `__DBG_REPR` infrastructure.
+
+## Implementation
+
+### 1. Metadata extraction (desugar phase)
+
+**File:** `src/core/metadata.rs`
+
+Add `trace` as a recognised declaration metadata key. Define:
+
+```rust
+pub enum TraceSpec {
+    Lazy,       // ` :trace
+    Strict,     // ` { trace: :strict }
+    Exit,       // ` { trace: :exit }
+    StrictExit, // ` { trace: :strict-exit }
+}
+```
+
+Normalisation rules in `normalise_metadata()`:
+- Bare `:trace` symbol already normalises to `{ target: :trace }` via
+  the existing symbol-to-target path — this needs special-casing.
+  Instead, detect `:trace` before the target fallback and normalise to
+  `{ trace: :lazy }`.
+- `{ trace: :strict }`, `{ trace: :exit }`, `{ trace: :strict-exit }`
+  pass through as-is.
+
+Read the `trace` key via `ReadMetadata` / `Extract` traits, producing
+`Option<TraceSpec>`. Strip the key after extraction (same pattern as
+fixity, target, import).
+
+### 2. Body wrapping (desugar phase)
+
+**File:** `src/core/desugar/rowan_ast.rs`
+
+When a declaration has `TraceSpec`, the desugarer wraps the body
+during declaration processing.
+
+For entry-only (`:trace` / `:strict`), conceptually:
+
+```
+f(x, y): body
+  becomes
+f(x, y): __TRACE_ENTRY("f", ["x", x, "y", y], false) seq body
+```
+
+For entry+exit (`:exit` / `:strict-exit`):
+
+```
+f(x, y): body
+  becomes
+f(x, y): __TRACE_EXIT("f", (__TRACE_ENTRY("f", ["x", x, "y", y], false) seq body), false)
+```
+
+The boolean flag controls strict vs lazy mode.
+
+The wrapping is done at the core expression level — it emits
+`Expr::App` calls to the new intrinsics. `seq` is the existing
+sequencing primitive that forces its first argument then returns the
+second.
+
+**Argument names** are available as string literals from the
+declaration's parameter list at desugar time.
+
+### 3. New intrinsics (STG runtime)
+
+**File:** `src/eval/stg/debug.rs`
+
+Two new intrinsics registered in `src/eval/stg/intrinsics.rs`:
+
+#### `__TRACE_ENTRY(name, args_array, strict)`
+
+- `name`: string — the declaration name.
+- `args_array`: a list alternating `[name_str, value, name_str, value, ...]`.
+- `strict`: bool — if true, force each value to WHNF before rendering;
+  if false, peek (render if already evaluated, else `<thunk>`).
+
+Behaviour:
+1. For each (name, value) pair, render the value using
+   `render_debug_repr()` (strict) or a new `peek_debug_repr()` (lazy).
+2. Format: `→ name(arg1: rendered1, arg2: rendered2)`.
+3. Print to stderr.
+4. Return unit (null / empty value for `seq` to discard).
+
+#### `__TRACE_EXIT(name, value, strict)`
+
+- `name`: string — the declaration name.
+- `value`: the body result.
+- `strict`: bool — if true, force to WHNF before rendering.
+
+Behaviour:
+1. If strict, force `value` to WHNF.
+2. Render using `render_debug_repr()` or `peek_debug_repr()`.
+3. Format: `← name: rendered`.
+4. Print to stderr.
+5. Return `value` (pass through transparently).
+
+#### `peek_debug_repr()` (new helper)
+
+A variant of `render_debug_repr()` that does not force evaluation.
+It inspects the heap cell:
+- If it is a Native value, render it.
+- If it is a data constructor (list, block), render the outer structure
+  tag without forcing contents (e.g. `[...]`, `{...}`).
+- If it is a closure/thunk (unevaluated), render `<thunk>`.
+
+This requires reading the heap cell's tag without entering evaluation,
+which is possible via the existing `HeapSyn` discriminant inspection.
+
+### 4. Metadata normalisation edge case
+
+The existing `normalise_metadata()` converts bare symbols on
+declarations into `{ target: <symbol> }`. The `:trace` symbol must be
+intercepted before this fallback. Add a check:
+
+```rust
+// In normalise_metadata():
+if sym == "trace" {
+    return block_with_entry("trace", sym_expr("lazy"));
+}
+```
+
+This ensures `` ` :trace `` becomes `{ trace: :lazy }` rather than
+`{ target: :trace }`.
+
+## Scope Exclusions
+
+These are explicitly out of scope for this iteration:
+
+- No call-depth tracking or nested indentation.
+- No CLI flag to activate tracing without source edits.
+- No per-argument strict/lazy control.
+- No STG structure dumping.
+- No integration with `eu dump` commands.
+- No tooling/editor integration.
+
+All could be added later without breaking this design.
+
+## Testing
+
+**New harness test:** `tests/harness/NNN_trace.eu`
+
+Test cases:
+1. `` ` :trace `` on a function — verify `→` line appears on stderr
+   with `<thunk>` placeholders.
+2. `` ` { trace: :strict } `` — verify args are rendered with values.
+3. `` ` { trace: :exit } `` — verify both `→` and `←` lines appear.
+4. `` ` { trace: :strict-exit } `` — verify both lines with forced values.
+5. Lazy mode does not force thunks — a side-effecting thunk must not
+   fire when traced lazily.
+6. Property declarations (no args) — verify entry trace shows just the
+   name with no arguments.
+7. Multiple traced declarations — verify ordering matches evaluation
+   order.
+
+**Stderr matching:** The harness already supports `.expect` files with
+`stderr:` regex patterns for error tests. Trace tests will use the
+same mechanism, or a new `trace-stderr:` pattern if the existing one
+is too restrictive.
+
+## Future Directions
+
+- **Conditional tracing**: `{ trace: { when: _(x) > 10 } }` — only
+  trace when a predicate holds.
+- **CLI activation**: `--trace f,g` to enable tracing without source
+  edits.
+- **Depth tracking**: thread-local counter for nested `→`/`←` with
+  indentation.
+- **Editor integration**: Emacs/VS Code gutter annotations showing
+  trace status.

--- a/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
@@ -77,10 +77,10 @@ pub enum TraceSpec {
 ```
 
 Normalisation rules in `normalise_metadata()`:
-- Bare `:trace` symbol already normalises to `{ target: :trace }` via
-  the existing symbol-to-target path — this needs special-casing.
-  Instead, detect `:trace` before the target fallback and normalise to
-  `{ trace: :lazy }`.
+- Add `:trace` as a named case alongside `:suppress`, `:internal`,
+  and `:target` — before the wildcard `_ if decl_name.is_some()`
+  fallback that converts unrecognised symbols to targets. Normalise
+  to `{ trace: :lazy }`.
 - `{ trace: :lazy }`, `{ trace: :strict }`, `{ trace: :exit }`,
   `{ trace: :strict-exit }` pass through as-is.
 
@@ -173,14 +173,15 @@ declarations into `{ target: <symbol> }`. The `:trace` symbol must be
 intercepted before this fallback. Add a check:
 
 ```rust
-// In normalise_metadata():
-if sym == "trace" {
-    return block_with_entry("trace", sym_expr("lazy"));
-}
+// In normalise_metadata(), add alongside "suppress" | "internal" | "target":
+"trace" => core::block(
+    *smid,
+    [("trace".to_string(), core::sym(*smid, "lazy"))].iter().cloned(),
+),
 ```
 
-This ensures `` ` :trace `` becomes `{ trace: :lazy }` rather than
-`{ target: :trace }`.
+This follows the same pattern as `:suppress` → `{ export: :suppress }`
+and `:target` → `{ target: <name> }`.
 
 ## Scope Exclusions
 

--- a/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
+++ b/docs/superpowers/specs/2026-06-09-declaration-trace-metadata-design.md
@@ -1,6 +1,6 @@
 # Declaration Trace Metadata
 
-**Bead:** eu-xu3e
+**Bead:** eu-yhk0.4
 **Target:** 0.8.0
 **Status:** Design
 

--- a/docs/superpowers/specs/2026-06-09-dump-ast-fix-design.md
+++ b/docs/superpowers/specs/2026-06-09-dump-ast-fix-design.md
@@ -1,0 +1,46 @@
+# Fix: `eu dump ast` Shows LALRPOP AST Not Rowan AST
+
+**Bead:** eu-yhk0.5
+**Target:** 0.8.0
+
+## Problem
+
+`eu dump ast` shows empty output for files that parse correctly via
+the Rowan parser. It appears to use the retired LALRPOP parser path,
+which produces nothing for input the Rowan parser accepts. The Rowan
+parser is the sole parser (ROADMAP.md Section 2 confirms "the LALRPOP
+grammar is retired").
+
+## Design
+
+Route `eu dump ast` through the Rowan parser and display the lossless
+syntax tree. Two display modes:
+
+1. **Default:** Pretty-print the Rowan `SyntaxNode` tree showing node
+   kinds, token text, and nesting — similar to rust-analyzer's
+   `syntax_tree` debug output.
+
+2. **`--debug-format`:** The Rust `Debug` representation of the
+   `GreenNode` (full structure including all interned tokens).
+
+## Implementation
+
+**File:** `src/driver/eval.rs` (or wherever `dump ast` is dispatched).
+
+Find the `dump ast` code path and replace the LALRPOP parse call with
+the Rowan parser. Use the `SyntaxNode` debug display for output.
+
+If any LALRPOP parser code is only reachable via `dump ast`, it can be
+deleted (or noted for deletion).
+
+Small change — likely under 50 lines.
+
+## Testing
+
+- `eu dump ast tests/harness/001_basic.eu` produces non-empty,
+  meaningful output showing the syntax tree structure
+- Output includes node kinds (`UNIT`, `BLOCK`, `DECLARATION`, etc.)
+  and token text
+- `--debug-format` produces the Rust Debug representation
+- A harness test or manual verification that the output is useful for
+  debugging parse issues

--- a/docs/superpowers/specs/2026-06-09-resilient-parser-design.md
+++ b/docs/superpowers/specs/2026-06-09-resilient-parser-design.md
@@ -1,0 +1,117 @@
+# W4: Resilient Parser Front-End & Error Recovery
+
+**Bead:** eu-yhk0.2
+**Target:** 0.8.0 (Phase 1), 0.9 (Phase 2)
+**Roadmap ref:** W4 (Section 7, ROADMAP.md)
+
+## Problem
+
+The Rowan parser already builds lossless syntax trees with error nodes
+(`ERROR_STOWAWAYS`) and collects multiple errors — it is already
+recovery-capable internally. But an **all-or-nothing shim** discards
+the tree on any error (`ParseResult::ok()` in `mod.rs:46` returns
+`Err(errors)` if any errors exist), so a single typo turns the whole
+file opaque to diagnostics and to every downstream pass. The LSP
+syntactic features work by calling the parser directly
+(`src/driver/lsp/mod.rs:805ff`); what is blocked is the pipeline.
+
+## Current State (already good)
+
+The parser implementation is already sophisticated:
+
+- **18 error types** with helpful messages and hints (`error.rs`)
+- **`ERROR_STOWAWAYS`** wraps erroneous tokens in the tree
+- **Recovery patterns**: token consumption up to block/list boundaries
+- **Two-phase**: parse builds tree + error list; validate walks tree
+  for structural issues
+- **LSP-friendly**: incomplete parses produce usable syntax trees
+
+The gap is not the parser itself — it is the **pipeline's refusal to
+use a tree that has errors**.
+
+## Design
+
+### Phase 1 (0.8): Surface the partial tree
+
+**Delete the all-or-nothing shim.** Change `ParseResult` so
+downstream consumers receive the tree *plus* accumulated errors,
+rather than tree-or-errors:
+
+```rust
+// Current (mod.rs:46):
+pub fn ok(self) -> Result<T, Vec<ParseError>> {
+    if self.errors.is_empty() {
+        Ok(self.tree())
+    } else {
+        Err(self.errors)
+    }
+}
+
+// New: always provide the tree
+pub fn into_parts(self) -> (T, Vec<ParseError>) {
+    (self.tree(), self.errors)
+}
+```
+
+**Pipeline changes:** Each downstream phase receives a tree that may
+contain `ERROR_STOWAWAYS` nodes. The phases must:
+
+1. **Desugarer**: skip `ERROR_STOWAWAYS` subtrees, emitting a
+   diagnostic for each. Continue desugaring the valid portions.
+2. **Cook/verify/typecheck**: operate on the partial core expression.
+   Missing bindings from errored regions produce normal unbound-name
+   diagnostics — this is acceptable and expected.
+3. **LSP**: already handles partial trees for syntactic features;
+   gains semantic features (hovers, completions) over the valid
+   portions.
+
+**~150 lines of change.** The main risk is that downstream phases
+panic on unexpected tree shapes — the panic policy applies (every
+panic becomes a diagnostic with a regression test).
+
+### Phase 2 (0.9): Improved error recovery in the parser
+
+Enhance the parser's own recovery to isolate malformed regions more
+tightly:
+
+1. **Block/list boundary synchronisation**: when an error occurs
+   inside a block or list, consume tokens until the matching closing
+   delimiter, wrapping the bad region in `ERROR_STOWAWAYS`. Resume
+   normal parsing after the boundary. (Partially implemented already
+   for apply-tuples at `parse.rs:552-575`; generalise.)
+
+2. **Declaration-level recovery**: a malformed declaration head or
+   missing colon should consume until the next declaration boundary
+   (next unindented name, or closing brace), not abort the whole
+   block.
+
+3. **Typed error nodes**: replace the generic `ERROR_STOWAWAYS` with
+   more specific error node kinds where possible (e.g.
+   `ERROR_DECLARATION`, `ERROR_EXPRESSION`) so downstream phases can
+   produce better diagnostics.
+
+4. **Bracket recovery**: couples with W2's deferred block/soup
+   decision — a mismatched bracket pair should be recoverable rather
+   than cascading.
+
+## Testing
+
+### Phase 1
+- A file with one syntax error still yields diagnostics and hovers
+  for the rest of the file
+- The partial tree always reaches the pipeline
+- Downstream phases do not panic on partial trees (fuzz with W5)
+- Error count and quality is at least as good as current
+
+### Phase 2
+- A malformed declaration in the middle of a file does not prevent
+  diagnostics for surrounding declarations
+- Block/list boundary recovery isolates errors to the containing
+  construct
+- The error node type is specific enough for useful diagnostics
+
+## Scope Exclusions
+
+- No changes to error message prose (that is Clarion's domain)
+- No incremental re-parsing (that is W7)
+- No new syntax — purely internal pipeline plumbing

--- a/docs/superpowers/specs/2026-06-09-versioning-stability-design.md
+++ b/docs/superpowers/specs/2026-06-09-versioning-stability-design.md
@@ -1,0 +1,162 @@
+# W3: Versioning & Stability Discipline
+
+**Bead:** eu-yhk0.1
+**Target:** 0.8.0 (begin), 1.0 (freeze)
+**Roadmap ref:** W3 (Section 7, ROADMAP.md)
+
+## Problem
+
+Eucalypt practises continuous delivery with a four-part build number
+(`0.8.0.1685`); the version in Cargo.toml is human-set and carries no
+compatibility meaning. A genuine breaking change shipped in
+patch-looking 0.6.2 (the `cond` rewrite). There is no stability
+discipline, no deprecation mechanism, and no way to evolve the prelude
+without breaking existing files.
+
+## Five Deliverables
+
+### 1. Semver plumbing
+
+**Current:** `build.eu` joins `[major, minor, patch, build_number]`
+with `.` producing `0.8.0.1685`.
+
+**Change:** Move build number to `+build.N` metadata per semver.org.
+
+In `build.eu`, change `new-version` to:
+
+```eu,notest
+new-version:
+  "{version.major}.{version.minor}.{version.patch}+{build.number str.of}"
+```
+
+The `semver` crate already ignores `+build` metadata during
+`VersionReq::matches()`, so `eu.requires(">=0.8")` works unchanged.
+
+**Field meanings** (from ROADMAP.md Section 4.1): **MAJOR** = a change
+an unmodified file can observe in its output, or a removal from the
+Stable surface. **MINOR** = backwards-compatible addition (including a
+new opt-in prelude version). **PATCH** = no observable semantic change.
+
+**CI impact:** GitHub release tag changes from `0.8.0.1685` to
+`0.8.0+1685`. GitHub tags allow `+` characters.
+
+**`eu.requires()` cleanup:** Remove the `.replace(".dev", "")` hack in
+`version.rs:39` — `semver::Version` handles `+` metadata natively.
+
+### 2. Stability tier table
+
+Publish `docs/development/stability-policy.md` — a one-page statement
+of what 1.0 commits to:
+
+| Tier | Contents | Promise |
+|------|----------|---------|
+| **Stable** | Core syntax, prelude v1 API, block-merge/lookup semantics, CLI surface, import/export formats, WASM/embedding API, error codes/locations, exit codes | Won't break except in a MAJOR, with a deprecation path for the prelude |
+| **Experimental** | Type-annotation DSL and checker | May change in a MINOR; opt-in/advisory |
+| **Not covered** | Internal IR/STG/GC, `dump` output, exact error prose | No promise |
+
+The type system being **Experimental** is what lets language + prelude
+reach 1.0 without the type system being "done" (it is advisory, so it
+need not be).
+
+The tier table is **ratified at 0.8** and **frozen at 1.0**.
+
+### 3. `requires` as a guard
+
+The runtime path already exists (`__REQUIRES` / `semver::VersionReq`).
+This deliverable is about making it real:
+
+- **Document** the range-pin convention in the language reference.
+- **Model** it in shipped library units (`lib/lens.eu`,
+  `lib/state.eu`) so users see the pattern.
+- **Optional hint:** `eu check` / LSP emits a "missing version pin"
+  hint for units that import but don't `requires`.
+
+### 4. Opt-in prelude versioning
+
+Ship a **frozen v1** and an in-development **v2** as two embedded
+resources. The prelude is already an embedded, swappable resource
+(`src/driver/resources.rs:14-18`); two preludes is two `include_bytes!`
+plus a selector.
+
+**Selection:** Read `{ prelude: :v2 }` from unit metadata in the
+loader (beside `import:`), default to v1.
+
+**Cache key:** The prelude type cache (`PreludeSummary` /
+`PRELUDE_CACHE`) must be keyed on the prelude selection, not just the
+prelude bytes. (Noted for W6.)
+
+**v1 is frozen:** Security-only fixes. Feature work happens in v2.
+
+**The deep-merge-as-default change** (when it lands) ships as a MAJOR
+or behind `prelude: :v2` — never as a silent default flip.
+
+### 5. Deprecation lifecycle
+
+Three metadata keys:
+- `` ` :deprecated `` / `` ` { deprecated: true } `` — marks a
+  declaration deprecated.
+- `` ` { deprecated: "message" } `` — with an explanation.
+- `` ` { replaced-by: "new-fn" } `` — pointer to the replacement
+  (co-occurs with `deprecated:`).
+
+**Metadata normalisation:** Handle `:deprecated` as a special symbol
+in `normalise_metadata()` (same pattern as `:suppress`, `:trace`):
+
+```rust
+"deprecated" => core::block(
+    *smid,
+    [("deprecated".to_string(), core::bool(*smid, true))].iter().cloned(),
+),
+```
+
+**Compile-time behaviour:** During desugaring, extract the
+`deprecated` and `replaced-by` keys. During binding verification
+(`src/core/verify/`), check references against the deprecated set and
+emit warnings:
+
+```
+warning: 'old-fn' is deprecated: use new-fn instead
+  --> file.eu:12:5
+```
+
+Warnings are **never errors under the advisory default**. Under
+`eu check --strict`, deprecation warnings become errors.
+
+**LSP quick-fix:** Reuse the existing `WorkspaceEdit` machinery
+(`src/driver/lsp/actions.rs`) to offer a quick-fix that replaces a
+deprecated name with its `replaced-by:` value.
+
+**Lifecycle:** `deprecated:` + WARNING → LSP quick-fix → removal in a
+MAJOR or simply omitted from prelude v2.
+
+## Implementation Notes
+
+All work is front-end/loader/docs — no runtime risk.
+
+- `build.eu` + release flow (Small)
+- `requires` docs + optional hint (Small)
+- Prelude versioning in `resources.rs`/`source.rs`/`check.rs` (Medium)
+- Deprecation metadata + diagnostics + LSP quick-fix (Small)
+- Tier table document (Small)
+
+## Testing
+
+- `eu version` outputs semver-compliant string with `+` build metadata
+- `eu.requires(">=0.8")` works with `+build` metadata versions
+- `{ prelude: :v2 }` selects the v2 prelude; default selects v1
+- Two units with different prelude selections both work in the same
+  import DAG
+- `` ` :deprecated `` emits a warning when the declaration is
+  referenced
+- `{ deprecated: "msg", replaced-by: "new" }` includes both in the
+  warning
+- `eu check --strict` fails on deprecation warnings
+- LSP quick-fix replaces deprecated name with replacement
+
+## Scope Exclusions
+
+- No automatic migration tooling beyond the LSP quick-fix
+- No `@since` version annotations
+- No runtime deprecation warnings (deferred)
+- No prelude v2 *content* — this deliverable creates the versioning
+  mechanism; populating v2 is ongoing work across releases


### PR DESCRIPTION
## Summary
- Bump version to 0.8.0 in Cargo.toml, add empty CHANGELOG section
- Add design spec for declaration trace metadata (`eu-xu3e`)

## 0.8.0 Scope
See epic `eu-yhk0` and children for the full roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)