### PR TITLE
Cloudflare v5: WAF / rulesets module (+ DNS v5 migration)

### DIFF
--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -66,8 +66,38 @@ hand-written; the admin rule, for instance, becomes:
 
     (starts_with(http.request.uri.path, "/admin")) and (not (ip.src in {203.0.113.0/24 198.51.100.0/24}))
 
-## Status
+## Roadmap
 
-- **Cloudflare** — DNS and WAF / rate-limiting (provider v5).
-- **GitHub, AWS** — planned. The same `lib/tf.eu` core is provider-agnostic;
-  adding a provider is mostly resource-constructor data entry.
+**Implemented** (Cloudflare provider v5):
+
+- DNS — zone lookup + A/AAAA/CNAME/TXT/MX (`lib/tf-cloudflare.eu`).
+- WAF / rate-limiting — `cloudflare_ruleset` + a wirefilter expression
+  builder (`lib/tf-cloudflare-waf.eu`).
+
+**Next (resume here under eu 0.8):**
+
+1. **Library-wide type pass.** Replace the prose shape descriptions with
+   checked types: `Node` / `Document` in `tf.eu`, and `Rule` / `Expr`
+   plus literal-union `action` / `phase` types in the Cloudflare modules
+   (so a typo'd action or phase is a type error). Done as one coherent
+   layer across `tf.eu` + cloudflare + waf, not module by module. While
+   here, swap the local `select` helper in `tf-cloudflare.eu` for the
+   prelude `select` that lands in 0.8.
+2. **Cloudflare dev platform** — Workers / KV / R2 / D1 / Queues / Pages.
+3. **More Cloudflare** — Zero Trust / Access, load balancing, account / ops.
+4. **Other providers** — GitHub, then AWS networking. The `tf.eu` core is
+   provider-agnostic; a new provider is mostly constructor data entry.
+
+**Tooling follow-ups** (raised, not scheduled):
+
+- A `merge-with` / `deep-merge-with` prelude primitive, and a
+  collision-detecting `document` — a duplicate resource address should be
+  a typed error, not a silently dropped resource.
+- `eu fmt` / lint enforcement of idioms (juxtaposed `f[...]` / `g{...}`
+  calls; no `:suppress` on functions) wired into CI, so style is
+  mechanically enforced rather than reviewer-caught.
+- Bake the `tf*` modules into the binary (`src/driver/resources.rs`) so
+  `{ import: "tf.eu" }` works without `-L lib`, like `state.eu`.
+- `terraform validate` in CI — needs an environment with the `terraform`
+  binary and network access; the generated JSON is currently checked
+  structurally against the v5 provider schema only.

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -13,7 +13,8 @@ loops, functions, data structures, in-place computation and typing.
 | Module                | Purpose                                                         |
 |-----------------------|----------------------------------------------------------------|
 | `lib/tf.eu`           | Provider-agnostic core: `ref`/handles, `resource`/`data` nodes, `document` assembly, and the other top-level blocks (`provider`, `terraform-settings`, `variable`, `output`, `locals`). |
-| `lib/tf-cloudflare.eu`| Cloudflare constructors (zone lookup, A/AAAA/CNAME/TXT/MX records). |
+| `lib/tf-cloudflare.eu`| Cloudflare DNS constructors (zone lookup, A/AAAA/CNAME/TXT/MX records). Provider **v5**. |
+| `lib/tf-cloudflare-waf.eu` | Cloudflare WAF / rate-limiting: `cloudflare_ruleset` constructors plus a wirefilter expression builder (`all-of`, `path-prefix`, `negate`, `country-in`, ...). |
 
 ### Generation time vs apply time
 
@@ -46,17 +47,27 @@ terraform init && terraform validate    # offline; no credentials needed
 
 `cloudflare-dns.eu` defines a handful of records once and fans them out
 across every zone in the model — two domains × eight records expands to
-sixteen `cloudflare_record` resources, each wired to the right zone via
-its handle. Credentials are read from `CLOUDFLARE_API_TOKEN` at apply
+sixteen `cloudflare_dns_record` resources, each wired to the right zone
+via its handle. Credentials are read from `CLOUDFLARE_API_TOKEN` at apply
 time; no secrets appear in the generated JSON.
 
-> The `-L lib` flag puts the Terraform modules on the import path. The
-> example targets the Cloudflare provider **v4** (`cloudflare_record`
-> with a `value` attribute); for v5 the resource is `cloudflare_dns_record`
-> and `value` became `content`.
+> The `-L lib` flag puts the Terraform modules on the import path.
+
+## Running the WAF example
+
+```sh
+eu -j -L lib examples/terraform/cloudflare-waf.eu > security.tf.json
+```
+
+`cloudflare-waf.eu` builds an edge-security baseline — WAF custom rules
+and a rate-limit rule — as `cloudflare_ruleset` resources across every
+zone. Rule expressions are *composed* from wirefilter helpers rather than
+hand-written; the admin rule, for instance, becomes:
+
+    (starts_with(http.request.uri.path, "/admin")) and (not (ip.src in {203.0.113.0/24 198.51.100.0/24}))
 
 ## Status
 
-- **Cloudflare** — implemented (DNS).
+- **Cloudflare** — DNS and WAF / rate-limiting (provider v5).
 - **GitHub, AWS** — planned. The same `lib/tf.eu` core is provider-agnostic;
   adding a provider is mostly resource-constructor data entry.

--- a/examples/terraform/cloudflare-dns.eu
+++ b/examples/terraform/cloudflare-dns.eu
@@ -71,4 +71,4 @@ all-nodes: domains elements mapcat(expand-zone)
 # ---- Document ------------------------------------------------------
 
 ` :main
-main: tf.document(cf.provider-config("~> 4") ‖ all-nodes)
+main: tf.document(cf.provider-config("~> 5") ‖ all-nodes)

--- a/examples/terraform/cloudflare-dns.eu
+++ b/examples/terraform/cloudflare-dns.eu
@@ -61,7 +61,7 @@ records-for(z): concat[
 ]
 
 # For each domain: a zone data-source handle plus all of its records.
-expand-zone([tag, domain]): {
+expand-zone[tag, domain]: {
   z: cf.zone(tag str.of, domain)
   nodes: z ‖ records-for(z)
 }.nodes

--- a/examples/terraform/cloudflare-waf.eu
+++ b/examples/terraform/cloudflare-waf.eu
@@ -1,0 +1,72 @@
+{ doc: "Cloudflare edge-security baseline generated from a compact
+model, targeting provider v5.
+
+A few WAF custom rules and a rate-limit rule expand into
+`cloudflare_ruleset` resources across every zone.  Rule expressions are
+*composed* from wirefilter helpers (`all-of`, `path-prefix`, `negate`,
+`country-in`, ...) rather than hand-written strings.
+
+Render:
+
+    eu -j -L lib examples/terraform/cloudflare-waf.eu > security.tf.json
+    terraform init && terraform validate"
+
+  import: ["tf=tf.eu", "cf=tf-cloudflare.eu", "waf=tf-cloudflare-waf.eu"] }
+
+# ---- Compact model, applied across every zone ----------------------
+
+domains: {
+  primary:   "example.com"
+  secondary: "example.net"
+}
+
+office-cidrs:      ["203.0.113.0/24", "198.51.100.0/24"]
+blocked-countries: ["KP", "SY"]
+
+# WAF custom rules — expressions composed from helpers, not hand-written.
+firewall-rules: [
+  waf.block{
+    ref: "admin_office_only"
+    description: "Admin area only reachable from the office network"
+    expression: waf.all-of[
+      waf.path-prefix("/admin"),
+      waf.negate(waf.ip-in-cidrs(office-cidrs)),
+    ]
+  },
+  waf.managed-challenge{
+    ref: "challenge_low_score_bots"
+    description: "Challenge low-score bots"
+    expression: "cf.bot_management.score lt 30"
+  },
+  waf.block{
+    ref: "block_high_risk_geo"
+    description: "Block high-risk countries with a custom response"
+    expression: waf.country-in(blocked-countries)
+    response: { status_code: 403, content_type: "text/plain", content: "Access denied." }
+  },
+]
+
+rate-rules: [
+  waf.rate-limit{
+    ref: "throttle_api"
+    description: "Throttle API traffic per IP"
+    expression: waf.path-prefix("/api/")
+    characteristics: ["ip.src", "cf.colo.id"]
+    requests: 100
+    period: 60
+  },
+]
+
+# ---- Expansion: per zone, the handle + its security rulesets --------
+
+zone-security([tag, domain]): {
+  z: cf.zone(tag str.of, domain)
+  nodes: [z, waf.custom-firewall(z, firewall-rules), waf.rate-limiting(z, rate-rules)]
+}.nodes
+
+all-nodes: domains elements mapcat(zone-security)
+
+# ---- Document ------------------------------------------------------
+
+` :main
+main: tf.document(cf.provider-config("~> 5") ‖ all-nodes)

--- a/examples/terraform/cloudflare-waf.eu
+++ b/examples/terraform/cloudflare-waf.eu
@@ -51,15 +51,13 @@ rate-rules: [
     ref: "throttle_api"
     description: "Throttle API traffic per IP"
     expression: waf.path-prefix("/api/")
-    characteristics: ["ip.src", "cf.colo.id"]
-    requests: 100
-    period: 60
+    ratelimit: { characteristics: ["ip.src", "cf.colo.id"], requests_per_period: 100 }
   },
 ]
 
 # ---- Expansion: per zone, the handle + its security rulesets --------
 
-zone-security([tag, domain]): {
+zone-security[tag, domain]: {
   z: cf.zone(tag str.of, domain)
   nodes: [z, waf.custom-firewall(z, firewall-rules), waf.rate-limiting(z, rate-rules)]
 }.nodes

--- a/lib/tf-cloudflare-waf.eu
+++ b/lib/tf-cloudflare-waf.eu
@@ -1,0 +1,178 @@
+{ doc: "Cloudflare WAF / rate-limiting constructors for the
+Terraform-JSON core (`tf.eu`), targeting provider v5.
+
+Cloudflare's modern security configuration is the unified **Rulesets**
+engine: a `cloudflare_ruleset` for a given phase holds a list of rules,
+each a wirefilter `expression` plus an `action`.  In v5 `rules` is a
+list of objects, which maps directly onto a Eucalypt list - so a compact
+rule model expands into a ruleset, and rule expressions can be *composed*
+from helpers rather than hand-written.
+
+  - all-of / any-of / negate / host-eq ...  : wirefilter expression builders
+  - block / managed-challenge / log / skip  : rule constructors
+  - rate-limit                              : a rate-limiting rule
+  - custom-firewall / rate-limiting         : zone-scoped entry-point rulesets"
+
+  import: "tf=tf.eu" }
+
+# Wirefilter expression builders --------------------------------------
+#
+# Expressions are strings in Cloudflare's wirefilter language.  Embedded
+# string literals need quotes, and set literals need braces - both of
+# which collide with Eucalypt interpolation, so the helpers below hide
+# the escaping (c-strings for `"`, doubled braces for `{` `}`).
+
+` :suppress
+parens(e): "({e})"
+
+` :suppress
+quoted(s): c"\"{s}\""
+
+` :suppress
+wf-set(items): { body: items str.join-on(" "), o: "{{", c: "}}" }."{o}{body}{c}"
+
+` { doc: "`all-of(exprs)` - conjoin wirefilter expressions with `and`." }
+all-of(es): es map(parens) str.join-on(" and ")
+
+` { doc: "`any-of(exprs)` - disjoin wirefilter expressions with `or`." }
+any-of(es): es map(parens) str.join-on(" or ")
+
+` { doc: "`negate(expr)` - logical `not` of a wirefilter expression." }
+negate(e): "not ({e})"
+
+` { doc: "`host-eq(host)` - request Host header equals `host`." }
+host-eq(h): c"http.host eq \"{h}\""
+
+` { doc: "`path-eq(path)` - request path equals `path`." }
+path-eq(p): c"http.request.uri.path eq \"{p}\""
+
+` { doc: "`path-prefix(prefix)` - request path starts with `prefix`." }
+path-prefix(p): c"starts_with(http.request.uri.path, \"{p}\")"
+
+` { doc: "`ip-in(list)` - source IP in a named Cloudflare list (`$list`)." }
+ip-in(list): "ip.src in ${list}"
+
+` { doc: "`ip-in-cidrs(cidrs)` - source IP in an inline set of CIDRs." }
+ip-in-cidrs(cidrs): { s: cidrs wf-set }."ip.src in {s}"
+
+` { doc: "`country-in(codes)` - visitor country in a set of ISO codes." }
+country-in(codes): { s: codes map(quoted) wf-set }."ip.geoip.country in {s}"
+
+# Rules ---------------------------------------------------------------
+#
+# A rule is a block { ref, description, expression, action, ... }.  `o`
+# carries at least `ref` and `expression`; `description` is optional.
+
+` :suppress
+rule(act, o): {
+  ref: o.ref
+  description: o lookup-or(:description, "")
+  expression: o.expression
+  action: act
+}
+
+` :suppress
+block-response(o): o has(:response) then({ action_parameters: { response: o.response } }, {})
+
+` { doc: "`block(o)` - block matching requests.  Optional `o.response`
+(status_code, content_type, content) sets a custom response body." }
+block(o): rule("block", o) << block-response(o)
+
+` { doc: "`managed-challenge(o)` - present a managed challenge." }
+managed-challenge(o): rule("managed_challenge", o)
+
+` { doc: "`js-challenge(o)` - present a JavaScript challenge." }
+js-challenge(o): rule("js_challenge", o)
+
+` { doc: "`interactive-challenge(o)` - present an interactive challenge." }
+interactive-challenge(o): rule("challenge", o)
+
+` { doc: "`log(o)` - log matching requests (Enterprise)." }
+log(o): rule("log", o)
+
+` { doc: "`skip(o)` - skip rules / phases / products; `o.skip` is the
+`action_parameters` block, e.g. a `phases` list or `ruleset: current`." }
+skip(o): rule("skip", o) << { action_parameters: o.skip }
+
+` { doc: "`rate-limit(o)` - a rate-limiting rule.  Keys: `ref`,
+`expression`, `characteristics`, `requests`, optional `period`
+(default 60), `timeout` (default 600) and `action` (default block)." }
+rate-limit(o): rule(o lookup-or(:action, "block"), o) << {
+  ratelimit: {
+    characteristics: o.characteristics
+    period: o lookup-or(:period, 60)
+    requests_per_period: o.requests
+    mitigation_timeout: o lookup-or(:timeout, 600)
+  }
+}
+
+# Rulesets ------------------------------------------------------------
+
+` { doc: "`ruleset(local, scope, opts)` - a `cloudflare_ruleset`.  `scope`
+gives the id key - `zone_id` from a zone handle, or `account_id`; `opts`
+keys: `name`, `phase`, optional `kind` (default zone), `description` and
+`rules`." }
+ruleset(local, scope, opts): tf.resource("cloudflare_ruleset", local, scope << {
+  name: opts.name
+  kind: opts lookup-or(:kind, "zone")
+  phase: opts.phase
+  description: opts lookup-or(:description, "")
+  rules: opts.rules
+})
+
+` { doc: "`custom-firewall(zone, rules)` - a zone's WAF custom-rules
+entry-point ruleset (phase http_request_firewall_custom)." }
+custom-firewall(zone, rs): ruleset("waf_{zone.name}", { zone_id: zone.id }, {
+  name: "Custom firewall rules"
+  phase: "http_request_firewall_custom"
+  rules: rs
+})
+
+` { doc: "`rate-limiting(zone, rules)` - a zone's rate-limiting
+entry-point ruleset (phase http_ratelimit)." }
+rate-limiting(zone, rs): ruleset("ratelimit_{zone.name}", { zone_id: zone.id }, {
+  name: "Rate limiting rules"
+  phase: "http_ratelimit"
+  rules: rs
+})
+
+# Embedded tests ------------------------------------------------------
+
+` { target: :test-expr }
+test-expr: {
+  α: all-of["a", "b"] = "(a) and (b)"
+  β: any-of["x", "y", "z"] = "(x) or (y) or (z)"
+  γ: negate("ip.src eq 1.2.3.4") = "not (ip.src eq 1.2.3.4)"
+  δ: ip-in("office") = "ip.src in $office"
+  ε: country-in["US", "GB"] = c"ip.geoip.country in \{\"US\" \"GB\"\}"
+  ζ: ip-in-cidrs["192.0.2.0/24"] = "ip.src in {{192.0.2.0/24}}"
+  RESULT: (α ∧ β ∧ γ ∧ δ ∧ ε ∧ ζ) then(:PASS, :FAIL)
+}
+
+` { target: :test-rule }
+test-rule: {
+  r: block{ ref: "r1", description: "Block one IP", expression: "ip.src eq 1.1.1.1" }
+  blocked: block{ ref: "r2", expression: "true",
+                  response: { status_code: 403, content_type: "text/plain", content: "no" } }
+  rl: rate-limit{ ref: "r3", expression: path-eq("/api"),
+                  characteristics: ["ip.src"], requests: 100 }
+  α: r.action = "block"
+  β: r.ref = "r1"
+  γ: blocked.action_parameters.response.status_code = 403
+  δ: rl.ratelimit.requests_per_period = 100
+  ε: rl.ratelimit.period = 60
+  RESULT: (α ∧ β ∧ γ ∧ δ ∧ ε) then(:PASS, :FAIL)
+}
+
+` { target: :test-ruleset }
+test-ruleset: {
+  z: { name: "main", id: "${{data.cloudflare_zone.main.id}}" }
+  rs: custom-firewall(z, [block{ ref: "r1", expression: "ip.src eq 1.1.1.1" }])
+  doc: tf.document[rs]
+  cfr: doc.resource.cloudflare_ruleset.waf_main
+  α: cfr.zone_id = "${{data.cloudflare_zone.main.id}}"
+  β: cfr.phase = "http_request_firewall_custom"
+  γ: cfr.kind = "zone"
+  δ: (cfr.rules head).action = "block"
+  RESULT: (α ∧ β ∧ γ ∧ δ) then(:PASS, :FAIL)
+}

--- a/lib/tf-cloudflare-waf.eu
+++ b/lib/tf-cloudflare-waf.eu
@@ -90,15 +90,11 @@ log(o): rule("log", o)
 skip(o): rule("skip", o) << { action_parameters: o.skip }
 
 ` { doc: "`rate-limit(o)` - a rate-limiting rule.  Keys: `ref`,
-`expression`, `characteristics`, `requests`, optional `period`
-(default 60), `timeout` (default 600) and `action` (default block)." }
+`expression`, optional `action` (default block), and a `ratelimit` block
+(`characteristics` and `requests_per_period` required; `period` defaults
+to 60, `mitigation_timeout` to 600)." }
 rate-limit(o): rule(o lookup-or(:action, "block"), o) << {
-  ratelimit: {
-    characteristics: o.characteristics
-    period: o lookup-or(:period, 60)
-    requests_per_period: o.requests
-    mitigation_timeout: o lookup-or(:timeout, 600)
-  }
+  ratelimit: { period: 60, mitigation_timeout: 600 } << o.ratelimit
 }
 
 # Rulesets ------------------------------------------------------------
@@ -150,7 +146,7 @@ test-rule: {
   blocked: block{ ref: "r2", expression: "true",
                   response: { status_code: 403, content_type: "text/plain", content: "no" } }
   rl: rate-limit{ ref: "r3", expression: path-eq("/api"),
-                  characteristics: ["ip.src"], requests: 100 }
+                  ratelimit: { characteristics: ["ip.src"], requests_per_period: 100 } }
   α: r.action = "block"
   β: r.ref = "r1"
   γ: blocked.action_parameters.response.status_code = 403

--- a/lib/tf-cloudflare-waf.eu
+++ b/lib/tf-cloudflare-waf.eu
@@ -22,13 +22,10 @@ from helpers rather than hand-written.
 # which collide with Eucalypt interpolation, so the helpers below hide
 # the escaping (c-strings for `"`, doubled braces for `{` `}`).
 
-` :suppress
 parens(e): "({e})"
 
-` :suppress
 quoted(s): c"\"{s}\""
 
-` :suppress
 wf-set(items): { body: items str.join-on(" "), o: "{{", c: "}}" }."{o}{body}{c}"
 
 ` { doc: "`all-of(exprs)` - conjoin wirefilter expressions with `and`." }
@@ -63,7 +60,6 @@ country-in(codes): { s: codes map(quoted) wf-set }."ip.geoip.country in {s}"
 # A rule is a block { ref, description, expression, action, ... }.  `o`
 # carries at least `ref` and `expression`; `description` is optional.
 
-` :suppress
 rule(act, o): {
   ref: o.ref
   description: o lookup-or(:description, "")
@@ -71,7 +67,6 @@ rule(act, o): {
   action: act
 }
 
-` :suppress
 block-response(o): o has(:response) then({ action_parameters: { response: o.response } }, {})
 
 ` { doc: "`block(o)` - block matching requests.  Optional `o.response`

--- a/lib/tf-cloudflare.eu
+++ b/lib/tf-cloudflare.eu
@@ -1,10 +1,8 @@
 { doc: "Cloudflare resource constructors for the Terraform-JSON core
 (`tf.eu`).
 
-Targets the Cloudflare Terraform provider v4 (`cloudflare_record` with a
-`value` attribute).  For provider v5 the DNS resource was renamed to
-`cloudflare_dns_record` and `value` became `content` - switch the type
-string and the value key accordingly.
+Targets the Cloudflare Terraform provider v5 (`cloudflare_dns_record`
+with a `content` attribute; the zone data source is filtered by name).
 
 Cloudflare configuration is almost entirely resolvable at generation
 time (DNS records, zone settings and rules are flat data), which makes
@@ -31,7 +29,7 @@ provider-config(ver): tf.document[
 ` { doc: "`zone(local-name, domain)` - look up a Cloudflare zone by
 domain name as a data source.  Use the returned handle's `.id` as the
 `zone_id` of records." }
-zone(local-name, domain): tf.data("cloudflare_zone", local-name, { name: domain })
+zone(local-name, domain): tf.data("cloudflare_zone", local-name, { filter: { name: domain } })
 
 # Local-name helpers --------------------------------------------------
 
@@ -50,18 +48,18 @@ optionals(o): { ttl: 1 } (o select[:ttl, :proxied, :priority])
 
 # Record constructors -------------------------------------------------
 
-` { doc: "`record(o)` - a generic `cloudflare_record` from a block with
-keys `zone` (a zone handle), `name`, `type` and `value`, plus optional
-`ttl`, `proxied`, `priority` and `suffix`.  The Terraform local name is
-derived as `type_zone_name` (`@` becomes `root`, other punctuation
-becomes `_`).  Local names must be unique, so when several records share
-a type and name (e.g. multiple MX or round-robin A records) pass a
-distinguishing `suffix`; otherwise they collide and all but one are
-lost." }
+` { doc: "`record(o)` - a generic `cloudflare_dns_record` from a block
+with keys `zone` (a zone handle), `name`, `type` and `value`, plus
+optional `ttl`, `proxied`, `priority` and `suffix`.  The Terraform local
+name is derived as `type_zone_name` (`@` becomes `root`, other
+punctuation becomes `_`).  Local names must be unique, so when several
+records share a type and name (e.g. multiple MX or round-robin A
+records) pass a distinguishing `suffix`; otherwise they collide and all
+but one are lost." }
 record(o): tf.resource(
-  "cloudflare_record",
+  "cloudflare_dns_record",
   local-name(o.type str.to-lower, o.zone.name, o.name, o lookup-or(:suffix, "")),
-  { zone_id: o.zone.id  name: o.name  type: o.type  value: o.value }
+  { zone_id: o.zone.id  name: o.name  type: o.type  content: o.value }
     << optionals(o))
 
 ` { doc: "`a(zone, name, value)` - an A record." }
@@ -88,11 +86,11 @@ mx(z, n, prio, v): record{ zone: z, name: n, type: "MX", value: v,
 test-record: {
   z: zone("main", "example.com")
   rec: a(z, "www", "203.0.113.10")
-  α: rec.type = "cloudflare_record"
+  α: rec.type = "cloudflare_dns_record"
   β: rec.name = "a_main_www"
   γ: rec.body.zone_id = "${{data.cloudflare_zone.main.id}}"
   δ: rec.body = { zone_id: "${{data.cloudflare_zone.main.id}}"
-                  name: "www"  type: "A"  value: "203.0.113.10"  ttl: 1 }
+                  name: "www"  type: "A"  content: "203.0.113.10"  ttl: 1 }
   RESULT: (α ∧ β ∧ γ ∧ δ) then(:PASS, :FAIL)
 }
 
@@ -112,8 +110,8 @@ test-apex-and-mx: {
 test-document: {
   z: zone("main", "example.com")
   doc: tf.document[z, a(z, "www", "203.0.113.10"), cname(z, "blog", "www")]
-  α: doc.data.cloudflare_zone.main.name = "example.com"
-  β: doc.resource.cloudflare_record.a_main_www.value = "203.0.113.10"
-  γ: doc.resource.cloudflare_record.cname_main_blog.type = "CNAME"
+  α: doc.data.cloudflare_zone.main.filter.name = "example.com"
+  β: doc.resource.cloudflare_dns_record.a_main_www.content = "203.0.113.10"
+  γ: doc.resource.cloudflare_dns_record.cname_main_blog.type = "CNAME"
   RESULT: (α ∧ β ∧ γ) then(:PASS, :FAIL)
 }

--- a/lib/tf-cloudflare.eu
+++ b/lib/tf-cloudflare.eu
@@ -33,17 +33,13 @@ zone(local-name, domain): tf.data("cloudflare_zone", local-name, { filter: { nam
 
 # Local-name helpers --------------------------------------------------
 
-` :suppress
 dns-label(name): name = "@" then("root", name str.replace("[^A-Za-z0-9]", "_"))
 
-` :suppress
 local-name(prefix, ztag, name, suffix): { label: name dns-label }."{prefix}_{ztag}_{label}{suffix}"
 
 # `select` keeps only the named keys of a block; due in the prelude at 0.8.
-` :suppress
 select(ks, b): b filter-items(by-key(∈ set.from-list(ks))) block
 
-` :suppress
 optionals(o): { ttl: 1 } (o select[:ttl, :proxied, :priority])
 
 # Record constructors -------------------------------------------------

--- a/lib/tf.eu
+++ b/lib/tf.eu
@@ -64,14 +64,12 @@ data(t, n, b): {
 
 # Document assembly --------------------------------------------------
 
-` :suppress
 node-fragment(node): {
   named: block[[node.name sym, node.body]]
   typed: block[[node.type sym, named]]
   result: block[[node.tf_kind, typed]]
 }.result
 
-` :suppress
 to-fragment(item): item has(:tf_kind) then(node-fragment(item), item)
 
 ` { doc: "`document(items)` - assemble a list of nodes and / or fragment


### PR DESCRIPTION
## Summary

Cloudflare **Security & WAF** — a `cloudflare_ruleset` module with a
wirefilter **expression builder** — plus the DNS module's migration to
provider **v5** (a prerequisite, since one Terraform config uses one
provider version).

Targets the GA v5 provider (verified latest **5.19.1**, ~100% API
coverage). In v5 a ruleset's `rules` is a **list of objects**, which
maps directly onto a Eucalypt list — so a compact rule model expands
straight into a ruleset, and expressions are *composed* from helpers
rather than hand-written.

## Commits

1. **Migrate DNS to v5** — `cloudflare_record`→`cloudflare_dns_record`,
   `value`→`content`, zone data source filtered by `filter { name }`.
2. **WAF / rulesets module** — `lib/tf-cloudflare-waf.eu` + example.

## What's here

| File | |
|------|---|
| `lib/tf-cloudflare-waf.eu` | `cloudflare_ruleset` constructors; rule builders (`block` w/ custom response, `managed-challenge`, `js-challenge`, `log`, `skip`, `rate-limit`); zone entry-points (`custom-firewall`, `rate-limiting`); and a wirefilter expression builder. |
| `examples/terraform/cloudflare-waf.eu` | a security baseline fanned across zones. |

## The expression builder (the showcase)

Expressions need embedded `"quotes"` and `{set}` braces, which collide
with Eucalypt interpolation — the helpers hide that (c-strings for
quotes, brace-building for sets). So this:

```eu
waf.all-of[
  waf.path-prefix("/admin"),
  waf.negate(waf.ip-in-cidrs(office-cidrs)),
]
```

composes into the wirefilter string:

```
(starts_with(http.request.uri.path, "/admin")) and (not (ip.src in {203.0.113.0/24 198.51.100.0/24}))
```

## Testing

- Three module test suites green (`eu test lib/tf.eu`,
  `lib/tf-cloudflare.eu`, `lib/tf-cloudflare-waf.eu`).
- Both demos render to independently valid JSON; the WAF demo produces 4
  rulesets across 2 zones with composed expressions, a custom block
  response, and a rate-limit block.

## Caveats

- **`terraform validate` still not run in CI** (no `terraform` binary /
  network here) — the JSON is built to the official v5 schema, pulled
  from the provider docs.
- v5's `cloudflare_zone`/`cloudflare_dns_record` are known to have some
  plan-diff churn upstream; an operational note, not a generation issue.

Next per the plan: the **dev platform** (Workers/KV/R2/D1).

https://claude.ai/code/session_01Q9v9fZWsqEMPZMqtYRdgBB