### PR TITLE
feat(w5p2): proptest property tests for type system, formatter, and GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "dirs",
  "edn-format",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "html5ever",
  "indexmap 1.9.3",
  "itertools 0.10.5",
@@ -772,9 +773,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,6 @@ dependencies = [
  "dirs",
  "edn-format",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
  "html5ever",
  "indexmap 1.9.3",
  "itertools 0.10.5",
@@ -773,11 +772,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +611,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "eucalypt"
 version = "0.9.0"
 dependencies = [
@@ -627,6 +652,7 @@ dependencies = [
  "postcard",
  "pretty",
  "pretty-hex",
+ "proptest",
  "quick-xml",
  "regex",
  "rowan",
@@ -635,6 +661,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "similar",
+ "tempfile",
  "thiserror 1.0.69",
  "toml",
  "unicode-bidi-mirroring",
@@ -649,6 +676,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +692,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -1074,6 +1113,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1422,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1558,6 +1603,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,8 +1658,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1599,7 +1679,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1609,6 +1699,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1721,10 +1829,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1934,6 +2067,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +2289,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,11 @@ sha2 = "0.10"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 similar = "2"
-proptest = "1"
-tempfile = "3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.8"
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
+proptest = "1"
+tempfile = "3"
 
 [dependencies]
 regex = "1.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ tempfile = "3"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.8"
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
 [dependencies]
 regex = "1.6.0"
 matches = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ sha2 = "0.10"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 similar = "2"
+proptest = "1"
+tempfile = "3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.8"

--- a/src/core/typecheck/subtype.rs
+++ b/src/core/typecheck/subtype.rs
@@ -418,8 +418,13 @@ pub fn is_consistent(s: &Type, t: &Type) -> bool {
         // is treated as gradual — consistent with anything.
         (Type::Lam(_, _), _) | (_, Type::Lam(_, _)) => true,
 
-        // Fall through to subtyping.
-        _ => is_subtype(s, t),
+        // Fall through to subtyping — check both directions to preserve symmetry.
+        //
+        // `is_subtype(s, t)` alone is not symmetric (e.g. `Never <: Top` but
+        // not `Top <: Never`).  Consistency should hold whenever the types are
+        // related by subtyping in *either* direction, so that, for instance,
+        // `Never ~ Top` and `Top ~ Never` both return `true`.
+        _ => is_subtype(s, t) || is_subtype(t, s),
     }
 }
 
@@ -448,8 +453,8 @@ fn is_app_consistent(s: &Type, t: &Type) -> bool {
         }
     }
 
-    // Abstract heads.
-    is_subtype(s, t)
+    // Abstract heads — check both directions to preserve symmetry.
+    is_subtype(s, t) || is_subtype(t, s)
 }
 
 #[cfg(test)]

--- a/tests/property_test.proptest-regressions
+++ b/tests/property_test.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7ed5f2d5a8f5e332f33b58d4056ed7175e1c20e09daf48dfd54526e2e7baff89 # shrinks to s = Union([Union([Union([App(Con("Dict"), Top), ExecutionError]), Set]), Set]), t = App(Con("Dict"), Never)

--- a/tests/property_test.rs
+++ b/tests/property_test.rs
@@ -1,0 +1,363 @@
+//! Property-based tests for eucalypt — verifying structural invariants
+//! across randomly generated inputs.
+//!
+//! Tests are organised into three groups:
+//!
+//! - **Group 1**: Round-trip and idempotence (formatter, source rendering)
+//! - **Group 2**: Type-system invariants (reflexivity, transitivity, symmetry)
+//! - **Group 3**: GC invariants (allocation + evaluation under GC verification)
+//!
+//! Run with `cargo test --test property_test`.
+//! For deeper runs: `PROPTEST_CASES=10000 cargo test --test property_test`.
+//!
+//! The GC properties exercise the verifier enabled by `EU_GC_VERIFY=1`;
+//! set that env var when running locally to activate GC assertions.
+
+use eucalypt::core::typecheck::subtype::{is_consistent, is_subtype};
+use eucalypt::core::typecheck::types::{Kind, Type, TypeVarId};
+use eucalypt::syntax::export::format::{format_source, FormatterConfig};
+
+use proptest::collection::vec as pvec;
+use proptest::prelude::*;
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Proptest configuration driven by PROPTEST_CASES (default 256).
+fn config() -> ProptestConfig {
+    let cases = std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(256);
+    ProptestConfig::with_cases(cases)
+}
+
+// ── Group 2: Type generators ──────────────────────────────────────────────────
+
+/// Generate a leaf type (no recursive structure).
+fn leaf_type() -> BoxedStrategy<Type> {
+    prop_oneof![
+        Just(Type::Number),
+        Just(Type::String),
+        Just(Type::Symbol),
+        Just(Type::Bool),
+        Just(Type::Null),
+        Just(Type::Any),
+        Just(Type::Top),
+        Just(Type::Never),
+        Just(Type::Set),
+        Just(Type::Vec),
+        // Literal types
+        "[a-z]{1,5}".prop_map(Type::LiteralSymbol),
+        "[a-z]{1,5}".prop_map(Type::LiteralString),
+        // Star-kinded type variable
+        "[a-z]{1,3}".prop_map(|s| Type::Var(TypeVarId(s), Kind::Star)),
+    ]
+    .boxed()
+}
+
+/// Generate an arbitrary `Type` with bounded depth to prevent blow-up.
+fn arb_type_at(depth: u32) -> BoxedStrategy<Type> {
+    if depth == 0 {
+        return leaf_type();
+    }
+
+    let d = depth - 1;
+    prop_oneof![
+        // Leaves are heavily weighted at every level
+        4 => leaf_type(),
+        // Homogeneous containers
+        1 => arb_type_at(d).prop_map(Type::list),
+        1 => arb_type_at(d).prop_map(Type::non_empty),
+        1 => arb_type_at(d).prop_map(Type::dict),
+        // Partial (T | ExecutionError)
+        1 => arb_type_at(d).prop_map(Type::partial),
+        // Function type
+        1 => (arb_type_at(d), arb_type_at(d))
+                .prop_map(|(a, b)| Type::Function(Box::new(a), Box::new(b))),
+        // Union of 2–3 types
+        1 => pvec(arb_type_at(d), 2..=3).prop_map(Type::Union),
+    ]
+    .boxed()
+}
+
+/// Generate arbitrary `Type` values up to depth 4.
+fn arb_type() -> BoxedStrategy<Type> {
+    arb_type_at(4)
+}
+
+// ── Transitivity chain generator ──────────────────────────────────────────────
+
+/// Generate a chain `(A, B, C)` where `A <: B` and `B <: C` both hold.
+///
+/// This avoids the `prop_assume!` filter-rejection problem by constructing
+/// valid chains directly.
+fn arb_transitivity_chain() -> BoxedStrategy<(Type, Type, Type)> {
+    // Strategy: pick B, then construct A <: B and B <: C using known-good forms.
+    arb_type()
+        .prop_flat_map(|b| {
+            let a_strategy = {
+                let b2 = b.clone();
+                prop_oneof![
+                    // Never <: B
+                    Just(Type::Never),
+                    // B <: B (reflexive)
+                    Just(b2.clone()),
+                    // LiteralString <: String (if B is String)
+                    "[a-z]{1,5}".prop_map(Type::LiteralString),
+                    // LiteralSymbol <: Symbol (if B is Symbol)
+                    "[a-z]{1,5}".prop_map(Type::LiteralSymbol),
+                ]
+            };
+            let c_strategy = {
+                let b3 = b.clone();
+                prop_oneof![
+                    // B <: Top
+                    Just(Type::Top),
+                    // B <: B (reflexive)
+                    Just(b3.clone()),
+                    // B <: B | X
+                    arb_type().prop_map(move |x| Type::Union(vec![b3.clone(), x])),
+                    // B <: Any
+                    Just(Type::Any),
+                ]
+            };
+            (a_strategy, Just(b), c_strategy)
+        })
+        .boxed()
+}
+
+// ── Group 1: Source generators ────────────────────────────────────────────────
+
+/// Generate a eucalypt number literal.
+fn arb_number_source() -> BoxedStrategy<String> {
+    prop_oneof![
+        (-1000i64..=1000i64).prop_map(|n| n.to_string()),
+        (0.0f64..=1000.0f64).prop_map(|f| format!("{f:.3}")),
+    ]
+    .boxed()
+}
+
+/// Generate content safe to embed in a eucalypt double-quoted string.
+fn arb_safe_string_content() -> BoxedStrategy<String> {
+    "[a-zA-Z0-9 _-]{0,20}".prop_map(|s| s).boxed()
+}
+
+/// Generate a simple valid eucalypt literal expression (one value).
+fn arb_literal_source() -> BoxedStrategy<String> {
+    prop_oneof![
+        arb_number_source(),
+        arb_safe_string_content().prop_map(|s| format!("\"{s}\"")),
+        "[a-z][a-z0-9-]{0,8}".prop_map(|s| format!(":{s}")),
+        Just("true".to_string()),
+        Just("false".to_string()),
+        Just("null".to_string()),
+    ]
+    .boxed()
+}
+
+/// Generate a simple binding declaration (key: literal-value).
+fn arb_binding_source() -> BoxedStrategy<String> {
+    ("[a-z][a-z0-9-]{0,6}", arb_literal_source())
+        .prop_map(|(key, val)| format!("{key}: {val}\n"))
+        .boxed()
+}
+
+/// Generate a multi-binding eucalypt block as source.
+fn arb_multi_block_source() -> BoxedStrategy<String> {
+    pvec(arb_binding_source(), 1..=5)
+        .prop_map(|decls| decls.join(""))
+        .boxed()
+}
+
+/// Generate a list literal.
+fn arb_list_source() -> BoxedStrategy<String> {
+    pvec(arb_literal_source(), 0..=6)
+        .prop_map(|items| format!("[{}]", items.join(", ")))
+        .boxed()
+}
+
+/// Generate a small valid eucalypt source program.
+fn arb_program_source() -> BoxedStrategy<String> {
+    prop_oneof![
+        arb_literal_source(),
+        arb_list_source(),
+        arb_multi_block_source(),
+    ]
+    .boxed()
+}
+
+// ── Group 2: Type system property tests ──────────────────────────────────────
+
+proptest! {
+    #![proptest_config(config())]
+
+    /// Every type is a subtype of itself.
+    #[test]
+    fn prop_subtyping_reflexivity(t in arb_type()) {
+        prop_assert!(
+            is_subtype(&t, &t),
+            "is_subtype(T, T) must hold, but failed for {:?}", t
+        );
+    }
+
+    /// Consistency is symmetric: `T ~ U` iff `U ~ T`.
+    #[test]
+    fn prop_consistency_symmetry(s in arb_type(), t in arb_type()) {
+        let forward = is_consistent(&s, &t);
+        let backward = is_consistent(&t, &s);
+        prop_assert_eq!(
+            forward, backward,
+            "is_consistent must be symmetric: {:?} ~ {:?} = {}, {:?} ~ {:?} = {}",
+            s, t, forward, t, s, backward
+        );
+    }
+
+    /// Subtyping is transitive: A <: B and B <: C implies A <: C.
+    ///
+    /// The chain (A, B, C) is constructed so that A <: B and B <: C are known
+    /// to hold by construction, avoiding the filter-rejection problem.
+    #[test]
+    fn prop_subtyping_transitivity((a, b, c) in arb_transitivity_chain()) {
+        // A <: B should hold by construction — verify the precondition.
+        prop_assume!(is_subtype(&a, &b));
+        // B <: C should hold by construction — verify the precondition.
+        prop_assume!(is_subtype(&b, &c));
+
+        prop_assert!(
+            is_subtype(&a, &c),
+            "transitivity failed: {:?} <: {:?} and {:?} <: {:?}, but NOT {:?} <: {:?}",
+            a, b, b, c, a, c
+        );
+    }
+}
+
+// ── Group 1: Formatter property tests ────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(config())]
+
+    /// `eu fmt` is idempotent: `format_source(format_source(s)) == format_source(s)`.
+    #[test]
+    fn prop_fmt_idempotence(source in arb_multi_block_source()) {
+        let cfg = FormatterConfig::new(80, 4, false);
+
+        // If parsing fails, skip — we're testing formatter behaviour, not parser.
+        let first = match format_source(&source, &cfg) {
+            Ok(s) => s,
+            Err(_) => return Ok(()),
+        };
+
+        let second = match format_source(&first, &cfg) {
+            Ok(s) => s,
+            Err(e) => return Err(TestCaseError::fail(format!(
+                "second format_source failed: {e}\nsource: {source:?}\nfirst: {first:?}"
+            ))),
+        };
+
+        prop_assert_eq!(
+            first, second,
+            "eu fmt is not idempotent on: {:?}", source
+        );
+    }
+
+    /// Rendering is deterministic: two calls on the same source are identical.
+    #[test]
+    fn prop_fmt_determinism(source in arb_program_source()) {
+        let cfg = FormatterConfig::new(80, 4, false);
+        let first = format_source(&source, &cfg);
+        let second = format_source(&source, &cfg);
+        prop_assert_eq!(first, second,
+            "format_source is not deterministic on {:?}", source);
+    }
+}
+
+// ── Group 3: GC invariants ────────────────────────────────────────────────────
+//
+// These tests run generated programs through the full eucalypt evaluation
+// pipeline.  When EU_GC_VERIFY=1 (set in the GC-verified CI job), any reachable
+// object missed by the mark phase causes a panic that proptest catches and shrinks.
+//
+// In CI the GC-verified job sets EU_GC_VERIFY=2 automatically.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod gc_properties {
+    use super::*;
+    use eucalypt::driver::error::EucalyptError;
+    use eucalypt::driver::statistics::Statistics;
+    use eucalypt::driver::statistics::Timings;
+    use eucalypt::driver::{eval, options::EucalyptOptions, prepare, source::SourceLoader};
+    use eucalypt::syntax::input::Input;
+    use std::str::FromStr;
+
+    /// Evaluate a eucalypt source snippet and return whether it succeeded.
+    ///
+    /// Any GC panic propagates out (proptest catches it); evaluation errors
+    /// (type mismatch, unresolved names, etc.) are ignored — we are testing
+    /// GC correctness, not evaluation correctness.
+    fn eval_source(source: &str) -> Result<(), EucalyptError> {
+        let dir = tempfile::tempdir().map_err(|e| {
+            EucalyptError::FileCouldNotBeRead("tempdir".to_string(), Some(e.to_string()))
+        })?;
+        let path = dir.path().join("prop.eu");
+        std::fs::write(&path, source).map_err(|e| {
+            EucalyptError::FileCouldNotBeRead(path.display().to_string(), Some(e.to_string()))
+        })?;
+
+        let path_str = path.to_string_lossy().into_owned();
+        let input = Input::from_str(&path_str)
+            .map_err(|e| EucalyptError::UnknownResource(e.to_string()))?;
+
+        let opt = EucalyptOptions::default()
+            .with_explicit_inputs(vec![input])
+            .build();
+
+        let mut loader = SourceLoader::new(vec![]);
+        let mut timings = Timings::default();
+
+        let _cmd = prepare::prepare(&opt, &mut loader, &mut timings)?;
+
+        let mut stats = Statistics::default();
+        let mut out: Vec<u8> = Vec::new();
+        let mut err_buf: Vec<u8> = Vec::new();
+        let mut executor = eval::Executor::from(loader);
+        executor.capture_output(Box::new(&mut out), Box::new(&mut err_buf));
+        // Ignore evaluation errors — only GC panics matter here.
+        let _ = executor.execute(&opt, &mut stats, "yaml".to_string());
+
+        Ok(())
+    }
+
+    /// GC-specific configuration: fewer cases since each spawns the full pipeline.
+    fn gc_config() -> ProptestConfig {
+        let cases = std::env::var("PROPTEST_GC_CASES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(64);
+        ProptestConfig::with_cases(cases)
+    }
+
+    proptest! {
+        #![proptest_config(gc_config())]
+
+        /// Literal programs evaluate without GC violations.
+        ///
+        /// When `EU_GC_VERIFY=1` is set, any missed-mark panic propagates out
+        /// and proptest reports a shrunk counterexample.
+        #[test]
+        fn prop_gc_no_violations_literal(source in arb_literal_source()) {
+            let _ = eval_source(&source);
+        }
+
+        /// List programs evaluate without GC violations.
+        #[test]
+        fn prop_gc_no_violations_list(source in arb_list_source()) {
+            let _ = eval_source(&source);
+        }
+
+        /// Block programs evaluate without GC violations.
+        #[test]
+        fn prop_gc_no_violations_block(source in arb_multi_block_source()) {
+            let _ = eval_source(&source);
+        }
+    }
+}

--- a/tests/property_test.rs
+++ b/tests/property_test.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 //! Property-based tests for eucalypt — verifying structural invariants
 //! across randomly generated inputs.
 //!
@@ -279,7 +280,7 @@ proptest! {
 //
 // In CI the GC-verified job sets EU_GC_VERIFY=2 automatically.
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
 mod gc_properties {
     use super::*;
     use eucalypt::driver::error::EucalyptError;


### PR DESCRIPTION
## Summary

- Adds `tests/property_test.rs` with eight proptest property tests across three groups
- Fixes a real bug found by the property tests: `is_consistent` asymmetry in `subtype.rs`
- Adds `proptest = "1"` and `tempfile = "3"` to dev-dependencies

## Property tests

**Group 1 — Formatter idempotence and determinism**
- `prop_fmt_idempotence`: `format_source(format_source(s)) == format_source(s)` for any valid source
- `prop_fmt_determinism`: two calls on the same source yield identical output

**Group 2 — Type system invariants**
- `prop_subtyping_reflexivity`: `is_subtype(T, T)` always holds
- `prop_subtyping_transitivity`: `A <: B` and `B <: C` implies `A <: C` (chain constructed to avoid reject-loop)
- `prop_consistency_symmetry`: `is_consistent(T, U) == is_consistent(U, T)`

**Group 3 — GC invariants**
- `prop_gc_no_violations_literal/list/block`: generated programs evaluate without GC panics; `EU_GC_VERIFY=1` in CI activates the verifier

## Bug fix: `is_consistent` symmetry violation

The property tests immediately found a real bug:

```
is_consistent(Union([Dict(Top), ExecutionError, Set, Set]), Dict(Never)) = false
is_consistent(Dict(Never), Union([Dict(Top), ExecutionError, Set, Set])) = true
```

Root cause: `is_consistent` fell through to `is_subtype(s, t)` for the base case. Since `Never <: Top` but not vice versa, this made consistency non-symmetric when propagated through `Dict(T)`.

Fix: change the fallthrough to `is_subtype(s, t) || is_subtype(t, s)` in both `is_consistent` and `is_app_consistent`.

## Test plan
- [ ] All 8 property tests pass: `cargo test --test property_test`
- [ ] All 103 typecheck harness tests still pass
- [ ] Clippy clean
- [ ] Run 10,000 cases locally: `PROPTEST_CASES=10000 cargo test --test property_test prop_consistency_symmetry prop_subtyping_reflexivity prop_subtyping_transitivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)