### PR TITLE
feat(stg): trace metadata intrinsics — __TRACE_ENTRY, __TRACE_EXIT, peek_debug_repr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "eucalypt"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -999,6 +999,19 @@ lazy_static! {
             ty: function(vec![any(), bool_()]).unwrap(),
             strict: vec![0],
     },
+    Intrinsic { // 190
+            name: "TRACE_ENTRY",
+            // name_str -> args_list -> strict_bool -> unit
+            ty: function(vec![str_(), list(), bool_(), unit()]).unwrap(),
+            strict: vec![0, 1, 2],
+    },
+    Intrinsic { // 191
+            name: "TRACE_EXIT",
+            // name_str -> value -> strict_bool -> value
+            // value (arg 1) is NOT strict — kept lazy so peek mode works
+            ty: function(vec![str_(), unk(), bool_(), unk()]).unwrap(),
+            strict: vec![0, 2],
+    },
     ];
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -3,43 +3,38 @@
 //! Provides:
 //! - `__DBG_REPR(value)` — render any eucalypt value to a compact, human-readable string
 //! - `__DBG(label, value)` — print value to stderr and return it transparently
+//! - `__TRACE_ENTRY(name, args_list, strict)` — print entry trace to stderr
+//! - `__TRACE_EXIT(name, value, strict)` — print exit trace to stderr, return value
 
 use std::convert::TryInto;
 
 use crate::eval::{
     emit::Emitter,
     error::ExecutionError,
-    machine::intrinsic::{CallGlobal1, CallGlobal3, IntrinsicMachine, StgIntrinsic},
+    machine::{
+        env::SynClosure,
+        intrinsic::{CallGlobal1, CallGlobal3, IntrinsicMachine, StgIntrinsic},
+    },
     memory::{
         mutator::MutatorHeapView,
         syntax::{HeapSyn, Native, Ref},
     },
-    stg::support::{machine_return_str, str_arg},
+    stg::support::{machine_return_str, machine_return_unit, str_arg},
 };
+
+use crate::common::sourcemap::Smid;
 
 use super::tags::DataConstructor;
 
-/// Render a eucalypt value to a compact, human-readable debug string.
+/// Render a eucalypt value from a resolved closure to a compact debug string.
 ///
-/// Scalars are rendered in their literal form:
-/// - Numbers: `42`, `3.14`
-/// - Strings: `"hello"` (with surrounding quotes)
-/// - Symbols: `:foo`
-/// - Booleans: `true`, `false`
-/// - Null: `null`
-///
-/// Structured types produce a type label: `[list]`, `{block}`.
-/// Unevaluated thunks produce `<unevaluated>`.
-pub fn render_debug_repr(
+/// Inner helper shared by `render_debug_repr` (takes `&Ref`) and the tracing
+/// intrinsics (which work with resolved `SynClosure` objects).
+fn render_debug_repr_closure(
     machine: &dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    r: &Ref,
+    closure: SynClosure,
 ) -> String {
-    let closure = match machine.nav(view).resolve(r) {
-        Ok(c) => c,
-        Err(_) => return "<error>".to_string(),
-    };
-
     let code = view.scoped(closure.code());
     let env = view.scoped(closure.env());
 
@@ -83,6 +78,28 @@ pub fn render_debug_repr(
             evaluand: Ref::V(n),
         } => render_native(n, view, machine),
         _ => "<unevaluated>".to_string(),
+    }
+}
+
+/// Render a eucalypt value to a compact, human-readable debug string.
+///
+/// Scalars are rendered in their literal form:
+/// - Numbers: `42`, `3.14`
+/// - Strings: `"hello"` (with surrounding quotes)
+/// - Symbols: `:foo`
+/// - Booleans: `true`, `false`
+/// - Null: `null`
+///
+/// Structured types produce a type label: `[list]`, `{block}`.
+/// Unevaluated thunks produce `<unevaluated>`.
+pub fn render_debug_repr(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    match machine.nav(view).resolve(r) {
+        Ok(closure) => render_debug_repr_closure(machine, view, closure),
+        Err(_) => "<error>".to_string(),
     }
 }
 
@@ -255,3 +272,371 @@ impl StgIntrinsic for Dbg {
 }
 
 impl CallGlobal3 for Dbg {}
+
+/// Render a value without forcing evaluation (non-strict peek).
+///
+/// - Native scalars (numbers, strings, symbols, booleans, null) are rendered
+///   using the same format as `render_debug_repr`.
+/// - Data constructors that represent structured types show their outer
+///   shape without recursing into contents: `[...]` for non-empty lists,
+///   `{...}` for blocks.
+/// - Anything unevaluated (thunks, applications, case expressions, etc.)
+///   renders as `<thunk>`.
+pub fn peek_debug_repr(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    match machine.nav(view).resolve(r) {
+        Ok(closure) => peek_debug_repr_closure(machine, view, closure),
+        Err(_) => "<error>".to_string(),
+    }
+}
+
+/// Inner helper for `peek_debug_repr` that works on an already-resolved closure.
+fn peek_debug_repr_closure(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    closure: SynClosure,
+) -> String {
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::BoolTrue) => "true".to_string(),
+                Ok(DataConstructor::BoolFalse) => "false".to_string(),
+                Ok(DataConstructor::Unit) => "null".to_string(),
+                Ok(DataConstructor::ListNil) => "[]".to_string(),
+                Ok(DataConstructor::ListCons) => "[...]".to_string(),
+                Ok(DataConstructor::Block)
+                | Ok(DataConstructor::BlockPair)
+                | Ok(DataConstructor::BlockKvList) => "{...}".to_string(),
+                Ok(DataConstructor::BoxedNumber) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<number>".to_string()),
+                Ok(DataConstructor::BoxedString) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<string>".to_string()),
+                Ok(DataConstructor::BoxedSymbol) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_symbol(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<symbol>".to_string()),
+                Ok(DataConstructor::BoxedZdt) => args
+                    .get(0)
+                    .and_then(|inner| render_inner(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<datetime>".to_string()),
+                _ => "<value>".to_string(),
+            }
+        }
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => render_native(n, view, machine),
+        _ => "<thunk>".to_string(),
+    }
+}
+
+/// Resolve a strict bool argument to a Rust `bool`.
+///
+/// Since the arg must be declared strict in the intrinsic catalogue, it will
+/// have been evaluated to WHNF (a `BoolTrue` or `BoolFalse` constructor)
+/// before `execute` runs.
+fn resolve_bool(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> bool {
+    let closure = match machine.nav(view).resolve(r) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let code = view.scoped(closure.code());
+    match &*code {
+        HeapSyn::Cons { tag, .. } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            matches!(dc, Ok(DataConstructor::BoolTrue))
+        }
+        _ => false,
+    }
+}
+
+/// Extract a string value from a closure representing a string literal.
+///
+/// Handles both unboxed atoms (`Atom { Ref::V(Native::Str(…)) }`) and
+/// boxed string constructors (`Cons(BoxedString, [inner_ref])`).
+/// Returns `None` if the closure does not hold a string.
+fn extract_str_from_closure(view: MutatorHeapView<'_>, closure: &SynClosure) -> Option<String> {
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Atom {
+            evaluand: Ref::V(Native::Str(s)),
+        } => Some((*view.scoped(*s)).as_str().to_string()),
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = DataConstructor::try_from(*tag);
+            match dc {
+                Ok(DataConstructor::BoxedString) => {
+                    let inner = args.get(0)?;
+                    let native = extract_native(view, &env, &inner)?;
+                    if let Native::Str(s) = native {
+                        Some((*view.scoped(s)).as_str().to_string())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Traverse a cons-list to the element at `index`, returning its closure.
+///
+/// The list is always re-resolved from `list_ref` (a stable `Ref` into the
+/// machine's env frame), so this is safe to call after a `evaluate_to_whnf`
+/// call that may have triggered GC.
+///
+/// Returns an error if the list is shorter than `index + 1` elements or if
+/// the structure is malformed.
+fn get_list_element_at(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    list_ref: &Ref,
+    index: usize,
+) -> Result<SynClosure, ExecutionError> {
+    let mut current = machine.nav(view).resolve(list_ref)?;
+
+    for _ in 0..index {
+        let code = view.scoped(current.code());
+        match &*code {
+            HeapSyn::Cons { tag, args } => {
+                let dc: Result<DataConstructor, _> = (*tag).try_into();
+                match dc {
+                    Ok(DataConstructor::ListCons) => {
+                        let t_ref = args.get(1).ok_or_else(|| {
+                            ExecutionError::Panic(
+                                Smid::default(),
+                                "malformed TRACE args_list cons cell (missing tail)".to_string(),
+                            )
+                        })?;
+                        current = current.navigate_local(&view, t_ref.clone());
+                    }
+                    Ok(DataConstructor::ListNil) => {
+                        return Err(ExecutionError::Panic(
+                            Smid::default(),
+                            format!("TRACE args_list too short: expected element at index {index}"),
+                        ))
+                    }
+                    _ => {
+                        return Err(ExecutionError::Panic(
+                            Smid::default(),
+                            "TRACE args_list: unexpected data constructor".to_string(),
+                        ))
+                    }
+                }
+            }
+            _ => {
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "TRACE args_list: expected cons cell, found unevaluated closure".to_string(),
+                ))
+            }
+        }
+    }
+
+    // Extract the head at the current position.
+    let code = view.scoped(current.code());
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::ListCons) => {
+                    let h_ref = args.get(0).ok_or_else(|| {
+                        ExecutionError::Panic(
+                            Smid::default(),
+                            "malformed TRACE args_list cons cell (missing head)".to_string(),
+                        )
+                    })?;
+                    Ok(current.navigate_local(&view, h_ref.clone()))
+                }
+                Ok(DataConstructor::ListNil) => Err(ExecutionError::Panic(
+                    Smid::default(),
+                    format!("TRACE args_list too short: expected element at index {index}"),
+                )),
+                _ => Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "TRACE args_list: unexpected data constructor".to_string(),
+                )),
+            }
+        }
+        _ => Err(ExecutionError::Panic(
+            Smid::default(),
+            "TRACE args_list: expected cons cell, found unevaluated closure".to_string(),
+        )),
+    }
+}
+
+/// Count the number of elements in a cons-list without forcing any values.
+fn count_list_elements(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    list_ref: &Ref,
+) -> Result<usize, ExecutionError> {
+    let mut count = 0usize;
+    let mut current = machine.nav(view).resolve(list_ref)?;
+    loop {
+        let code = view.scoped(current.code());
+        match &*code {
+            HeapSyn::Cons { tag, args } => {
+                let dc: Result<DataConstructor, _> = (*tag).try_into();
+                match dc {
+                    Ok(DataConstructor::ListNil) => break,
+                    Ok(DataConstructor::ListCons) => {
+                        count += 1;
+                        let t_ref = args.get(1).ok_or_else(|| {
+                            ExecutionError::Panic(
+                                Smid::default(),
+                                "malformed cons cell in TRACE args_list".to_string(),
+                            )
+                        })?;
+                        current = current.navigate_local(&view, t_ref.clone());
+                    }
+                    _ => {
+                        return Err(ExecutionError::Panic(
+                            Smid::default(),
+                            "unexpected data constructor in TRACE args_list".to_string(),
+                        ))
+                    }
+                }
+            }
+            _ => {
+                return Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "expected cons cell in TRACE args_list, found unevaluated closure".to_string(),
+                ))
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// `__TRACE_ENTRY(name, args_list, strict)` — print a function entry trace to stderr.
+///
+/// - `name`: string — the declaration name.
+/// - `args_list`: cons-list alternating `[arg_name, value, arg_name, value, …]`.
+/// - `strict`: bool — if `true`, force each value to WHNF before rendering;
+///   if `false`, peek (render already-evaluated values, show `<thunk>` for the rest).
+///
+/// Output format: `→ name(arg1: repr1, arg2: repr2)`
+///
+/// Returns unit (null) so that `seq` can discard it.
+pub struct TraceEntry;
+
+impl StgIntrinsic for TraceEntry {
+    fn name(&self) -> &str {
+        "TRACE_ENTRY"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args[0] = name (strict string)
+        // args[1] = args_list (strict cons-list structure, values may be thunks)
+        // args[2] = strict_bool (strict bool)
+        let name = str_arg(machine, view, &args[0])?;
+        let strict = resolve_bool(machine, view, &args[2]);
+
+        // Count pairs: the list has 2*n elements for n arguments.
+        let n_elements = count_list_elements(machine, view, &args[1])?;
+        let n_pairs = n_elements / 2;
+
+        // Pass 1: collect names (no GC — no evaluate_to_whnf calls here).
+        let mut arg_names: Vec<String> = Vec::with_capacity(n_pairs);
+        for i in 0..n_pairs {
+            let name_closure = get_list_element_at(machine, view, &args[1], 2 * i)?;
+            let s = extract_str_from_closure(view, &name_closure)
+                .unwrap_or_else(|| "<arg>".to_string());
+            arg_names.push(s);
+        }
+
+        // Pass 2: render values (may trigger GC via evaluate_to_whnf in strict mode).
+        // Each iteration re-traverses from args[1] to remain GC-safe.
+        let mut arg_reprs: Vec<String> = Vec::with_capacity(n_pairs);
+        for i in 0..n_pairs {
+            let value_closure = get_list_element_at(machine, view, &args[1], 2 * i + 1)?;
+            let repr = if strict {
+                let forced = machine.evaluate_to_whnf(value_closure)?;
+                render_debug_repr_closure(machine, view, forced)
+            } else {
+                peek_debug_repr_closure(machine, view, value_closure)
+            };
+            arg_reprs.push(repr);
+        }
+
+        // Format and print.
+        let arg_strs: Vec<String> = arg_names
+            .iter()
+            .zip(arg_reprs.iter())
+            .map(|(n, r)| format!("{n}: {r}"))
+            .collect();
+        eprintln!("\u{2192} {name}({})", arg_strs.join(", "));
+
+        machine_return_unit(machine, view)
+    }
+}
+
+impl CallGlobal3 for TraceEntry {}
+
+/// `__TRACE_EXIT(name, value, strict)` — print a function exit trace to stderr and
+/// return `value` transparently.
+///
+/// - `name`: string — the declaration name.
+/// - `value`: the body result (lazy — not forced by the wrapper).
+/// - `strict`: bool — if `true`, force `value` to WHNF before rendering.
+///
+/// Output format: `← name: repr`
+///
+/// Returns `value` (or the forced closure in strict mode) unchanged.
+pub struct TraceExit;
+
+impl StgIntrinsic for TraceExit {
+    fn name(&self) -> &str {
+        "TRACE_EXIT"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // args[0] = name (strict string)
+        // args[1] = value (lazy — may be a thunk)
+        // args[2] = strict_bool (strict bool)
+        let name = str_arg(machine, view, &args[0])?;
+        let strict = resolve_bool(machine, view, &args[2]);
+
+        let result_closure = if strict {
+            let value_closure = machine.nav(view).resolve(&args[1])?;
+            let forced = machine.evaluate_to_whnf(value_closure)?;
+            let repr = render_debug_repr_closure(machine, view, forced.clone());
+            eprintln!("\u{2190} {name}: {repr}");
+            forced
+        } else {
+            let repr = peek_debug_repr(machine, view, &args[1]);
+            eprintln!("\u{2190} {name}: {repr}");
+            machine.nav(view).resolve(&args[1])?
+        };
+
+        machine.set_closure(result_closure)
+    }
+}
+
+impl CallGlobal3 for TraceExit {}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -228,6 +228,8 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(debug::DbgRepr));
     rt.add(Box::new(expect::Expect));
     rt.add(Box::new(debug::Dbg));
+    rt.add(Box::new(debug::TraceEntry));
+    rt.add(Box::new(debug::TraceExit));
     rt.add(Box::new(list::IsNumber));
     rt.add(Box::new(list::IsString));
     rt.add(Box::new(list::IsSymbol));


### PR DESCRIPTION
## Summary

- Adds `peek_debug_repr()` helper: non-forcing variant of `render_debug_repr()` that returns `<thunk>` for unevaluated closures and `[...]`/`{...}` for structured types
- Adds `__TRACE_ENTRY(name, args_list, strict)` intrinsic: prints `→ name(arg: repr, …)` to stderr, with lazy or strict value rendering
- Adds `__TRACE_EXIT(name, value, strict)` intrinsic: prints `← name: repr` to stderr and returns value transparently
- Registers both as intrinsic #190 and #191 in the catalogue and standard runtime
- Factored `render_debug_repr` into a shared `render_debug_repr_closure` inner helper

**GC safety**: `__TRACE_ENTRY` in strict mode calls `evaluate_to_whnf` for each value. To avoid stale raw pointers after GC, the list is re-traversed from `args[1]` (a stable `Ref::L` index into the env frame) before each access. This is O(n²) in the number of arguments but safe and correct for the typical case of ≤ 10 args.

This is part of bead eu-yhk0.4 (declaration trace metadata). Bead eu-yhk0.4b (desugarer body wrapping) will emit calls to these intrinsics.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test --lib` — 973 tests pass
- [x] `cargo test --test harness_test` — 400 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)