### PR TITLE
fix(errors): stop execution when content verifier reports errors

### DIFF
--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -284,9 +284,14 @@ pub fn prepare(
         errors
     };
 
-    for e in errors {
-        let diag = e.to_diagnostic(loader.source_map());
-        loader.diagnose_to_stderr(&diag);
+    if !errors.is_empty() {
+        // Content verifier errors (e.g. always-divergent self-assignments) are
+        // fatal: continuing to evaluate would only produce a second, less
+        // informative runtime error (e.g. "infinite loop detected") for the
+        // same underlying problem.  Report all errors and stop.
+        let eu_errors: Vec<EucalyptError> = errors.into_iter().map(EucalyptError::Core).collect();
+        diagnose_additional(loader, &eu_errors);
+        return Err(eu_errors.into_iter().next().unwrap());
     }
 
     Ok(Command::Continue)

--- a/tests/harness/errors/004_circular.eu.expect
+++ b/tests/harness/errors/004_circular.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "binding 'f' refers to itself"

--- a/tests/harness/errors/027_self_ref.eu.expect
+++ b/tests/harness/errors/027_self_ref.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "infinite loop detected"
+stderr: "binding 'x' refers to itself"

--- a/tests/harness/errors/153_unexpected_expr_stg_compiler.eu.expect
+++ b/tests/harness/errors/153_unexpected_expr_stg_compiler.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "internal compiler error"
+stderr: "pseudo-operators"

--- a/tests/harness/errors/157_self_ref_function_call.eu.expect
+++ b/tests/harness/errors/157_self_ref_function_call.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "infinite loop detected"
+stderr: "binding 'p' refers to itself"


### PR DESCRIPTION
## Summary

- Content verifier errors (e.g. `TrivialSelfAssignment` for `x: x` or `f: f(1)`) now stop execution rather than allowing the runtime to run and produce a second, conflicting error
- Previously: users saw two errors — a clear compile-time message ("binding 'x' refers to itself — this will always diverge") followed by a confusing runtime message ("infinite loop detected: binding refers to itself")
- After: users see exactly one error — the compile-time message, which is more specific and actionable
- All 424 harness tests pass; 151 error tests pass

## Changed files

- `src/driver/prepare.rs`: treat non-empty verify results as fatal (use `diagnose_additional` + `Err` pattern, matching translate error handling)
- `tests/harness/errors/004_circular.eu.expect`: add missing expect file (now shows compile-time error)
- `tests/harness/errors/027_self_ref.eu.expect`: update from "infinite loop detected" to compile-time message
- `tests/harness/errors/157_self_ref_function_call.eu.expect`: update from "infinite loop detected" to compile-time message
- `tests/harness/errors/153_unexpected_expr_stg_compiler.eu.expect`: verifier now catches `UneliminatedPseudoOperators` before the STG compiler reaches its wildcard arm

## For owner review

This PR is from Clarion (diagnostics agent). Please review personally — Wicket should NOT merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)