### PR TITLE
fix(ci): strip +build metadata from release tags

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -397,12 +397,25 @@ jobs:
       - name: Query binary for version number
         run: |
           chmod +x eu_amd64
-          echo "RELEASE_VERSION=$(./eu_amd64 -e eu.build.version -x text)" >> $GITHUB_ENV
+          FULL_VERSION=$(./eu_amd64 -e eu.build.version -x text)
+          # Strip +build metadata for the release tag (semver build metadata
+          # is not suitable for GitHub release tags — '+' breaks download URLs
+          # and build numbers don't distinguish semantic versions).
+          RELEASE_TAG="${FULL_VERSION%%+*}"
+          echo "RELEASE_VERSION=$FULL_VERSION" >> $GITHUB_ENV
+          echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+
+      - name: Check for duplicate release tag
+        run: |
+          if gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft' 2>/dev/null | grep -q 'false'; then
+            echo "::error::Release tag $RELEASE_TAG already exists and is published. Bump the version in Cargo.toml before releasing."
+            exit 1
+          fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.RELEASE_VERSION }}
+          tag_name: ${{ env.RELEASE_TAG }}
           draft: true
           prerelease: false
           body_path: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,19 @@ All notable changes to eucalypt are documented here.
 
 - **Declaration trace metadata** — annotate declarations with `` ` :trace ``, `{ trace: :strict }`, `{ trace: :exit }`, or `{ trace: :strict-exit }` to trace entry arguments and/or exit values to stderr. Lazy mode peeks without forcing; strict mode forces arguments to WHNF before rendering
 - **Deprecation metadata** — mark declarations deprecated with `` ` :deprecated ``, `{ deprecated: "message" }`, and optionally `{ replaced-by: "new-fn" }`. Emits compile-time warnings visible in `eu check` and LSP; `--strict` mode treats them as errors
+- **Deprecation LSP quick-fix** — when a deprecated function has a `replaced-by` field, the LSP offers a code action to replace the old name with the new one
 - **Prelude selection mechanism** — units can specify an alternative prelude via `{ prelude: "path/to/alt.eu" }` metadata. The prelude type cache is keyed per selection
 - **`requires` unit metadata** — units can declare a minimum version via `{ requires: ">=0.8" }` in their metadata block, checked at load time before evaluation. Replaces the `_ : eu.requires(...)` binding pattern. Shipped libraries updated to use the metadata form
 - **Stability policy** — published `docs/development/stability-policy.md` defining three tiers (Stable, Experimental, Not covered) and semver field meanings
 - **Conformance corpus** — `tests/conform/` directory with 20 conformance files and `.golden` sidecars pinning rendered output bytes across all export formats. Separate `conform_test.rs` runner with `BLESS=1` regeneration and unified diff on mismatch
 - **GC-verified CI job** — full harness under `EU_GC_VERIFY=2` + `EU_GC_STRESS=1` + `EU_GC_POISON=1` on x86-64
 - **Static self-assignment diagnostic** — `eu check` now flags always-divergent self-referential bindings (`{ x: x }`, `{ f: f(...) }`) as errors. Argument-position self-reference (`ones: cons(1, ones)`) is not flagged
-- **`select` prelude function** — `block select([:a, :c])` returns a sub-block containing only the listed keys
+- **`select` and `dissoc` prelude functions** — `block select[:a, :c]` returns a sub-block containing only the listed keys; `block dissoc[:b]` returns a sub-block with the listed keys removed
+- **`type-def: true` shorthand** — `type-def: true` in declaration metadata uses the binding name as the type alias (instead of requiring an explicit string). Bare `:type-def` symbol expands to `{ type-def: true }`. New `result-def` metadata key registers the function's return type as a type alias
 
 ### Changed
 
-- **Semver-compliant build versioning** — CI build number moved from fourth dot-segment (`0.8.0.1685`) to `+build` metadata (`0.8.0+1685`) per semver.org
+- **Semver-compliant build versioning** — release tags now use base semver (`0.8.0`) instead of four-dot build numbers (`0.8.0.1685`). The CI build number appears as `+build` metadata in `eu version` output only. Bug fix releases bump the patch version (`0.8.1`)
 - **Resilient parser pipeline** — the all-or-nothing parse shim is removed; a file with syntax errors now produces a partial tree that reaches the desugarer, type-checker, and `eu dump` commands. Valid declarations in a file with errors still get diagnostics
 - **`eu dump ast` shows Rowan syntax tree** — default output is now the indented Rowan node tree (kinds, ranges, token text) instead of re-rendered source. `--embed` gives the old behaviour
 

--- a/docs/superpowers/specs/2026-06-09-versioning-stability-design.md
+++ b/docs/superpowers/specs/2026-06-09-versioning-stability-design.md
@@ -37,8 +37,10 @@ an unmodified file can observe in its output, or a removal from the
 Stable surface. **MINOR** = backwards-compatible addition (including a
 new opt-in prelude version). **PATCH** = no observable semantic change.
 
-**CI impact:** GitHub release tag changes from `0.8.0.1685` to
-`0.8.0+1685`. GitHub tags allow `+` characters.
+**CI impact:** GitHub release tags use the base semver version only
+(e.g. `0.8.0`). The `+build` metadata appears in `eu version` output
+but is stripped from the tag — `+` characters break GitHub download
+URLs and build numbers don't distinguish semantic versions.
 
 **`eu.requires()` cleanup:** Remove the `.replace(".dev", "")` hack in
 `version.rs:39` — `semver::Version` handles `+` metadata natively.


### PR DESCRIPTION
## Summary

- Release tags now use base semver (`0.8.0`) instead of `0.8.0+1950` — the `+` character breaks GitHub download URLs and `install.sh` version pinning
- Added duplicate-tag guard: CI fails if a published release with the same tag already exists (forces Cargo.toml version bump for each release)
- CHANGELOG updated: added `dissoc`, `type-def: true` shorthand, LSP quick-fix entries; fixed juxtaposed call syntax; corrected semver description
- Versioning spec corrected to reflect that `+build` is stripped from tags

## Test plan

- [ ] CI passes on this PR
- [ ] Next draft release uses clean semver tag (e.g. `0.8.0` not `0.8.0+NNNN`)
- [ ] `install.sh` works with `EUCALYPT_VERSION=0.8.0` after publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)