### PR TITLE
docs: literal string types need a c-string annotation (and argument unions need parens)

### DIFF
--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -550,7 +550,7 @@ origin: { x: 0, y: 0 }
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
 | `Name` (capitalised) | type alias — defined via `types: { Name: "..." }` |
-| `"value"`          | literal string type (subtype of `string`); in annotation string: `\"value\"` |
+| `"value"`          | literal string type (subtype of `string`); needs a c-string annotation: `c"\"value\""` |
 | `:name`            | literal symbol type (subtype of `symbol`)      |
 | `T?`               | partial — sugar for `T \| ExecutionError`; marks functions that may raise an error |
 | `ExecutionError`   | the type of a raised runtime error     |

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -550,7 +550,7 @@ origin: { x: 0, y: 0 }
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
 | `Name` (capitalised) | type alias — defined via `types: { Name: "..." }` |
-| `"value"`          | literal string type (subtype of `string`); needs a c-string annotation: `c"\"value\""` |
+| `"value"`          | literal string type (subtype of `string`); c-string escapes for the quotes: `c"\"value\""` |
 | `:name`            | literal symbol type (subtype of `symbol`)      |
 | `T?`               | partial — sugar for `T \| ExecutionError`; marks functions that may raise an error |
 | `ExecutionError`   | the type of a raised runtime error     |

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -519,38 +519,18 @@ are fine as-is:
 ` { type-def: "Point" }                  # fine — just a name, no braces
 ```
 
-### Literal String Types Need a C-String, and Argument Unions Need Parens
+### Literal Types in Annotations
 
-A **literal string type** (`"block"`) embeds a `"` in the annotation, but a
-plain `"..."` eucalypt string does not process the `\"` escape — the
-backslash reaches the type parser and it errors (`unexpected character
-'\'`). Use a **c-string**, which does process `\"`:
+Two things to remember when a `type:` annotation contains literal types:
 
-```eu,notest
-# WRONG — \" is not an escape in a plain string; the type parser sees the \
-` { type: "\"block\" | \"log\"" }
-
-# RIGHT — a c-string yields literal quotes for the type parser
-` { type: c"\"block\" | \"log\"" }
-```
-
-Literal *symbol* types (`:block`) contain no quotes, so a plain string is
-fine — but a union in **argument position** still needs parentheses,
-because `->` binds tighter than `|`:
-
-```eu,notest
-# WRONG — parses as the overload :block | (:log -> bool), so even a valid
-# :block argument is rejected
-` { type: ":block | :log -> bool" }
-
-# RIGHT — parenthesise the argument union
-` { type: "(:block | :log) -> bool" }
-```
-
-The unparenthesised `A | B -> C` form is intentional for *overloaded*
-function types (`number -> number | string -> string`); it just is not
-what you want for a union-typed argument. Naming the union in a `types:`
-alias avoids the trap entirely, since the alias name is a single token.
+- **Literal string types need c-string escapes for the quotes** —
+  `c"\"block\" | \"log\""`. A plain `"..."` string does not process `\"`.
+  (Literal *symbol* types like `:block` have no quotes, so a plain string
+  is fine.)
+- **Mind `|`/`->` precedence** — `->` binds tighter, so a disjunction in
+  argument position needs brackets: `(:block | :log) -> bool`, not
+  `:block | :log -> bool` (which is an overloaded-function type). Naming
+  the union in a `types:` alias avoids the question.
 
 ## Flow-Sensitive Narrowing and User-Defined Branchers
 

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -519,6 +519,39 @@ are fine as-is:
 ` { type-def: "Point" }                  # fine — just a name, no braces
 ```
 
+### Literal String Types Need a C-String, and Argument Unions Need Parens
+
+A **literal string type** (`"block"`) embeds a `"` in the annotation, but a
+plain `"..."` eucalypt string does not process the `\"` escape — the
+backslash reaches the type parser and it errors (`unexpected character
+'\'`). Use a **c-string**, which does process `\"`:
+
+```eu,notest
+# WRONG — \" is not an escape in a plain string; the type parser sees the \
+` { type: "\"block\" | \"log\"" }
+
+# RIGHT — a c-string yields literal quotes for the type parser
+` { type: c"\"block\" | \"log\"" }
+```
+
+Literal *symbol* types (`:block`) contain no quotes, so a plain string is
+fine — but a union in **argument position** still needs parentheses,
+because `->` binds tighter than `|`:
+
+```eu,notest
+# WRONG — parses as the overload :block | (:log -> bool), so even a valid
+# :block argument is rejected
+` { type: ":block | :log -> bool" }
+
+# RIGHT — parenthesise the argument union
+` { type: "(:block | :log) -> bool" }
+```
+
+The unparenthesised `A | B -> C` form is intentional for *overloaded*
+function types (`number -> number | string -> string`); it just is not
+what you want for a union-typed argument. Naming the union in a `types:`
+alias avoids the trap entirely, since the alias name is a single token.
+
 ## Flow-Sensitive Narrowing and User-Defined Branchers
 
 ### `=>` (Clause) vs `//=>` (Assertion)

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -120,11 +120,12 @@ Literal types are most useful in **discriminated unions** — type aliases
 where a tag field distinguishes variants:
 
 ```eu,notest
-{ types: { Shape: "{{type: \"circle\", radius: number, ..}} | {{type: \"rect\", w: number, h: number, ..}}" } }
+{ types: { Shape: c"{{type: \"circle\", radius: number, ..}} | {{type: \"rect\", w: number, h: number, ..}}" } }
 ```
 
 Because writing complex union types inline is verbose, defining a `types:`
-alias is the recommended approach.
+alias is the recommended approach. (Note the `c"..."` **c-string** — see
+*Writing literal types in annotation strings* below.)
 
 **Subtyping rules**:
 - `"foo"` is consistent with `string` — a literal satisfies a string parameter
@@ -132,17 +133,40 @@ alias is the recommended approach.
 - `:active` is consistent with `symbol` — same for symbols
 
 **Writing literal types in annotation strings**: the type syntax uses
-`"value"` (double-quoted) for literal strings. Since this appears inside
-a eucalypt string, the inner quotes must be escaped with `\"`:
+`"value"` (double-quoted) for literal strings. The `"` must survive
+inside the eucalypt annotation string, so the annotation must be a
+**c-string** (`c"..."`), whose `\"` escape yields a literal quote. A plain
+`"..."` string does *not* process `\"`, so the backslashes reach the type
+parser and it errors. Literal *symbol* types (`:name`) contain no quotes,
+so they need neither escaping nor a c-string.
+
+A second trap: in the type language `->` binds **tighter** than `|`
+(this is what lets overloaded function types — see *Unions* below — be
+written without parentheses). So a union in *argument* position must be
+parenthesised. `"circle" | "rect" -> bool` parses as the overload
+`"circle" | ("rect" -> bool)`; the one-argument reading is
+`("circle" | "rect") -> bool`.
 
 ```eu,notest
-# Literal string type in a type annotation — inner quotes escaped with \"
-` { type: "\"circle\" | \"rect\" -> bool" }
-is-shape-name(s): s match?("circle") or s match?("rect")
+# Literal string union as an argument: c-string for the quotes, parens
+# around the union.
+` { type: c"(\"circle\" | \"rect\") -> bool" }
+is-shape-name(s): s = "circle" or s = "rect"
 
-# Literal symbol type — no escaping needed (: is not special in strings)
-` { type: ":ok | :err -> bool" }
+# Literal symbol union: no c-string needed, but still parenthesised.
+` { type: "(:ok | :err) -> bool" }
 ok?(status): status = :ok
+```
+
+Most often you name the union in a `types:` alias, which sidesteps both
+traps at the use site — the alias name is a single token, so no
+parentheses are needed around it:
+
+```eu,notest
+{ types: { Status: c"\"ok\" | \"err\"" } }
+
+` { type: "Status -> bool" }
+ok?(s): s = "ok"
 ```
 
 ### Lists
@@ -910,7 +934,7 @@ but is not written to disk.
 | IO action                | `IO(T)`                                          |
 | Lens                     | `Lens(a, b)`                                     |
 | Traversal                | `Traversal(a, b)`                                |
-| Literal string type      | `"value"` (`\"value\"` in annotation string)     |
+| Literal string type      | `"value"` — c-string annotation: `c"\"value\""`  |
 | Literal symbol type      | `:name`                                           |
 | Type variable            | lowercase identifier: `a`, `b`, `s`              |
 | Explicit quantification  | `forall a. T` or `forall (m :: * -> *) a. T`    |

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -132,35 +132,30 @@ alias is the recommended approach. (Note the `c"..."` **c-string** — see
 - `"foo" | string` simplifies to `string` — the specific literal is absorbed
 - `:active` is consistent with `symbol` — same for symbols
 
-**Writing literal types in annotation strings**: the type syntax uses
-`"value"` (double-quoted) for literal strings. The `"` must survive
-inside the eucalypt annotation string, so the annotation must be a
-**c-string** (`c"..."`), whose `\"` escape yields a literal quote. A plain
-`"..."` string does *not* process `\"`, so the backslashes reach the type
-parser and it errors. Literal *symbol* types (`:name`) contain no quotes,
-so they need neither escaping nor a c-string.
+**Writing literal types in annotation strings**: a literal string type is
+written `"value"`, so its quotes need escaping inside the eucalypt
+annotation string — use **c-string escapes**: `c"\"value\""`. (A plain
+`"..."` string does not process `\"`.) Literal *symbol* types (`:name`)
+have no quotes, so need no escaping.
 
-A second trap: in the type language `->` binds **tighter** than `|`
-(this is what lets overloaded function types — see *Unions* below — be
-written without parentheses). So a union in *argument* position must be
-parenthesised. `"circle" | "rect" -> bool` parses as the overload
-`"circle" | ("rect" -> bool)`; the one-argument reading is
+Mind the precedence of `|` and `->`: as in most type languages `->` binds
+tighter, so a union in *argument* position needs brackets.
+`"circle" | "rect" -> bool` is the overload `"circle" | ("rect" -> bool)`
+(see *Unions* below); the one-argument reading is
 `("circle" | "rect") -> bool`.
 
 ```eu,notest
-# Literal string union as an argument: c-string for the quotes, parens
-# around the union.
+# Literal string union as an argument: c-string escapes, bracketed union.
 ` { type: c"(\"circle\" | \"rect\") -> bool" }
 is-shape-name(s): s = "circle" or s = "rect"
 
-# Literal symbol union: no c-string needed, but still parenthesised.
+# Literal symbol union: no escaping needed, still bracketed.
 ` { type: "(:ok | :err) -> bool" }
 ok?(status): status = :ok
 ```
 
-Most often you name the union in a `types:` alias, which sidesteps both
-traps at the use site — the alias name is a single token, so no
-parentheses are needed around it:
+Most often you name the union in a `types:` alias, which avoids the
+bracketing at the use site — the alias name is a single token:
 
 ```eu,notest
 { types: { Status: c"\"ok\" | \"err\"" } }
@@ -934,7 +929,7 @@ but is not written to disk.
 | IO action                | `IO(T)`                                          |
 | Lens                     | `Lens(a, b)`                                     |
 | Traversal                | `Traversal(a, b)`                                |
-| Literal string type      | `"value"` — c-string annotation: `c"\"value\""`  |
+| Literal string type      | `"value"` — c-string escapes: `c"\"value\""`     |
 | Literal symbol type      | `:name`                                           |
 | Type variable            | lowercase identifier: `a`, `b`, `s`              |
 | Explicit quantification  | `forall a. T` or `forall (m :: * -> *) a. T`    |

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -269,7 +269,7 @@ non-function binding emits a warning and is skipped.
 | `{{k: T}}`         | closed record                          |
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
-| `"value"`          | literal string — subtype of `string`; needs a c-string annotation: `c"\"value\""` |
+| `"value"`          | literal string — subtype of `string`; c-string escapes for the quotes: `c"\"value\""` |
 | `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
@@ -298,10 +298,9 @@ my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
 string interpolation. Always escape with `{{` and `}}`:
 `"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
 Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
-Literal string types (`"value"`) need a c-string annotation so the quotes
-survive: `c"\"value\""` (a plain `"..."` string leaves the backslashes for
-the type parser). A union in argument position needs parentheses —
-`c"(\"a\" | \"b\") -> bool"` — since `->` binds tighter than `|`.
+Literal string types (`"value"`) escape their quotes with c-string escapes:
+`c"\"value\""`. Mind `|`/`->` precedence — bracket a union in argument
+position: `c"(\"a\" | \"b\") -> bool"`.
 
 **Partial functions**: functions that may raise a runtime error use the
 `T?` postfix sugar — equivalent to `T | ExecutionError`.  Several

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -269,7 +269,7 @@ non-function binding emits a warning and is skipped.
 | `{{k: T}}`         | closed record                          |
 | `block`            | any block (no known shape)             |
 | `Dict(T)`          | homogeneous block — all values type T  |
-| `"value"`          | literal string — subtype of `string`; in annotation string: `\"value\"` |
+| `"value"`          | literal string — subtype of `string`; needs a c-string annotation: `c"\"value\""` |
 | `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
@@ -298,7 +298,10 @@ my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
 string interpolation. Always escape with `{{` and `}}`:
 `"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
 Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
-Literal string types (`"value"`) need `\"` escaping inside annotation strings.
+Literal string types (`"value"`) need a c-string annotation so the quotes
+survive: `c"\"value\""` (a plain `"..."` string leaves the backslashes for
+the type parser). A union in argument position needs parentheses —
+`c"(\"a\" | \"b\") -> bool"` — since `->` binds tighter than `|`.
 
 **Partial functions**: functions that may raise a runtime error use the
 `T?` postfix sugar — equivalent to `T | ExecutionError`.  Several


### PR DESCRIPTION
## What

The type-checking guide documents literal **string** types with a plain
annotation string:

```eu
` { type: "\"circle\" | \"rect\" -> bool" }   # documented, but does not parse
```

`\"` is a **c-string** escape — a plain `"..."` eucalypt string does not
process it, so the backslashes reach the type-annotation parser, which
errors with `unexpected character '\'`. The example as written cannot be
used.

This corrects the docs to the working form across the guide, the agent
reference, the cheat sheet, and the syntax-gotchas traps list:

```eu
` { type: c"(\"circle\" | \"rect\") -> bool" }   # c-string + parens
```

Two fixes, since the original examples have two defects:

1. **C-string for literal string types** — so the `\"` escapes survive to
   the type parser. (Literal *symbol* types like `:ok` contain no quotes
   and need no c-string.)
2. **Parenthesise a union in argument position** — `->` binds tighter
   than `|`, so `"circle" | "rect" -> bool` parses as the overload
   `"circle" | ("rect" -> bool)` and rejects even a valid `"circle"`
   argument. The one-argument reading is `("circle" | "rect") -> bool`.
   (The unparenthesised form is intentional and correct for *overloaded*
   function types — that distinction is now spelled out.)

## Files

- `docs/guide/type-checking.md` — the discriminated-union alias example,
  the "Writing literal types" section + examples, and the summary table.
- `docs/reference/agent-reference.md` — the type-forms table note and the
  escaping paragraph.
- `docs/appendices/cheat-sheet.md` — the type-forms table note.
- `docs/appendices/syntax-gotchas.md` — a new trap entry alongside the
  existing record-brace escaping section.

## Notes

- Docs only; no code changes. All edited fences stay `eu,notest`, so
  `scripts/test-doc-examples.py` skips them; the corrected forms were
  separately verified to `eu check` clean (valid literals accepted, typos
  rejected) on the 0.8.0 build.
- Found while doing the eucalypt-grove terraform type pass, whose WAF
  module relies on exactly this (c-string literal-union `Action` / `Phase`
  types).

### Possible follow-up (not in this PR)

The friendlier fix would be to make the *documented* plain-string form
work — i.e. process `\"` when extracting a `type:` annotation, or have the
type-annotation lexer tolerate a leading/again backslash-quote. Happy to
open a separate issue / change for that if preferred over requiring
c-strings.

https://claude.ai/code/session_016REnLgkxCxX3CmJefCYQEw

---
_Generated by [Claude Code](https://claude.ai/code/session_016REnLgkxCxX3CmJefCYQEw)_