### PR TITLE
feat(lib): add eu.requires version pinning to shipped libraries (eu-yhk0.1c)

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -1187,3 +1187,36 @@ Output format: `▶ <repr>` or `▶ label: <repr>`.
 
 `▶` is intentionally prominent — the Unicode triangle is hard to overlook
 in a code review.
+
+## 10. Version Requirements
+
+**Declare a minimum eucalypt version at the top of any `.eu` file that depends
+on features introduced in a specific release.**
+
+```eu
+_ : eu.requires(">=0.8")
+```
+
+`eu.requires` takes a semver constraint string.  It returns `null` on success
+and raises `VersionRequirementFailed` on failure.  Because `eu.requires`
+returns `null` it must be assigned to `_` (a discard binding) — a bare
+expression at the top level cannot reference `eu` directly.
+
+### Constraint syntax
+
+Uses [semver constraint syntax](https://docs.rs/semver/latest/semver/#requirements):
+
+| Constraint | Meaning |
+|------------|---------|
+| `">=0.8"` | Version 0.8.0 or later |
+| `"^0.8"` | Compatible with 0.8 (i.e. 0.8.x) |
+| `">=0.8, <1.0"` | 0.8.x up to but not including 1.0 |
+
+### Convention
+
+- Every shipped library file (`lib/lens.eu`, `lib/state.eu`, `lib/markup.eu`)
+  uses `_ : eu.requires(">=0.8")` near the top.
+- Place the declaration after any unit-level metadata block or file-level doc
+  string, before the first binding definition.
+- Build metadata (`+N`) is ignored by the version check — `">=0.8"` matches
+  `0.8.0+1685`.

--- a/lib/lens.eu
+++ b/lib/lens.eu
@@ -22,6 +22,8 @@ bracket syntax below for a more convenient way to define paths into data
 structures using lenses.
 "
 
+_ : eu.requires(">=0.8")
+
 ` { doc: "`at(key)` defines a lens that focuses within a block on the value with key `key`."
     type: "symbol → Lens({{..r}}, a)" }
 at(key, k): {

--- a/lib/markup.eu
+++ b/lib/markup.eu
@@ -1,6 +1,8 @@
 "Facilities for working with hiccup style markup representations that
 encode XML, HTML etc."
 
+_ : eu.requires(">=0.8")
+
 # Normalise
 
 ` "When authored in eucalypt, a shorthand can be used to

--- a/lib/state.eu
+++ b/lib/state.eu
@@ -1,6 +1,8 @@
 { import: "resource:lens"
   doc: "State monad for Eucalypt. Each state action is a function from state to a value/state block. Use state.run(action, initial) to execute a computation and state.exec / state.eval to extract just the final state or final value." }
 
+_ : eu.requires(">=0.8")
+
 # ─── Primitive bind / return ────────────────────────────────────────────────
 
 ` "state-ret(v, s) - wrap value v in the state monad: returns a value/state block unchanged."


### PR DESCRIPTION
## Summary

- Adds `_ : eu.requires(">=0.8")` to `lib/lens.eu`, `lib/state.eu`, and `lib/markup.eu`
- Documents the `eu.requires` pinning convention in `docs/reference/agent-reference.md`

## Changes

**`lib/lens.eu`** — version requirement added after the file-level doc string, before the first binding.

**`lib/state.eu`** — version requirement added after the unit metadata block (which contains the `import:` directive).

**`lib/markup.eu`** — version requirement added after the file-level doc string.

**`docs/reference/agent-reference.md`** — new section 10 "Version Requirements" documents:
- The `_ : eu.requires(">=0.8")` syntax (bare expression form does not work — `eu` is not in scope for top-level bare expressions)
- Constraint syntax table
- Placement convention (after unit metadata / file doc string, before first binding)
- Build metadata note (`+N` is ignored, `">=0.8"` matches `0.8.0+1685`)

## Notes

- `markup.eu` has a pre-existing parse error (backticks inside a multi-line doc string at lines 8–17) that is not introduced by this PR. No tests use `markup.eu` directly so this is an existing known issue.
- `lib/markup.eu` is not registered as a baked-in resource (unlike `lens` and `state`), so it cannot be tested via `resource:markup`.

## Test plan

- [x] `cargo test test_harness_065` passes (existing `eu.requires` tests)
- [x] `cargo test test_harness_0` — all 89 tests pass (lens/state not broken)
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)