### PR TITLE
feat: s"..." type-data string literal (eu-kgsi.5)

### DIFF
--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -395,6 +395,10 @@ symbol?: __ISSYMBOL
     type: "any → bool" }
 bool?: __ISBOOL
 
+` { doc: "type-data?(v) - true if and only if v is a type-data literal produced by the s prefix."
+    type: "any → bool" }
+type-data?: __ISTYPEDATA
+
 ` { doc: "`elements(b)` - expose list of elements of block `b`."
     type: "{{..}} → [(symbol, any)]" }
 elements: __ELEMENTS

--- a/src/core/desugar/literal.rs
+++ b/src/core/desugar/literal.rs
@@ -95,6 +95,16 @@ pub fn desugar_literal(
                     ));
                 }
             }
+            rowan_ast::LiteralValue::SStr(s) => {
+                if let Some(text) = s.value() {
+                    Primitive::TypeData(text.to_string())
+                } else {
+                    return Err(CoreError::InvalidEmbedding(
+                        "invalid type-data literal".to_string(),
+                        smid,
+                    ));
+                }
+            }
             rowan_ast::LiteralValue::Num(n) => {
                 if let Some(num) = n.value() {
                     Primitive::Num(num)

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -633,6 +633,16 @@ impl Desugarable for rowan_ast::Literal {
                         ));
                     }
                 }
+                rowan_ast::LiteralValue::SStr(s) => {
+                    if let Some(text) = s.value() {
+                        Primitive::TypeData(text.to_string())
+                    } else {
+                        return Err(CoreError::InvalidEmbedding(
+                            "invalid type-data literal".to_string(),
+                            desugarer.new_smid(span),
+                        ));
+                    }
+                }
                 rowan_ast::LiteralValue::Num(n) => {
                     if let Some(num) = n.value() {
                         Primitive::Num(num)

--- a/src/core/desugar/rowan_disembed.rs
+++ b/src/core/desugar/rowan_disembed.rs
@@ -314,6 +314,16 @@ fn c_lit_rowan(
                         ));
                     }
                 }
+                rowan_ast::LiteralValue::SStr(s) => {
+                    if let Some(text) = s.value() {
+                        Primitive::TypeData(text.to_string())
+                    } else {
+                        return Err(CoreError::InvalidEmbedding(
+                            "invalid type-data literal".to_string(),
+                            smid,
+                        ));
+                    }
+                }
                 rowan_ast::LiteralValue::Num(n) => {
                     if let Some(num) = n.value() {
                         Primitive::Num(num)

--- a/src/core/export/embed.rs
+++ b/src/core/export/embed.rs
@@ -303,6 +303,9 @@ impl Embed for Primitive {
             Primitive::Null => {
                 b.token("null");
             }
+            Primitive::TypeData(s) => {
+                b.string(s);
+            }
         }
         b.finish()
     }

--- a/src/core/export/pretty.rs
+++ b/src/core/export/pretty.rs
@@ -39,6 +39,10 @@ impl ToPretty for Primitive {
             Primitive::Num(n) => allocator.text(format!("{n}")),
             Primitive::Bool(b) => allocator.text(if *b { "true" } else { "false" }),
             Primitive::Null => allocator.text("null"),
+            Primitive::TypeData(s) => allocator
+                .text("s\"")
+                .append(allocator.text(s))
+                .append(allocator.text("\"")),
         }
     }
 }

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -29,6 +29,8 @@ pub enum Primitive {
     Num(Number),
     Bool(bool),
     Null,
+    /// Type-data literal (s"..." syntax) — distinct from Str at the runtime level
+    TypeData(String),
 }
 
 /// Fixity of operator

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -3035,6 +3035,8 @@ fn synthesise_primitive(prim: &Primitive) -> Type {
         Primitive::Sym(name) => Type::LiteralSymbol(name.clone()),
         Primitive::Bool(_) => Type::Bool,
         Primitive::Null => Type::Null,
+        // Type-data synthesises as String for now (no distinct type-data type in 0.9)
+        Primitive::TypeData(s) => Type::LiteralString(s.clone()),
     }
 }
 

--- a/src/eval/intrinsics.rs
+++ b/src/eval/intrinsics.rs
@@ -880,6 +880,11 @@ lazy_static! {
             strict: vec![0],
     },
     Intrinsic { // 166
+            name: "ISTYPEDATA",
+            ty: function(vec![any(), bool_()]).unwrap(),
+            strict: vec![0],
+    },
+    Intrinsic { // 167
             name: "VEC.OF",
             ty: function(vec![list(), unk()]).unwrap(),
             strict: vec![0],

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -69,6 +69,10 @@ fn format_ref(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref
                     .get(0)
                     .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
                     .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::BoxedTypeData) => args
+                    .get(0)
+                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<type-data>".to_string()),
                 Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
                 Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
                 Ok(DataConstructor::IoAction) => "<io-action>".to_string(),

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1086,6 +1086,7 @@ pub fn compile_boxed_literal(prim: &Primitive) -> Rc<StgSyn> {
         Primitive::Num(n) => dsl::box_num(n.clone()),
         Primitive::Bool(b) => dsl::bool_(*b),
         Primitive::Null => dsl::unit(),
+        Primitive::TypeData(s) => dsl::box_type_data(s),
     }
 }
 

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -66,6 +66,10 @@ fn render_debug_repr_closure(
                     .get(0)
                     .and_then(|inner| render_inner(machine, view, &env, &inner))
                     .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::BoxedTypeData) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<type-data>".to_string()),
                 Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
                 Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
                 Ok(DataConstructor::IoAction) => "<io-action>".to_string(),

--- a/src/eval/stg/eq.rs
+++ b/src/eval/stg/eq.rs
@@ -133,6 +133,7 @@ impl StgIntrinsic for Eq {
                     unary_branch(DataConstructor::BoxedString.tag()),
                     unary_branch(DataConstructor::BoxedSymbol.tag()),
                     unary_branch(DataConstructor::BoxedZdt.tag()),
+                    unary_branch(DataConstructor::BoxedTypeData.tag()),
                     // binary
                     binary_branch(DataConstructor::ListCons.tag()),
                     // block pair can be eq to block kv_list
@@ -236,6 +237,15 @@ impl StgIntrinsic for Eq {
                             force(
                                 local(0), // zdt_field
                                 // [y-native] [zdt_field] [x-eval] [x] [y]
+                                app_bif(self.index() as u8, vec![lref(2), lref(0)]),
+                            ),
+                        ),
+                        (
+                            DataConstructor::BoxedTypeData.tag(),
+                            // [str_field] [x-eval] [x] [y]
+                            force(
+                                local(0), // str_field
+                                // [y-native] [str_field] [x-eval] [x] [y]
                                 app_bif(self.index() as u8, vec![lref(2), lref(0)]),
                             ),
                         ),

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -362,6 +362,36 @@ impl StgIntrinsic for IsBool {
 
 impl CallGlobal1 for IsBool {}
 
+/// ISTYPEDATA(value)
+///
+/// Return true if the value is a type-data literal (s"..." syntax), false otherwise
+pub struct IsTypeData;
+
+impl StgIntrinsic for IsTypeData {
+    fn name(&self) -> &str {
+        "ISTYPEDATA"
+    }
+
+    fn execute(
+        &self,
+        machine: &mut dyn IntrinsicMachine,
+        view: MutatorHeapView<'_>,
+        _emitter: &mut dyn Emitter,
+        args: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        use crate::eval::memory::syntax;
+        let closure = machine.nav(view).resolve(&args[0])?;
+        let code = view.scoped(closure.code());
+        let result = matches!(
+            &*code,
+            syntax::HeapSyn::Cons { tag, .. } if *tag == DataConstructor::BoxedTypeData.tag()
+        );
+        machine_return_bool(machine, view, result)
+    }
+}
+
+impl CallGlobal1 for IsTypeData {}
+
 /// SORT_NUM_LIST — sort a list of numbers in Rust
 ///
 /// The wrapper first applies SeqNumList to force and unbox all elements,

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -234,6 +234,7 @@ pub fn make_standard_runtime(source_map: &mut SourceMap) -> Box<runtime::Standar
     rt.add(Box::new(list::IsString));
     rt.add(Box::new(list::IsSymbol));
     rt.add(Box::new(list::IsBool));
+    rt.add(Box::new(list::IsTypeData));
     rt.add(Box::new(vec::VecOf));
     rt.add(Box::new(vec::VecLen));
     rt.add(Box::new(vec::VecNth));

--- a/src/eval/stg/pretty.rs
+++ b/src/eval/stg/pretty.rs
@@ -29,6 +29,7 @@ fn tag_name(tag: u8) -> String {
         Ok(DataConstructor::IoAction) => "IoAction".to_string(),
         Ok(DataConstructor::IoFail) => "IoFail".to_string(),
         Ok(DataConstructor::Clause) => "Clause".to_string(),
+        Ok(DataConstructor::BoxedTypeData) => "TypeData".to_string(),
         Err(()) => format!("#{tag}"),
     }
 }

--- a/src/eval/stg/render.rs
+++ b/src/eval/stg/render.rs
@@ -101,6 +101,17 @@ impl StgIntrinsic for Render {
                             ),
                         ),
                         (
+                            DataConstructor::BoxedTypeData.tag(), // [str] [tagfn tag] [boxtd]
+                            case(
+                                local(2),
+                                vec![(
+                                    DataConstructor::BoxedString.tag(), // [tagstr] [str] [tagfn tag] [boxtd]
+                                    force(call::bif::emit_tag_native(lref(0), lref(1)), unit()),
+                                )],
+                                force(EmitNative.global(lref(1)), unit()), // [()] [str] [boxtd] [tagfn tag]
+                            ),
+                        ),
+                        (
                             DataConstructor::BoxedZdt.tag(), // [zdt] [tagfn tag] [boxzdt]
                             case(
                                 local(2),

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -496,7 +496,8 @@ pub fn resolve_native_unboxing(
                 Ok(DataConstructor::BoxedNumber)
                 | Ok(DataConstructor::BoxedString)
                 | Ok(DataConstructor::BoxedSymbol)
-                | Ok(DataConstructor::BoxedZdt) => {
+                | Ok(DataConstructor::BoxedZdt)
+                | Ok(DataConstructor::BoxedTypeData) => {
                     let inner_ref = args.get(0).ok_or_else(|| {
                         ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())
                     })?;

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -366,6 +366,11 @@ pub mod dsl {
         data(DataConstructor::BoxedSymbol.tag(), vec![sym(s)])
     }
 
+    /// Create a boxed type-data value (s"..." literal)
+    pub fn box_type_data<T: AsRef<str>>(s: T) -> Rc<StgSyn> {
+        data(DataConstructor::BoxedTypeData.tag(), vec![str(s)])
+    }
+
     /// Create a zoned datetime
     pub fn zdt(dt: DateTime<FixedOffset>) -> Ref {
         vref(Native::Zdt(dt))

--- a/src/eval/stg/tags.rs
+++ b/src/eval/stg/tags.rs
@@ -41,6 +41,8 @@ pub enum DataConstructor {
     IoFail = 15,
     /// Cond clause — (condition, result) pair built by the `=>` operator
     Clause = 16,
+    /// Boxed type-data string (s"..." syntax) — distinct from BoxedString
+    BoxedTypeData = 17,
 }
 
 impl fmt::Display for DataConstructor {
@@ -63,6 +65,7 @@ impl fmt::Display for DataConstructor {
             DataConstructor::IoAction => write!(f, "io-action"),
             DataConstructor::IoFail => write!(f, "io-fail"),
             DataConstructor::Clause => write!(f, "clause"),
+            DataConstructor::BoxedTypeData => write!(f, "type-data"),
         }
     }
 }
@@ -91,6 +94,7 @@ impl DataConstructor {
             DataConstructor::IoAction => 2,
             DataConstructor::IoFail => 2,
             DataConstructor::Clause => 2,
+            DataConstructor::BoxedTypeData => 1,
         }
     }
 }
@@ -138,6 +142,9 @@ impl TryFrom<Tag> for DataConstructor {
             value if value == DataConstructor::IoAction as Tag => Ok(DataConstructor::IoAction),
             value if value == DataConstructor::IoFail as Tag => Ok(DataConstructor::IoFail),
             value if value == DataConstructor::Clause as Tag => Ok(DataConstructor::Clause),
+            value if value == DataConstructor::BoxedTypeData as Tag => {
+                Ok(DataConstructor::BoxedTypeData)
+            }
             _ => Err(()),
         }
     }

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -207,6 +207,16 @@ impl TStr {
     }
 }
 
+ast_token!(SStr, S_STRING);
+impl SStr {
+    /// Get the raw content between quotes (without prefix, no escape processing)
+    pub fn value(&self) -> Option<&str> {
+        self.text()
+            .strip_prefix("s\"")
+            .and_then(|s| s.strip_suffix('\"'))
+    }
+}
+
 ast_token!(Num, NUMBER);
 
 impl Num {
@@ -223,6 +233,7 @@ impl Num {
 // - `CStr`: `[:a-cstr "text"]` - C-string literal (e.g. `c"hello\n"`)
 // - `RawStr`: `[:a-rstr "text"]` - Raw string literal (e.g. `r"hello\n"`)
 // - `TStr`: `[:a-tstr "text"]` - ZDT timestamp literal (e.g. `t"2023-01-15T10:30:00Z"`)
+// - `SStr`: `[:a-sstr "text"]` - Type-data literal (e.g. `s"number -> string"`)
 // - `Num`: `[:a-num value]` - Number literal (e.g. `42`, `3.14`)
 pub enum LiteralValue {
     /// A symbol e.g. :foo - Embedding: `[:a-sym "foo"]`
@@ -235,6 +246,8 @@ pub enum LiteralValue {
     RawStr(RawStr),
     /// A ZDT literal e.g. t"2023-01-15T10:30:00Z" - Embedding: `[:a-tstr "..."]`
     TStr(TStr),
+    /// A type-data literal e.g. s"number -> string" - Embedding: `[:a-sstr "..."]`
+    SStr(SStr),
     /// A number e.g. 99 - Embedding: `[:a-num 99]`
     Num(Num),
 }
@@ -247,6 +260,7 @@ impl AstToken for LiteralValue {
             SyntaxKind::C_STRING => CStr::cast(token).map(LiteralValue::CStr),
             SyntaxKind::RAW_STRING => RawStr::cast(token).map(LiteralValue::RawStr),
             SyntaxKind::T_STRING => TStr::cast(token).map(LiteralValue::TStr),
+            SyntaxKind::S_STRING => SStr::cast(token).map(LiteralValue::SStr),
             SyntaxKind::SYMBOL => Sym::cast(token).map(LiteralValue::Sym),
             _ => None,
         }
@@ -263,6 +277,7 @@ impl AstToken for LiteralValue {
                 | SyntaxKind::C_STRING
                 | SyntaxKind::RAW_STRING
                 | SyntaxKind::T_STRING
+                | SyntaxKind::S_STRING
                 | SyntaxKind::SYMBOL
         )
     }
@@ -274,6 +289,7 @@ impl AstToken for LiteralValue {
             LiteralValue::CStr(s) => s.syntax(),
             LiteralValue::RawStr(s) => s.syntax(),
             LiteralValue::TStr(s) => s.syntax(),
+            LiteralValue::SStr(s) => s.syntax(),
             LiteralValue::Sym(s) => s.syntax(),
         }
     }

--- a/src/syntax/rowan/kind.rs
+++ b/src/syntax/rowan/kind.rs
@@ -106,6 +106,9 @@ pub enum SyntaxKind {
     /// ZDT (timestamp) string literal e.g. t"2023-01-15T10:30:00Z"
     T_STRING,
 
+    /// Type-data string literal e.g. s"number -> string"
+    S_STRING,
+
     /// Open token of a Unicode bracket pair (idiot bracket expression)
     BRACKET_OPEN,
     /// Close token of a Unicode bracket pair (idiot bracket expression)
@@ -141,6 +144,7 @@ impl SyntaxKind {
             || *self == C_STRING
             || *self == RAW_STRING
             || *self == T_STRING
+            || *self == S_STRING
     }
 
     pub fn is_name_terminal(&self) -> bool {

--- a/src/syntax/rowan/lex.rs
+++ b/src/syntax/rowan/lex.rs
@@ -33,13 +33,15 @@ fn is_punctuation_category(cat: GeneralCategory) -> bool {
     )
 }
 
-/// String prefix type for c-strings, r-strings and t-strings
+/// String prefix type for c-strings, r-strings, t-strings and s-strings
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StringPrefix {
     None,
     CString,
     RawString,
     TString,
+    /// s"..." — type-data string literal (no interpolation, no escape processing)
+    SString,
 }
 
 /// Eucalypt lexer
@@ -280,6 +282,11 @@ where
                         self.bump(); // consume the opening quote
                         return self.dquote_with_prefix(i, StringPrefix::TString);
                     }
+                    's' => {
+                        // This is an s-string (type-data literal) prefix
+                        self.bump(); // consume the opening quote
+                        return self.dquote_with_prefix(i, StringPrefix::SString);
+                    }
                     _ => {}
                 }
             }
@@ -359,6 +366,7 @@ where
                         StringPrefix::CString => C_STRING,
                         StringPrefix::RawString => RAW_STRING,
                         StringPrefix::TString => T_STRING,
+                        StringPrefix::SString => S_STRING,
                     };
                     return (kind, Span::new(prefix_start, self.location));
                 }
@@ -372,6 +380,11 @@ where
             return (T_STRING, full_span);
         }
 
+        // S-strings are type-data literals — no interpolation, no escape processing
+        if string_prefix == StringPrefix::SString {
+            return (S_STRING, full_span);
+        }
+
         // Determine the token kinds based on prefix
         let (simple_kind, pattern_start_kind, pattern_end_kind) = match string_prefix {
             StringPrefix::None => (STRING, STRING_PATTERN_START, STRING_PATTERN_END),
@@ -380,6 +393,7 @@ where
                 (RAW_STRING, RAW_STRING_PATTERN_START, RAW_STRING_PATTERN_END)
             }
             StringPrefix::TString => unreachable!(),
+            StringPrefix::SString => unreachable!(),
         };
 
         // Check if this string contains interpolation
@@ -395,6 +409,7 @@ where
                 content.contains('{') || content.contains('}')
             }
             StringPrefix::TString => unreachable!(),
+            StringPrefix::SString => unreachable!(),
         };
 
         if has_interpolation {
@@ -422,7 +437,7 @@ where
                         self.token_buffer.push_back((token_kind, span));
                     }
                 }
-                StringPrefix::TString => unreachable!(),
+                StringPrefix::TString | StringPrefix::SString => unreachable!(),
             }
 
             // Buffer the closing quote

--- a/src/syntax/rowan/validate.rs
+++ b/src/syntax/rowan/validate.rs
@@ -135,6 +135,17 @@ impl Validatable for TStr {
     }
 }
 
+impl Validatable for SStr {
+    /// Type-data literal — only validate that it is properly closed
+    fn validate(&self, errors: &mut Vec<ParseError>) {
+        if self.text().starts_with("s\"") && !self.text().ends_with('"') {
+            errors.push(ParseError::UnclosedDoubleQuote {
+                range: self.syntax().text_range(),
+            });
+        }
+    }
+}
+
 impl Validatable for Num {}
 
 impl Validatable for LiteralValue {
@@ -145,6 +156,7 @@ impl Validatable for LiteralValue {
             LiteralValue::CStr(s) => s.validate(errors),
             LiteralValue::RawStr(s) => s.validate(errors),
             LiteralValue::TStr(s) => s.validate(errors),
+            LiteralValue::SStr(s) => s.validate(errors),
             LiteralValue::Sym(s) => s.validate(errors),
         }
     }

--- a/tests/harness/164_s_string.eu
+++ b/tests/harness/164_s_string.eu
@@ -22,11 +22,19 @@ td-not-sym: not(symbol?(s"number"))
 # Type-data with different content is not equal
 not-equal-td: not(s"number" = s"string")
 
+# Braces inside s"..." are literal — no interpolation, no doubling required
+literal-braces: type-data?(s"{x: number}")
+
+# Curly-brace content that looks like interpolation is still literal in s-strings
+no-interp: type-data?(s"hi {name}")
+
 RESULT: if(
   and(td-is-type-data,
   and(not(str-is-not-type-data),
   and(not-equal,
   and(equal-td,
   and(td-not-str,
-  and(td-not-sym, not-equal-td)))))),
+  and(td-not-sym,
+  and(not-equal-td,
+  and(literal-braces, no-interp)))))))),
   :PASS, :FAIL)

--- a/tests/harness/164_s_string.eu
+++ b/tests/harness/164_s_string.eu
@@ -1,0 +1,32 @@
+#!/usr/bin/env eu
+# Tests for s"..." type-data string literals
+
+# type-data? predicate identifies type-data values
+td-is-type-data: type-data?(s"number")
+
+# Plain strings are not type-data
+str-is-not-type-data: type-data?("number")
+
+# Type-data is not equal to a plain string with same content
+not-equal: not(s"number" = "number")
+
+# Two type-data values with the same content are equal
+equal-td: s"number" = s"number"
+
+# Type-data is not a plain string
+td-not-str: not(string?(s"number"))
+
+# Type-data is not a symbol
+td-not-sym: not(symbol?(s"number"))
+
+# Type-data with different content is not equal
+not-equal-td: not(s"number" = s"string")
+
+RESULT: if(
+  and(td-is-type-data,
+  and(not(str-is-not-type-data),
+  and(not-equal,
+  and(equal-td,
+  and(td-not-str,
+  and(td-not-sym, not-equal-td)))))),
+  :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1768,6 +1768,11 @@ pub fn test_harness_163() {
 }
 
 #[test]
+pub fn test_harness_164() {
+    run_test(&opts("164_s_string.eu"));
+}
+
+#[test]
 pub fn test_error_154() {
     run_error_test(&error_opts("154_internal_import_error.eu"));
 }


### PR DESCRIPTION
## Summary

- Implements the `s"..."` string prefix producing `Native::TypeData` values — first-class type-data literals distinct from plain strings at runtime
- Braces are literal (no interpolation, no escape processing); renders as string content in all export formats
- Adds `type-data?` predicate intrinsic for runtime type inspection
- Prerequisite for W8 (`eu doc`) and W16 (contracts)

## Changes

- **Lexer/parser**: `SString` prefix, `S_STRING` `SyntaxKind`, `SStr` AST token — handled like T_STRING (no interpolation)
- **Core**: `Primitive::TypeData(String)` in `core/expr.rs`; desugared in all three desugarer paths
- **Runtime**: `BoxedTypeData = 17` `DataConstructor`; compiled via `box_type_data()` DSL helper
- **Rendering**: `BoxedTypeData` case in `Render` intrinsic emits inner `Native::Str` → `Primitive::Str` in all exporters
- **Equality**: `BoxedTypeData` handled in `eq.rs` `unary_branch` — `s"x" = s"x"` is true, `s"x" = "x"` is false
- **Intrinsics**: `IsTypeData` (`__ISTYPEDATA`) registered at index 166; `type-data?` added to prelude
- **Tests**: Harness test 164 covering predicate, equality semantics, and type checks

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test --lib` — 991 passed
- [x] `cargo test --lib --test harness_test` — 425 passed including new test 164

🤖 Generated with [Claude Code](https://claude.com/claude-code)