### PR TITLE
feat(typecheck): migrate lib type annotations to s-strings

### DIFF
--- a/lib/lens.eu
+++ b/lib/lens.eu
@@ -2,7 +2,7 @@
   doc: "Lenses in Eucalypt - highly experimental and subject to change." }
 
 ` { doc: "`at(key)` defines a lens that focuses within a block on the value with key `key`."
-    type: "symbol → Lens({{..r}}, a)" }
+    type: s"symbol → Lens({..r}, a)" }
 at(key, k): {
   fmap: meta(k).fmap
   s(obj): fmap({ nv: • }.(obj alter-value(key, nv)), k(obj lookup(key)))
@@ -13,15 +13,15 @@ fmap-set: identity
 fmap-get: flip(const)
 
 ` { doc: "`view(lens, data)` - return the value within `data` focussed on by `lens`. Only valid for lenses (single focus). Using view on a traversal will error."
-    type: "Lens(a, b) → a → b" }
+    type: s"Lens(a, b) → a → b" }
 view(lens, data): data lens(identity // { fmap: fmap-get })
 
 ` { doc: "`over(lens, fn, data)` - apply fn to each focus within `data` and return the whole modified data structure. Works for both lenses and traversals."
-    type: "(Lens(a, b) | Traversal(a, b)) → (b → b) → a → a" }
+    type: s"(Lens(a, b) | Traversal(a, b)) → (b → b) → a → a" }
 over(lens, fn, data): data lens(fn // { fmap: fmap-set, pure: identity, ap: identity })
 
 ` { doc: "`to-list-of(optic, data)` - collect all foci of an optic into a flat list. Works for both lenses (returns singleton list) and traversals (returns all foci, flattened)."
-    type: "(Lens(a, b) | Traversal(a, b)) → a → [b]" }
+    type: s"(Lens(a, b) | Traversal(a, b)) → a → [b]" }
 to-list-of(optic, data): data optic((_ ‖ []) // { fmap: fmap-get, pure: -> [], ap: ++ })
 
 
@@ -56,7 +56,7 @@ example-basic: {
 
 
 ` { doc: "`ix(n)` defines a lens which focusses on a list item at index `n`."
-    type: "number → Lens([a], a)" }
+    type: s"number → Lens([a], a)" }
 ix(n, k): {
   fmap: meta(k).fmap
   s(data): fmap({ nv: • }.(data update-nth(n, ->nv)), k(data !! n))
@@ -126,7 +126,7 @@ example-paths: {
 # predicate lenses - first matching list element
 
 ` { doc: "`item(p?)` defines a lens that focuses on the first list element matching predicate `p?`."
-    type: "(a → bool) → Lens([a], a)" }
+    type: s"(a → bool) → Lens([a], a)" }
 item(p?, k): {
   fmap: meta(k).fmap
   s(data): fmap({ nv: • }.(data update-first(p?, ->nv)), k(data filter(p?) head))
@@ -145,18 +145,18 @@ example-predicate: {
 # block element lenses
 
 ` { doc: "`element(p?)` defines a lens that focuses on the first kv pair [key, value] in a block matching `p?`. Use prelude helpers like `by-key`, `by-value` to define the predicate. Compose with `_value` to focus on just the value."
-    type: "((symbol, any) → bool) → Lens({{..}}, (symbol, any))" }
+    type: s"((symbol, any) → bool) → Lens({..}, (symbol, any))" }
 element(p?, k): {
   fmap: meta(k).fmap
   s(data): fmap({ nv: • }.(data elements update-first(p?, ->nv) block), k(data filter-items(p?) head))
 }.(s // meta(k))
 
 ` { doc: "`_value` lens focuses on the value (index 1) of a kv pair [key, value]."
-    type: "Lens([a], a)" }
+    type: s"Lens([a], a)" }
 _value: ix(1)
 
 ` { doc: "`_key` lens focuses on the key (index 0) of a kv pair [key, value]."
-    type: "Lens([a], a)" }
+    type: s"Lens([a], a)" }
 _key: ix(0)
 
 ` { target: :test-element }
@@ -187,7 +187,7 @@ example-element: {
 # traversals
 
 ` { doc: "`each` traverses all elements of a list."
-    type: "Traversal([a], a)" }
+    type: s"Traversal([a], a)" }
 each(k): {
   fmap: meta(k).fmap
   pure: meta(k).pure
@@ -197,7 +197,7 @@ each(k): {
 }.(s // meta(k))
 
 ` { doc: "`filtered(p?)` traverses list elements matching predicate `p?`."
-    type: "(a → bool) → Traversal([a], a)" }
+    type: s"(a → bool) → Traversal([a], a)" }
 filtered(p?, k): {
   fmap: meta(k).fmap
   pure: meta(k).pure
@@ -211,7 +211,7 @@ filtered(p?, k): {
 # parts-of — turn a traversal into a lens on the list of foci
 
 ` { doc: "`parts-of(traversal)` turns a traversal into a lens focusing on the list of all foci. `view` collects foci into a list. `over` applies a list transformation and distributes results back."
-    type: "Traversal(a, b) → Lens(a, [b])" }
+    type: s"Traversal(a, b) → Lens(a, [b])" }
 parts-of(traversal, k): {
   fmap: meta(k).fmap
 
@@ -236,7 +236,7 @@ parts-of(traversal, k): {
 }.(s // meta(k))
 
 ` { doc: "`each-element` traverses all kv pairs of a block."
-    type: "Traversal({{..}}, (symbol, any))" }
+    type: s"Traversal({..}, (symbol, any))" }
 each-element(k): {
   fmap: meta(k).fmap
   pure: meta(k).pure
@@ -247,7 +247,7 @@ each-element(k): {
 }.(s // meta(k))
 
 ` { doc: "`filtered-elements(p?)` traverses block kv pairs matching predicate `p?`."
-    type: "((symbol, any) → bool) → Traversal({{..}}, (symbol, any))" }
+    type: s"((symbol, any) → bool) → Traversal({..}, (symbol, any))" }
 filtered-elements(p?, k): {
   fmap: meta(k).fmap
   pure: meta(k).pure

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -13,30 +13,30 @@ eu: {
   build: __build
 
   ` { doc: "requires(constraint) - assert that the eucalypt version satisfies the given semver constraint (e.g. '>=0.2.0')."
-      type: "string → null" }
+      type: s"string → null" }
   requires: __REQUIRES
 
   ` { doc: "Operating system: linux, macos, windows, etc."
-      type: "string" }
+      type: s"string" }
   os: __OS
 
   ` { doc: "CPU architecture: x86_64, aarch64, etc."
-      type: "string" }
+      type: s"string" }
   arch: __ARCH
 }
 
 ` { doc: "IO related declarations. The io namespace is a monad: io.bind, io.return, io.sequence, io.map-m, io.filter-m, io.then, io.join are derived automatically."
-    monad: "IO(a)" }
+    monad: s"IO(a)" }
 io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
   ` { doc: "Read access to environment variables at time of launch." }
   env: __io.ENV
 
   ` { doc: "Seconds since the Unix epoch at launch time."
-      type: "number" }
+      type: s"number" }
   epoch-time: __io.EPOCHTIME
 
   ` { doc: "Command-line arguments passed after -- separator."
-      type: "[string]" }
+      type: s"[string]" }
   args: __args
 
   ` "Seed for random number generation (from --seed or system time)"
@@ -50,33 +50,33 @@ io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
   ##
 
   ` { doc: "Run a shell command via sh -c. Returns a block with stdout, stderr, and exit-code fields."
-      type: "string → IO({{..}})" }
+      type: s"string → IO({..})" }
   shell(c): __IO_ACTION({:io-shell cmd: c, timeout: 30})
 
   ` { doc: "Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout."
-      type: "{{..}} → string → IO({{..}})" }
+      type: s"{..} → string → IO({..})" }
   shell-with(opts, c): __IO_ACTION({:io-shell cmd: c, timeout: opts lookup-or(:timeout, 30), stdin: opts lookup-or(:stdin, null)})
 
   ` { doc: "Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields."
-      type: "string → IO({{..}})" }
+      type: s"string → IO({..})" }
   exec([c : as]): __IO_ACTION({:io-exec cmd: c, args: as, timeout: 30})
 
   ` { doc: "Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout."
-      type: "{{..}} → string → IO({{..}})" }
+      type: s"{..} → string → IO({..})" }
   exec-with(opts, [c : as]): __IO_ACTION({:io-exec cmd: c, args: as, timeout: opts lookup-or(:timeout, 30), stdin: opts lookup-or(:stdin, null)})
 
   ` { doc: "Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result."
-      type: "{{..}} → IO({{..}})" }
+      type: s"{..} → IO({..})" }
   check(result): if(result.'exit-code' = 0,
     io.return(result),
     __IO_ACTION({:io-fail message: result.stderr}))
 
   ` { doc: "Pipeline-friendly check: bind the preceding IO action through check."
-      type: "IO({{..}}) → IO({{..}})" }
+      type: s"IO({..}) → IO({..})" }
   checked: io.and-then(io.check)
 
   ` { doc: "Fail the IO action with the given error message."
-      type: "string → IO(a)" }
+      type: s"string → IO(a)" }
   fail(msg): __IO_ACTION({:io-fail message: msg})
 }
 
@@ -90,7 +90,7 @@ io: monad{bind(a, c): __IO_BIND(a, c), return(a): __IO_RETURN(a)} {
 list-map: map
 
 ` { doc: "monad(m) - derive standard monad combinators from a block m with bind and return fields. Returns a block with bind, return, map, then, and-then, join, sequence, map-m, and filter-m."
-    type: "!forall (m :: * -> *). {{..}} → {{bind: forall a b. m a → (a → m b) → m b,
+    type: s"!forall (m :: * -> *). {..} → {bind: forall a b. m a → (a → m b) → m b,
                return: forall a. a → m a,
                map: forall a b. (a → b) → m a → m b,
                then: forall a b. m b → m a → m b,
@@ -98,7 +98,7 @@ list-map: map
                join: forall a. m (m a) → m a,
                sequence: forall a. [m a] → m [a],
                map-m: forall a b. (a → m b) → [a] → m [b],
-               filter-m: forall a. (a → m bool) → [a] → m [a]}}" }
+               filter-m: forall a. (a → m bool) → [a] → m [a]}" }
 monad(m): {
   ` "Sequence two monadic actions: run action and pass its result to continuation."
   bind: m.bind
@@ -154,18 +154,18 @@ random-bind(m, f, stream): {
 }
 
 ` { doc: "Monadic random: namespace. Each operation is a state-monad action: a function from stream to a value/rest block. Use random.stream(seed) to create the initial stream, then run actions by calling them with the stream."
-    monad: "stream → {{value: a, rest: stream}}" }
+    monad: s"stream → {value: a, rest: stream}" }
 random: monad{bind: random-bind, return: random-ret} {
   ` { doc: "random.stream(seed) - create an opaque PRNG stream from integer seed."
-      type: "number → any" }
+      type: s"number → any" }
   stream(seed): __STREAM_NEW(seed)
 
   ` { doc: "random.as-list(stream) - convert an opaque random stream to a lazy cons-list of floats."
-      type: "array → [number]" }
+      type: s"array → [number]" }
   as-list(s): cons(__STREAM_VALUE(s), as-list(__STREAM_ADVANCE(s)))
 
   ` { doc: "random.float - state-monad action returning a random float in [0,1)."
-      type: "any → {{..}}" }
+      type: s"any → {..}" }
   float(s): {
     pair: __STREAM_FLOAT(s)
     value: pair head
@@ -173,7 +173,7 @@ random: monad{bind: random-bind, return: random-ret} {
   }
 
   ` { doc: "random.int(n) - state-monad action returning a random integer in [0,n)."
-      type: "number → any → {{..}}" }
+      type: s"number → any → {..}" }
   int(n, s): {
     pair: __STREAM_INT(n, s)
     value: pair head
@@ -181,7 +181,7 @@ random: monad{bind: random-bind, return: random-ret} {
   }
 
   ` { doc: "random.split - state-monad action that splits the stream into two independent streams. Returns a value/rest block where value and rest are each independent streams."
-      type: "any → {{..}}" }
+      type: s"any → {..}" }
   split(s): {
     pair: __STREAM_SPLIT(s)
     value: pair head
@@ -189,7 +189,7 @@ random: monad{bind: random-bind, return: random-ret} {
   }
 
   ` { doc: "random.choice(list) - state-monad action returning a random element from list."
-      type: "[a] → any → {{..}}" }
+      type: s"[a] → any → {..}" }
   choice(lst, stream): {
     r: int(lst count, stream)
     next: random-ret(lst nth(r.value), r.rest)
@@ -198,14 +198,14 @@ random: monad{bind: random-bind, return: random-ret} {
   }
 
   ` { doc: "random.shuffle(list) - state-monad action returning a shuffled copy of list."
-      type: "[a] → any → {{..}}" }
+      type: s"[a] → any → {..}" }
   shuffle(lst): {
-    ` { type: "![a] → number → [a] → any → {{..}}" }
+    ` { type: s"![a] → number → [a] → any → {..}" }
     shuffle-impl(remaining, n, acc, stream):
       if(n = 0,
         { value: acc, rest: stream },
         shuffle-step(remaining, n, acc, stream))
-    ` { type: "![a] → number → [a] → any → {{..}}" }
+    ` { type: s"![a] → number → [a] → any → {..}" }
     shuffle-step(remaining, n, acc, stream): {
       r: int(n, stream)
       picked: remaining nth(r.value)
@@ -217,7 +217,7 @@ random: monad{bind: random-bind, return: random-ret} {
   }.(shuffle-impl(lst, lst count, []))
 
   ` { doc: "random.sample(n, list) - state-monad action returning n elements sampled without replacement."
-      type: "number → [a] → any → {{..}}" }
+      type: s"number → [a] → any → {..}" }
   sample(n, lst, stream): {
     shuffled: shuffle(lst, stream)
     value: shuffled.value take(n)
@@ -225,15 +225,15 @@ random: monad{bind: random-bind, return: random-ret} {
   }
 
   ` { doc: "random.run(action, stream) - run a random action on a stream; returns a value/rest block."
-      type: "(any → {{..}}) → any → {{..}}" }
+      type: s"(any → {..}) → any → {..}" }
   run(action, stream): action(stream)
 
   ` { doc: "random.eval(action, stream) - run a random action and return only the value."
-      type: "(any → {{..}}) → any → any" }
+      type: s"(any → {..}) → any → any" }
   eval(action, stream): action(stream).value
 
   ` { doc: "random.exec(action, stream) - run a random action and return only the remaining stream."
-      type: "(any → {{..}}) → any → any" }
+      type: s"(any → {..}) → any → any" }
   exec(action, stream): action(stream).rest
 }
 
@@ -243,7 +243,7 @@ random: monad{bind: random-bind, return: random-ret} {
 ##
 
 ` { doc: "`panic(s)` - raise runtime error with message string `s`."
-    type: "string → never" }
+    type: s"string → never" }
 panic: __PANIC
 
 ##
@@ -251,27 +251,27 @@ panic: __PANIC
 ##
 
 ` { doc: "A null value. To export as `null` in JSON or ~ in YAML."
-    type: "null" }
+    type: s"null" }
 null: __NULL
 
 ` { doc: "`true` - constant logical true."
-    type: "bool" }
+    type: s"bool" }
 true: __TRUE
 
 ` { doc: "`false` - constant logical false."
-    type: "bool" }
+    type: s"bool" }
 false: __FALSE
 
 ` { doc: "`if(c, t, f)` - if `c` is `true`, return `t` else `f`."
-    type: "bool → a → b → (a | b)" }
+    type: s"bool → a → b → (a | b)" }
 if: __IF
 
 ` { doc: "`then(t, f, c)` - for pipeline if: `x? then(t, f)`."
-    type: "a → b → bool → (a | b)" }
+    type: s"a → b → bool → (a | b)" }
 then(t, f, c): if(c, t, f)
 
 ` { doc: "`when(p?, f, x)` - when `x` satisfies `p?` apply `f` else pass through unchanged."
-    type: "(a → bool) → (a → a) → a → a" }
+    type: s"(a → bool) → (a → a) → a → a" }
 when(p?, f, x): if(x p?, x f, x)
 
 ##
@@ -279,21 +279,21 @@ when(p?, f, x): if(x p?, x f, x)
 ##
 
 ` { doc: "`cons(h, t)` - construct new list by prepending item `h` to list `t`."
-    type: "a → [a] → NonEmpty([a])" }
+    type: s"a → [a] → NonEmpty([a])" }
 cons: __CONS
 
 ` { doc: "`snoc(x, l)` - append element `x` to the end of list `l`."
-    type: "a → [a] → [a]" }
+    type: s"a → [a] → [a]" }
 snoc(x, l): l ++ [x]
 
 ` { doc: "`x ‖ xs` - prepend element `x` to list `xs`. Right-associative cons operator."
-    type: "a → [a] → NonEmpty([a])"
+    type: s"a → [a] → NonEmpty([a])"
     associates: :right
     precedence: 55 }
 (x ‖ xs): __CONS(x, xs)
 
 ` { doc: "`head(xs)` - return the head item of list `xs`, panic if empty."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 head: __HEAD
 
 ` { doc: "`↑xs` - return first element of list `xs`. Tight-binding prefix operator."
@@ -301,15 +301,15 @@ head: __HEAD
 (↑ xs): xs head
 
 ` { doc: "`nil?(xs)` - `true` if list `xs` is empty, `false` otherwise."
-    type: "[a] → bool" }
+    type: s"[a] → bool" }
 nil?: __NILP
 
 ` { doc: "`non-nil?(xs)` - `true` if list `xs` is non-empty, `false` otherwise."
-    type: "[a] → bool" }
+    type: s"[a] → bool" }
 non-nil?: nil? complement
 
 ` { doc: "`null?(x)` - `true` if `x` is null, `false` otherwise."
-    type: "any → bool" }
+    type: s"any → bool" }
 null?: = null
 
 ` { doc: "`x✓` - `true` if `x` is not null, `false` otherwise. Postfix not-null check operator."
@@ -317,35 +317,35 @@ null?: = null
 (x ✓): not(x = null)
 
 ` { doc: "`coalesce(xs)` - return the first non-null element from list `xs`, or null if all are null."
-    type: "[a | null] → a | null" }
+    type: s"[a | null] → a | null" }
 coalesce(xs): (xs nil?) then(null, (xs head)✓ then(xs head, xs tail coalesce))
 
 ` { doc: "`head-or(xs, d)` - return the head item of list `xs` or default `d` if empty."
-    type: "b → [a] → (a | b)" }
+    type: s"b → [a] → (a | b)" }
 head-or(d, xs): xs nil? then(d, xs head)
 
 ` { doc: "`tail(xs)` - return list `xs` without the head item. [] causes error."
-    type: "[a] → [a]" }
+    type: s"[a] → [a]" }
 tail: __TAIL
 
 ` { doc: "`tail-or(xs, d)` - return list `xs` without the head item or `d` for empty list."
-    type: "b → [a] → ([a] | b)" }
+    type: s"b → [a] → ([a] | b)" }
 tail-or(d, xs): xs nil? then(d, xs tail)
 
 ` { doc: "`nil` - identical to `[]`, the empty list."
-    type: "[a]" }
+    type: s"[a]" }
 nil: []
 
 ` { doc: "`first(xs)` - return first item of list `xs` - error if the list is empty."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 first: head
 
 ` { doc: "`second(xs)` - return second item of list - error if there is none."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 second(xs): xs tail head
 
 ` { doc: "`second-or(xs, d)` - return second item of list - default `d` if there is none."
-    type: "b → [a] → (a | b)" }
+    type: s"b → [a] → (a | b)" }
 second-or(d, xs): xs tail-or([d]) head-or(d)
 
 ##
@@ -353,78 +353,78 @@ second-or(d, xs): xs tail-or([d]) head-or(d)
 ##
 
 ` { doc: "`sym(s)` - create symbol with name given by string `s`."
-    type: "string → symbol" }
+    type: s"string → symbol" }
 sym: __SYM
 
 ` { doc: "`merge(b1, b2)` - shallow merge block `b2` on top of `b1`."
-    type: "{{..r}} → {{..s}} → {{..r, ..s}}" }
+    type: s"{..r} → {..s} → {..r, ..s}" }
 merge: __MERGE
 
 ` { doc: "`deep-merge(b1, b2)` - deep merge block `b2` on top of `b1`, merges nested blocks but not lists."
-    type: "{{..}} → {{..}} → {{..}}" }
+    type: s"{..} → {..} → {..}" }
 deep-merge: __DEEPMERGE
 
 ` { doc: "`l << r` - deep merge block `r` on top of `l`, merging nested blocks, not lists."
-    type: "{{..}} → {{..}} → {{..}}"
+    type: s"{..} → {..} → {..}"
     export: :suppress
     associates: :left
     precedence: :append }
 (l << r): __DEEPMERGE(l, r)
 
 ` { doc: "`block?(v)` - true if and only if `v` is a block."
-    type: "any → bool" }
+    type: s"any → bool" }
 block?: __ISBLOCK
 
 ` { doc: "`list?(v)` - true if and only if `v` is a list."
-    type: "any → bool" }
+    type: s"any → bool" }
 list?: __ISLIST
 
 ` { doc: "`number?(v)` - true if and only if `v` is a number."
-    type: "any → bool" }
+    type: s"any → bool" }
 number?: __ISNUMBER
 
 ` { doc: "`string?(v)` - true if and only if `v` is a string."
-    type: "any → bool" }
+    type: s"any → bool" }
 string?: __ISSTRING
 
 ` { doc: "`symbol?(v)` - true if and only if `v` is a symbol."
-    type: "any → bool" }
+    type: s"any → bool" }
 symbol?: __ISSYMBOL
 
 ` { doc: "`bool?(v)` - true if and only if `v` is a boolean."
-    type: "any → bool" }
+    type: s"any → bool" }
 bool?: __ISBOOL
 
 ` { doc: "type-data?(v) - true if and only if v is a type-data literal produced by the s prefix."
-    type: "any → bool" }
+    type: s"any → bool" }
 type-data?: __ISTYPEDATA
 
 ` { doc: "`elements(b)` - expose list of elements of block `b`."
-    type: "{{..}} → [(symbol, any)]" }
+    type: s"{..} → [(symbol, any)]" }
 elements: __ELEMENTS
 
 ` { doc: "`block(kvs)` - (re)construct block from list `kvs` of elements."
-    type: "[(symbol, any)] → {{..}}" }
+    type: s"[(symbol, any)] → {..}" }
 block: __BLOCK
 
 ` { doc: "`has(s, b)` - true if and only if block `b` has key (symbol) `s`."
-    type: "symbol → {{..}} → bool" }
+    type: s"symbol → {..} → bool" }
 has(s, b): b map-values(const(true)) lookup-or(s, false)
 
 ` { doc: "`lookup(s, b)` - look up symbol `s` in block `b`, error if not found."
-    type: "symbol → Dict(a) → a?" }
+    type: s"symbol → Dict(a) → a?" }
 lookup(s, b): __LOOKUP(s, b)
 
 ` { doc: "`lookup-in(b, s)` - look up symbol `s` in block `b`, error if not found."
-    type: "{{..}} → symbol → any?" }
+    type: s"{..} → symbol → any?" }
 lookup-in(b, s): __LOOKUP(s, b)
 
 ` { doc: "`lookup-or(s, d, b)` - look up symbol `s` in block `b`, default `d` if not found."
-    type: "symbol → a → {{..}} → any | a" }
+    type: s"symbol → a → {..} → any | a" }
 lookup-or(s, d, b): __LOOKUPOR(s, d, b)
 
 ` { doc: "`lookup-or-in(b, s, d)` - look up symbol `s` in block `b`, default `d` if not found."
-    type: "{{..}} → symbol → a → any | a" }
+    type: s"{..} → symbol → a → any | a" }
 lookup-or-in(b, s, d): lookup-or(s, d, b)
 
 ` { doc: "a ~ :k - safe key lookup. Returns value at key :k if a is a block containing :k, else null. Null-propagating for chained navigation."
@@ -441,7 +441,7 @@ lookup-across(s, d, bs): {
 }.(foldr(f, d, bs))
 
 ` { doc: "`lookup-path(ks, b)` - look up value at key path `ks` in block `b`."
-    type: "[symbol] → {{..}} → any" }
+    type: s"[symbol] → {..} → any" }
 lookup-path(ks, b): foldl(lookup-in, b, ks)
 
 ##
@@ -449,7 +449,7 @@ lookup-path(ks, b): foldl(lookup-in, b, ks)
 ##
 
 ` { doc: "`deep-fold(emit, next-state, s, b)` - depth-first fold over nested blocks and lists. `emit(state, block)` returns a list of results at each block node. `next-state(state, child-key)` updates state for recursion into a child. `s` is the initial state."
-    type: "(s → {{..}} → [b]) → (s → symbol → s) → s → any → [b]" }
+    type: s"(s → {..} → [b]) → (s → symbol → s) → s → any → [b]" }
 deep-fold(emit, next-state, s, b): {
   walk-child(s, [ck, cv]): walk(next-state(s, ck), cv)
   walk(s, v): if(v block?,
@@ -522,7 +522,7 @@ deep-query-paths(pattern, b): b deep-query-fold(pattern) map(first)
 ##
 
 ` { doc: "`deep-transform(rule, data)` - recursively transform a nested structure. At each node, call `rule(node)`. If it returns non-null, use that as the replacement (stop recursing into that node). If it returns null, recurse into children (block values and list elements)."
-    type: "(any → any | null) → any → any" }
+    type: s"(any → any | null) → any → any" }
 deep-transform(rule, data): {
   attempt: rule(data)
   recurse: if(data block?, data map-values(deep-transform(rule)),
@@ -538,7 +538,7 @@ deep-transform(rule, data): {
 any?: const(true)
 
 ` { doc: "`match?(pattern, target)` - structural predicate. Returns true if `target` conforms to `pattern`. Pattern values are interpreted by type: blocks and lists recurse as sub-patterns, functions are applied as predicates, literals are exact equality checks. Open matching: extra keys in target are ignored."
-    type: "any → any → bool" }
+    type: s"any → any → bool" }
 match?(pat, target): {
   mv?(p, actual):
     if(p block?, mb?(p, actual),
@@ -562,7 +562,7 @@ match?(pat, target): {
 ##
 
 ` { doc: "`not(b)` - toggle boolean."
-    type: "bool → bool" }
+    type: s"bool → bool" }
 not: __NOT
 
 ` { doc: "`!x` - not x, toggle boolean."
@@ -574,36 +574,36 @@ not: __NOT
 (¬ b): b not
 
 ` { doc: "`l && r` - true if and only if `l` and `r` are true."
-    type: "bool → bool → bool"
+    type: s"bool → bool → bool"
     export: :suppress
     associates: :left
     precedence: :bool-prod }
 (l && r): __AND(l, r)
 
 ` { doc: "`and(l, r)` - true if and only if `l` and `r` are true."
-    type: "bool → bool → bool" }
+    type: s"bool → bool → bool" }
 and: __AND
 
 ` { doc: "`l ∧ r` - true if and only if `l` and `r`"
-    type: "bool → bool → bool"
+    type: s"bool → bool → bool"
     export: :suppress
     associates: :left
     precedence: :bool-prod }
 (l ∧ r): l && r
 
 ` { doc: "`or(l, r)` - true if and only if `l` or `r` is true."
-    type: "bool → bool → bool" }
+    type: s"bool → bool → bool" }
 or: __OR
 
 ` { doc: "`l || r` - true if and only if `l` or `r`"
-    type: "bool → bool → bool"
+    type: s"bool → bool → bool"
     export: :suppress
     associates: :left
     precedence: :bool-sum }
 (l || r): __OR(l, r)
 
 ` { doc: "`l ∨ r` - true if and only if `l` or `r`"
-    type: "bool → bool → bool"
+    type: s"bool → bool → bool"
     export: :suppress
     associates: :left
     precedence: :bool-sum }
@@ -616,21 +616,21 @@ or: __OR
 ##
 
 ` { doc: "`l = r` - `true` if and only if value `l` equals value `r`."
-    type: "a → a → bool"
+    type: s"a → a → bool"
     export: :suppress
     associates: :left
     precedence: :eq }
 (l = r): __EQ(l, r)
 
 ` { doc: "`l != r` - `true` if and only if value `l` is not equal to value `r`."
-    type: "a → a → bool"
+    type: s"a → a → bool"
     export: :suppress
     associates: :left
     precedence: :eq }
 (l != r): not(__EQ(l, r))
 
 ` { doc: "`l ≠ r` - `true` if and only if value `l` is not equal to value `r`."
-    type: "a → a → bool"
+    type: s"a → a → bool"
     export: :suppress
     associates: :left
     precedence: :eq }
@@ -641,137 +641,137 @@ or: __OR
 ##
 
 ` { doc: "`l + r` - adds `l` and `r`. For numbers, both must be numeric. For arrays, performs element-wise addition; one operand may be a scalar."
-    type: "number → number → number | array → array → array"
+    type: s"number → number → number | array → array → array"
     export: :suppress
     associates: :left
     precedence: :sum }
 (l + r): __ADD(l, r)
 
 ` { doc: "`l - r` - subtracts `r` from `l`. For numbers, both must be numeric. For arrays, performs element-wise subtraction; one operand may be a scalar."
-    type: "number → number → number | array → array → array"
+    type: s"number → number → number | array → array → array"
     export: :suppress
     associates: :left
     precedence: :sum }
 (l - r): __SUB(l, r)
 
 ` { doc: "`l ^ r` - raise `l` to the power `r`."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :right
     precedence: :exp }
 (l ^ r): __POW(l, r)
 
 ` { doc: "`l * r` - multiplies `l` and `r`. For numbers, both must be numeric. For arrays, performs element-wise multiplication; one operand may be a scalar."
-    type: "number → number → number | array → array → array"
+    type: s"number → number → number | array → array → array"
     export: :suppress
     associates: :left
     precedence: :prod }
 (l * r): __MUL(l, r)
 
 ` { doc: "`l / r` - floor division of `l` by `r` for numbers (rounds toward negative infinity; always returns integer). For arrays, performs element-wise division; one operand may be a scalar."
-    type: "number → number → number | array → array → array"
+    type: s"number → number → number | array → array → array"
     export: :suppress
     associates: :left
     precedence: :prod }
 (l / r): __DIV(l, r)
 
 ` { doc: "`l ÷ r` - precise division of `l` by `r`; returns exact result."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :prod }
 (l ÷ r): __PDIV(l, r)
 
 ` { doc: "`l % r` - floor modulus of `l` by `r`; result has same sign as `r`."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :prod }
 (l % r): __MOD(l, r)
 
 ` { doc: "`l < r` - `true` if `l` is less than `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l < r): __LT(l, r)
 
 ` { doc: "`l > r` - `true` if `l` is greater than `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l > r): __GT(l, r)
 
 ` { doc: "`l <= r` - `true` if `l` is less than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l <= r): __LTE(l, r)
 
 ` { doc: "`l ≤ r` - `true` if `l` is less than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l ≤ r): l <= r
 
 ` { doc: "`l >= r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l >= r): __GTE(l, r)
 
 ` { doc: "`l ≥ r` - `true` if `l` is greater than or equal to `r`. Works on numbers, strings, symbols, and datetimes."
-    type: "number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
+    type: s"number → number → bool | string → string → bool | symbol → symbol → bool | datetime → datetime → bool"
     export: :suppress
     associates: :left
     precedence: :cmp }
 (l ≥ r): l >= r
 
 ` { doc: "`inc(x)` - increment number `x` by 1."
-    type: "number → number" }
+    type: s"number → number" }
 inc: _ + 1
 
 ` { doc: "`dec(x)` - decrement number `x` by 1."
-    type: "number → number" }
+    type: s"number → number" }
 dec: _ - 1
 
 ` { doc: "`negate(n)` - negate number `n`."
-    type: "number → number" }
+    type: s"number → number" }
 negate: 0 -
 
 ` "`∸ n` - unary minus; negate."
 (∸ n): negate(n)
 
 ` { doc: "`abs(n)` - absolute value of number `n`."
-    type: "number → number" }
+    type: s"number → number" }
 abs(n): if(n < 0, 0 - n, n)
 
 ` { doc: "`zero?(n)` - return true if and only if number `n` is 0."
-    type: "number → bool" }
+    type: s"number → bool" }
 zero?: = 0
 
 ` { doc: "`pos?(n)` - return true if and only if number `n` is strictly positive."
-    type: "number → bool" }
+    type: s"number → bool" }
 pos?: > 0
 
 ` { doc: "`neg?(n)` - return true if and only if number `n` is strictly negative."
-    type: "number → bool" }
+    type: s"number → bool" }
 neg?: < 0
 
 ` { doc: "`num(s)` - parse number from string."
-    type: "string → number" }
+    type: s"string → number" }
 num: __NUMPARSE
 
 ` { doc: "`floor(n)` - round number downwards to nearest integer."
-    type: "number → number" }
+    type: s"number → number" }
 floor: __FLOOR
 
 ` { doc: "`ceiling(n)` - round number upwards to nearest integer."
-    type: "number → number" }
+    type: s"number → number" }
 ceiling: __CEILING
 
 ` "`⌈n⌉` - ceiling bracket notation, round `n` upwards to nearest integer"
@@ -781,63 +781,63 @@ ceiling: __CEILING
 ⌊[x]⌋: x floor
 
 ` { doc: "`pow(b, e)` - raise `b` to the power `e`."
-    type: "number → number → number" }
+    type: s"number → number → number" }
 pow(b, e): __POW(b, e)
 
 ` { doc: "`div(a, b)` - floor division; same as `a / b`."
-    type: "number → number → number" }
+    type: s"number → number → number" }
 div(a, b): __DIV(a, b)
 
 ` { doc: "`mod(a, b)` - floor modulus; same as `a % b`."
-    type: "number → number → number" }
+    type: s"number → number → number" }
 mod(a, b): __MOD(a, b)
 
 ` { doc: "`quot(a, b)` - truncation division; rounds toward zero."
-    type: "number → number → number" }
+    type: s"number → number → number" }
 quot(a, b): __QUOT(a, b)
 
 ` { doc: "`rem(a, b)` - truncation remainder; result has same sign as dividend."
-    type: "number → number → number" }
+    type: s"number → number → number" }
 rem(a, b): __REM(a, b)
 
 # --- Bitwise operators ---
 
 ` { doc: "`l & r` - bitwise AND of integers `l` and `r`."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :bitwise }
 (l & r): __BITAND(l, r)
 
 ` { doc: "`l | r` - bitwise OR of integers `l` and `r`."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :bitwise }
 (l | r): __BITOR(l, r)
 
 ` { doc: "`l ⊕ r` - bitwise XOR of integers `l` and `r`."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :bitwise }
 (l ⊕ r): __BITXOR(l, r)
 
 ` { doc: "`⊝ n` - bitwise NOT (complement) of integer `n`."
-    type: "number → number"
+    type: s"number → number"
     export: :suppress
     precedence: :bool-unary }
 (⊝ n): __BITNOT(n)
 
 ` { doc: "`n ≪ k` - left shift `n` by `k` bits."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :shift }
 (n ≪ k): __SHL(n, k)
 
 ` { doc: "`n ≫ k` - arithmetic right shift `n` by `k` bits."
-    type: "number → number → number"
+    type: s"number → number → number"
     export: :suppress
     associates: :left
     precedence: :shift }
@@ -847,52 +847,52 @@ rem(a, b): __REM(a, b)
     doc: "Bitwise utility functions for integer bit manipulation." }
 bit: {
   ` { doc: "Bitwise AND of integers `l` and `r`."
-      type: "number → number → number" }
+      type: s"number → number → number" }
   and(l, r): __BITAND(l, r)
 
   ` { doc: "Bitwise OR of integers `l` and `r`."
-      type: "number → number → number" }
+      type: s"number → number → number" }
   or(l, r): __BITOR(l, r)
 
   ` { doc: "Bitwise XOR of integers `l` and `r`."
-      type: "number → number → number" }
+      type: s"number → number → number" }
   xor(l, r): __BITXOR(l, r)
 
   ` { doc: "Bitwise NOT of integer `n`."
-      type: "number → number" }
+      type: s"number → number" }
   not(n): __BITNOT(n)
 
   ` { doc: "Left shift `n` by `k` bits."
-      type: "number → number → number" }
+      type: s"number → number → number" }
   shl(n, k): __SHL(n, k)
 
   ` { doc: "Arithmetic right shift `n` by `k` bits."
-      type: "number → number → number" }
+      type: s"number → number → number" }
   shr(n, k): __SHR(n, k)
 
   ` { doc: "Count set bits in integer `n`."
-      type: "number → number" }
+      type: s"number → number" }
   popcount(n): __POPCOUNT(n)
 
   ` { doc: "Count trailing zeros in integer `n` (position of lowest set bit). Returns 64 if n is 0."
-      type: "number → number" }
+      type: s"number → number" }
   ctz(n): __CTZ(n)
 
   ` { doc: "Count leading zeros in integer `n`."
-      type: "number → number" }
+      type: s"number → number" }
   clz(n): __CLZ(n)
 }
 
 ` { doc: "`sum(l)` - sum a list of numbers."
-    type: "[number] → number" }
+    type: s"[number] → number" }
 sum(l): foldl(+, 0, l)
 
 ` { doc: "`product(l)` - multiply a list of numbers."
-    type: "[number] → number" }
+    type: s"[number] → number" }
 product(l): foldl(*, 1, l)
 
 ` { doc: "`max(l, r)` - return max of `l` and `r` by `>`."
-    type: ">(a, a) => a → a → a" }
+    type: s">(a, a) => a → a → a" }
 max(l, r): if(l > r, l, r)
 
 ` "`max-of(l) - return max element in list of numbers `l` - error if empty`"
@@ -917,7 +917,7 @@ max-map(f, l): l map(f) max-of
 max-of-or(d, l): l nil? then(d, max-of(l))
 
 ` { doc: "`min(l, r)` - return min of `l` and `r` by `<`."
-    type: "<(a, a) => a → a → a" }
+    type: s"<(a, a) => a → a → a" }
 min(l, r): if(l < r, l, r)
 
 ` "`min-of(l) - return min element in list of numbers `l` - error if empty`"
@@ -959,134 +959,134 @@ ch: {
 str: {
 
   ` { doc: "of(e) - convert `e` to string."
-      type: "any → string" }
+      type: s"any → string" }
   of: __STR
 
   ` { doc: "split(s, re) - split string `s` on separators matching regex `re`."
-      type: "string → string → [string]" }
+      type: s"string → string → [string]" }
   split: __SPLIT
 
   ` { doc: "split-on(re, s) - split string `s` on separators matching regex `re`."
-      type: "string → string → [string]" }
+      type: s"string → string → [string]" }
   split-on: split flip
 
   ` { doc: "join(l, s) - join list of strings `l` by interposing string s."
-      type: "[string] → string → string" }
+      type: s"[string] → string → string" }
   join: __JOIN
 
   ` { doc: "join-on(s, l) - join list of strings `l` by interposing string s."
-      type: "string → [string] → string" }
+      type: s"string → [string] → string" }
   join-on: join flip
 
   ` { doc: "match(s, re) - match string `s` using regex `re`, return list of full match then capture groups."
-      type: "string → string → [string]" }
+      type: s"string → string → [string]" }
   match: __MATCH
 
   ` { doc: "match-with(re, s) - match string `s` using regex `re`, return list of full match then capture groups."
-      type: "string → string → [string]" }
+      type: s"string → string → [string]" }
   match-with: match flip
 
   ` { doc: "extract(re, s) - use regex `re` (with single capture) to extract substring of s - or error."
-      type: "string → string → string" }
+      type: s"string → string → string" }
   extract(re): second ∘ match-with(re)
 
   ` "extract-or(re, d, s) - use regex `re` (with single capture) to extract substring of `s` - or default `d`."
   extract-or(re, d, s): s match-with(re) second-or(d)
 
   ` { doc: "matches(s, re) - return list of all matches in string `s` of regex `re`."
-      type: "string → string → [[string]]" }
+      type: s"string → string → [[string]]" }
   matches: __MATCHES
 
   ` { doc: "matches-of(re, s) - return list of all matches in string `s` of regex `re`."
-      type: "string → string → [[string]]" }
+      type: s"string → string → [[string]]" }
   matches-of: matches flip
 
   ` { doc: "matches?(re, s) - return true if `re` matches full string `s`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   matches?(re, s): match(s, re) (not ∘ nil?)
 
   ` { doc: "suffix(b, a) - return string `b` suffixed onto `a`."
-      type: "string → string → string" }
+      type: s"string → string → string" }
   suffix(b, a): [a, b] join-on("")
 
   ` { doc: "prefix(b, a) - return string `b` prefixed onto `a`."
-      type: "string → string → string" }
+      type: s"string → string → string" }
   prefix(b, a): [b, a] join-on("")
 
   ` { doc: "letters(s) - return individual letters of `s` as list of strings."
-      type: "string → [string]" }
+      type: s"string → [string]" }
   letters: __LETTERS
 
   ` { doc: "`len(s)` - return length of string in characters."
-      type: "string → number" }
+      type: s"string → number" }
   len: count ∘ letters
 
   ` { doc: "`fmt(x, spec)` - format `x` using printf-style format `spec`."
-      type: "any → string → string" }
+      type: s"any → string → string" }
   fmt: __FMT
 
   ` { doc: "`to-upper(s)` - convert string `s` to upper case."
-      type: "string → string" }
+      type: s"string → string" }
   to-upper: __UPPER
 
   ` { doc: "`to-lower(s)` - convert string `s` to lower case."
-      type: "string → string" }
+      type: s"string → string" }
   to-lower: __LOWER
 
   ` { doc: "`lt(a, b)` - true if string `a` is lexicographically less than `b`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   lt(a, b): a < b
 
   ` { doc: "`gt(a, b)` - true if string `a` is lexicographically greater than `b`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   gt(a, b): a > b
 
   ` { doc: "`lte(a, b)` - true if string `a` is lexicographically less than or equal to `b`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   lte(a, b): a <= b
 
   ` { doc: "`gte(a, b)` - true if string `a` is lexicographically greater than or equal to `b`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   gte(a, b): a >= b
 
   ` { doc: "`base64-encode(s)` - encode string `s` as base64."
-      type: "string → string" }
+      type: s"string → string" }
   base64-encode: __BASE64_ENCODE
 
   ` { doc: "`base64-decode(s)` - decode base64 string `s` back to its original string."
-      type: "string → string" }
+      type: s"string → string" }
   base64-decode: __BASE64_DECODE
 
   ` { doc: "`sha256(s)` - return the SHA-256 hash of string `s` as lowercase hex."
-      type: "string → string" }
+      type: s"string → string" }
   sha256: __SHA256
 
   ` { doc: "`replace(pattern, replacement, s)` - replace all occurrences of regex `pattern` with `replacement` in string `s`. Pipeline: s str.replace(pat, rep)."
-      type: "string → string → string → string" }
+      type: s"string → string → string → string" }
   replace(pattern, replacement, s): __STR_REPLACE(pattern, replacement, s)
 
   ` { doc: "`contains?(pattern, s)` - true if string `s` contains a match for regex `pattern`. Pipeline: s str.contains?(pat)."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   contains?(pattern, s): __STR_CONTAINS(pattern, s)
 
   ` { doc: "`trim(s)` - trim leading and trailing whitespace from string `s`."
-      type: "string → string" }
+      type: s"string → string" }
   trim: __STR_TRIM
 
   ` { doc: "`starts-with?(re, s)` - true if string `s` starts with a match for regex `re`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   starts-with?(re, s): __STR_CONTAINS(["^", re] join-on(""), s)
 
   ` { doc: "`ends-with?(re, s)` - true if string `s` ends with a match for regex `re`."
-      type: "string → string → bool" }
+      type: s"string → string → bool" }
   ends-with?(re, s): __STR_CONTAINS([re, "$"] join-on(""), s)
 
   ` { doc: "`shell-escape(s)` - wrap string in single quotes for safe shell use. Embedded single quotes are escaped."
-      type: "string → string" }
+      type: s"string → string" }
   shell-escape(s): [c"'", replace("'", c"'\\''", s), c"'"] join-on("")
 
   ` { doc: "dq-escape(s) - escape string for use inside double quotes in shell commands. Escapes backslash, dollar, backtick, and double quote."
-      type: "string → string" }
+      type: s"string → string" }
   dq-escape(s): s replace(c"\\\\", c"\\\\\\\\") replace("[$]", c"\\$") replace("[`]", c"\\`") replace(ch.dq, [c"\\", ch.dq] join-on(""))
 }
 
@@ -1095,15 +1095,15 @@ str: {
 ##
 
 ` { doc: "render(value) - serialise value to a YAML string."
-    type: "any → string" }
+    type: s"any → string" }
 render(value): __RENDER_TO_STRING(value, :yaml)
 
 ` { doc: "render-as(fmt, value) - serialise value to a string in the named format. Pipeline-friendly: data render-as(:json). Supported formats: :yaml, :json, :toml, :text, :edn, :html, :eu."
-    type: "symbol → any → string" }
+    type: s"symbol → any → string" }
 render-as(fmt, value): __RENDER_TO_STRING(value, fmt)
 
 ` { doc: "parse-as(fmt, str) - parse a string of structured data in the named format and return eucalypt data. The inverse of render-as. Supported formats: :json, :yaml, :toml, :csv, :xml, :edn, :jsonl. Content is parsed as inert data; embedded eucalypt expressions (e.g. YAML !eu tags) are never evaluated."
-    type: "symbol → string → any?" }
+    type: s"symbol → string → any?" }
 parse-as(fmt, str): __PARSE_STRING(fmt, str)
 
 ##
@@ -1111,64 +1111,64 @@ parse-as(fmt, str): __PARSE_STRING(fmt, str)
 ##
 
 ` { doc: "`identity(v)` - identity function, return value `v`."
-    type: "a → a" }
+    type: s"a → a" }
 identity(v): v
 
 ` { doc: "`const(k)` - return single arg function that always returns `k`."
-    type: "b → a → b" }
+    type: s"b → a → b" }
 const(k, _): k
 
 ` "`(-> k)` - const; return single arg function that always returns `k`."
 (-> k): const(k)
 
 ` { doc: "`compose(f,g,x)` - apply function `f` to `g(x)`."
-    type: "(b → c) → (a → b) → a → c" }
+    type: s"(b → c) → (a → b) → a → c" }
 compose(f, g, x): x g f
 
 ` { doc: "`(f ∘ g)` - return composition of `f` and `g` (`g` then `f`)"
-    type: "(b → c) → (a → b) → (a → c)"
+    type: s"(b → c) → (a → b) → (a → c)"
     export: :suppress
     associates: :right
     precedence: 88 }
 (f ∘ g): compose(f, g)
 
 ` { doc: "`(f ; g)` - return composition of `f` then `g`"
-    type: "(a → b) → (b → c) → (a → c)"
+    type: s"(a → b) → (b → c) → (a → c)"
     export: :suppress
     associates: :left
     precedence: 88 }
 (f ; g): compose(g, f)
 
 ` { doc: "(l @ r) - function application operator, for reversing catentation args and eliding parentheses"
-    type: "(a → b) → a → b"
+    type: s"(a → b) → a → b"
     export: :suppress
     associates: :left
     precedence: :apply }
 (l @ r): l(r)
 
 ` { doc: "`apply(f, xs)` - apply function `f` to arguments in list `xs`."
-    type: "any → [any] → any" }
+    type: s"any → [any] → any" }
 apply(f, xs): foldl(_0(_1), f, xs)
 
 ` { doc: "`flip(f)` - flip arguments of function `f`, flip(f)(x, y) == f(y, x)."
-    type: "(a → b → c) → b → a → c" }
+    type: s"(a → b → c) → b → a → c" }
 flip(f, x, y): f(y, x)
 
 ` { doc: "`complement(p?)` - invert truth value of predicate function."
-    type: "(a → bool) → a → bool" }
+    type: s"(a → bool) → a → bool" }
 complement(p?): compose(not, p?)
 
 ` { doc: "`curry(f)` - turn f((x, y)) into f(x, y)."
-    type: "((a, b) → c) → a → b → c" }
+    type: s"((a, b) → c) → a → b → c" }
 curry(f, x, y): f([x, y])
 
 ` { doc: "`uncurry(f)` - turn f(x, y) into f([x, y]). Semantically: (a → b → c) → (a, b) → c."
-    type: "(a → b → c) → (a, b) → c" }
+    type: s"(a → b → c) → (a, b) → c" }
 uncurry(f, l): f(first(l), second(l))
 
 
 ` { doc: "`cond(clauses)` - multi-way conditional: evaluate each `cond => result` clause in turn, returning the first matching result, or the last element as a default."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 cond: __COND
 
 ` { doc: "`c => r` - build a cond clause: condition `c` paired with result `r`. Use inside `cond([...])` lists."
@@ -1180,14 +1180,14 @@ cond: __COND
 (c ⇒ r): __CLAUSE(c, r)
 
 ` { doc: "`juxt(f, g, x)` - apply both `f` and `g` to `x`, returning pair (f(x), g(x))."
-    type: "(a → b) → (a → c) → a → (b, c)" }
+    type: s"(a → b) → (a → c) → a → (b, c)" }
 juxt(f, g, x): [x f, x g]
 
 #
 # Utilities
 #
 ` { doc: "`fnil(f, v, x)` - return a function equivalent to f except it sees `x` instead of `null` when null is passed."
-    type: "(a → b) → a → a | null → b" }
+    type: s"(a → b) → a → a | null → b" }
 fnil(f, v, x): if(x = null, f(v), f(x))
 
 #
@@ -1195,29 +1195,29 @@ fnil(f, v, x): if(x = null, f(v), f(x))
 #
 
 ` { doc: "`with-meta(m, e)` - add metadata block `m` to expression `e`."
-    type: "{{..}} → a → a" }
+    type: s"{..} → a → a" }
 with-meta: __WITHMETA
 
 ` { doc: "`e // m` - add metadata block `m` to expression `e`."
-    type: "a → {{..}} → a"
+    type: s"a → {..} → a"
     export: :suppress
     associates: :left
     precedence: :meta }
 (e // m): e with-meta(m)
 
 ` { doc: "`meta(e)` - retrieve expression metadata for `e`."
-    type: "a → {{..}}" }
+    type: s"a → {..}" }
 meta: __META
 
 ` "`raw-meta(e)` - retrieve immediate metadata of e without recursing into inner layers."
 raw-meta: __RAWMETA
 
 ` { doc: "`merge-meta(m, e)` - merge block `m` into `e`'s metadata."
-    type: "{{..}} → a → a" }
+    type: s"{..} → a → a" }
 merge-meta(m, e): e // (meta(e) m)
 
 ` { doc: "`e //<< m` - merge metadata block `m` into expression `e`'s metadata."
-    type: "a → {{..}} → a"
+    type: s"a → {..} → a"
     export: :suppress
     associates: :left
     precedence: :meta }
@@ -1242,7 +1242,7 @@ assert(p?, s, v): if(v p?, v, panic(s))
     On success: return true.
     On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
-    type: "a → a → bool"
+    type: s"a → a → bool"
     export: :suppress
     associates: :left
     precedence: :meta }
@@ -1253,7 +1253,7 @@ assert(p?, s, v): if(v p?, v, panic(s))
     On success: return true.
     On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
-    type: "a → (a → bool) → bool"
+    type: s"a → (a → bool) → bool"
     export: :suppress
     associates: :left
     precedence: :meta }
@@ -1264,7 +1264,7 @@ assert(p?, s, v): if(v p?, v, panic(s))
     On success: return true.
     On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
-    type: "bool → bool"
+    type: s"bool → bool"
     export: :suppress
     precedence: :meta }
 (e //!): __EXPECT(e, "true", e = true, true)
@@ -1274,7 +1274,7 @@ assert(p?, s, v): if(v p?, v, panic(s))
     On success: return e (pass-through).
     On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
-    type: "a → a → a"
+    type: s"a → a → a"
     export: :suppress
     associates: :left
     precedence: :meta }
@@ -1285,7 +1285,7 @@ assert(p?, s, v): if(v p?, v, panic(s))
     On success: return e (pass-through).
     On failure (normal mode): panic with diagnostic.
     On failure (test mode): emit diagnostic to stderr, return false."
-    type: "a → (a → bool) → a"
+    type: s"a → (a → bool) → a"
     export: :suppress
     associates: :left
     precedence: :meta }
@@ -1312,49 +1312,49 @@ __dbg-after(f, x): ▶(f(x))
 #
 
 ` { doc: "`take(n, l)` - return initial segment of integer `n` elements from list `l`."
-    type: "number → [a] → [a]" }
+    type: s"number → [a] → [a]" }
 take(n, l): __IF((n zero?) ∨ (l nil?), [], cons(l head, take(n dec, l tail)))
  
 ` { doc: "`drop(n, l)` - return result of dropping integer `n` elements from list `l`."
-    type: "number → [a] → [a]" }
+    type: s"number → [a] → [a]" }
 drop(n, l): __IF((n zero?), l, drop(n dec, l tail))
 
 ` { doc: "`rotate(n, l)` - rotate list `l` left by `n` positions."
-    type: "number → [a] → [a]" }
+    type: s"number → [a] → [a]" }
 rotate(n, l): { s: split-at(n, l) }.(second(s) ++ first(s))
 
 ` { doc: "`split-at(n, l)` - split list into two at `n`th item and return pair."
-    type: "number → [a] → ([a], [a])" }
+    type: s"number → [a] → ([a], [a])" }
 split-at(n, l): {
   aux(n, xs, prefix): if((xs nil?) ∨ (n zero?), [prefix reverse, xs], aux(n dec, xs tail, cons(xs head, prefix)))
 }.aux(n, l, [])
 
 ` { doc: "`transpose(rows)` - transpose a matrix (list of lists)."
-    type: "[[a]] → [[a]]" }
+    type: s"[[a]] → [[a]]" }
 transpose(rows): {
   aux(rs): if(rs head nil?, [], cons(rs map(head), aux(rs map(tail))))
 }.aux(rows)
 
 ` { doc: "`take-while(p?, l)` - initial elements of list `l` while `p?` is true."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 take-while(p?, l): {
   aux(xs, prefix): if(not(xs nil?) ∧ (xs head p?), aux(xs tail, cons(xs head, prefix)), prefix reverse)
 }.aux(l, [])
 
 ` { doc: "`take-until(p?, l)` - initial elements of list `l` while `p?` is false."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 take-until(p?): take-while(p? complement)
 
 ` { doc: "`drop-while(p?, l)` - skip initial elements of list `l` while `p?` is true."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 drop-while(p?, l): if(l nil?, [], if(l head p?, drop-while(p?, l tail), l))
 
 ` { doc: "`drop-until(p?, l)` - skip initial elements of list `l` while `p?` is false."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 drop-until(p?): drop-while(p? complement)
 
 ` { doc: "`split-after(p?, l)` - split list where `p?` becomes false and return pair."
-    type: "(a → bool) → [a] → ([a], [a])" }
+    type: s"(a → bool) → [a] → ([a], [a])" }
 split-after(p?, l): {
   aux(xs, prefix): if(xs nil?, [prefix reverse, []],
                      if(xs head p?,
@@ -1363,11 +1363,11 @@ split-after(p?, l): {
 }.aux(l, [])
 
 ` { doc: "`split-when(p?, l)` - split list where `p?` becomes true and return pair."
-    type: "(a → bool) → [a] → ([a], [a])" }
+    type: s"(a → bool) → [a] → ([a], [a])" }
 split-when(p?, l): split-after(p? complement, l)
 
 ` { doc: "`nth(n, l)` - return `n`th item of list if it exists, otherwise error."
-    type: "number → [a] → a?" }
+    type: s"number → [a] → a?" }
 nth(n, l): l drop(n) head
 
 ` "`update-nth(n, f, l)` - apply `f` to element at index `n` in list `l`.
@@ -1381,196 +1381,196 @@ update-first(p?, f, l): {
 }.(l split-when(p?) go)
 
 ` { doc: "`l !! n` - return `n`th item of list `l` if it exists, otherwise error. For arrays, `n` must be a coordinate list (e.g. `[row, col]`) and !! delegates to `arr.get`."
-    type: "[a] → number → a | array → [number] → number"
+    type: s"[a] → number → a | array → [number] → number"
     precedence: :exp }
 (l !! n): if(l is-array?, l arr.get(n), l nth(n))
 
 ` { doc: "`repeat(i)` - return infinite list of instances of item `i`."
-    type: "a → [a]" }
+    type: s"a → [a]" }
 repeat(i): __CONS(i, repeat(i))
 
 ` { doc: "`foldl(op, i, l)` - left fold operator `op` over list `l` starting from value `i`."
-    type: "(b → a → b) → b → [a] → b" }
+    type: s"(b → a → b) → b → [a] → b" }
 foldl(op, i, l): if(l nil?, i, foldl(op, op(i, l head), l tail))
 
 ` { doc: "`reduce(op, l)` - left fold with no initial value; uses first element as seed. Panics on empty list."
-    type: "(a → a → a) → [a] → a" }
+    type: s"(a → a → a) → [a] → a" }
 reduce(op, l): foldl(op, l head, l tail)
 
 ` { doc: "`foldr(op, i, l)` - right fold operator `op` over list `l` ending with value `i`."
-    type: "(a → b → b) → b → [a] → b" }
+    type: s"(a → b → b) → b → [a] → b" }
 foldr(op, i, l): if(l nil?, i, op(l head, foldr(op, i, l tail)))
 
 ` { doc: "`scanl(op, i, l)` - left scan operator `op` over list `l` starting from value `i`."
-    type: "(b → a → b) → b → [a] → [b]" }
+    type: s"(b → a → b) → b → [a] → [b]" }
 scanl(op, i, l): if(l nil?, [i], scanl(op, op(i, l head), l tail) cons(i))
 
 ` { doc: "`scanr(op, i, l)` - right scan operator `op` over list `l` ending with value `i`."
-    type: "(a → b → b) → b → [a] → [b]" }
+    type: s"(a → b → b) → b → [a] → [b]" }
 scanr(op, i, l): if(l nil?, [i], { scan: scanr(op, i, l tail) }.(cons(op(l head, scan head), scan)))
 
 ` { doc: "`iterate(f, i)` - return list of `i` with subsequent repeated applications of `f` to `i`."
-    type: "(a → a) → a → [a]" }
+    type: s"(a → a) → a → [a]" }
 iterate(f, i): cons(i, iterate(f, f(i)))
 
 ` { doc: "`tails(l)` - return list of successive tails of `l`: `[l, tail(l), tail(tail(l)), ...]`."
-    type: "[a] → [[a]]" }
+    type: s"[a] → [[a]]" }
 tails(l): iterate(tail, l) take-while(non-nil?)
 
 ` { doc: "`iota(n)` - return infinite list of integers from `n` upwards."
-    type: "number → [number]" }
+    type: s"number → [number]" }
 iota(n): cons(n, iota(n + 1))
 
 ` { doc: "`ints-from(n)` - return infinite list of integers from `n` upwards, alias `iota` for backwards compatibility."
-    type: "number → [number]" }
+    type: s"number → [number]" }
 ints-from: iota
 
 ` { doc: "`ℕ` - the natural numbers: `[0, 1, 2, ...]`."
-    type: "[number]" }
+    type: s"[number]" }
 ℕ: iota(0)
 
 ` { doc: "`range(b, e)` - return list of ints from `b` to `e` (not including `e`)."
-    type: "number → number → [number]" }
+    type: s"number → number → [number]" }
 range(b, e): ints-from(b) take(e - b)
 
 ` { doc: "`count(l)` - return count of items in list `l`."
-    type: "[a] → number" }
+    type: s"[a] → number" }
 count(l): foldl({ n: • el: •}.(n inc), 0, l)
 
 ` { doc: "`last(l)` - return last element of list `l`."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 last: head ∘ reverse
 
 ` { doc: "`butlast(l)` - return all elements of list `l` except the last."
-    type: "[a] → [a]" }
+    type: s"[a] → [a]" }
 butlast(l): l reverse tail reverse
 
 ` { doc: "`cycle(l)` - create infinite list by cycling elements of list `l`."
-    type: "[a] → [a]" }
+    type: s"[a] → [a]" }
 cycle(l): if(l nil?, [], l ++ cycle(l))
 
 ` { doc: "`map(f, l)` - map function `f` over list `l`."
-    type: "(a → b) → [a] → [b]" }
+    type: s"(a → b) → [a] → [b]" }
 map(f, l): if(l nil?, l, cons(l head f, l tail map(f)))
 
 ` { doc: "`f <$> l` - map function `f` over list `l`"
-    type: "(a → b) → [a] → [b]"
+    type: s"(a → b) → [a] → [b]"
     export: :suppress
     associates: :left
     precedence: :map }
 (f <$> l): map(f, l)
 
 ` { doc: "`map2(f, l1, l2)` - map function `f` over lists `l1` and `l2`, until the shorter is exhausted."
-    type: "(a → b → c) → [a] → [b] → [c]" }
+    type: s"(a → b → c) → [a] → [b] → [c]" }
 map2(f, l1, l2): if(nil?(l1) || nil?(l2), [], cons(f(l1 head, l2 head), map2(f, l1 tail, l2 tail)))
 
 ` { doc: "`zip-with(f, l1, l2)` - map function `f` over lists `l1` and `l2`, until the shorter is exhausted."
-    type: "(a → b → c) → [a] → [b] → [c]" }
+    type: s"(a → b → c) → [a] → [b] → [c]" }
 zip-with: map2
 
 ` { doc: "`zip(l1, l2)` - list of pairs of elements  `l1` and `l2`, until the shorter is exhausted."
-    type: "[a] → [b] → [(a, b)]" }
+    type: s"[a] → [b] → [(a, b)]" }
 zip: zip-with(pair)
 
 ` { doc: "`unzip(pairs)` - list of pairs to pair of lists. Inverse of zip."
-    type: "[(a, b)] → ([a], [b])" }
+    type: s"[(a, b)] → ([a], [b])" }
 unzip(pairs): [pairs map(first), pairs map(second)]
 
 ` { doc: "`interleave(a, b)` - alternate elements from lists `a` and `b`. When one is exhausted, the remainder of the other is appended."
-    type: "[a] → [a] → [a]" }
+    type: s"[a] → [a] → [a]" }
 interleave(a, b): if(a nil?, b, cons(a head, interleave(b, a tail)))
 
 ` { doc: "`cross(f, xs, ys)` - apply `f` to every combination of elements from `xs` and `ys` (cartesian product)."
-    type: "(a → b → c) → [a] → [b] → [c]" }
+    type: s"(a → b → c) → [a] → [b] → [c]" }
 cross(f, xs, ys): xs mapcat({x: •}.(ys map(f(x))))
 
 ` { doc: "`filter(p?, l)` - return list of elements of list `l` that satisfy predicate `p?`."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 filter(p?, l): foldr({x: • xs: • }.(if(x p?, cons(x, xs), xs)), [], l)
 
 ` { doc: "`remove(p?, l)` - return list of elements of list `l` that do not satisfy predicate `p?`."
-    type: "(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]" }
 remove(p?, l): l filter(p? complement)
 
 ` { doc: "`append(l1, l2)` - concatenate two lists `l1` and `l2`."
-    type: "[a] → [a] → [a]" }
+    type: s"[a] → [a] → [a]" }
 append(l1, l2): foldr(cons, l2, l1)
 
 ` { doc: "`prepend(l1, l2)` - concatenate two lists with `l1` after `l2`."
-    type: "[a] → [a] → [a]" }
+    type: s"[a] → [a] → [a]" }
 prepend: flip(append)
 
 ` { doc: "`l1 ++ l2` - concatenate lists `l1` and `l2`."
-    type: "[a] → [a] → [a]"
+    type: s"[a] → [a] → [a]"
     export: :suppress
     associates: :left
     precedence: :append }
 (l1 ++ l2): append(l1, l2)
 
 ` { doc: "`concat(ls)` - concatenate all lists in `ls` together."
-    type: "[[a]] → [a]" }
+    type: s"[[a]] → [a]" }
 concat(ls): foldr(append, [], ls)
 
 ` { doc: "`mapcat(f, l)` - map items in l with `f` and concatenate the resulting lists."
-    type: "(a → [b]) → [a] → [b]" }
+    type: s"(a → [b]) → [a] → [b]" }
 mapcat(f): concat ∘ map(f)
 
 ` { doc: "`zip-apply(fs, vs)` - apply fns in list `fs` to corresponding values in list `vs`, until shorter is exhausted."
-    type: "[(a → b)] → [a] → [b]" }
+    type: s"[(a → b)] → [a] → [b]" }
 zip-apply(fs, vs): zip-with(_0(_1), fs, vs)
 
 ` { doc: "`reverse(l)` - reverse list `l`."
-    type: "[a] → [a]" }
+    type: s"[a] → [a]" }
 reverse(l): foldl(cons flip, [], l)
 
 ` { doc: "`all-true?(l)` - true if and only if all items in list `l` are true."
-    type: "[bool] → bool" }
+    type: s"[bool] → bool" }
 all-true?(l): foldl(and, true, l)
 
 ` { doc: "`all(p?, l)` - true if and only if all items in list `l` satisfy predicate `p?`."
-    type: "(a → bool) → [a] → bool" }
+    type: s"(a → bool) → [a] → bool" }
 all(p?, l): l map(p?) all-true?
 
 ` { doc: "`any-true?(l)` - true if and only if any items in list `l` are true."
-    type: "[bool] → bool" }
+    type: s"[bool] → bool" }
 any-true?(l): foldr(or, false, l)
 
 ` { doc: "`any(p?, l)` - true if and only if any items in list `l` satisfy predicate `p?`."
-    type: "(a → bool) → [a] → bool" }
+    type: s"(a → bool) → [a] → bool" }
 any(p?, l): l map(p?) any-true?
 
 ` { doc: "`window(n, step, l)` - list of lists of sliding windows over list `l` of size `n` and offset `step`."
-    type: "number → number → [a] → [[a]]" }
+    type: s"number → number → [a] → [[a]]" }
 window(n, step, l): { chunk: l take(n) }.(if(count(chunk) >= n, cons(chunk, l drop(step) window(n, step)), []))
 
 ` { doc: "`partition(n, l)` - list of lists of non-overlapping segments of list `l` of size `n`."
-    type: "number → [a] → [[a]]" }
+    type: s"number → [a] → [[a]]" }
 partition(n): window(n, n)
 
 ` { doc: "`window-all(n, step, l)` - like window but includes the final short chunk even if smaller than `n`."
-    type: "number → number → [a] → [[a]]" }
+    type: s"number → number → [a] → [[a]]" }
 window-all(n, step, l): { chunk: l take(n) }.(if(chunk nil?, [], cons(chunk, (if(count(l) <= step, [], l drop(step))) window-all(n, step))))
 
 ` { doc: "`partition-all(n, l)` - list of lists of non-overlapping segments of `l`, including any final short chunk."
-    type: "number → [a] → [[a]]" }
+    type: s"number → [a] → [[a]]" }
 partition-all(n): window-all(n, n)
 
 ` { doc: "`over-sliding-pairs(f, l)` - apply binary fn `f` to each overlapping pair in `l` to form new list."
-    type: "!(a → a → b) → [a] → [b]" }
+    type: s"!(a → a → b) → [a] → [b]" }
 over-sliding-pairs(f, l): l window(2, 1) map(f uncurry)
 
 ` { doc: "`differences(l)` - calculate difference between each overlapping pair in list of numbers `l`."
-    type: "[number] → [number]" }
+    type: s"[number] → [number]" }
 differences: over-sliding-pairs(_1 - _0)
 
 ` { doc: "`discriminate(pred, xs)` - return pair of `xs` for which `pred(_)` is true and `xs` for which `pred(_)` is false."
-    type: "(a → bool) → [a] → ([a], [a])" }
+    type: s"(a → bool) → [a] → ([a], [a])" }
 discriminate(pred, xs): {
   acc(a, e): a if(e pred, bimap(cons(e), identity), bimap(identity, cons(e)))
 }.(xs foldl(acc, [[], []]) bimap(reverse, reverse))
 
 ` { doc: "`group-by(k, xs)` - group xs by key function returning block of key to subgroups, maintains order."
-    type: "(a → any) → [a] → Dict([a])" }
+    type: s"(a → any) → [a] → Dict([a])" }
 group-by(k, xs): {
   acc(a, e): a update-value-or(e._k, cons(e._v), [e._v])
 }.(xs map({ _k: k(•0), _v: •0 }) foldl(acc, {}) map-values(reverse))
@@ -1587,11 +1587,11 @@ group-consecutive-by(f, xs): if(xs nil?, [],
 group-consecutive: group-consecutive-by(identity)
 
 ` { doc: "`uniq(xs)` - remove consecutive duplicates from a list."
-    type: "[a] → [a]" }
+    type: s"[a] → [a]" }
 uniq(xs): xs group-consecutive map(head)
 
 ` { doc: "`nub-by(key, xs)` - remove duplicates from `xs`, keeping the first occurrence of each distinct `key(x)` value. Unlike `uniq`, works on non-consecutive duplicates."
-    type: "(a → any) → [a] → [a]" }
+    type: s"(a → any) → [a] → [a]" }
 nub-by(key, xs): {
   step(acc, x): {
     seen: acc first
@@ -1611,7 +1611,7 @@ split-on(pred, xs): {
 }.(foldl(step, [[]], xs))
 
 ` { doc: "`qsort(lt, xs)` - sort `xs` using 'less-than' function `lt`."
-    type: "(a → a → bool) → [a] → [a]" }
+    type: s"(a → a → bool) → [a] → [a]" }
 qsort(lt, xs): if(xs nil?,
                   xs,
                   {
@@ -1624,7 +1624,7 @@ qsort(lt, xs): if(xs nil?,
                   }.(smaller ++ [h] ++ bigger))
 
 ` { doc: "`sort-nums(xs)` - sort list of numbers ascending (Rust-level intrinsic)."
-    type: "[number] → [number]" }
+    type: s"[number] → [number]" }
 sort-nums: '__SORT_NUM_LIST'
 
 ` "`running-max(nums)` - running maximum over a number list.
@@ -1640,29 +1640,29 @@ running-min: '__RUNNING_MIN'
 running-sum: '__RUNNING_SUM'
 
 ` { doc: "`sort-strs(xs)` - sort list of strings or symbols ascending."
-    type: "[string] → [string]" }
+    type: s"[string] → [string]" }
 sort-strs(xs): xs qsort(<)
 
 ` { doc: "`sort-zdts(xs)` - sort list of zoned date-times ascending."
-    type: "[datetime] → [datetime]" }
+    type: s"[datetime] → [datetime]" }
 sort-zdts(xs): xs qsort(<)
 
 ` { doc: "`sort-by(key-fn, cmp, xs)` - sort list `xs` by key extracted with `key-fn` using comparator `cmp`."
-    type: "(a → b) → (b → b → bool) → [a] → [a]" }
+    type: s"(a → b) → (b → b → bool) → [a] → [a]" }
 sort-by(key-fn, cmp, xs): {
   lt(a, b): cmp(key-fn(a), key-fn(b))
 }.(xs qsort(lt))
 
 ` { doc: "`sort-by-num(key-fn, xs)` - sort list `xs` ascending by numeric key extracted with `key-fn`."
-    type: "(a → number) → [a] → [a]" }
+    type: s"(a → number) → [a] → [a]" }
 sort-by-num(key-fn): sort-by(key-fn, <)
 
 ` { doc: "`sort-by-str(key-fn, xs)` - sort list `xs` ascending by string key extracted with `key-fn`."
-    type: "(a → string) → [a] → [a]" }
+    type: s"(a → string) → [a] → [a]" }
 sort-by-str(key-fn): sort-by(key-fn, <)
 
 ` { doc: "`sort-by-zdt(key-fn, xs)` - sort list `xs` ascending by zoned date-time key extracted with `key-fn`."
-    type: "(a → datetime) → [a] → [a]" }
+    type: s"(a → datetime) → [a] → [a]" }
 sort-by-zdt(key-fn): sort-by(key-fn, <)
 
 #
@@ -1670,112 +1670,112 @@ sort-by-zdt(key-fn): sort-by(key-fn, <)
 #
 
 ` { doc: "`merge-all(bs)` - merge all blocks in list `bs` together, later overriding earlier."
-    type: "[{{..r}}] → {{..r}}" }
+    type: s"[{..r}] → {..r}" }
 merge-all(bs): foldl(merge, {}, bs)
 
 ` { doc: "`key(pr)` - return key in a block element / pair."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 key: head
 
 ` { doc: "`value(pr)` - return value in a block element / pair."
-    type: "[a] → a" }
+    type: s"[a] → a" }
 value: second
 
 ` { doc: "`keys(b)` - return keys of block `b`."
-    type: "Dict(a) → [symbol]" }
+    type: s"Dict(a) → [symbol]" }
 keys(b): b elements map(key)
 
 ` { doc: "`values(b)` - return values of block `b`."
-    type: "Dict(a) → [a]" }
+    type: s"Dict(a) → [a]" }
 values(b): b elements map(value)
 
 ` { doc: "`sort-keys(b)` - return block `b` with keys sorted alphabetically."
-    type: "{{..}} → {{..}}" }
+    type: s"{..} → {..}" }
 sort-keys(b): b elements qsort(pair-key-lt) block
   pair-key-lt(p1, p2): key(p1) < key(p2)
 
 ` { doc: "`bimap(f, g, pr)` - apply f to first item of pair and g to second, return pair."
-    type: "(a → c) → (b → d) → (a, b) → (c, d)" }
+    type: s"(a → c) → (b → d) → (a, b) → (c, d)" }
 bimap(f, g, pr): [f(first(pr)), g(second(pr))]
 
 ` { doc: "`map-first(f, prs)` - apply f to first elements of all pairs in list of pairs `prs`."
-    type: "(a → c) → [(a, b)] → [(c, b)]" }
+    type: s"(a → c) → [(a, b)] → [(c, b)]" }
 map-first(f, prs): map(bimap(f, identity), prs)
 
 ` { doc: "`map-second(f, prs)` - apply f to second elements of all pairs in list of pairs `prs`."
-    type: "(b → c) → [(a, b)] → [(a, c)]" }
+    type: s"(b → c) → [(a, b)] → [(a, c)]" }
 map-second(f, prs): map(bimap(identity, f), prs)
 
 ` { doc: "`map-kv(f, b)` - apply `f(k, v)` to each key / value pair in block `b`, returning list."
-    type: "(symbol → any → b) → {{..}} → [b]" }
+    type: s"(symbol → any → b) → {..} → [b]" }
 map-kv(f, b): b elements map(uncurry(f))
 
 ` { doc: "`map-elements(f, b)` - apply `f([k, v])` to each element of block `b`, returning a new block. `f` receives and should return a `[key, value]` pair."
-    type: "((symbol, any) → (symbol, any)) → {{..}} → {{..}}" }
+    type: s"((symbol, any) → (symbol, any)) → {..} → {..}" }
 map-elements(f, b): b elements map(f) block
 
 ` "`map-as-block(f, syms)` - map each symbol in `syms` and create block mapping `syms` to mapped values."
 map-as-block(f, syms): syms map({k: •}.[k, f(k)]) block
 
 ` { doc: "`pair(k, v)` - form a block element from key (symbol) `k` and value `v`."
-    type: "a → b → (a, b)" }
+    type: s"a → b → (a, b)" }
 pair(k, v): [k, v]
 
 ` { doc: "`kv-block(k, v)` - create a single-entry block from key `k` and value `v`."
-    type: "symbol → any → {{..}}" }
+    type: s"symbol → any → {..}" }
 kv-block(k, v): block([[k, v]])
 
 ` { doc: "`zip-kv(ks, vs)` - create a block by zipping together keys `ks` and values `vs`."
-    type: "[symbol] → [any] → {{..}}" }
+    type: s"[symbol] → [any] → {..}" }
 zip-kv(ks, vs): zip-with(pair, ks, vs) block
 
 ` { doc: "`with-keys(ks)` - create block from list of values by assigning list of keys `ks` against them."
-    type: "[symbol] → [any] → {{..}}" }
+    type: s"[symbol] → [any] → {..}" }
 with-keys: zip-kv
 
 ` { doc: "`map-values(f, b)` - apply `f(v)` to each value in block `b`."
-    type: "(a → b) → Dict(a) → Dict(b)" }
+    type: s"(a → b) → Dict(a) → Dict(b)" }
 map-values(f, b): b elements map-second(f) block
 
 ` { doc: "`map-keys(f, b)` - apply `f(k)` to each key in block `b`."
-    type: "(symbol → symbol) → {{..}} → {{..}}" }
+    type: s"(symbol → symbol) → {..} → {..}" }
 map-keys(f, b): b elements map-first(f) block
 
 ` { doc: "`filter-items(f, b)` - return items from block `b` which match item match function `f`."
-    type: "((symbol, any) → bool) → {{..}} → [(symbol, any)]" }
+    type: s"((symbol, any) → bool) → {..} → [(symbol, any)]" }
 filter-items(f, b): b elements filter(f)
 
 ` { doc: "`by-key(p?)` - return item match function that checks predicate `p?` against the (symbol) key."
-    type: "(symbol → bool) → (symbol, any) → bool" }
+    type: s"(symbol → bool) → (symbol, any) → bool" }
 by-key(p?): p? ∘ key
 
 ` { doc: "`by-key-name(p?)` - return item match function that checks predicate `p?` against string representation of the key."
-    type: "(string → bool) → (symbol, any) → bool" }
+    type: s"(string → bool) → (symbol, any) → bool" }
 by-key-name(p?): p? ∘ str.of ∘ key
 
 ` { doc: "`by-key-match(re)` - return item match function that checks string representation of the key matches regex `re`."
-    type: "string → (symbol, any) → bool" }
+    type: s"string → (symbol, any) → bool" }
 by-key-match(re): by-key-name(str.matches?(re))
 
 ` { doc: "`by-value(p?)` - return item match function that checks predicate `p?` against the item value."
-    type: "(any → bool) → (symbol, any) → bool" }
+    type: s"(any → bool) → (symbol, any) → bool" }
 by-value(p?): p? ∘ value
 
 ` { doc: "`match-filter-values(re, b)` - return list of values from block `b` with keys matching regex `re`."
-    type: "string → {{..}} → [any]" }
+    type: s"string → {..} → [any]" }
 match-filter-values(re, b): b filter-items(by-key-match(re)) map(value)
 
 ` { doc: "`filter-values(p?, b)` - return items from block `b` where values match predicate `p?`."
-    type: "(any → bool) → {{..}} → [any]" }
+    type: s"(any → bool) → {..} → [any]" }
 filter-values(p?, b): b values filter(p?)
 
 ` { doc: "`select(ks, b)` - return block containing only keys listed in `ks`. `b select([:a, :c])` returns a sub-block with just those keys."
-    type: "[symbol] → {{..}} → {{..}}" }
+    type: s"[symbol] → {..} → {..}" }
 select(ks, b):
   b filter-items(by-key(∈ set.from-list(ks))) block
 
 ` { doc: "`dissoc(ks, b)` - return block with keys listed in `ks` removed. `b dissoc([:a, :c])` returns a sub-block without those keys."
-    type: "[symbol] → {{..}} → {{..}}" }
+    type: s"[symbol] → {..} → {..}" }
 dissoc(ks, b):
   b filter-items(by-key(∉ set.from-list(ks))) block
 
@@ -1790,23 +1790,23 @@ _block: {
 # By property alteration of blocks
 
 ` { doc: "`alter-value(k, v, b)` - alter `b.k` to value `v`."
-    type: "symbol → any → {{..}} → {{..}}" }
+    type: s"symbol → any → {..} → {..}" }
 alter-value(k, v, b): b map-kv(_block.alter?(= k, v)) block
 
 ` { doc: "`update-value(k, f, b)` - update `b.k` to `f(b.k)`."
-    type: "symbol → (any → any) → {{..}} → {{..}}" }
+    type: s"symbol → (any → any) → {..} → {..}" }
 update-value(k, f, b): b map-kv(_block.update?(= k, f)) block
 
 ` { doc: "`alter(ks, v, b)` - in nested block `b` alter value to value `v` at path-of-keys `ks`."
-    type: "[symbol] → any → {{..}} → {{..}}" }
+    type: s"[symbol] → any → {..} → {..}" }
 alter(ks, v, b): b foldr(update-value, const(v), ks)
 
 ` { doc: "`update(ks, f, b)` - in nested block `b` apply `f` to value at path-of-keys `ks`."
-    type: "[symbol] → (any → any) → {{..}} → {{..}}" }
+    type: s"[symbol] → (any → any) → {..} → {..}" }
 update(ks, f, b): b foldr(update-value, f, ks)
 
 ` { doc: "`update-value-or(k, f, d, b)` - set `b.k` to `f(v)` where v is current value, otherwise add with default value `d`."
-    type: "symbol → (any → any) → any → {{..}} → {{..}}" }
+    type: s"symbol → (any → any) → any → {..} → {..}" }
 update-value-or(k, f, d, b): {
   acc(st, el): if(k = (el key),
                   [cons([k, f(el value)], st first), []],
@@ -1818,7 +1818,7 @@ update-value-or(k, f, d, b): {
 }.final-block
 
 ` { doc: "`set-value(k, v, b)` - set `b.k` to `v`, adding if absent."
-    type: "symbol → any → {{..}} → {{..}}" }
+    type: s"symbol → any → {..} → {..}" }
 set-value(k, v): update-value-or(k, const(v), v)
 
 ` "tongue(ks, v) - construct block with a single nested path-of-keys `ks` down to value `v`"
@@ -1826,7 +1826,7 @@ tongue(ks, v): foldr({k: • e: •}.([[k, e]] block), v, ks)
 
 
 ` { doc: "`merge-at(ks, v, b)` - shallow merge block `v` into block value at path-of-keys `ks`."
-    type: "[symbol] → {{..}} → {{..}} → {{..}}" }
+    type: s"[symbol] → {..} → {..} → {..}" }
 merge-at(ks, v, b): if(ks nil?,
                        merge(b, v),
                        b update-value-or(ks head,
@@ -1834,7 +1834,7 @@ merge-at(ks, v, b): if(ks nil?,
                                             tongue(ks tail, v)))
 
 ` { doc: "`deep-merge-at(ks, v, b)` - deep merge block `v` into block value at path-of-keys `ks`."
-    type: "[symbol] → {{..}} → {{..}} → {{..}}" }
+    type: s"[symbol] → {..} → {..} → {..}" }
 deep-merge-at(ks, v, b): if(ks nil?,
                              deep-merge(b, v),
                              b update-value-or(ks head,
@@ -1886,50 +1886,50 @@ cal: {
 set: {
 
   ` { doc: "`set.from-list(xs)` - create a set from list `xs` of primitive values."
-      type: "[a] → any" }
+      type: s"[a] → any" }
   from-list(xs): foldl({s: • e: •}.(s add(e)), ∅, xs)
 
   ` { doc: "`set.to-list(s)` - return sorted list of elements in set `s`."
-      type: "any → [a]" }
+      type: s"any → [a]" }
   to-list: '__SET.TO_LIST'
 
   ` { doc: "`set.add(e, s)` - add element `e` to set `s`."
-      type: "a → any → any" }
+      type: s"a → any → any" }
   add: '__SET.ADD'
 
   ` { doc: "`set.remove(e, s)` - remove element `e` from set `s`."
-      type: "a → any → any" }
+      type: s"a → any → any" }
   remove: '__SET.REMOVE'
 
   ` { doc: "`set.contains?(e, s)` - true if set `s` contains element `e`."
-      type: "a → any → bool" }
+      type: s"a → any → bool" }
   contains?: '__SET.CONTAINS'
 
   ` { doc: "`set.size(s)` - return number of elements in set `s`."
-      type: "array → number" }
+      type: s"array → number" }
   size: '__SET.SIZE'
 
   ` { doc: "`set.empty?(s)` - true if set `s` has no elements."
-      type: "any → bool" }
+      type: s"any → bool" }
   empty?(s): (s size) = 0
 
   ` { doc: "`set.union(a, b)` - return union of sets `a` and `b`."
-      type: "any → any → any" }
+      type: s"any → any → any" }
   union: '__SET.UNION'
 
   ` { doc: "`set.intersect(a, b)` - return intersection of sets `a` and `b`."
-      type: "any → any → any" }
+      type: s"any → any → any" }
   intersect: '__SET.INTERSECT'
 
   ` { doc: "`set.diff(a, b)` - return elements in set `a` that are not in set `b`."
-      type: "any → any → any" }
+      type: s"any → any → any" }
   diff: '__SET.DIFF'
 
   ` :suppress
   sample-raw: '__SET.SAMPLE'
 
   ` { doc: "`set.sample(n, s)` - random monad action: pick `n` random elements from set `s`. Returns value/rest block."
-      type: "number → any → any → {{..}}" }
+      type: s"number → any → any → {..}" }
   sample(k, s, stream): {
     floats: (stream random.as-list) take(k)
     value: s sample-raw(floats)
@@ -1961,26 +1961,26 @@ set: {
 vec: {
 
   ` { doc: "`vec.of(xs)` - convert list `xs` of primitive values to a vec for O(1) indexed access."
-      type: "[a] → any" }
+      type: s"[a] → any" }
   of: '__VEC.OF'
 
   ` { doc: "`vec.len(v)` - return the number of elements in vec `v`."
-      type: "vec → number" }
+      type: s"vec → number" }
   len: '__VEC.LEN'
 
   ` { doc: "`vec.nth(n, v)` - return the element at index `n` (0-based) in vec `v`."
-      type: "number → vec → any" }
+      type: s"number → vec → any" }
   nth: '__VEC.NTH'
 
   ` { doc: "`vec.slice(from, to, v)` - return a new vec with elements in the range `[from, to)` of `v`."
-      type: "number → number → vec → vec" }
+      type: s"number → number → vec → vec" }
   slice: '__VEC.SLICE'
 
   ` :suppress
   sample-raw: '__VEC.SAMPLE'
 
   ` { doc: "`vec.sample(n, v)` - random monad action: pick `n` random elements from vec `v` without replacement."
-      type: "number → vec → any → {{..}}" }
+      type: s"number → vec → any → {..}" }
   sample(n, v, stream): {
     floats: (stream random.as-list) take(n)
     value: v sample-raw(floats)
@@ -1991,7 +1991,7 @@ vec: {
   shuffle-raw: '__VEC.SHUFFLE'
 
   ` { doc: "`vec.shuffle(v)` - random monad action: return vec `v` in random order."
-      type: "vec → any → {{..}}" }
+      type: s"vec → any → {..}" }
   shuffle(v, stream): {
     needed: (v vec.len) - 1
     floats: (stream random.as-list) take(needed)
@@ -2000,7 +2000,7 @@ vec: {
   }
 
   ` { doc: "`vec.to-list(v)` - convert vec `v` back to a cons-list."
-      type: "any → [a]" }
+      type: s"any → [a]" }
   to-list: '__VEC.TO_LIST'
 }
 
@@ -2015,98 +2015,98 @@ vec: {
 arr: {
 
   ` { doc: "`arr.zeros(shape)` - create an array of zeros with the given shape list."
-      type: "[number] → array" }
+      type: s"[number] → array" }
   zeros: '__ARRAY.ZEROS'
 
   ` { doc: "`arr.fill(shape, val)` - create an array filled with `val` with the given shape list."
-      type: "[number] → number → array" }
+      type: s"[number] → number → array" }
   fill: '__ARRAY.FILL'
 
   ` { doc: "`arr.from-flat(shape, vals)` - create an array from a flat list of numbers with the given shape."
-      type: "[number] → [number] → array" }
+      type: s"[number] → [number] → array" }
   from-flat: '__ARRAY.FROM_FLAT'
 
   ` { doc: "`arr.get(coords, a)` - get element at coordinate list `coords` in array `a`. Pipeline: `a arr.get(coords)`."
-      type: "[number] → array → number" }
+      type: s"[number] → array → number" }
   get: '__ARRAY.GET'
 
   ` { doc: "`arr.set(coords, val, a)` - return new array with element at `coords` set to `val`. Pipeline: `a arr.set(coords, val)`."
-      type: "[number] → number → array → array" }
+      type: s"[number] → number → array → array" }
   set: '__ARRAY.SET'
 
   ` { doc: "`arr.shape(a)` - return shape of array `a` as a list of integers."
-      type: "array → [number]" }
+      type: s"array → [number]" }
   shape: '__ARRAY.SHAPE'
 
   ` { doc: "`arr.rank(a)` - return number of dimensions of array `a`."
-      type: "array → number" }
+      type: s"array → number" }
   rank: '__ARRAY.RANK'
 
   ` { doc: "`arr.length(a)` - return total number of elements in array `a`."
-      type: "array → number" }
+      type: s"array → number" }
   length: '__ARRAY.LENGTH'
 
   ` { doc: "`arr.to-list(a)` - return flat list of elements in row-major order."
-      type: "array → [number]" }
+      type: s"array → [number]" }
   to-list: '__ARRAY.TO_LIST'
 
   ` { doc: "`arr.array?(x)` - true if `x` is an array."
-      type: "any → bool" }
+      type: s"any → bool" }
   array?: '__ARRAY.ISARRAY'
 
   ` { doc: "`arr.transpose(a)` - reverse all axes of array `a`."
-      type: "array → array" }
+      type: s"array → array" }
   transpose: '__ARRAY.TRANSPOSE'
 
   ` { doc: "`arr.reshape(shape, a)` - reshape array `a` to new shape (total elements must match). Pipeline: `a arr.reshape(shape)`."
-      type: "[number] → array → array" }
+      type: s"[number] → array → array" }
   reshape: '__ARRAY.RESHAPE'
 
   ` :suppress
   slice-raw: '__ARRAY.SLICE'
 
   ` { doc: "`arr.slice(axis, idx, a)` - take a slice along `axis` at `idx`, reducing rank by 1. Pipeline: `a arr.slice(axis, idx)`."
-      type: "number → number → array → array" }
+      type: s"number → number → array → array" }
   slice(axis, idx, a): slice-raw(a, axis, idx)
 
   ` { doc: "`arr.add(a, b)` - element-wise addition; `b` may be a scalar."
-      type: "array → (array | number) → array" }
+      type: s"array → (array | number) → array" }
   add: '__ARRAY.ADD'
 
   ` { doc: "`arr.sub(a, b)` - element-wise subtraction; `b` may be a scalar."
-      type: "array → (array | number) → array" }
+      type: s"array → (array | number) → array" }
   sub: '__ARRAY.SUB'
 
   ` { doc: "`arr.mul(a, b)` - element-wise multiplication; `b` may be a scalar."
-      type: "array → (array | number) → array" }
+      type: s"array → (array | number) → array" }
   mul: '__ARRAY.MUL'
 
   ` { doc: "`arr.div(a, b)` - element-wise division; `b` may be a scalar."
-      type: "array → (array | number) → array" }
+      type: s"array → (array | number) → array" }
   div: '__ARRAY.DIV'
 
   ` { doc: "`arr.indices(a)` - return list of coordinate lists for all elements in row-major order."
-      type: "array → [[number]]" }
+      type: s"array → [[number]]" }
   indices: '__ARRAY_INDICES'
 
   ` { doc: "`arr.map(f, a)` - apply `f` to each element, return new array of same shape."
-      type: "(number → number) → array → array" }
+      type: s"(number → number) → array → array" }
   map(f, a): arr.from-flat(arr.shape(a), f <$> (a arr.to-list))
 
   ` { doc: "`arr.map-indexed(f, a)` - apply `f(coords, val)` to each element, return new array of same shape."
-      type: "([number] → number → number) → array → array" }
+      type: s"([number] → number → number) → array → array" }
   map-indexed(f, a): arr.from-flat(arr.shape(a), (f uncurry) <$> zip(arr.indices(a), a arr.to-list))
 
   ` { doc: "`arr.fold(f, init, a)` - left-fold `f` over all elements of `a` in row-major order."
-      type: "(b → number → b) → b → array → b" }
+      type: s"(b → number → b) → b → array → b" }
   fold(f, init, a): a arr.to-list foldl(f, init)
 
   ` { doc: "`arr.neighbours(coords, offsets, a)` - return list of values at valid neighbouring coordinates. Pipeline: `a arr.neighbours(coords, offsets)`. `offsets` is a list of offset lists (one per neighbour direction). Out-of-bounds neighbours are omitted."
-      type: "[number] → [[number]] → array → [number]" }
+      type: s"[number] → [[number]] → array → [number]" }
   neighbours(coords, offsets, a): __ARRAY_NEIGHBOURS(coords, offsets concat, a arr.rank, a)
 
   ` { doc: "arr.unit-arrays(shape) - list of arrays with a single 1 at each coordinate position."
-      type: "[number] → [array]" }
+      type: s"[number] → [array]" }
   unit-arrays(shape): {
     basis(coords): zeros(shape) set(coords, 1)
   }.(basis <$> (zeros(shape) indices))
@@ -2155,7 +2155,7 @@ let: monad({bind(m, f): f(m), return: identity})
 ##
 
 ` { doc: "List monad for list comprehensions. Each binding draws from a list; subsequent bindings can depend on earlier ones. Use [x] filter(pred?) for guards."
-    monad: "[a]" }
+    monad: s"[a]" }
 for: monad({bind(m, f): m mapcat(f), return(v): [v]})
 
 ##
@@ -2163,7 +2163,7 @@ for: monad({bind(m, f): m mapcat(f), return(v): [v]})
 ##
 
 ` { doc: "Parse command-line argument list against a defaults block. Each key in `defaults` defines an option with its default value. Field metadata configures parsing: `short` (symbol for short flag), `doc` (description), `flag` (true for boolean toggle). Returns the `defaults` block updated with parsed values, plus an `args` key containing positional arguments as a list. Unknown options cause a runtime error. Use `--help` for auto-generated help text."
-    type: "{{..}} → [string] → {{..}}" }
+    type: s"{..} → [string] → {..}" }
 parse-args(defaults, args): {
 
   ` "Build lookup table mapping short-flag symbols to option key symbols"

--- a/lib/state.eu
+++ b/lib/state.eu
@@ -51,7 +51,7 @@ mod-at(lens, f, s): { value: null, state: over(lens, f, s) }
 # ─── Namespace (enables { :state ... } blocks) ───────────────────────────────
 
 ` { doc: "State monad namespace.  Each declaration in a colon-state block is a monadic bind step."
-    monad: "state → {{value: a, state: state}}" }
+    monad: s"state → {value: a, state: state}" }
 state: monad{bind: state-bind, return: state-ret} {
 
   ` "state.get - action returning the whole state as the value."

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -86,6 +86,8 @@ fn extract_type_str_from_block(block_expr: &RcExpr) -> Option<String> {
 fn extract_str_literal(expr: &RcExpr) -> Option<String> {
     match &*expr.inner {
         Expr::Literal(_, Primitive::Str(s)) => Some(s.clone()),
+        // s"..." type-data literals are accepted as type annotation strings.
+        Expr::Literal(_, Primitive::TypeData(s)) => Some(s.clone()),
         _ => None,
     }
 }

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -714,6 +714,12 @@ fn extract_monad_meta(decl: &rowan_ast::Declaration) -> Option<Option<String>> {
                                             return Some(Some(v.to_string()));
                                         }
                                     }
+                                    // monad: s"{value: a}" (type-data s-string)
+                                    if let Some(rowan_ast::LiteralValue::SStr(s)) = lit.value() {
+                                        if let Some(v) = s.value() {
+                                            return Some(Some(v.to_string()));
+                                        }
+                                    }
                                 }
                                 // monad: "{{value: a}}" (string pattern with escapes)
                                 if let rowan_ast::Element::StringPattern(pat) = &elems[0] {

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -3092,6 +3092,11 @@ fn extract_string_literal(expr: &RcExpr) -> Option<String> {
         return Some(s.clone());
     }
 
+    // Type-data literal (s"...") — accepted as type annotation string.
+    if let Expr::Literal(_, Primitive::TypeData(s)) = &*inner.inner {
+        return Some(s.clone());
+    }
+
     // JOIN([chunk, …], sep) — produced by the desugarer for interpolated
     // strings.  Evaluate it statically when all chunks are string literals.
     if let Expr::App(_, func, args) = &*inner.inner {

--- a/src/driver/lsp/symbol_table.rs
+++ b/src/driver/lsp/symbol_table.rs
@@ -407,6 +407,15 @@ fn extract_meta_string(decl: &Declaration, key: &str) -> Option<String> {
                                                 {
                                                     return s.value().map(|v| v.to_string());
                                                 }
+                                                // type: s"..." (type-data s-string)
+                                                if let Some(
+                                                    crate::syntax::rowan::ast::LiteralValue::SStr(
+                                                        s,
+                                                    ),
+                                                ) = lit.value()
+                                                {
+                                                    return s.value().map(|v| v.to_string());
+                                                }
                                             }
                                             crate::syntax::rowan::ast::Element::StringPattern(
                                                 sp,
@@ -456,6 +465,13 @@ fn extract_monad_metadata(decl: &Declaration) -> (bool, Option<String>) {
                                         if let crate::syntax::rowan::ast::Element::Lit(lit) = &el {
                                             if let Some(
                                                 crate::syntax::rowan::ast::LiteralValue::Str(s),
+                                            ) = lit.value()
+                                            {
+                                                return (true, s.value().map(|v| v.to_string()));
+                                            }
+                                            // monad: s"type" (type-data s-string)
+                                            if let Some(
+                                                crate::syntax::rowan::ast::LiteralValue::SStr(s),
                                             ) = lit.value()
                                             {
                                                 return (true, s.value().map(|v| v.to_string()));
@@ -776,6 +792,27 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].is_monad, "should be marked as monad");
         assert_eq!(results[0].monad_type.as_deref(), Some("[a]"));
+    }
+
+    #[test]
+    fn test_monad_typed_s_string_metadata() {
+        let source = "` { monad: s\"[a]\" }\nfor: 1\n";
+        let parse = parse_unit(source);
+        let unit = parse.tree();
+        let mut table = SymbolTable::new();
+        table.add_from_unit(&unit, source, &test_uri(), SymbolSource::Local);
+
+        let results = table.lookup("for");
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].is_monad,
+            "s-string monad should be marked as monad"
+        );
+        assert_eq!(
+            results[0].monad_type.as_deref(),
+            Some("[a]"),
+            "s-string monad type should be extracted"
+        );
     }
 
     #[test]

--- a/src/driver/unit_interface.rs
+++ b/src/driver/unit_interface.rs
@@ -269,6 +269,8 @@ fn extract_type_str_from_block(block_expr: &RcExpr) -> Option<String> {
 fn extract_str_literal(expr: &RcExpr) -> Option<String> {
     match &*expr.inner {
         Expr::Literal(_, Primitive::Str(s)) => Some(s.clone()),
+        // s"..." type-data literals are accepted as type annotation strings.
+        Expr::Literal(_, Primitive::TypeData(s)) => Some(s.clone()),
         _ => None,
     }
 }

--- a/src/syntax/rowan/ast.rs
+++ b/src/syntax/rowan/ast.rs
@@ -305,10 +305,11 @@ impl LiteralValue {
     }
 
     pub fn string_value(&self) -> Option<&str> {
-        if let LiteralValue::Str(s) = self {
-            s.value()
-        } else {
-            None
+        match self {
+            LiteralValue::Str(s) => s.value(),
+            // s"..." type-data literals are accepted as type annotation strings.
+            LiteralValue::SStr(s) => s.value(),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Converts all `type:` and `monad:` annotation strings in `lib/prelude.eu`, `lib/lens.eu`, and `lib/state.eu` from `"{{..}}"` double-brace escaping to `s"..."` literals where braces are literal — e.g. `s"{..r} → {..s} → {..r, ..s}"` instead of `"{{..r}} → {{..s}} → {{..r, ..s}}"`
- Extends four type-annotation extraction points to accept `Primitive::TypeData` (s-string) alongside `Primitive::Str` so the type checker, operator overload registry, fixity distributor, and monad-meta extractor all recognise s-string annotations
- `LiteralValue::string_value()` in `ast.rs` now accepts `SStr` for phase-1 annotation syntax checking

## Files changed

- `lib/prelude.eu`, `lib/lens.eu`, `lib/state.eu` — annotations converted to s-strings
- `src/syntax/rowan/ast.rs` — `string_value()` accepts `SStr`
- `src/core/cook/fixity.rs` — `extract_str_literal()` accepts `TypeData`
- `src/core/typecheck/check.rs` — `extract_string_literal()` accepts `TypeData`
- `src/driver/unit_interface.rs` — `extract_str_literal()` accepts `TypeData`
- `src/core/desugar/rowan_ast.rs` — `extract_monad_meta()` accepts `SStr`

## Test plan

- [x] `cargo test --lib` — 991 passed
- [x] `cargo test --test harness_test` — 429 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)