### PR TITLE
docs: eucalypt authoring guidance (:suppress gotcha + mandatory style guide)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ When writing or modifying `.eu` files, you MUST read these files first:
 - `docs/reference/agent-reference.md` — dense syntax reference, prelude functions, pipeline patterns, and common pitfalls (READ THIS FIRST)
 - `docs/appendices/syntax-gotchas.md` — critical precedence and syntax traps
 - `docs/appendices/cheat-sheet.md` — quick syntax and operator reference
+- `docs/eucalypt-style.md` — idiomatic style: pipeline/catenation over nested calls, juxtaposed `f[...]` / `g{...}` calls, `then` over `if`, `.result` over `.(...)`, point-free composition
 
 For specific topics, also consult:
 - `docs/guide/expressions-and-pipelines.md` — pipeline style and catenation

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -574,6 +574,33 @@ safe-head(xs): if(xs nil?, 0, xs head)   # xs is NonEmpty([number]) in the false
 Or annotate the input as `NonEmpty([T])` when the caller guarantees
 non-emptiness.
 
+## `:suppress` Leaks Through References
+
+`` ` :suppress `` hides a binding from output, but the flag travels with
+the binding's **value**. Reference that value somewhere else and the field
+it lands in silently disappears too.
+
+```eu,notest
+# WRONG — log4j is suppressed, so the @id field it feeds is dropped
+` :suppress
+log4j: "pkg:maven/log4j-core@2.17.1"
+
+entry: { '@id': log4j }     # renders as {} — @id silently gone
+```
+
+Suppress a **block** rather than a value you reference; members looked up
+out of it are clean:
+
+```eu,notest
+` :suppress
+purls: { log4j: "pkg:maven/log4j-core@2.17.1" }
+
+entry: { '@id': purls.log4j }   # => { "@id": "pkg:maven/log4j-core@2.17.1" }
+```
+
+**Rule**: only `` ` :suppress `` a binding you don't reference elsewhere; to
+hide values you *do* reference, group them in a block and suppress that.
+
 ---
 
 ## Future Improvements


### PR DESCRIPTION
Two small, related documentation-guidance changes:

1. **Trim the `:suppress` syntax-gotcha entry** to the essentials — the
   trap (suppression rides a binding's *value*, so referencing it
   elsewhere silently drops that field), one wrong/right pair, and a
   one-line rule. Dropped the `Meta(expr, meta)` implementation detail
   that was just confusing.

2. **Make `docs/eucalypt-style.md` mandatory reading** in `CLAUDE.md` —
   promoted from the "also consult" list into the MUST-read Required
   Reading list, so idiomatic style (pipeline/catenation, juxtaposed
   `f[...]` / `g{...}` calls, `then` over `if`, point-free composition)
   is covered before writing `.eu` code.

Docs-only; no code change.

https://claude.ai/code/session_01Q9v9fZWsqEMPZMqtYRdgBB