### PR TITLE
feat: add dissoc(ks, b) to prelude

### DIFF
--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -692,6 +692,15 @@ Patterns: bare `foo` = `**.foo`; `*` = one level; `**` = any depth.
 { a: 1 b: 2 } select([:z])             # {}
 ```
 
+#### `dissoc(ks, b)` — sub-block with listed keys removed
+
+```
+{ a: 1 b: 2 c: 3 } dissoc([:a, :c])   # { b: 2 }
+{ a: 1 b: 2 } dissoc([])               # { a: 1 b: 2 }
+{ a: 1 b: 2 } dissoc([:z])             # { a: 1 b: 2 }
+{ a: 1 } dissoc([:a])                  # {}
+```
+
 ### 3.3 String Functions (str namespace)
 
 #### `str.split-on(re, s)` — split string on regex

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -1770,6 +1770,11 @@ filter-values(p?, b): b values filter(p?)
 select(ks, b):
   b filter-items(by-key(∈ set.from-list(ks))) block
 
+` { doc: "`dissoc(ks, b)` - return block with keys listed in `ks` removed. `b dissoc([:a, :c])` returns a sub-block without those keys."
+    type: "[symbol] → {{..}} → {{..}}" }
+dissoc(ks, b):
+  b filter-items(by-key(∉ set.from-list(ks))) block
+
 _block: {
   ` "If `k` satisfies `k?` then `v!` else `v`"
   alter?(k?, v!, k, v): [k, if(k k?, v!, v)]

--- a/tests/harness/015_block_fns.eu
+++ b/tests/harness/015_block_fns.eu
@@ -136,12 +136,22 @@ select-checks: {
   ]
 }
 
+dissoc-checks: {
+  trues: [
+    ({ a: 1, b: 2, c: 3 } dissoc([:a, :c])) = { b: 2 },
+    ({ a: 1, b: 2 } dissoc([])) = { a: 1, b: 2 },
+    ({ a: 1, b: 2 } dissoc([:z])) = { a: 1, b: 2 },
+    ({ a: 1 } dissoc([:a])) = {}
+  ]
+}
+
 pass: [ checks.trues values all-true?
       , merging.checks.trues all-true?
       , lookups.checks.trues all-true?
       , deep-merge.pass
       , map-elements-checks.trues all-true?
       , select-checks.trues all-true?
+      , dissoc-checks.trues all-true?
       ] all-true?
 
 RESULT: if(pass, :PASS, :FAIL)


### PR DESCRIPTION
## Summary

- Adds `dissoc(ks, b)` to the prelude as the complement of `select`
- Removes listed keys from a block: `{ a: 1, b: 2, c: 3 } dissoc([:a, :c])` → `{ b: 2 }`
- Implemented via `filter-items(by-key(∉ set.from-list(ks))) block`, mirroring `select`'s use of `∈`
- Four test cases added to `tests/harness/015_block_fns.eu` (basic removal, empty key list, missing key, remove all)
- Agent reference updated with examples next to `select`

## Test plan

- [ ] `cargo build --release` clean
- [ ] `eu test tests/harness/015_block_fns.eu` → PASS
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)