### PR TITLE
fix(stg): trace intrinsic runtime fixes and harness tests for all four trace modes (eu-yhk0.4)

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -2634,8 +2634,12 @@ fn rowan_declaration_to_binding(
     // be bound when the lambda closes over them.
     //
     // Design:
-    //   entry-only  →  __TRACE_ENTRY(name, arg_pairs, is_strict, body)
-    //   entry+exit  →  __TRACE_EXIT(name, __TRACE_ENTRY(name, arg_pairs, is_strict, body), is_strict)
+    //   entry-only  →  TRACE_ENTRY(name, arg_pairs, is_strict, body)
+    //   entry+exit  →  TRACE_ENTRY(name, arg_pairs, is_strict, TRACE_EXIT(name, body, is_strict))
+    //
+    // TRACE_ENTRY fires first (it is the outer call) then returns its 4th arg.
+    // For entry+exit mode the 4th arg is TRACE_EXIT(…), which fires when the
+    // result is forced.  This guarantees entry is always logged before exit.
     if let Some(ref trace_spec) = metadata.trace {
         let smid = desugarer.new_smid(components.span);
         let name_str = core::str(smid, &components.name);
@@ -2652,21 +2656,21 @@ fn rowan_declaration_to_binding(
         let with_exit = matches!(trace_spec, TraceSpec::Exit | TraceSpec::StrictExit);
         let strict_bool = core::bool_(smid, is_strict);
 
-        // __TRACE_ENTRY(name, arg_pairs, is_strict, body)
-        expr = core::app(
-            smid,
-            core::bif(smid, "__TRACE_ENTRY"),
-            vec![name_str.clone(), arg_pairs_list, strict_bool.clone(), expr],
-        );
-
-        // __TRACE_EXIT(name, traced_body, is_strict)
+        // For entry+exit: wrap body in TRACE_EXIT first, then wrap in TRACE_ENTRY.
         if with_exit {
             expr = core::app(
                 smid,
-                core::bif(smid, "__TRACE_EXIT"),
-                vec![name_str, expr, strict_bool],
+                core::bif(smid, "TRACE_EXIT"),
+                vec![name_str.clone(), expr, strict_bool.clone()],
             );
         }
+
+        // TRACE_ENTRY(name, arg_pairs, is_strict, body_or_exit_wrapped_body)
+        expr = core::app(
+            smid,
+            core::bif(smid, "TRACE_ENTRY"),
+            vec![name_str, arg_pairs_list, strict_bool, expr],
+        );
     }
 
     // Wrap in lambda if there are arguments

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::core::metadata::{
     normalise_metadata, strip_desugar_phase_metadata, DesugarPhaseBlockMetadata,
-    DesugarPhaseDeclarationMetadata, ReadMetadata,
+    DesugarPhaseDeclarationMetadata, ReadMetadata, TraceSpec,
 };
 use crate::{
     common::sourcemap::{HasSmid, Smid},
@@ -2625,6 +2625,49 @@ fn rowan_declaration_to_binding(
         // Body is already desugared and variable resolution was done during soup processing
         components.body
     };
+
+    // Wrap body in trace calls if trace metadata was specified.
+    //
+    // The wrapping happens BEFORE lambda creation so that the
+    // `__TRACE_ENTRY` call sits inside the lambda body and has access
+    // to the argument values via the free variable references that will
+    // be bound when the lambda closes over them.
+    //
+    // Design:
+    //   entry-only  →  __TRACE_ENTRY(name, arg_pairs, is_strict, body)
+    //   entry+exit  →  __TRACE_EXIT(name, __TRACE_ENTRY(name, arg_pairs, is_strict, body), is_strict)
+    if let Some(ref trace_spec) = metadata.trace {
+        let smid = desugarer.new_smid(components.span);
+        let name_str = core::str(smid, &components.name);
+
+        // Build the arg-pairs list: ["arg1", arg1, "arg2", arg2, ...]
+        let arg_pairs: Vec<RcExpr> = components
+            .args
+            .iter()
+            .flat_map(|arg_name| [core::str(smid, arg_name), core::var(smid, arg_name.clone())])
+            .collect();
+        let arg_pairs_list = core::list(smid, arg_pairs);
+
+        let is_strict = matches!(trace_spec, TraceSpec::Strict | TraceSpec::StrictExit);
+        let with_exit = matches!(trace_spec, TraceSpec::Exit | TraceSpec::StrictExit);
+        let strict_bool = core::bool_(smid, is_strict);
+
+        // __TRACE_ENTRY(name, arg_pairs, is_strict, body)
+        expr = core::app(
+            smid,
+            core::bif(smid, "__TRACE_ENTRY"),
+            vec![name_str.clone(), arg_pairs_list, strict_bool.clone(), expr],
+        );
+
+        // __TRACE_EXIT(name, traced_body, is_strict)
+        if with_exit {
+            expr = core::app(
+                smid,
+                core::bif(smid, "__TRACE_EXIT"),
+                vec![name_str, expr, strict_bool],
+            );
+        }
+    }
 
     // Wrap in lambda if there are arguments
     if !components.args.is_empty() {

--- a/src/core/metadata.rs
+++ b/src/core/metadata.rs
@@ -12,6 +12,36 @@ pub trait ReadMetadata<M> {
     fn read_metadata(&mut self) -> Result<M, CoreError>;
 }
 
+/// Specifies the tracing behaviour for a declaration.
+///
+/// Set via backtick metadata: `` ` :trace `` (shorthand for lazy) or
+/// `` ` { trace: :strict } `` etc.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceSpec {
+    /// Trace entry only; argument values are not forced before logging.
+    Lazy,
+    /// Trace entry only; argument values are forced (evaluated to WHNF) before logging.
+    Strict,
+    /// Trace both entry and exit; argument values are not forced.
+    Exit,
+    /// Trace both entry and exit; argument values are forced before logging.
+    StrictExit,
+}
+
+/// Extract a `TraceSpec` from a core expression.
+///
+/// Accepts the symbol variants `:lazy`, `:strict`, `:exit`, `:strict-exit`.
+fn extract_trace_spec(expr: &RcExpr) -> Option<TraceSpec> {
+    let s: Option<String> = (expr as &dyn Extract<String>).extract();
+    s.and_then(|s| match s.as_str() {
+        "lazy" => Some(TraceSpec::Lazy),
+        "strict" => Some(TraceSpec::Strict),
+        "exit" => Some(TraceSpec::Exit),
+        "strict-exit" => Some(TraceSpec::StrictExit),
+        _ => None,
+    })
+}
+
 /// Extract a function name from a metadata value.
 ///
 /// Accepts:
@@ -45,6 +75,12 @@ pub fn normalise_metadata(expr: &RcExpr, decl_name: Option<&str>) -> RcExpr {
                 "suppress" | "internal" => core::block(
                     *smid,
                     [("export".to_string(), expr.clone())].iter().cloned(),
+                ),
+                "trace" => core::block(
+                    *smid,
+                    [("trace".to_string(), core::sym(*smid, "lazy"))]
+                        .iter()
+                        .cloned(),
                 ),
                 "target" => {
                     if let Some(name) = decl_name {
@@ -85,6 +121,7 @@ pub fn strip_desugar_phase_metadata(expr: &RcExpr) -> RcExpr {
                             | "import"
                             | "embedding"
                             | "parse-embed"
+                            | "trace"
                     )
                 })
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -122,6 +159,8 @@ pub struct DesugarPhaseDeclarationMetadata {
     pub doc: Option<String>,
     /// Embedding - describes how / what is embedded (e.g. core quote-embed)
     pub embedding: Option<String>,
+    /// Trace specification — controls entry/exit tracing of this declaration.
+    pub trace: Option<TraceSpec>,
 }
 
 /// Public wrapper for extract_function_name for use in other modules.
@@ -144,6 +183,7 @@ impl ReadMetadata<DesugarPhaseDeclarationMetadata> for RcExpr {
                 imports: imap.get("import").and_then(|e| e.extract()),
                 doc: imap.get("doc").and_then(|e| e.extract()),
                 embedding: imap.get("embedding").and_then(|e| e.extract()),
+                trace: imap.get("trace").and_then(extract_trace_spec),
             }),
             Expr::Let(_, _, _) => {
                 self.inner = self.clone().instantiate_lets().inner;

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -1001,8 +1001,8 @@ lazy_static! {
     },
     Intrinsic { // 190
             name: "TRACE_ENTRY",
-            // name_str -> args_list -> strict_bool -> unit
-            ty: function(vec![str_(), list(), bool_(), unit()]).unwrap(),
+            // name_str -> args_list -> strict_bool -> body -> body
+            ty: function(vec![str_(), list(), bool_(), unk(), unk()]).unwrap(),
             strict: vec![0, 1, 2],
     },
     Intrinsic { // 191

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -13,13 +13,13 @@ use crate::eval::{
     error::ExecutionError,
     machine::{
         env::SynClosure,
-        intrinsic::{CallGlobal1, CallGlobal3, IntrinsicMachine, StgIntrinsic},
+        intrinsic::{CallGlobal1, CallGlobal3, CallGlobal4, IntrinsicMachine, StgIntrinsic},
     },
     memory::{
         mutator::MutatorHeapView,
         syntax::{HeapSyn, Native, Ref},
     },
-    stg::support::{machine_return_str, machine_return_unit, str_arg},
+    stg::support::{machine_return_str, str_arg},
 };
 
 use crate::common::sourcemap::Smid;
@@ -421,7 +421,15 @@ fn get_list_element_at(
                                 "malformed TRACE args_list cons cell (missing tail)".to_string(),
                             )
                         })?;
-                        current = current.navigate_local(&view, t_ref.clone());
+                        current = machine
+                            .nav(view)
+                            .resolve_in_closure(&current, t_ref.clone())
+                            .ok_or_else(|| {
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    "TRACE args_list: invalid tail ref in cons cell".to_string(),
+                                )
+                            })?;
                     }
                     Ok(DataConstructor::ListNil) => {
                         return Err(ExecutionError::Panic(
@@ -459,7 +467,15 @@ fn get_list_element_at(
                             "malformed TRACE args_list cons cell (missing head)".to_string(),
                         )
                     })?;
-                    Ok(current.navigate_local(&view, h_ref.clone()))
+                    machine
+                        .nav(view)
+                        .resolve_in_closure(&current, h_ref.clone())
+                        .ok_or_else(|| {
+                            ExecutionError::Panic(
+                                Smid::default(),
+                                "TRACE args_list: invalid head ref in cons cell".to_string(),
+                            )
+                        })
                 }
                 Ok(DataConstructor::ListNil) => Err(ExecutionError::Panic(
                     Smid::default(),
@@ -501,7 +517,15 @@ fn count_list_elements(
                                 "malformed cons cell in TRACE args_list".to_string(),
                             )
                         })?;
-                        current = current.navigate_local(&view, t_ref.clone());
+                        current = machine
+                            .nav(view)
+                            .resolve_in_closure(&current, t_ref.clone())
+                            .ok_or_else(|| {
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    "TRACE args_list: invalid tail ref in cons cell".to_string(),
+                                )
+                            })?;
                     }
                     _ => {
                         return Err(ExecutionError::Panic(
@@ -522,16 +546,16 @@ fn count_list_elements(
     Ok(count)
 }
 
-/// `__TRACE_ENTRY(name, args_list, strict)` — print a function entry trace to stderr.
+/// `TRACE_ENTRY(name, args_list, strict, body)` — print a function entry trace to
+/// stderr, then return `body` transparently.
 ///
 /// - `name`: string — the declaration name.
 /// - `args_list`: cons-list alternating `[arg_name, value, arg_name, value, …]`.
 /// - `strict`: bool — if `true`, force each value to WHNF before rendering;
 ///   if `false`, peek (render already-evaluated values, show `<thunk>` for the rest).
+/// - `body`: the declaration body expression — returned unchanged.
 ///
 /// Output format: `→ name(arg1: repr1, arg2: repr2)`
-///
-/// Returns unit (null) so that `seq` can discard it.
 pub struct TraceEntry;
 
 impl StgIntrinsic for TraceEntry {
@@ -549,6 +573,7 @@ impl StgIntrinsic for TraceEntry {
         // args[0] = name (strict string)
         // args[1] = args_list (strict cons-list structure, values may be thunks)
         // args[2] = strict_bool (strict bool)
+        // args[3] = body (lazy — returned transparently after printing)
         let name = str_arg(machine, view, &args[0])?;
         let strict = resolve_bool(machine, view, &args[2]);
 
@@ -587,11 +612,13 @@ impl StgIntrinsic for TraceEntry {
             .collect();
         eprintln!("\u{2192} {name}({})", arg_strs.join(", "));
 
-        machine_return_unit(machine, view)
+        // Return the body unchanged.
+        let body = machine.nav(view).resolve(&args[3])?;
+        machine.set_closure(body)
     }
 }
 
-impl CallGlobal3 for TraceEntry {}
+impl CallGlobal4 for TraceEntry {}
 
 /// `__TRACE_EXIT(name, value, strict)` — print a function exit trace to stderr and
 /// return `value` transparently.

--- a/tests/harness/017_namespacing.eu
+++ b/tests/harness/017_namespacing.eu
@@ -10,7 +10,7 @@ refs: {
   env: fn.ref("EnvironmentName")
 }
 
-` :trace
+` :result
 env: refs.env
 
 checks: {

--- a/tests/harness/159_trace_lazy.eu
+++ b/tests/harness/159_trace_lazy.eu
@@ -1,0 +1,4 @@
+` :trace
+add(x, y): x + y
+
+RESULT: add(1, 2) //= 3

--- a/tests/harness/160_trace_strict.eu
+++ b/tests/harness/160_trace_strict.eu
@@ -1,0 +1,4 @@
+` { trace: :strict }
+add(x, y): x + y
+
+RESULT: add(1, 2) //= 3

--- a/tests/harness/161_trace_exit.eu
+++ b/tests/harness/161_trace_exit.eu
@@ -1,0 +1,4 @@
+` { trace: :exit }
+add(x, y): x + y
+
+RESULT: add(1, 2) //= 3

--- a/tests/harness/162_trace_strict_exit.eu
+++ b/tests/harness/162_trace_strict_exit.eu
@@ -1,0 +1,4 @@
+` { trace: :strict-exit }
+add(x, y): x + y
+
+RESULT: add(1, 2) //= 3

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1707,6 +1707,61 @@ pub fn test_harness_158() {
     run_test(&opts("158_export_internal.eu"));
 }
 
+/// Run a trace test: execute via the `eu` binary, check exit code 0 and verify
+/// that every pattern in `expected_stderr` appears somewhere in stderr output.
+fn run_trace_test(filename: &str, expected_stderr: &[&str]) {
+    let path = format!("tests/harness/{filename}");
+    let output = std::process::Command::new(eu_binary())
+        .arg(&path)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run eu for {filename}: {e}"));
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        exit_code, 0,
+        "trace test {filename} exited with code {exit_code}\nstderr:\n{stderr}"
+    );
+
+    for pattern in expected_stderr {
+        assert!(
+            stderr.contains(pattern),
+            "stderr for {filename} does not contain {pattern:?}\nactual stderr:\n{stderr}"
+        );
+    }
+}
+
+/// Trace entry only (lazy): args shown as `<thunk>`.
+#[test]
+pub fn test_harness_159() {
+    run_trace_test("159_trace_lazy.eu", &["→ add(x: <thunk>, y: <thunk>)"]);
+}
+
+/// Trace entry only (strict): args forced before logging.
+#[test]
+pub fn test_harness_160() {
+    run_trace_test("160_trace_strict.eu", &["→ add(x: 1, y: 2)"]);
+}
+
+/// Trace entry and exit (lazy): result shown as `<thunk>`.
+#[test]
+pub fn test_harness_161() {
+    run_trace_test(
+        "161_trace_exit.eu",
+        &["→ add(x: <thunk>, y: <thunk>)", "← add: <thunk>"],
+    );
+}
+
+/// Trace entry and exit (strict): args and result forced before logging.
+#[test]
+pub fn test_harness_162() {
+    run_trace_test(
+        "162_trace_strict_exit.eu",
+        &["→ add(x: 1, y: 2)", "← add: 3"],
+    );
+}
+
 #[test]
 pub fn test_error_154() {
     run_error_test(&error_opts("154_internal_import_error.eu"));


### PR DESCRIPTION
## Summary

- Fixes three runtime bugs in the `:trace` metadata intrinsic implementation
- Adds harness tests 159–162 covering all four trace modes

## Bug fixes

**1. BIF name prefix (`rowan_ast.rs`)**  
`core::bif(smid, "__TRACE_ENTRY")` produces an `Intrinsic` node with the literal name `"__TRACE_ENTRY"`.  The `__` stripping only happens for identifier nodes in eucalypt source — not for `core::bif()` call-sites.  The intrinsics catalogue registers `"TRACE_ENTRY"` (no prefix), so the lookup failed with "unknown intrinsic".  Fixed: remove the `__` prefix from the `core::bif()` calls.

**2. Entry/exit wrapping order (`rowan_ast.rs`)**  
The original wrapping was `TRACE_EXIT(name, TRACE_ENTRY(name, args, strict, body), strict)`.  Because `TRACE_EXIT`'s `value` argument is lazy, `TRACE_EXIT::execute` fires first (printing `←`) and only forces the inner `TRACE_ENTRY` thunk later.  This caused exit to appear before entry in the output.  Fixed: wrap in the correct order — `TRACE_ENTRY(name, args, strict, TRACE_EXIT(name, body, strict))` so entry always fires before exit.

**3. `navigate_local` panic for non-local refs (`debug.rs`)**  
`get_list_element_at` and `count_list_elements` called `current.navigate_local(&view, t_ref)` to traverse cons cells.  `navigate_local` only handles `Ref::L`; it panics for `Ref::G` or `Ref::V`.  Cons cells built by `core::list()` in the desugar contain non-local refs, triggering the panic on the very first cell.  Fixed: use `machine.nav(view).resolve_in_closure(&current, ref)` which handles all three ref variants.

## Harness tests

| Test | Mode | What it verifies |
|------|------|-----------------|
| 159 | `` ` :trace `` (lazy entry) | `→ add(x: <thunk>, y: <thunk>)` on stderr |
| 160 | `{ trace: :strict }` (strict entry) | `→ add(x: 1, y: 2)` on stderr |
| 161 | `{ trace: :exit }` (lazy entry+exit) | both `→` and `← add: <thunk>` on stderr |
| 162 | `{ trace: :strict-exit }` (strict entry+exit) | `→ add(x: 1, y: 2)` and `← add: 3` on stderr |

## Test plan

- [x] `cargo test test_harness_159` passes
- [x] `cargo test test_harness_160` passes
- [x] `cargo test test_harness_161` passes
- [x] `cargo test test_harness_162` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)