### PR TITLE
docs: document :let blocks for same-name reuse in a block

### DIFF
--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -429,6 +429,19 @@ reference `x` without the self-reference gotcha that affects ordinary block
 bindings (`{ x: expr  y: x + 1 }` would make `x` and `y` mutually
 self-referential).
 
+A `:let` binding may even **reuse a name from the enclosing scope** — the one
+case where `name: name …` is not self-reference — because its right-hand side
+is evaluated in the outer scope, before the new binding takes effect:
+
+```eu
+normalise(xs): { :let xs: xs map(_ + 1) }.xs
+shifted: normalise([1, 2, 3])   # => [2, 3, 4]
+```
+
+This is the idiom to reach for when an ordinary `{ name: name … }` would
+self-reference — common when a renderer maps over a parameter it would rather
+keep calling by its own name.
+
 **Why this matters**: Before `let` was defined as a prelude name, attempts to
 write `let x: 1 in x + 2` gave a diagnostic error "eucalypt has no 'let'
 expression". That specific hint is no longer raised; the error now falls through

--- a/docs/eucalypt-style.md
+++ b/docs/eucalypt-style.md
@@ -131,6 +131,16 @@ When in doubt, ask: "how will this function most commonly be called?" and put th
     helper(x): f(x) + 1
   }.(xs map(helper))
   ```
+- **Reuse a name with `:let`**: an ordinary block binding sees *itself* on its
+  right-hand side, so `{ xs: xs map(f) }` is self-reference — `xs` is the new
+  binding, not an outer `xs` — which errors with "binding refers to itself" (or
+  loops when the shadowed name is in function position, e.g. `{ f: f(x) }`). To
+  transform a value and keep its name, use a sequential **`:let`** block, whose
+  RHS sees the *outer* scope and prior bindings, not itself:
+  ```eu,notest
+  normalise(xs): { :let xs: xs map(clean) }.xs   # RHS xs is the parameter
+  ```
+  Otherwise just pick a different local name: `{ cleaned: xs map(clean) }.cleaned`.
 
 ## Prefer `when` over `if` for conditional transforms
 


### PR DESCRIPTION
The self-reference gotcha (`{ x: x }`) and the `:let` block idiom were already
documented, but the `:let` example used distinct names. Make the key point
explicit in both the style guide and the gotchas appendix: a `:let` binding may
reuse a name from the enclosing scope (`{ :let xs: xs map(f) }`) because its RHS
is evaluated in the outer scope — the idiom to reach for when an ordinary
`{ name: name … }` would self-reference (which errors, or loops when the
shadowed name is in function position).

https://claude.ai/code/session_01Q9v9fZWsqEMPZMqtYRdgBB