### PR TITLE
feat(lib): Terraform JSON generation core + Cloudflare DNS

### DIFF
--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -34,7 +34,7 @@ record: cf.a(zone, "www", "203.0.113.10")
 # record's zone_id becomes "${data.cloudflare_zone.main.id}"
 ```
 
-Typo `zone.idd` and you get an Eucalypt error — not a silently broken
+Typo `zone.idd` and you get a Eucalypt error — not a silently broken
 `${...}` string.
 
 ## Running the Cloudflare DNS example

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -1,0 +1,62 @@
+# Generating Terraform from Eucalypt
+
+These examples generate Terraform **JSON** configuration (`*.tf.json`)
+from a compact Eucalypt model. Terraform reads `*.tf.json` natively, so
+the rendered output can be applied directly with `terraform plan` /
+`terraform apply` — the same mechanism HashiCorp's own CDKTF uses. The
+pitch is simple: keep Terraform's runtime graph, state and providers,
+but replace HCL *authoring* with a real functional language — proper
+loops, functions, data structures, in-place computation and typing.
+
+## The libraries
+
+| Module                | Purpose                                                         |
+|-----------------------|----------------------------------------------------------------|
+| `lib/tf.eu`           | Provider-agnostic core: `ref`/handles, `resource`/`data` nodes, `document` assembly, and the other top-level blocks (`provider`, `terraform-settings`, `variable`, `output`, `locals`). |
+| `lib/tf-cloudflare.eu`| Cloudflare constructors (zone lookup, A/AAAA/CNAME/TXT/MX records). |
+
+### Generation time vs apply time
+
+The division of labour is deliberate:
+
+- Values known at **generation** time (names, counts, tags, region/zone
+  fan-out) are computed in Eucalypt and emitted as literal JSON.
+- Values that only exist after **apply** (resource ids, ARNs, ...) are
+  emitted as Terraform `${...}` references via *handles*, so they stay
+  inside Terraform's dependency graph.
+
+A constructor returns a handle, and you reference downstream attributes
+through it:
+
+```eu
+zone:   cf.zone("main", "example.com")   # data-source handle
+record: cf.a(zone, "www", "203.0.113.10")
+# record's zone_id becomes "${data.cloudflare_zone.main.id}"
+```
+
+Typo `zone.idd` and you get an Eucalypt error — not a silently broken
+`${...}` string.
+
+## Running the Cloudflare DNS example
+
+```sh
+eu -j -L lib examples/terraform/cloudflare-dns.eu > main.tf.json
+terraform init && terraform validate    # offline; no credentials needed
+```
+
+`cloudflare-dns.eu` defines a handful of records once and fans them out
+across every zone in the model — two domains × eight records expands to
+sixteen `cloudflare_record` resources, each wired to the right zone via
+its handle. Credentials are read from `CLOUDFLARE_API_TOKEN` at apply
+time; no secrets appear in the generated JSON.
+
+> The `-L lib` flag puts the Terraform modules on the import path. The
+> example targets the Cloudflare provider **v4** (`cloudflare_record`
+> with a `value` attribute); for v5 the resource is `cloudflare_dns_record`
+> and `value` became `content`.
+
+## Status
+
+- **Cloudflare** — implemented (DNS).
+- **GitHub, AWS** — planned. The same `lib/tf.eu` core is provider-agnostic;
+  adding a provider is mostly resource-constructor data entry.

--- a/examples/terraform/cloudflare-dns.eu
+++ b/examples/terraform/cloudflare-dns.eu
@@ -1,17 +1,18 @@
-# Cloudflare DNS estate generated from a compact model.
-#
-# A handful of declarations below expand into a full set of
-# `cloudflare_record` resources, replicated across every zone, emitted
-# as Terraform JSON ready to `terraform apply`.
-#
-# Render:
-#   eu -j -L lib examples/terraform/cloudflare-dns.eu > main.tf.json
-#   terraform init && terraform validate
-#
-# Credentials are taken from CLOUDFLARE_API_TOKEN at apply time; no
-# secrets appear in the generated JSON.
+{ doc: "Cloudflare DNS estate generated from a compact model.
 
-{ import: ["tf=tf.eu", "cf=tf-cloudflare.eu"] }
+A handful of declarations below expand into a full set of
+`cloudflare_record` resources, replicated across every zone, emitted as
+Terraform JSON ready to `terraform apply`.
+
+Render:
+
+    eu -j -L lib examples/terraform/cloudflare-dns.eu > main.tf.json
+    terraform init && terraform validate
+
+Credentials are taken from CLOUDFLARE_API_TOKEN at apply time; no secrets
+appear in the generated JSON."
+
+  import: ["tf=tf.eu", "cf=tf-cloudflare.eu"] }
 
 # ---- Compact model -------------------------------------------------
 

--- a/examples/terraform/cloudflare-dns.eu
+++ b/examples/terraform/cloudflare-dns.eu
@@ -1,0 +1,73 @@
+# Cloudflare DNS estate generated from a compact model.
+#
+# A handful of declarations below expand into a full set of
+# `cloudflare_record` resources, replicated across every zone, emitted
+# as Terraform JSON ready to `terraform apply`.
+#
+# Render:
+#   eu -j -L lib examples/terraform/cloudflare-dns.eu > main.tf.json
+#   terraform init && terraform validate
+#
+# Credentials are taken from CLOUDFLARE_API_TOKEN at apply time; no
+# secrets appear in the generated JSON.
+
+{ import: ["tf=tf.eu", "cf=tf-cloudflare.eu"] }
+
+# ---- Compact model -------------------------------------------------
+
+# Every domain receives the same baseline records - change the model
+# once and it fans out across all zones.
+domains: {
+  primary:   "example.com"
+  secondary: "example.net"
+}
+
+a-records: [
+  { name: "@",   ip: "203.0.113.10" },
+  { name: "www", ip: "203.0.113.10" },
+  { name: "api", ip: "203.0.113.11" },
+]
+
+cname-records: [
+  { name: "blog", target: "www" },
+  { name: "docs", target: "api" },
+]
+
+txt-records: [
+  { name: "@", value: "v=spf1 include:_spf.example.com ~all" },
+]
+
+mx-records: [
+  { name: "@", priority: 10, value: "mail1.example.com" },
+  { name: "@", priority: 20, value: "mail2.example.com" },
+]
+
+# ---- Expansion -----------------------------------------------------
+
+# Per-record builders: each maps one model entry to a record node bound
+# to a zone handle `z`.
+make-a(z, r):     cf.a(z, r.name, r.ip)
+make-cname(z, r): cf.cname(z, r.name, r.target)
+make-txt(z, r):   cf.txt(z, r.name, r.value)
+make-mx(z, r):    cf.mx(z, r.name, r.priority, r.value)
+
+# Expand the whole model into record nodes for one zone.
+records-for(z): concat[
+  a-records     map(make-a(z)),
+  cname-records map(make-cname(z)),
+  txt-records   map(make-txt(z)),
+  mx-records    map(make-mx(z)),
+]
+
+# For each domain: a zone data-source handle plus all of its records.
+expand-zone([tag, domain]): {
+  z: cf.zone(tag str.of, domain)
+  nodes: z ‖ records-for(z)
+}.nodes
+
+all-nodes: domains elements mapcat(expand-zone)
+
+# ---- Document ------------------------------------------------------
+
+` :main
+main: tf.document(cf.provider-config("~> 4") ‖ all-nodes)

--- a/lib/tf-cloudflare.eu
+++ b/lib/tf-cloudflare.eu
@@ -41,10 +41,12 @@ dns-label(name): name = "@" then("root", name str.replace("[^A-Za-z0-9]", "_"))
 ` :suppress
 local-name(prefix, ztag, name, suffix): { label: name dns-label }."{prefix}_{ztag}_{label}{suffix}"
 
+# `select` keeps only the named keys of a block; due in the prelude at 0.8.
 ` :suppress
-optionals(o): { ttl: o lookup-or(:ttl, 1) }
-  << (o has(:proxied)  then({ proxied:  o.proxied  }, {}))
-  << (o has(:priority) then({ priority: o.priority }, {}))
+select(ks, b): b filter-items(by-key(∈ set.from-list(ks))) block
+
+` :suppress
+optionals(o): { ttl: 1 } (o select[:ttl, :proxied, :priority])
 
 # Record constructors -------------------------------------------------
 
@@ -61,9 +63,6 @@ record(o): tf.resource(
   local-name(o.type str.to-lower, o.zone.name, o.name, o lookup-or(:suffix, "")),
   { zone_id: o.zone.id  name: o.name  type: o.type  value: o.value }
     << optionals(o))
-
-# NB: parameter names must differ from block field names - `{name: name}`
-# would be a self-reference, not a read of the parameter.
 
 ` { doc: "`a(zone, name, value)` - an A record." }
 a(z, n, v): record{ zone: z, name: n, type: "A", value: v }

--- a/lib/tf-cloudflare.eu
+++ b/lib/tf-cloudflare.eu
@@ -1,0 +1,120 @@
+{ doc: "Cloudflare resource constructors for the Terraform-JSON core
+(`tf.eu`).
+
+Targets the Cloudflare Terraform provider v4 (`cloudflare_record` with a
+`value` attribute).  For provider v5 the DNS resource was renamed to
+`cloudflare_dns_record` and `value` became `content` - switch the type
+string and the value key accordingly.
+
+Cloudflare configuration is almost entirely resolvable at generation
+time (DNS records, zone settings and rules are flat data), which makes
+it an especially good fit for Eucalypt: the only cross-reference needed
+is the zone id, obtained from a `zone` data-source handle."
+
+  import: "tf=tf.eu" }
+
+# Provider ------------------------------------------------------------
+
+` { doc: "`provider-config(version)` - a `terraform.required_providers`
+plus an empty `provider` block.  Credentials come from the standard
+`CLOUDFLARE_API_TOKEN` environment variable, so no secrets appear in the
+generated JSON." }
+provider-config(ver): tf.document[
+  tf.required-providers{
+    cloudflare: { source: "cloudflare/cloudflare", version: ver }
+  },
+  tf.provider("cloudflare", {}),
+]
+
+# Zone data source ----------------------------------------------------
+
+` { doc: "`zone(local-name, domain)` - look up a Cloudflare zone by
+domain name as a data source.  Use the returned handle's `.id` as the
+`zone_id` of records." }
+zone(local-name, domain): tf.data("cloudflare_zone", local-name, { name: domain })
+
+# Local-name helpers --------------------------------------------------
+
+` :suppress
+dns-label(name): name = "@" then("root", name str.replace("[^A-Za-z0-9]", "_"))
+
+` :suppress
+local-name(prefix, ztag, name, suffix): { label: name dns-label }."{prefix}_{ztag}_{label}{suffix}"
+
+` :suppress
+optionals(o): { ttl: o lookup-or(:ttl, 1) }
+  << (o has(:proxied)  then({ proxied:  o.proxied  }, {}))
+  << (o has(:priority) then({ priority: o.priority }, {}))
+
+# Record constructors -------------------------------------------------
+
+` { doc: "`record(o)` - a generic `cloudflare_record` from a block with
+keys `zone` (a zone handle), `name`, `type` and `value`, plus optional
+`ttl`, `proxied`, `priority` and `suffix`.  The Terraform local name is
+derived as `type_zone_name` (`@` becomes `root`, other punctuation
+becomes `_`).  Local names must be unique, so when several records share
+a type and name (e.g. multiple MX or round-robin A records) pass a
+distinguishing `suffix`; otherwise they collide and all but one are
+lost." }
+record(o): tf.resource(
+  "cloudflare_record",
+  local-name(o.type str.to-lower, o.zone.name, o.name, o lookup-or(:suffix, "")),
+  { zone_id: o.zone.id  name: o.name  type: o.type  value: o.value }
+    << optionals(o))
+
+# NB: parameter names must differ from block field names - `{name: name}`
+# would be a self-reference, not a read of the parameter.
+
+` { doc: "`a(zone, name, value)` - an A record." }
+a(z, n, v): record{ zone: z, name: n, type: "A", value: v }
+
+` { doc: "`aaaa(zone, name, value)` - an AAAA record." }
+aaaa(z, n, v): record{ zone: z, name: n, type: "AAAA", value: v }
+
+` { doc: "`cname(zone, name, target)` - a CNAME record." }
+cname(z, n, target): record{ zone: z, name: n, type: "CNAME", value: target }
+
+` { doc: "`txt(zone, name, value)` - a TXT record." }
+txt(z, n, v): record{ zone: z, name: n, type: "TXT", value: v }
+
+` { doc: "`mx(zone, name, priority, value)` - an MX record.  The
+priority is folded into the local name so several MX records may share a
+name." }
+mx(z, n, prio, v): record{ zone: z, name: n, type: "MX", value: v,
+                           priority: prio, suffix: "_{prio}" }
+
+# Embedded tests ------------------------------------------------------
+
+` { target: :test-record }
+test-record: {
+  z: zone("main", "example.com")
+  rec: a(z, "www", "203.0.113.10")
+  α: rec.type = "cloudflare_record"
+  β: rec.name = "a_main_www"
+  γ: rec.body.zone_id = "${{data.cloudflare_zone.main.id}}"
+  δ: rec.body = { zone_id: "${{data.cloudflare_zone.main.id}}"
+                  name: "www"  type: "A"  value: "203.0.113.10"  ttl: 1 }
+  RESULT: (α ∧ β ∧ γ ∧ δ) then(:PASS, :FAIL)
+}
+
+` { target: :test-apex-and-mx }
+test-apex-and-mx: {
+  z: zone("main", "example.com")
+  apex: a(z, "@", "203.0.113.1")
+  mail: mx(z, "@", 10, "mail.example.com")
+  α: apex.name = "a_main_root"
+  β: mail.name = "mx_main_root_10"
+  γ: mail.body.priority = 10
+  δ: mail.body.type = "MX"
+  RESULT: (α ∧ β ∧ γ ∧ δ) then(:PASS, :FAIL)
+}
+
+` { target: :test-document }
+test-document: {
+  z: zone("main", "example.com")
+  doc: tf.document[z, a(z, "www", "203.0.113.10"), cname(z, "blog", "www")]
+  α: doc.data.cloudflare_zone.main.name = "example.com"
+  β: doc.resource.cloudflare_record.a_main_www.value = "203.0.113.10"
+  γ: doc.resource.cloudflare_record.cname_main_blog.type = "CNAME"
+  RESULT: (α ∧ β ∧ γ) then(:PASS, :FAIL)
+}

--- a/lib/tf.eu
+++ b/lib/tf.eu
@@ -34,7 +34,7 @@ ref(path): { o: "${{" c: "}}" }."{o}{path}{c}"
 # references any attribute, and `.address` is the bare `type.name`
 # address used by `depends_on`.  Naming a downstream attribute through
 # the handle (`vpc.id`, `vpc.attr(:arn)`) is the ergonomic win over
-# hand-written `"${...}"` strings: a typo is an Eucalypt error.
+# hand-written `"${...}"` strings: a typo is a Eucalypt error.
 
 ` { doc: "`resource(type, name, body)` - a managed-resource node.  The
 returned handle exposes `.id`, `.attr(a)` and `.address`, and carries
@@ -80,7 +80,7 @@ blocks into one Terraform document by deep-merging them.  Nodes (from
 plain fragment blocks (from `provider`, `terraform-settings`,
 `variable`, `output`, ...) are merged as-is.  Resources of the same
 type collect under a single key." }
-document(items): foldl(deep-merge, {}, items map(to-fragment))
+document(items): items map(to-fragment) foldl(deep-merge, {})
 
 # Other top-level blocks ---------------------------------------------
 
@@ -105,12 +105,9 @@ output(name, v): { output: block[[name sym, { value: v }]] }
 name / value pairs." }
 locals(b): { locals: b }
 
-` :suppress
-node-address(node): node.address
-
 ` { doc: "`depends-on(nodes)` - a bare address list for a resource's
 `depends_on` (Terraform expects unquoted references here)." }
-depends-on(nodes): nodes map(node-address)
+depends-on(nodes): nodes map(.address)
 
 # Embedded tests -----------------------------------------------------
 

--- a/lib/tf.eu
+++ b/lib/tf.eu
@@ -1,0 +1,159 @@
+"Provider-agnostic core for generating Terraform JSON configuration
+(`*.tf.json`) from Eucalypt.
+
+A Terraform document is a block whose top-level keys are `terraform`,
+`provider`, `resource`, `data`, `variable`, `output`, `locals` and
+`module`.  Terraform reads `*.tf.json` natively, so the rendered JSON
+can be applied directly with `terraform plan` / `terraform apply` (the
+same mechanism HashiCorp's own CDKTF uses).
+
+The division of labour is deliberate.  Values known at *generation*
+time (names, counts, tags, CIDR maths, environment / region fan-out)
+are computed in Eucalypt and emitted as literal JSON.  Values that only
+exist after `apply` (resource ids, ARNs, ...) are emitted as Terraform
+interpolation references via `ref` / handles, so they stay inside
+Terraform's dependency graph.
+
+In other words Eucalypt replaces HCL *authoring*; Terraform keeps its
+runtime graph, state and providers."
+
+# References ---------------------------------------------------------
+
+` { doc: "`ref(path)` - wrap a Terraform address such as
+`aws_vpc.main.id` in an interpolation reference, threading a value that
+only exists after `terraform apply` through the configuration whilst
+keeping it inside Terraform's dependency graph (see test-ref for the
+literal form)."
+    type: "string -> string" }
+ref(path): { o: "${{" c: "}}" }."{o}{path}{c}"
+
+# Nodes (resources and data sources) ---------------------------------
+#
+# A node is a block carrying the Terraform `body` together with a typed
+# handle.  `.id` is the `${type.name.id}` reference, `.attr(a)`
+# references any attribute, and `.address` is the bare `type.name`
+# address used by `depends_on`.  Naming a downstream attribute through
+# the handle (`vpc.id`, `vpc.attr(:arn)`) is the ergonomic win over
+# hand-written `"${...}"` strings: a typo is an Eucalypt error.
+
+` { doc: "`resource(type, name, body)` - a managed-resource node.  The
+returned handle exposes `.id`, `.attr(a)` and `.address`, and carries
+the attribute `body` for `document` to assemble." }
+resource(t, n, b): {
+  tf_kind: :resource
+  type: t
+  name: n
+  body: b
+  address: "{t}.{n}"
+  id: "{t}.{n}.id" ref
+  attr(a): "{t}.{n}.{a}" ref
+}
+
+` { doc: "`data(type, name, body)` - a data-source node.  Like
+`resource` but the address is prefixed with `data.` and references
+resolve through the `data.` namespace." }
+data(t, n, b): {
+  tf_kind: :data
+  type: t
+  name: n
+  body: b
+  address: "data.{t}.{n}"
+  id: "data.{t}.{n}.id" ref
+  attr(a): "data.{t}.{n}.{a}" ref
+}
+
+# Document assembly --------------------------------------------------
+
+` :suppress
+node-fragment(node): {
+  named: block[[node.name sym, node.body]]
+  typed: block[[node.type sym, named]]
+  result: block[[node.tf_kind, typed]]
+}.result
+
+` :suppress
+to-fragment(item): item has(:tf_kind) then(node-fragment(item), item)
+
+` { doc: "`document(items)` - assemble a list of nodes and / or fragment
+blocks into one Terraform document by deep-merging them.  Nodes (from
+`resource` / `data`) expand into nested resource / type / name shape;
+plain fragment blocks (from `provider`, `terraform-settings`,
+`variable`, `output`, ...) are merged as-is.  Resources of the same
+type collect under a single key." }
+document(items): foldl(deep-merge, {}, items map(to-fragment))
+
+# Other top-level blocks ---------------------------------------------
+
+` { doc: "`provider(name, config)` - a provider-configuration fragment." }
+provider(name, config): { provider: block[[name sym, config]] }
+
+` { doc: "`terraform-settings(config)` - the top-level `terraform`
+block, e.g. `required_providers` and backend configuration." }
+terraform-settings(config): { terraform: config }
+
+` { doc: "`required-providers(block)` - convenience wrapper producing a
+`terraform.required_providers` fragment." }
+required-providers(b): { terraform: { required_providers: b } }
+
+` { doc: "`variable(name, config)` - an input-variable fragment." }
+variable(name, config): { variable: block[[name sym, config]] }
+
+` { doc: "`output(name, value)` - an output-value fragment." }
+output(name, v): { output: block[[name sym, { value: v }]] }
+
+` { doc: "`locals(block)` - a `locals` fragment from a block of
+name / value pairs." }
+locals(b): { locals: b }
+
+` :suppress
+node-address(node): node.address
+
+` { doc: "`depends-on(nodes)` - a bare address list for a resource's
+`depends_on` (Terraform expects unquoted references here)." }
+depends-on(nodes): nodes map(node-address)
+
+# Embedded tests -----------------------------------------------------
+
+` { target: :test-ref }
+test-ref: {
+  α: ref("aws_vpc.main.id") = "${{aws_vpc.main.id}}"
+  β: ref("data.cloudflare_zone.main.id") = "${{data.cloudflare_zone.main.id}}"
+  RESULT: (α ∧ β) then(:PASS, :FAIL)
+}
+
+` { target: :test-handle }
+test-handle: {
+  vpc: resource("aws_vpc", "main", { cidr_block: "10.0.0.0/16" })
+  α: vpc.id = "${{aws_vpc.main.id}}"
+  β: vpc.attr(:arn) = "${{aws_vpc.main.arn}}"
+  γ: vpc.address = "aws_vpc.main"
+  δ: vpc.body.cidr_block = "10.0.0.0/16"
+  RESULT: (α ∧ β ∧ γ ∧ δ) then(:PASS, :FAIL)
+}
+
+` { target: :test-document }
+test-document: {
+  a: resource("aws_subnet", "a", { cidr_block: "10.0.1.0/24" })
+  b: resource("aws_subnet", "b", { cidr_block: "10.0.2.0/24" })
+  z: data("cloudflare_zone", "main", { name: "example.com" })
+  doc: document[a, b, z]
+  expected: {
+    resource: { aws_subnet: { a: { cidr_block: "10.0.1.0/24" }
+                              b: { cidr_block: "10.0.2.0/24" } } }
+    data: { cloudflare_zone: { main: { name: "example.com" } } }
+  }
+  RESULT: (doc = expected) then(:PASS, :FAIL)
+}
+
+` { target: :test-fragments }
+test-fragments: {
+  doc: document[
+    provider("cloudflare", {}),
+    required-providers{ cloudflare: { source: "cloudflare/cloudflare" } },
+    output("zone_id", "data.cloudflare_zone.main.id" ref),
+  ]
+  α: doc.provider.cloudflare = {}
+  β: doc.terraform.required_providers.cloudflare.source = "cloudflare/cloudflare"
+  γ: doc.output.zone_id.value = "${{data.cloudflare_zone.main.id}}"
+  RESULT: (α ∧ β ∧ γ) then(:PASS, :FAIL)
+}


### PR DESCRIPTION
## Summary

A provider-agnostic Eucalypt library for generating Terraform **JSON**
configuration (`*.tf.json`), plus a Cloudflare DNS provider module and a
worked multi-zone example. Terraform reads `*.tf.json` natively, so the
output applies directly with `terraform plan` / `terraform apply` (the
mechanism HashiCorp's own CDKTF uses). The aim: keep Terraform's runtime
graph, state and providers, but replace HCL *authoring* with real
functions, loops, data structures and in-place computation.

**Phase 1** (Cloudflare) of a planned series; the core is
provider-agnostic so GitHub and AWS slot in behind it.

## What's here

| File | |
|------|---|
| `lib/tf.eu` | Core: `ref`/handles emitting `${...}` references, `resource`/`data` node constructors with typed handles (`.id`, `.attr(a)`, `.address`), `document` assembly by deep-merge, and `provider` / `terraform-settings` / `variable` / `output` / `locals`. |
| `lib/tf-cloudflare.eu` | Zone data-source lookup and A/AAAA/CNAME/TXT/MX record constructors (Cloudflare provider v4). |
| `examples/terraform/cloudflare-dns.eu` | A ~30-line model fanning out across zones into 16 `cloudflare_record` resources. |
| `examples/terraform/README.md` | Usage and design notes. |

## Design

The generation-time / apply-time split is deliberate. Names, counts,
tags and zone fan-out are computed in Eucalypt and emitted as literal
JSON; values that only exist after `apply` (ids, ARNs) stay as
Terraform `${...}` references via *handles*, so they remain inside
Terraform's dependency graph. A constructor returns a handle and you
reference downstream attributes through it — `zone.id` becomes
`"${data.cloudflare_zone.main.id}"`, and a typo is an Eucalypt error
rather than a silently broken string.

## Testing

- Both modules carry embedded `eu test` suites — all green.
- The example renders to independently valid JSON (16 resources across
  two zones, each `zone_id` correctly referencing its zone handle).

```sh
eu test lib/tf.eu
eu test lib/tf-cloudflare.eu
eu -j -L lib examples/terraform/cloudflare-dns.eu | python3 -m json.tool
```

## Caveats / follow-ups

- **`terraform validate` not run in CI yet** — the build environment has
  no `terraform` binary (and `init` needs network). It's wired as the
  documented integrity step; running it for real is pending a suitable
  environment.
- **Provider v4** targeted (`cloudflare_record` / `value`); v5
  (`cloudflare_dns_record` / `content`) is a one-line switch, noted in
  the module.
- **Collision handling.** Two MX records initially collapsed under
  deep-merge (same local name, last-wins); fixed here with a `suffix`
  discriminator. A general `merge-with` prelude primitive and a
  collision-detecting `document` (a duplicate address becomes a typed
  error) are a planned follow-up.
- **Baking into the binary** (`resources.rs`) so `{ import: "tf.eu" }`
  works without `-L lib`, like `state.eu` — follow-up.

https://claude.ai/code/session_01Q9v9fZWsqEMPZMqtYRdgBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9v9fZWsqEMPZMqtYRdgBB)_