### PR TITLE
fix(check): static diagnostic for trivial self-assignment

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -71,6 +71,16 @@ pub enum CoreError {
     /// was eliminated during dead code elimination.
     #[error("internal compiler error: {1}")]
     InternalCompilerError(Smid, String),
+    /// A binding whose value is trivially self-referential in a way that is
+    /// *always* divergent:
+    ///
+    /// - **direct**: `x: x`
+    /// - **function/operator position**: `x: x(...)`, `x: a x b`
+    ///
+    /// Argument-position self-reference (e.g. `ones: cons(1, ones)`) is NOT
+    /// flagged — that is legitimate lazy / fixpoint usage.
+    #[error("binding '{1}' refers to itself — this will always diverge")]
+    TrivialSelfAssignment(Smid, String),
 }
 
 impl HasSmid for CoreError {
@@ -90,6 +100,7 @@ impl HasSmid for CoreError {
             MonadSpecMissingMarker(_, _, s) => s,
             InvalidStringInterpolation(s) => s,
             InternalCompilerError(s, _) => s,
+            TrivialSelfAssignment(s, _) => s,
             _ => Smid::default(),
         }
     }
@@ -159,6 +170,12 @@ impl CoreError {
                         pair_name.chars().next().unwrap_or('?'),
                         pair_name.chars().last().unwrap_or('?')
                     ),
+                ])
+            }
+            CoreError::TrivialSelfAssignment(_, name) => {
+                source_map.diagnostic(self).with_notes(vec![
+                    format!("the binding `{name}: {name}` (or `{name}: {name}(…)`) always loops"),
+                    "if you want a lazy fixpoint, put the self-reference in argument position: e.g. `ones: cons(1, ones)`".to_string(),
                 ])
             }
             _ => source_map.diagnostic(self),

--- a/src/core/verify/content.rs
+++ b/src/core/verify/content.rs
@@ -1,4 +1,6 @@
 //! Verify integrity of core expression before eval / compiles
+use crate::common::sourcemap::HasSmid;
+use crate::core::binding::{BoundVar, Var};
 use crate::core::error::CoreError;
 use crate::core::expr::*;
 
@@ -7,6 +9,53 @@ pub fn verify(expr: RcExpr) -> Result<Vec<CoreError>, CoreError> {
     let mut verifier = Verifier::default();
     verifier.verify(expr)?;
     Ok(verifier.errors)
+}
+
+/// Strip any `Meta` wrappers from an expression to reach its inner form.
+fn strip_meta(expr: &RcExpr) -> &RcExpr {
+    let mut e = expr;
+    loop {
+        match &*e.inner {
+            Expr::Meta(_, _, inner) => e = inner,
+            _ => return e,
+        }
+    }
+}
+
+/// Return `true` if `expr` (after stripping `Meta`) is exactly
+/// `BoundVar { scope: 0, binder }`.
+fn is_self_bv(expr: &RcExpr, binder: u32) -> bool {
+    matches!(
+        &*strip_meta(expr).inner,
+        Expr::Var(
+            _,
+            Var::Bound(BoundVar {
+                scope: 0,
+                binder: b,
+                ..
+            }),
+        ) if *b == binder
+    )
+}
+
+/// Return `true` if `value` is an always-divergent self-reference for binder
+/// `binder` at scope 0.  We flag:
+///
+/// - **direct**: the value IS `BoundVar(scope=0, binder)`
+/// - **function/operator position**: the value is `App(head, _)` and `head`
+///   (after stripping `Meta`) IS `BoundVar(scope=0, binder)`
+///
+/// Argument-position self-reference (`cons(1, ones)`) is NOT flagged.
+fn is_trivially_self_referential(value: &RcExpr, binder: u32) -> bool {
+    if is_self_bv(value, binder) {
+        return true;
+    }
+    if let Expr::App(_, head, _) = &*strip_meta(value).inner {
+        if is_self_bv(head, binder) {
+            return true;
+        }
+    }
+    false
 }
 
 #[derive(Default)]
@@ -39,6 +88,19 @@ impl Verifier {
                 self.errors.push(CoreError::UneliminatedSoup(*s));
                 Ok(expr)
             }
+            Expr::Let(_, scope, _) => {
+                // Check each binding value for trivial self-assignment before
+                // walking into the scope body.
+                for (binder, (name, value)) in scope.pattern.iter().enumerate() {
+                    if is_trivially_self_referential(value, binder as u32) {
+                        self.errors.push(CoreError::TrivialSelfAssignment(
+                            value.smid(),
+                            name.clone(),
+                        ));
+                    }
+                }
+                expr.walk_safe(&mut |x| self.verify(x))
+            }
             _ => expr.walk_safe(&mut |x| self.verify(x)),
         }
     }
@@ -47,7 +109,10 @@ impl Verifier {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{common::sourcemap::Smid, core::expr::acore::*};
+    use crate::{
+        common::sourcemap::Smid,
+        core::expr::acore::*,
+    };
 
     #[test]
     pub fn test_verify_pseudo_ops() {
@@ -73,6 +138,61 @@ pub mod tests {
             ))
             .unwrap(),
             vec![CoreError::UneliminatedPseudoOperators]
+        );
+    }
+
+    #[test]
+    pub fn test_verify_self_assignment_direct() {
+        // Simulates desugaring `{ x: x }`: after close_let_scope, the FreeVar("x")
+        // in the binding value becomes BoundVar(scope=0, binder=0).
+        let expr = let_(
+            vec![("x".to_string(), var(free("x")))],
+            block(vec![]),
+        );
+        let errors = verify(expr).unwrap();
+        assert_eq!(errors.len(), 1, "expected 1 error, got {errors:?}");
+        assert!(
+            matches!(&errors[0], CoreError::TrivialSelfAssignment(_, n) if n == "x"),
+            "expected TrivialSelfAssignment for x, got {errors:?}"
+        );
+    }
+
+    #[test]
+    pub fn test_verify_self_assignment_function_position() {
+        // Simulates desugaring `{ f: f(1) }`: after close_let_scope the head
+        // FreeVar("f") becomes BoundVar(scope=0, binder=0).
+        let expr = let_(
+            vec![(
+                "f".to_string(),
+                app(var(free("f")), vec![num(1)]),
+            )],
+            block(vec![]),
+        );
+        let errors = verify(expr).unwrap();
+        assert_eq!(errors.len(), 1, "expected 1 error, got {errors:?}");
+        assert!(
+            matches!(&errors[0], CoreError::TrivialSelfAssignment(_, n) if n == "f"),
+            "expected TrivialSelfAssignment for f, got {errors:?}"
+        );
+    }
+
+    #[test]
+    pub fn test_verify_no_flag_argument_position() {
+        // Simulates desugaring `{ ones: cons(1, ones) }`: self-reference is in
+        // argument position → must NOT be flagged (legitimate lazy fixpoint).
+        let expr = let_(
+            vec![(
+                "ones".to_string(),
+                app(var(free("cons")), vec![num(1), var(free("ones"))]),
+            )],
+            block(vec![]),
+        );
+        let errors = verify(expr).unwrap();
+        assert!(
+            errors
+                .iter()
+                .all(|e| !matches!(e, CoreError::TrivialSelfAssignment(..))),
+            "argument-position self-reference must NOT be flagged, got {errors:?}"
         );
     }
 }

--- a/src/core/verify/content.rs
+++ b/src/core/verify/content.rs
@@ -93,10 +93,8 @@ impl Verifier {
                 // walking into the scope body.
                 for (binder, (name, value)) in scope.pattern.iter().enumerate() {
                     if is_trivially_self_referential(value, binder as u32) {
-                        self.errors.push(CoreError::TrivialSelfAssignment(
-                            value.smid(),
-                            name.clone(),
-                        ));
+                        self.errors
+                            .push(CoreError::TrivialSelfAssignment(value.smid(), name.clone()));
                     }
                 }
                 expr.walk_safe(&mut |x| self.verify(x))
@@ -109,10 +107,7 @@ impl Verifier {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{
-        common::sourcemap::Smid,
-        core::expr::acore::*,
-    };
+    use crate::{common::sourcemap::Smid, core::expr::acore::*};
 
     #[test]
     pub fn test_verify_pseudo_ops() {
@@ -145,10 +140,7 @@ pub mod tests {
     pub fn test_verify_self_assignment_direct() {
         // Simulates desugaring `{ x: x }`: after close_let_scope, the FreeVar("x")
         // in the binding value becomes BoundVar(scope=0, binder=0).
-        let expr = let_(
-            vec![("x".to_string(), var(free("x")))],
-            block(vec![]),
-        );
+        let expr = let_(vec![("x".to_string(), var(free("x")))], block(vec![]));
         let errors = verify(expr).unwrap();
         assert_eq!(errors.len(), 1, "expected 1 error, got {errors:?}");
         assert!(
@@ -162,10 +154,7 @@ pub mod tests {
         // Simulates desugaring `{ f: f(1) }`: after close_let_scope the head
         // FreeVar("f") becomes BoundVar(scope=0, binder=0).
         let expr = let_(
-            vec![(
-                "f".to_string(),
-                app(var(free("f")), vec![num(1)]),
-            )],
+            vec![("f".to_string(), app(var(free("f")), vec![num(1)]))],
             block(vec![]),
         );
         let errors = verify(expr).unwrap();

--- a/src/core/verify/content.rs
+++ b/src/core/verify/content.rs
@@ -16,13 +16,13 @@ fn strip_meta(expr: &RcExpr) -> &RcExpr {
     let mut e = expr;
     loop {
         match &*e.inner {
-            Expr::Meta(_, _, inner) => e = inner,
+            Expr::Meta(_, inner, _) => e = inner,
             _ => return e,
         }
     }
 }
 
-/// Return `true` if `expr` (after stripping `Meta`) is exactly
+/// Return `true` if `expr` (after stripping `Meta` wrappers) is exactly
 /// `BoundVar { scope: 0, binder }`.
 fn is_self_bv(expr: &RcExpr, binder: u32) -> bool {
     matches!(
@@ -42,7 +42,7 @@ fn is_self_bv(expr: &RcExpr, binder: u32) -> bool {
 /// `binder` at scope 0.  We flag:
 ///
 /// - **direct**: the value IS `BoundVar(scope=0, binder)`
-/// - **function/operator position**: the value is `App(head, _)` and `head`
+/// - **function-head position**: the value is `App(head, _)` and `head`
 ///   (after stripping `Meta`) IS `BoundVar(scope=0, binder)`
 ///
 /// Argument-position self-reference (`cons(1, ones)`) is NOT flagged.
@@ -173,6 +173,23 @@ pub mod tests {
         assert!(
             matches!(&errors[0], CoreError::TrivialSelfAssignment(_, n) if n == "f"),
             "expected TrivialSelfAssignment for f, got {errors:?}"
+        );
+    }
+
+    #[test]
+    pub fn test_verify_self_assignment_meta_wrapped() {
+        // A Meta wrapper around a self-referential value must still be detected.
+        // After close_let_scope the FreeVar("x") → BoundVar(scope=0, binder=0),
+        // wrapped in Meta(_, BoundVar, _).
+        let expr = let_(
+            vec![("x".to_string(), meta(var(free("x")), sym("doc")))],
+            block(vec![]),
+        );
+        let errors = verify(expr).unwrap();
+        assert_eq!(errors.len(), 1, "expected 1 error, got {errors:?}");
+        assert!(
+            matches!(&errors[0], CoreError::TrivialSelfAssignment(_, n) if n == "x"),
+            "expected TrivialSelfAssignment for meta-wrapped x, got {errors:?}"
         );
     }
 

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -26,6 +26,7 @@ use crate::core::typecheck::{
     },
     parse,
 };
+use crate::core::error::CoreError;
 use crate::core::verify::deprecation::check_deprecated_references;
 use crate::driver::error::EucalyptError;
 use crate::driver::options::EucalyptOptions;
@@ -160,15 +161,16 @@ pub fn check(opt: &EucalyptOptions) -> Result<i32, String> {
     }
     let phase1_elapsed = t_phase1.elapsed();
 
-    // ── Phase 2: bidirectional type check via pipeline ─────────────────────
+    // ── Phase 2: bidirectional type check + content verifier via pipeline ─────
     let t_phase2 = Instant::now();
-    let type_warning_count = match run_type_checker(opt) {
+    let (type_warning_count, content_error_count) = match run_type_checker(opt) {
         Ok(result) => {
-            let count = result.warnings.len();
             let writer = codespan_reporting::term::termcolor::StandardStream::stderr(
                 codespan_reporting::term::termcolor::ColorChoice::Auto,
             );
             let config = codespan_reporting::term::Config::default();
+
+            // Emit type warnings.
             for w in &result.warnings {
                 let diag = w.to_diagnostic(&result.source_map);
                 // Ignore render errors — best effort
@@ -179,13 +181,25 @@ pub fn check(opt: &EucalyptOptions) -> Result<i32, String> {
                     &diag,
                 );
             }
-            count
+
+            // Emit content verifier errors (e.g. trivial self-assignment).
+            for e in &result.core_errors {
+                let diag = e.to_diagnostic(&result.source_map);
+                let _ = codespan_reporting::term::emit(
+                    &mut writer.lock(),
+                    &config,
+                    &result.files,
+                    &diag,
+                );
+            }
+
+            (result.warnings.len(), result.core_errors.len())
         }
         Err(e) => {
             // Pipeline failure is not a type error — log at debug level and
             // continue with the annotation syntax results only.
             eprintln!("eu check: pipeline warning: {e}");
-            0
+            (0, 0)
         }
     };
     let phase2_elapsed = t_phase2.elapsed();
@@ -199,14 +213,16 @@ pub fn check(opt: &EucalyptOptions) -> Result<i32, String> {
         );
     }
 
-    let total_issues = syntax_errors + type_warning_count;
+    let total_issues = syntax_errors + type_warning_count + content_error_count;
 
     if total_issues == 0 {
         Ok(0)
-    } else if opt.check_strict() {
+    } else if opt.check_strict() || content_error_count > 0 {
+        // Content verifier errors (e.g. always-divergent bindings) are always
+        // hard errors, regardless of --strict.
         Ok(1)
     } else {
-        // Warnings never cause non-zero exit unless --strict.
+        // Type warnings never cause non-zero exit unless --strict.
         // Annotation *syntax* errors are always real errors, though.
         if syntax_errors > 0 {
             Ok(1)
@@ -421,6 +437,8 @@ fn type_check_path_merged(
 /// Result of running the type checker through the full pipeline.
 struct PipelineCheckResult {
     warnings: Vec<crate::core::typecheck::error::TypeWarning>,
+    /// Static errors detected by the content verifier (e.g. trivial self-assignment).
+    core_errors: Vec<CoreError>,
     files: codespan_reporting::files::SimpleFiles<String, String>,
     source_map: crate::common::sourcemap::SourceMap,
 }
@@ -487,9 +505,14 @@ fn run_type_checker(opt: &EucalyptOptions) -> Result<PipelineCheckResult, Eucaly
         type_check_with_operator_overloads(&core_expr, operator_overloads)
     };
     warnings.extend(deprecation_warnings);
+
+    // Run content verifier to catch static errors (e.g. trivial self-assignment).
+    let core_errors = loader.verify().unwrap_or_default();
+
     let (files, source_map, _) = loader.complete();
     Ok(PipelineCheckResult {
         warnings,
+        core_errors,
         files,
         source_map,
     })

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::time::Instant;
 
+use crate::core::error::CoreError;
 use crate::core::typecheck::{
     check::{
         parse_operator_overloads, type_check, type_check_for_prelude, type_check_full,
@@ -26,7 +27,6 @@ use crate::core::typecheck::{
     },
     parse,
 };
-use crate::core::error::CoreError;
 use crate::core::verify::deprecation::check_deprecated_references;
 use crate::driver::error::EucalyptError;
 use crate::driver::options::EucalyptOptions;

--- a/tests/harness/typecheck/092_self_assign_direct.eu
+++ b/tests/harness/typecheck/092_self_assign_direct.eu
@@ -1,0 +1,2 @@
+# Trivial self-assignment: x: x always diverges.
+out: { x: x }

--- a/tests/harness/typecheck/092_self_assign_direct.eu.expect
+++ b/tests/harness/typecheck/092_self_assign_direct.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "binding 'x' refers to itself"

--- a/tests/harness/typecheck/093_self_assign_function_pos.eu
+++ b/tests/harness/typecheck/093_self_assign_function_pos.eu
@@ -1,0 +1,2 @@
+# Trivial self-assignment in function position: f: f(1) always diverges.
+out: { f: f(1) }

--- a/tests/harness/typecheck/093_self_assign_function_pos.eu.expect
+++ b/tests/harness/typecheck/093_self_assign_function_pos.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "binding 'f' refers to itself"

--- a/tests/harness/typecheck/094_self_assign_arg_pos_ok.eu
+++ b/tests/harness/typecheck/094_self_assign_arg_pos_ok.eu
@@ -1,0 +1,2 @@
+# Argument-position self-reference is a legitimate lazy fixpoint — must NOT be flagged.
+ones: cons(1, ones)

--- a/tests/harness/typecheck/094_self_assign_arg_pos_ok.eu.expect
+++ b/tests/harness/typecheck/094_self_assign_arg_pos_ok.eu.expect
@@ -1,0 +1,2 @@
+exit: 0
+stderr: ""

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2349,3 +2349,18 @@ pub fn test_typecheck_090_deprecated_with_replacement() {
 pub fn test_typecheck_091_deprecated_not_referenced() {
     run_typecheck_test("091_deprecated_not_referenced.eu");
 }
+
+#[test]
+pub fn test_typecheck_092_self_assign_direct() {
+    run_typecheck_test("092_self_assign_direct.eu");
+}
+
+#[test]
+pub fn test_typecheck_093_self_assign_function_pos() {
+    run_typecheck_test("093_self_assign_function_pos.eu");
+}
+
+#[test]
+pub fn test_typecheck_094_self_assign_arg_pos_ok() {
+    run_typecheck_test("094_self_assign_arg_pos_ok.eu");
+}


### PR DESCRIPTION
## Summary

- Adds a new `TrivialSelfAssignment(Smid, String)` variant to `CoreError` with a `to_diagnostic` that emits source location and helpful notes
- Adds `strip_meta`, `is_self_bv`, and `is_trivially_self_referential` helpers to `src/core/verify/content.rs`; the `Verifier` now inspects each `Let` binding value for direct (`x: x`) and function-position (`f: f(1)`) self-reference
- Argument-position self-reference (`ones: cons(1, ones)`) is NOT flagged — it is a legitimate lazy fixpoint
- `eu check` now calls `loader.verify()` after the type-check pipeline and surfaces any `TrivialSelfAssignment` errors as hard errors (exit 1, regardless of `--strict`)
- Three typecheck harness tests (088–090) cover direct, function-position, and safe argument-position cases

The detection works on the de Bruijn `BoundVar(scope=0, binder=i)` form that `close_let_scope` produces after desugaring, so no name-lookup is needed at check time.

## Test plan

- [x] `cargo test --lib core::verify::content` — 4 unit tests pass
- [x] `eu check` on `{ x: x }` → exit 1 with source-location diagnostic
- [x] `eu check` on `{ f: f(1) }` → exit 1 with source-location diagnostic  
- [x] `eu check` on `ones: cons(1, ones)` → exit 0 (not flagged)
- [x] `cargo test test_typecheck_08 test_typecheck_09` — 3 new harness tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)