### PR TITLE
feat(desugar): trace metadata extraction and body wrapping

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::core::metadata::{
     normalise_metadata, strip_desugar_phase_metadata, DesugarPhaseBlockMetadata,
-    DesugarPhaseDeclarationMetadata, ReadMetadata,
+    DesugarPhaseDeclarationMetadata, ReadMetadata, TraceSpec,
 };
 use crate::{
     common::sourcemap::{HasSmid, Smid},
@@ -2625,6 +2625,49 @@ fn rowan_declaration_to_binding(
         // Body is already desugared and variable resolution was done during soup processing
         components.body
     };
+
+    // Wrap body in trace calls if trace metadata was specified.
+    //
+    // The wrapping happens BEFORE lambda creation so that the
+    // `__TRACE_ENTRY` call sits inside the lambda body and has access
+    // to the argument values via the free variable references that will
+    // be bound when the lambda closes over them.
+    //
+    // Design:
+    //   entry-only  →  __TRACE_ENTRY(name, arg_pairs, is_strict, body)
+    //   entry+exit  →  __TRACE_EXIT(name, __TRACE_ENTRY(name, arg_pairs, is_strict, body), is_strict)
+    if let Some(ref trace_spec) = metadata.trace {
+        let smid = desugarer.new_smid(components.span);
+        let name_str = core::str(smid, &components.name);
+
+        // Build the arg-pairs list: ["arg1", arg1, "arg2", arg2, ...]
+        let arg_pairs: Vec<RcExpr> = components
+            .args
+            .iter()
+            .flat_map(|arg_name| [core::str(smid, arg_name), core::var(smid, arg_name.clone())])
+            .collect();
+        let arg_pairs_list = core::list(smid, arg_pairs);
+
+        let is_strict = matches!(trace_spec, TraceSpec::Strict | TraceSpec::StrictExit);
+        let with_exit = matches!(trace_spec, TraceSpec::Exit | TraceSpec::StrictExit);
+        let strict_bool = core::bool_(smid, is_strict);
+
+        // __TRACE_ENTRY(name, arg_pairs, is_strict, body)
+        expr = core::app(
+            smid,
+            core::bif(smid, "__TRACE_ENTRY"),
+            vec![name_str.clone(), arg_pairs_list, strict_bool.clone(), expr],
+        );
+
+        // __TRACE_EXIT(name, traced_body, is_strict)
+        if with_exit {
+            expr = core::app(
+                smid,
+                core::bif(smid, "__TRACE_EXIT"),
+                vec![name_str, expr, strict_bool],
+            );
+        }
+    }
 
     // Wrap in lambda if there are arguments
     if !components.args.is_empty() {

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -12,6 +12,36 @@ pub trait ReadMetadata<M> {
     fn read_metadata(&mut self) -> Result<M, CoreError>;
 }
 
+/// Specifies the tracing behaviour for a declaration.
+///
+/// Set via backtick metadata: `` ` :trace `` (shorthand for lazy) or
+/// `` ` { trace: :strict } `` etc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceSpec {
+    /// Trace entry only; argument values are not forced before logging.
+    Lazy,
+    /// Trace entry only; argument values are forced (evaluated to WHNF) before logging.
+    Strict,
+    /// Trace both entry and exit; argument values are not forced.
+    Exit,
+    /// Trace both entry and exit; argument values are forced before logging.
+    StrictExit,
+}
+
+/// Extract a `TraceSpec` from a core expression.
+///
+/// Accepts the symbol variants `:lazy`, `:strict`, `:exit`, `:strict-exit`.
+fn extract_trace_spec(expr: &RcExpr) -> Option<TraceSpec> {
+    let s: Option<String> = (expr as &dyn Extract<String>).extract();
+    s.and_then(|s| match s.as_str() {
+        "lazy" => Some(TraceSpec::Lazy),
+        "strict" => Some(TraceSpec::Strict),
+        "exit" => Some(TraceSpec::Exit),
+        "strict-exit" => Some(TraceSpec::StrictExit),
+        _ => None,
+    })
+}
+
 /// Extract a function name from a metadata value.
 ///
 /// Accepts:
@@ -45,6 +75,12 @@ pub fn normalise_metadata(expr: &RcExpr, decl_name: Option<&str>) -> RcExpr {
                 "suppress" | "internal" => core::block(
                     *smid,
                     [("export".to_string(), expr.clone())].iter().cloned(),
+                ),
+                "trace" => core::block(
+                    *smid,
+                    [("trace".to_string(), core::sym(*smid, "lazy"))]
+                        .iter()
+                        .cloned(),
                 ),
                 "target" => {
                     if let Some(name) = decl_name {
@@ -85,6 +121,7 @@ pub fn strip_desugar_phase_metadata(expr: &RcExpr) -> RcExpr {
                             | "import"
                             | "embedding"
                             | "parse-embed"
+                            | "trace"
                     )
                 })
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -122,6 +159,8 @@ pub struct DesugarPhaseDeclarationMetadata {
     pub doc: Option<String>,
     /// Embedding - describes how / what is embedded (e.g. core quote-embed)
     pub embedding: Option<String>,
+    /// Trace specification — controls entry/exit tracing of this declaration.
+    pub trace: Option<TraceSpec>,
 }
 
 /// Public wrapper for extract_function_name for use in other modules.
@@ -144,6 +183,7 @@ impl ReadMetadata<DesugarPhaseDeclarationMetadata> for RcExpr {
                 imports: imap.get("import").and_then(|e| e.extract()),
                 doc: imap.get("doc").and_then(|e| e.extract()),
                 embedding: imap.get("embedding").and_then(|e| e.extract()),
+                trace: imap.get("trace").and_then(extract_trace_spec),
             }),
             Expr::Let(_, _, _) => {
                 self.inner = self.clone().instantiate_lets().inner;


### PR DESCRIPTION
## Summary

Implements the desugar-phase side of declaration trace metadata (eu-yhk0.4b).

- `TraceSpec` enum (`Lazy`/`Strict`/`Exit`/`StrictExit`) added to `metadata.rs`
- `:trace` symbol shorthand normalised to `{ trace: :lazy }` in `normalise_metadata()`
- `trace: Option<TraceSpec>` added to `DesugarPhaseDeclarationMetadata`
- `"trace"` key stripped from metadata after extraction (alongside fixity, target, etc.)
- Declaration bodies wrapped in `__TRACE_ENTRY`/`__TRACE_EXIT` intrinsic calls:
  - `Lazy`: `__TRACE_ENTRY(name, arg_pairs, false, body)`
  - `Strict`: `__TRACE_ENTRY(name, arg_pairs, true, body)`
  - `Exit`: `__TRACE_EXIT(name, __TRACE_ENTRY(name, arg_pairs, false, body), false)`
  - `StrictExit`: `__TRACE_EXIT(name, __TRACE_ENTRY(name, arg_pairs, true, body), true)`

The wrapping inserts inside the lambda body so argument variables are in scope.

The `__TRACE_ENTRY`/`__TRACE_EXIT` intrinsics are being implemented by Furnace in a companion PR. This PR compiles and desugars correctly but is not end-to-end testable until those intrinsics land.

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes clean
- [ ] `cargo test --lib` — all 973 tests pass
- [ ] `` ` :trace \n f(x): x `` desugars to `__TRACE_ENTRY("f", ["x", x], false, x)` inside lambda
- [ ] `` ` { trace: :strict-exit } \n g(x, y): x `` desugars to `__TRACE_EXIT("g", __TRACE_ENTRY("g", ["x", x, "y", y], true, x), true)`
- [ ] Existing tests unaffected (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)