### PR TITLE
fix(vm): black-hole App callable to detect self-referential function calls (GH #785)

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -481,6 +481,7 @@ impl MachineState {
                 self.return_data(view, *tag, args.as_slice())?;
             }
             HeapSyn::App { callable, args } => {
+                let suppress_update = std::mem::replace(&mut self.suppress_next_update, false);
                 let array = view.create_arg_array(args.as_slice(), environment)?;
                 self.push(
                     view,
@@ -489,7 +490,35 @@ impl MachineState {
                         annotation: self.annotation,
                     },
                 )?;
-                self.closure = self.nav(view).resolve_callable(callable)?;
+                // Mirror the black-holing logic from the Atom handler: when the
+                // callable is a local ref to an updateable thunk, overwrite the
+                // env slot with a BlackHole before entering the thunk body.
+                // Without this, `{ f: f(x) }` bypasses black-holing because the
+                // App handler resolves the callable directly from the env without
+                // ever going through the Atom{Ref::L} branch.
+                if let Ref::L(i) = callable {
+                    let callee = self.nav(view).get(*i)?;
+                    let is_thunk = callee.update();
+                    let updateable = is_thunk && !suppress_update;
+                    if updateable {
+                        let hole = view.alloc(HeapSyn::BlackHole)?;
+                        let black_hole = SynClosure::new(hole.as_ptr(), environment);
+                        let cont_env = view.scoped(environment);
+                        cont_env.update(&view, *i, black_hole)?;
+                        self.push(
+                            view,
+                            Continuation::Update {
+                                environment,
+                                index: *i,
+                            },
+                        )?;
+                        self.closure = callee;
+                    } else {
+                        self.closure = self.nav(view).resolve_callable(callable)?;
+                    }
+                } else {
+                    self.closure = self.nav(view).resolve_callable(callable)?;
+                }
             }
             HeapSyn::Bif { intrinsic, args } => {
                 // Defer BIF execution to Machine::step() so that the full

--- a/tests/harness/errors/157_self_ref_function_call.eu
+++ b/tests/harness/errors/157_self_ref_function_call.eu
@@ -1,0 +1,8 @@
+#!/usr/bin/env eu
+
+# Regression test for GH #785: a binding that calls itself in function
+# position (e.g. `p: p(1)`) must raise a BlackHole error rather
+# than hanging.  Previously the App handler in vm.rs did not black-hole the
+# env slot, so `resolve_callable` re-read the original thunk and looped.
+
+p: p(1)

--- a/tests/harness/errors/157_self_ref_function_call.eu.expect
+++ b/tests/harness/errors/157_self_ref_function_call.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "infinite loop detected"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1778,6 +1778,11 @@ pub fn test_error_156() {
 }
 
 #[test]
+pub fn test_error_157() {
+    run_error_test(&error_opts("157_self_ref_function_call.eu"));
+}
+
+#[test]
 pub fn test_target_symbol_shortcut_alpha() {
     let output = std::process::Command::new(eu_binary())
         .args(["-t", "alpha", "tests/harness/148_symbol_target_shortcut.eu"])


### PR DESCRIPTION
## Summary

- **Root cause**: The `Atom { Ref::L(i) }` handler in `handle_instruction` installed a BlackHole and pushed an Update continuation, but the `App { callable, args }` handler called `resolve_callable` directly — bypassing black-holing entirely.  For a thunk like `p: p(1)`, whose body is `App { callable: Ref::L(0), ... }`, the App handler read the original thunk back from the letrec env on every re-entry, creating an infinite loop instead of a `BlackHole` error.
- **Fix**: Mirror the Atom handler's black-holing logic in the App handler: when `callable = Ref::L(i)` and the closure at that index has `update = true`, overwrite the env slot with a `BlackHole` node and push an `Update` continuation before entering the callee.
- **Regression test**: `tests/harness/errors/157_self_ref_function_call.eu` — validates that `p: p(1)` exits 1 with "infinite loop detected".

## Test plan

- [x] `cargo test` — all 973 lib tests pass, all harness tests pass (including new test_error_157)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — formatting clean
- [x] Manual: `eu -e '{ sum: sum([1,2,3]) }'` → raises BlackHole error
- [x] Manual: `eu -e '{ p: p(1) }'` → raises BlackHole error
- [x] Manual: `eu -e '{ x: 42, y: x + 1 }'` → evaluates correctly (normal letrec unaffected)
- [x] Manual: `eu -e '{ x: x }'` → raises BlackHole error (existing Atom case still works)

Fixes GH #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)