### PR TITLE
fix(version): semver-compliant build versioning and stability policy

### DIFF
--- a/build.eu
+++ b/build.eu
@@ -56,10 +56,7 @@ build: {
 ` {target: :version
    format: :text
    doc: "version number for the current build"}
-new-version: [version.major,
-              version.minor,
-              version.patch,
-              build.number] map(str.of) str.join-on(".")
+new-version: "{version.major}.{version.minor}.{version.patch}+{build.number str.of}"
 
 ` {target: :build-meta
    doc: "build metadata to embed as resource in binary"}

--- a/docs/development/stability-policy.md
+++ b/docs/development/stability-policy.md
@@ -1,0 +1,54 @@
+# Stability Policy
+
+This document defines eucalypt's stability tiers and the meaning of
+each semver field. It was ratified at 0.8.0. The enumerated Stable
+surface is frozen at 1.0.
+
+## Semver field meanings
+
+| Field | Meaning |
+|-------|---------|
+| **MAJOR** | A change an unmodified `.eu` file can observe in its output, or a removal from the Stable surface. Requires a documented deprecation path. |
+| **MINOR** | A backwards-compatible addition to the Stable surface. |
+| **PATCH** | No observable semantic change to any input/output or CLI behaviour. |
+
+Build metadata (`+N`, e.g. `0.8.0+1685`) is ignored by
+`VersionReq::matches()`. Use `eu.requires(">=0.8")` to pin against a
+minimum version.
+
+## Stability tiers
+
+| Tier | Contents | Promise |
+|------|----------|---------|
+| **Stable** | Core syntax and semantics; prelude API (all exported names and their signatures); block-merge and lookup semantics; CLI surface (`eu`, `-t`, `-x`, `-e`, `--allow-io`, `--lib`, `--help`, `--version`, `check`, `test`, `dump`); all import/export formats (YAML, JSON, TOML, EDN, CSV, XML, text); error codes and source-location accuracy; exit codes | Will not break in a MINOR or PATCH. Breaking changes require a MAJOR with a deprecation path. |
+| **Experimental** | Gradual type-annotation DSL (`:type` metadata, `eu check`, bidirectional checker); type warning messages and exact locations | May change in a MINOR. The feature is opt-in and advisory — it never changes runtime behaviour. |
+| **Not covered** | Internal IR (Core, STG); GC internals and `EU_GC_*` env variables; `eu dump` output format; exact prose of error messages; names with `` ` :internal `` metadata | No promise. These may change in any release. |
+
+## `eu.requires` pinning convention
+
+Every `.eu` file that depends on features introduced in a specific
+release should declare a version requirement near the top:
+
+```eu
+eu.requires(">=0.8")
+```
+
+Shipped library files (`lib/lens.eu`, `lib/state.eu`, `lib/markup.eu`)
+serve as exemplars of this pattern.
+
+Running a file on an incompatible version produces a
+`VersionRequirementFailed` error with a clear message.
+
+## Applying this policy
+
+When considering a change to eucalypt:
+
+1. **Identify the tier.** Is the affected surface Stable, Experimental,
+   or Not covered?
+2. **If Stable:** the change must not break existing files that rely on
+   the current behaviour. If a breaking change is necessary, deprecate
+   in a MINOR and remove in the next MAJOR.
+3. **If Experimental:** a MINOR bump with a changelog entry is
+   sufficient. No deprecation path is required.
+4. **If Not covered:** any version bump is sufficient. Document changes
+   in the changelog if they may affect debugging workflows.

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -35,9 +35,8 @@ impl StgIntrinsic for Requires {
             )
         })?;
 
-        // Strip any ".dev" suffix from the Cargo package version
-        let version_str = env!("CARGO_PKG_VERSION").replace(".dev", "");
-        let version = semver::Version::parse(&version_str).map_err(|e| {
+        let version_str = env!("CARGO_PKG_VERSION");
+        let version = semver::Version::parse(version_str).map_err(|e| {
             ExecutionError::Panic(
                 smid,
                 format!("failed to parse eucalypt version \"{version_str}\": {e}"),


### PR DESCRIPTION
## Summary

- **build.eu**: `new-version` now produces `0.8.0+1685` (valid semver with build metadata) instead of `0.8.0.1685` (which `semver::Version::parse` rejects)
- **version.rs**: removes the `.replace(".dev", "")` hack — `CARGO_PKG_VERSION` is plain semver and `semver::Version::parse` handles `+N` metadata natively
- **docs/development/stability-policy.md**: three-tier stability table (Stable / Experimental / Not covered), semver field meanings, and the `eu.requires` pinning convention

Closes beads eu-yhk0.1a and eu-yhk0.1b.

## Test plan

- [x] `cargo build --lib` — compiles cleanly
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] `eu version` outputs `\d+\.\d+\.\d+(\+\d+)?` (verified in CI; locally outputs `0.7.1` since no live build-meta)
- [ ] `eu.requires(">=0.8")` passes against `0.8.0+1685` in CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)