### PR TITLE
feat(core): add Demand annotation to core bindings (W9 Phase 2+3)

### DIFF
--- a/src/core/binding.rs
+++ b/src/core/binding.rs
@@ -3,6 +3,41 @@
 //! Provides de Bruijn indexed variable binding with free/bound variable
 //! distinction, scopes, and helper operations.
 
+use crate::core::demand::Demand;
+
+/// A single let-binding entry: a name, its bound expression, and its demand
+/// annotation.
+///
+/// The `demand` field starts at `Demand::default()` (all `Unknown`) and is
+/// refined by analysis passes.  The STG compiler reads it at
+/// `take_lambda_form` time to decide Value vs. Thunk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreBinding<T: Clone> {
+    /// The binding name (used to resolve `Var::Free` references during scoping).
+    pub name: String,
+    /// The bound expression.
+    pub expr: T,
+    /// Demand annotation — populated by analysis passes and the prune pass.
+    pub demand: Demand,
+}
+
+impl<T: Clone> CoreBinding<T> {
+    /// Create a binding with the given name and expression and a default
+    /// (conservative, all-`Unknown`) demand annotation.
+    pub fn new(name: String, expr: T) -> Self {
+        CoreBinding {
+            name,
+            expr,
+            demand: Demand::default(),
+        }
+    }
+
+    /// Create a binding with an explicit demand annotation.
+    pub fn with_demand(name: String, expr: T, demand: Demand) -> Self {
+        CoreBinding { name, expr, demand }
+    }
+}
+
 /// A variable reference — either free (by name) or bound (de Bruijn indexed)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Var {

--- a/src/core/cook/fixity.rs
+++ b/src/core/cook/fixity.rs
@@ -53,9 +53,9 @@ fn collect_operator_type_strings(expr: &RcExpr, out: &mut HashMap<String, String
             // We only open one Let level shallowly here because `dist()` is called
             // on the closed form; the body (which may contain nested Lets from user
             // files merged with the prelude) is walked recursively.
-            for (name, value) in &scope.pattern {
-                if let Some(type_str) = extract_op_type_string(value) {
-                    out.insert(name.clone(), type_str);
+            for b in &scope.pattern {
+                if let Some(type_str) = extract_op_type_string(&b.expr) {
+                    out.insert(b.name.clone(), type_str);
                 }
             }
             // Recurse into the Let body (may contain nested Lets).

--- a/src/core/cook/mod.rs
+++ b/src/core/cook/mod.rs
@@ -266,8 +266,8 @@ impl Cooker {
             let bindings = &scope.pattern;
             let body = &scope.body;
 
-            let all_alias = bindings.iter().all(|(_, val)| {
-                if let Expr::Var(_, Var::Free(name)) = &*val.inner {
+            let all_alias = bindings.iter().all(|b| {
+                if let Expr::Var(_, Var::Free(name)) = &*b.expr.inner {
                     anaphora_vars.contains(name)
                 } else {
                     false
@@ -284,7 +284,7 @@ impl Cooker {
                 // anaphor var name (e.g. "_b_a[…]") so that the BoundVar
                 // name field in the body agrees with the lambda pattern,
                 // keeping the binding verifier happy.
-                let let_name = bindings[0].0.clone();
+                let let_name = bindings[0].name.clone();
                 return Ok(RcExpr::from(Expr::Lam(
                     expr.smid(),
                     false,

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -809,9 +809,9 @@ fn find_monad_spec_in_bindings(expr: &RcExpr) -> Option<super::desugarer::MonadS
             let mut bind_name = None;
             let mut return_name = None;
             let mut namespace = None;
-            for (key, val_expr) in &bindings {
-                let val = extract_function_name_from_expr(val_expr);
-                match key.as_str() {
+            for b in &bindings {
+                let val = extract_function_name_from_expr(&b.expr);
+                match b.name.as_str() {
                     "bind" => bind_name = val,
                     "return" => return_name = val,
                     "namespace" => namespace = val,
@@ -1273,9 +1273,9 @@ fn desugar_monadic_block_implicit(
     } else {
         // Let bindings: each value is the lambda-bound FreeVar.
         // These must NOT be closed over the Let's own names.
-        let let_bindings: Vec<(String, RcExpr)> = non_underscore
+        let let_bindings: Vec<CoreBinding<RcExpr>> = non_underscore
             .iter()
-            .map(|(name, fv)| (name.clone(), core::var(smid, fv.clone())))
+            .map(|(name, fv)| CoreBinding::new(name.clone(), core::var(smid, fv.clone())))
             .collect();
 
         // Body: Block where each key reads from the Let (BoundVar scope=0).

--- a/src/core/export/embed.rs
+++ b/src/core/export/embed.rs
@@ -256,7 +256,11 @@ impl Embed for CoreExpr {
             CoreExpr::ErrPseudoCall => EmbedBuilder::new("e-pseudocall").finish(),
             CoreExpr::ErrPseudoCat => EmbedBuilder::new("e-pseudocat").finish(),
             CoreExpr::Let(_, scope, _) => {
-                let entries: Vec<(String, RcExpr)> = scope.pattern.clone();
+                let entries: Vec<(String, RcExpr)> = scope
+                    .pattern
+                    .iter()
+                    .map(|b| (b.name.clone(), b.expr.clone()))
+                    .collect();
                 let mut b = EmbedBuilder::new("c-let");
                 b.block(&entries)?;
                 b.embed(&scope.body)?;

--- a/src/core/export/pretty.rs
+++ b/src/core/export/pretty.rs
@@ -70,11 +70,11 @@ impl ToPretty for RcExpr {
             Expr::Var(_, v) => v.pretty(allocator),
             Expr::Name(_, n) => allocator.text(n),
             Expr::Let(_, scope, _) => {
-                let binding_docs = scope.pattern.iter().map(|(name, def)| {
+                let binding_docs = scope.pattern.iter().map(|b| {
                     allocator
-                        .text(name.clone())
+                        .text(b.name.clone())
                         .append(allocator.text(" = "))
-                        .append(def.pretty(allocator))
+                        .append(b.expr.pretty(allocator))
                         .group()
                 });
 

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -17,6 +17,7 @@ use std::iter::FromIterator;
 use std::rc::Rc;
 use std::str::FromStr;
 
+pub use crate::core::binding::CoreBinding;
 pub use crate::core::binding::Var::Free;
 
 /// Primitive types in core
@@ -274,7 +275,7 @@ where
     }
 }
 
-pub type LetScope<T> = Scope<Vec<(String, T)>, T>;
+pub type LetScope<T> = Scope<Vec<CoreBinding<T>>, T>;
 pub type LamScope<T> = Scope<Vec<String>, T>;
 
 /// The main core expression type
@@ -448,7 +449,7 @@ where
                 pattern: scope
                     .pattern
                     .iter()
-                    .map(|(n, value)| (n.clone(), V::from(value)))
+                    .map(|b| CoreBinding::with_demand(b.name.clone(), V::from(&b.expr), b.demand))
                     .collect(),
                 body: V::from(&scope.body),
             },
@@ -557,8 +558,8 @@ impl RcExpr {
         scope
             .pattern
             .iter()
-            .filter(|(_, v)| !has_internal_export(v))
-            .map(|(k, _)| (k.clone(), k.clone()))
+            .filter(|b| !has_internal_export(&b.expr))
+            .map(|b| (b.name.clone(), b.name.clone()))
             .collect()
     }
 
@@ -584,11 +585,11 @@ impl RcExpr {
                 let names: Vec<&str> = scope
                     .pattern
                     .iter()
-                    .map(|(n, v)| {
-                        if has_internal_export(v) {
+                    .map(|b| {
+                        if has_internal_export(&b.expr) {
                             "\x00"
                         } else {
-                            n.as_str()
+                            b.name.as_str()
                         }
                     })
                     .collect();
@@ -661,7 +662,9 @@ impl RcExpr {
                     pattern: scope
                         .pattern
                         .iter()
-                        .map(|(n, value)| (n.clone(), f(value.clone())))
+                        .map(|b| {
+                            CoreBinding::with_demand(b.name.clone(), f(b.expr.clone()), b.demand)
+                        })
                         .collect(),
                     body: f(scope.body.clone()),
                 },
@@ -730,8 +733,11 @@ impl RcExpr {
                 let bindings = scope
                     .pattern
                     .iter()
-                    .map(|(n, value)| f(value.clone()).map(|v| (n.clone(), v)))
-                    .collect::<Result<Vec<(String, RcExpr)>, E>>()?;
+                    .map(|b| {
+                        f(b.expr.clone())
+                            .map(|v| CoreBinding::with_demand(b.name.clone(), v, b.demand))
+                    })
+                    .collect::<Result<Vec<CoreBinding<RcExpr>>, E>>()?;
                 RcExpr::from(Expr::Let(
                     *s,
                     Scope {
@@ -847,18 +853,14 @@ impl RcExpr {
                 }
             }
             Expr::Let(s, scope, t) => {
-                let new_bindings: Vec<_> = scope
-                    .pattern
-                    .iter()
-                    .map(|(n, value)| (n, f(value)))
-                    .collect();
+                let new_exprs: Vec<RcExpr> = scope.pattern.iter().map(|b| f(&b.expr)).collect();
                 let new_body = f(&scope.body);
 
                 let bindings_same = scope
                     .pattern
                     .iter()
-                    .zip(new_bindings.iter())
-                    .all(|((_, v), (_, new_v))| v.ptr_eq(new_v));
+                    .zip(new_exprs.iter())
+                    .all(|(b, new_v)| b.expr.ptr_eq(new_v));
                 let body_same = scope.body.ptr_eq(&new_body);
 
                 if bindings_same && body_same {
@@ -867,9 +869,13 @@ impl RcExpr {
                     RcExpr::from(Expr::Let(
                         *s,
                         Scope {
-                            pattern: new_bindings
-                                .into_iter()
-                                .map(|(n, v)| (n.clone(), v))
+                            pattern: scope
+                                .pattern
+                                .iter()
+                                .zip(new_exprs)
+                                .map(|(b, new_v)| {
+                                    CoreBinding::with_demand(b.name.clone(), new_v, b.demand)
+                                })
                                 .collect(),
                             body: new_body,
                         },
@@ -996,14 +1002,18 @@ impl RcExpr {
                 }
             }
             Expr::Let(s, scope, t) => {
-                let new_bindings: Vec<_> = scope
+                let new_exprs: Vec<RcExpr> = scope
                     .pattern
                     .iter()
-                    .map(|(n, value)| f(value).map(|new_v| (n, value, new_v)))
+                    .map(|b| f(&b.expr))
                     .collect::<Result<_, E>>()?;
                 let new_body = f(&scope.body)?;
 
-                let bindings_same = new_bindings.iter().all(|(_, v, new_v)| v.ptr_eq(new_v));
+                let bindings_same = scope
+                    .pattern
+                    .iter()
+                    .zip(new_exprs.iter())
+                    .all(|(b, new_v)| b.expr.ptr_eq(new_v));
                 let body_same = scope.body.ptr_eq(&new_body);
 
                 if bindings_same && body_same {
@@ -1012,9 +1022,13 @@ impl RcExpr {
                     RcExpr::from(Expr::Let(
                         *s,
                         Scope {
-                            pattern: new_bindings
-                                .into_iter()
-                                .map(|(n, _, v)| (n.clone(), v))
+                            pattern: scope
+                                .pattern
+                                .iter()
+                                .zip(new_exprs)
+                                .map(|(b, new_v)| {
+                                    CoreBinding::with_demand(b.name.clone(), new_v, b.demand)
+                                })
                                 .collect(),
                             body: new_body,
                         },
@@ -1269,9 +1283,9 @@ pub fn free(n: &str) -> String {
 pub fn close_let_scope(bindings: Vec<(String, RcExpr)>, body: RcExpr) -> LetScope<RcExpr> {
     let names: Vec<String> = bindings.iter().map(|(n, _)| n.clone()).collect();
     let name_refs: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
-    let closed_bindings: Vec<(String, RcExpr)> = bindings
+    let closed_bindings: Vec<CoreBinding<RcExpr>> = bindings
         .into_iter()
-        .map(|(n, v)| (n, close_expr_vars(&name_refs, 0, &v)))
+        .map(|(n, v)| CoreBinding::new(n, close_expr_vars(&name_refs, 0, &v)))
         .collect();
     let closed_body = close_expr_vars(&name_refs, 0, &body);
     Scope {
@@ -1296,7 +1310,7 @@ pub fn open_let_scope(scope: &LetScope<RcExpr>) -> RcExpr {
     let names: Vec<Option<&str>> = scope
         .pattern
         .iter()
-        .map(|(n, _)| Some(n.as_str()))
+        .map(|b| Some(b.name.as_str()))
         .collect();
     open_expr_vars(&names, 0, &scope.body)
 }
@@ -1313,12 +1327,12 @@ pub fn open_let_scope_full(scope: &LetScope<RcExpr>) -> (Vec<(String, RcExpr)>, 
     let names: Vec<Option<&str>> = scope
         .pattern
         .iter()
-        .map(|(n, _)| Some(n.as_str()))
+        .map(|b| Some(b.name.as_str()))
         .collect();
     let open_bindings = scope
         .pattern
         .iter()
-        .map(|(n, v)| (n.clone(), open_expr_vars(&names, 0, v)))
+        .map(|b| (b.name.clone(), open_expr_vars(&names, 0, &b.expr)))
         .collect();
     let open_body = open_expr_vars(&names, 0, &scope.body);
     (open_bindings, open_body)
@@ -1357,7 +1371,13 @@ pub fn bind_free_vars(names: &[&str], depth: u32, expr: &RcExpr) -> RcExpr {
             let new_bindings = scope
                 .pattern
                 .iter()
-                .map(|(n, v)| (n.clone(), bind_free_vars(names, depth + 1, v)))
+                .map(|b| {
+                    CoreBinding::with_demand(
+                        b.name.clone(),
+                        bind_free_vars(names, depth + 1, &b.expr),
+                        b.demand,
+                    )
+                })
                 .collect();
             let new_body = bind_free_vars(names, depth + 1, &scope.body);
             RcExpr::from(Expr::Let(
@@ -1415,7 +1435,13 @@ pub fn close_expr_vars(names: &[&str], depth: u32, expr: &RcExpr) -> RcExpr {
             let new_bindings = scope
                 .pattern
                 .iter()
-                .map(|(n, v)| (n.clone(), close_expr_vars(names, depth + 1, v)))
+                .map(|b| {
+                    CoreBinding::with_demand(
+                        b.name.clone(),
+                        close_expr_vars(names, depth + 1, &b.expr),
+                        b.demand,
+                    )
+                })
                 .collect();
             let new_body = close_expr_vars(names, depth + 1, &scope.body);
             RcExpr::from(Expr::Let(
@@ -1472,7 +1498,13 @@ pub fn open_expr_vars(names: &[Option<&str>], depth: u32, expr: &RcExpr) -> RcEx
             let new_bindings = scope
                 .pattern
                 .iter()
-                .map(|(n, v)| (n.clone(), open_expr_vars(names, depth + 1, v)))
+                .map(|b| {
+                    CoreBinding::with_demand(
+                        b.name.clone(),
+                        open_expr_vars(names, depth + 1, &b.expr),
+                        b.demand,
+                    )
+                })
                 .collect();
             let new_body = open_expr_vars(names, depth + 1, &scope.body);
             RcExpr::from(Expr::Let(
@@ -1538,9 +1570,9 @@ pub fn collect_internal_binding_names(expr: &RcExpr) -> Vec<String> {
 fn collect_internal_binding_names_inner(expr: &RcExpr, out: &mut Vec<String>) {
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            for (n, v) in &scope.pattern {
-                if has_internal_export(v) {
-                    out.push(n.clone());
+            for b in &scope.pattern {
+                if has_internal_export(&b.expr) {
+                    out.push(b.name.clone());
                 }
             }
             collect_internal_binding_names_inner(&scope.body, out);
@@ -1580,8 +1612,8 @@ fn collect_free_vars(expr: &RcExpr, result: &mut std::collections::HashSet<Strin
         }
         Expr::Var(_, Var::Bound(_)) => {}
         Expr::Let(_, scope, _) => {
-            for (_, v) in &scope.pattern {
-                collect_free_vars(v, result);
+            for b in &scope.pattern {
+                collect_free_vars(&b.expr, result);
             }
             collect_free_vars(&scope.body, result);
         }
@@ -2055,7 +2087,13 @@ pub mod tests {
                 let new_pattern = scope
                     .pattern
                     .iter()
-                    .map(|(k, v)| (k.clone(), alpha_norm_inner(v, counter)))
+                    .map(|b| {
+                        CoreBinding::with_demand(
+                            b.name.clone(),
+                            alpha_norm_inner(&b.expr, counter),
+                            b.demand,
+                        )
+                    })
                     .collect();
                 let new_body = alpha_norm_inner(&scope.body, counter);
                 RcExpr::from(Expr::Let(
@@ -2185,12 +2223,11 @@ pub mod tests {
                 let new_bindings = scope
                     .pattern
                     .iter()
-                    .map(|(k, v)| {
-                        (
-                            k.clone(),
-                            rename_lam_params(v, old_names, new_names, depth + 1),
-                        )
-                    })
+                    .map(|b| CoreBinding::with_demand(
+                        b.name.clone(),
+                        rename_lam_params(&b.expr, old_names, new_names, depth + 1),
+                        b.demand,
+                    ))
                     .collect();
                 let new_body = rename_lam_params(&scope.body, old_names, new_names, depth + 1);
                 RcExpr::from(Expr::Let(
@@ -2238,7 +2275,13 @@ pub mod tests {
                 let new_pattern = scope
                     .pattern
                     .iter()
-                    .map(|(k, v)| (k.clone(), smid_strip_inner(v)))
+                    .map(|b| {
+                        CoreBinding::with_demand(
+                            b.name.clone(),
+                            smid_strip_inner(&b.expr),
+                            b.demand,
+                        )
+                    })
                     .collect();
                 let new_body = smid_strip_inner(&scope.body);
                 RcExpr::from(Expr::Let(

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -2223,11 +2223,13 @@ pub mod tests {
                 let new_bindings = scope
                     .pattern
                     .iter()
-                    .map(|b| CoreBinding::with_demand(
-                        b.name.clone(),
-                        rename_lam_params(&b.expr, old_names, new_names, depth + 1),
-                        b.demand,
-                    ))
+                    .map(|b| {
+                        CoreBinding::with_demand(
+                            b.name.clone(),
+                            rename_lam_params(&b.expr, old_names, new_names, depth + 1),
+                            b.demand,
+                        )
+                    })
                     .collect();
                 let new_body = rename_lam_params(&scope.body, old_names, new_names, depth + 1);
                 RcExpr::from(Expr::Let(

--- a/src/core/inline/reduce.rs
+++ b/src/core/inline/reduce.rs
@@ -43,10 +43,13 @@ fn substs_depth(
         // Descend into Let: the binding values are inside the new scope
         // boundary, so depth increases by 1.
         Expr::Let(s, scope, t) => {
-            let new_bindings: Result<Vec<_>, CoreError> = scope
+            let new_bindings: Result<Vec<CoreBinding<RcExpr>>, CoreError> = scope
                 .pattern
                 .iter()
-                .map(|(n, value)| substs_depth(value, mappings, depth + 1).map(|v| (n.clone(), v)))
+                .map(|b| {
+                    substs_depth(&b.expr, mappings, depth + 1)
+                        .map(|v| CoreBinding::with_demand(b.name.clone(), v, b.demand))
+                })
                 .collect();
             let new_body = substs_depth(&scope.body, mappings, depth + 1)?;
             Ok(RcExpr::from(Expr::Let(

--- a/src/core/simplify/compress.rs
+++ b/src/core/simplify/compress.rs
@@ -44,11 +44,14 @@ impl ScopeCompressor {
             Expr::Let(s, scope, t) => {
                 self.enter(permutation_from_let_scope(scope));
 
-                let new_bindings: Result<Vec<_>, CoreError> = scope
+                let new_bindings: Result<Vec<CoreBinding<RcExpr>>, CoreError> = scope
                     .pattern
                     .iter()
-                    .filter(|(_, value)| !matches!(*value.inner, Expr::ErrEliminated))
-                    .map(|(n, value)| self.compress(value).map(|val| (n.clone(), val)))
+                    .filter(|b| !matches!(*b.expr.inner, Expr::ErrEliminated))
+                    .map(|b| {
+                        self.compress(&b.expr)
+                            .map(|val| CoreBinding::with_demand(b.name.clone(), val, b.demand))
+                    })
                     .collect();
 
                 let new_bindings = match new_bindings {
@@ -118,8 +121,8 @@ impl ScopeCompressor {
 fn permutation_from_let_scope(scope: &LetScope<RcExpr>) -> Permutation {
     let mut perm = Vec::new();
     let mut i = 0;
-    for (_, value) in &scope.pattern {
-        if matches!(*value.inner, Expr::ErrEliminated) {
+    for b in &scope.pattern {
+        if matches!(*b.expr.inner, Expr::ErrEliminated) {
             perm.push(None);
         } else {
             perm.push(Some(i));

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -1011,4 +1011,70 @@ pub mod tests {
         // ns escapes bare in body block, so all members preserved
         assert_eq!(strip_demands(&pruned), strip_demands(&expr));
     }
+
+    /// A single-use binding receives `Cardinality::AtMostOnce` after pruning.
+    ///
+    /// The prune pass counts references; a binding used exactly once gets
+    /// `Demand::at_most_once()`, which later causes the STG compiler to emit
+    /// a `Value` instead of a `Thunk` (W9 §3.4).
+    #[test]
+    pub fn test_single_use_binding_gets_at_most_once_cardinality() {
+        use crate::core::demand::{Cardinality, Demand};
+
+        let x = free("x");
+        let y = free("y");
+
+        // `x` is used exactly once (in the body); `y` is unused.
+        let expr = let_(vec![(x.clone(), num(42)), (y.clone(), num(0))], var(x));
+
+        let pruned = prune(&expr);
+
+        match &*pruned.inner {
+            Expr::Let(_, scope, _) => {
+                let x_binding = &scope.pattern[0];
+                assert_eq!(
+                    x_binding.demand,
+                    Demand::at_most_once(),
+                    "single-use binding should have AtMostOnce cardinality after pruning"
+                );
+
+                // The unused binding keeps the default demand.
+                let y_binding = &scope.pattern[1];
+                assert_eq!(
+                    y_binding.demand.cardinality,
+                    Cardinality::Unknown,
+                    "unused binding should keep Unknown cardinality"
+                );
+            }
+            other => panic!("expected outer Let, got: {other:?}"),
+        }
+    }
+
+    /// A binding used more than once receives `Cardinality::Multi` after pruning.
+    #[test]
+    pub fn test_multi_use_binding_gets_multi_cardinality() {
+        use crate::core::demand::Cardinality;
+
+        let x = free("x");
+
+        // `x` appears in both argument positions — used twice.
+        let expr = let_(
+            vec![(x.clone(), num(5))],
+            app(bif("ADD"), vec![var(x.clone()), var(x)]),
+        );
+
+        let pruned = prune(&expr);
+
+        match &*pruned.inner {
+            Expr::Let(_, scope, _) => {
+                let x_binding = &scope.pattern[0];
+                assert_eq!(
+                    x_binding.demand.cardinality,
+                    Cardinality::Multi,
+                    "multi-use binding should have Multi cardinality after pruning"
+                );
+            }
+            other => panic!("expected outer Let, got: {other:?}"),
+        }
+    }
 }

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -5,6 +5,7 @@
 //! only accessed via static `Lookup` patterns (`ns.member`), inner
 //! members that are never looked up are eliminated from the Block body.
 use crate::core::binding::{BoundVar, Scope, Var};
+use crate::core::demand::{Cardinality, Demand};
 use crate::core::expr::*;
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -42,12 +43,18 @@ pub enum SeenState {
 #[derive(Default, Debug)]
 pub struct Tracker {
     seen: Cell<SeenState>,
+    /// Number of times this binding has been referenced.
+    ///
+    /// Used by Phase 3 of W9 to annotate single-use bindings with
+    /// `Cardinality::AtMostOnce`.
+    use_count: Cell<u32>,
 }
 
 impl Clone for Tracker {
     fn clone(&self) -> Self {
         Tracker {
             seen: self.seen.clone(),
+            use_count: self.use_count.clone(),
         }
     }
 }
@@ -55,6 +62,18 @@ impl Clone for Tracker {
 impl Tracker {
     pub fn seen(&self) -> SeenState {
         self.seen.get()
+    }
+
+    /// Returns the number of times this binding was referenced during traversal.
+    pub fn use_count(&self) -> u32 {
+        self.use_count.get()
+    }
+
+    /// Increment the use counter and return the new count.
+    fn increment_use(&self) -> u32 {
+        let c = self.use_count.get() + 1;
+        self.use_count.set(c);
+        c
     }
 }
 
@@ -235,10 +254,12 @@ impl<'expr> ScopeTracker<'expr> {
         if self.reachable {
             let expr = self.scopes[bound_var.scope as usize];
             if let Expr::Let(_, scope, _) = &*expr.inner {
-                let (_, rc) = &scope.pattern[bound_var.binder as usize];
+                let rc = &scope.pattern[bound_var.binder as usize].expr;
                 // Disqualify from block-level DCE on bare access
                 let id: BindingId = Rc::as_ptr(&rc.inner);
                 self.block_tracker.disqualify(id);
+                // Increment the usage counter for cardinality tracking (W9 Phase 3).
+                rc.data.increment_use();
                 if rc.mark() {
                     self.marked_count += 1
                 }
@@ -254,8 +275,10 @@ impl<'expr> ScopeTracker<'expr> {
         if self.reachable {
             let expr = self.scopes[bound_var.scope as usize];
             if let Expr::Let(_, scope, _) = &*expr.inner {
-                let (_, rc) = &scope.pattern[bound_var.binder as usize];
+                let rc = &scope.pattern[bound_var.binder as usize].expr;
                 let id: BindingId = Rc::as_ptr(&rc.inner);
+                // Increment usage counter for static lookups too (W9 Phase 3).
+                rc.data.increment_use();
                 if self.block_tracker.is_candidate(id) {
                     self.block_tracker.record_access(id, member.to_owned());
                 }
@@ -309,16 +332,16 @@ impl<'expr> ScopeTracker<'expr> {
             Expr::Let(_, scope, _) => {
                 // Register DefaultBlockLet bindings as candidates
                 // for block-level DCE
-                for (_, rc) in &scope.pattern {
-                    if rc.inner.is_default_let() {
-                        let id: BindingId = Rc::as_ptr(&rc.inner);
+                for b in &scope.pattern {
+                    if b.expr.inner.is_default_let() {
+                        let id: BindingId = Rc::as_ptr(&b.expr.inner);
                         self.block_tracker.register(id);
                     }
                 }
                 self.enter(expr);
-                for (_, rc) in &scope.pattern {
-                    self.soft_depend(rc, expr);
-                    self.traverse(rc);
+                for b in &scope.pattern {
+                    self.soft_depend(&b.expr, expr);
+                    self.traverse(&b.expr);
                 }
                 self.traverse(&scope.body);
                 self.exit();
@@ -399,6 +422,24 @@ impl<'expr> ScopeTracker<'expr> {
         }
     }
 
+    /// Compute the demand annotation for a binding after the mark phase.
+    ///
+    /// - A binding used exactly once gets `Cardinality::AtMostOnce` (W9 Phase 3):
+    ///   no memoisation benefit, so the STG compiler can skip the Update frame.
+    /// - A binding used more than once gets `Cardinality::Multi`.
+    /// - A binding not reached (use_count == 0) keeps `Unknown` (it will be
+    ///   eliminated, so the annotation is moot).
+    fn demand_from_use_count(use_count: u32) -> Demand {
+        match use_count {
+            0 => Demand::default(),
+            1 => Demand::at_most_once(),
+            _ => Demand {
+                cardinality: Cardinality::Multi,
+                ..Default::default()
+            },
+        }
+    }
+
     pub fn blank_unseen(&self, expr: &RcMarkExpr) -> RcExpr {
         RcExpr::from(match &*expr.inner {
             Expr::Let(s, scope, t) => Expr::Let(
@@ -407,15 +448,26 @@ impl<'expr> ScopeTracker<'expr> {
                     pattern: scope
                         .pattern
                         .iter()
-                        .map(|(n, value)| {
-                            if value.unseen() {
-                                (n.clone(), RcExpr::from(Expr::ErrEliminated))
+                        .map(|b| {
+                            if b.expr.unseen() {
+                                CoreBinding::new(b.name.clone(), RcExpr::from(Expr::ErrEliminated))
                             } else {
-                                let id: BindingId = Rc::as_ptr(&value.inner);
+                                // Compute demand from usage count (W9 Phase 3).
+                                let use_count = b.expr.data.use_count();
+                                let demand = Self::demand_from_use_count(use_count);
+                                let id: BindingId = Rc::as_ptr(&b.expr.inner);
                                 if let Some(members) = self.block_tracker.accessed_members(id) {
-                                    (n.clone(), self.blank_default_block_let(value, members))
+                                    CoreBinding::with_demand(
+                                        b.name.clone(),
+                                        self.blank_default_block_let(&b.expr, members),
+                                        demand,
+                                    )
                                 } else {
-                                    (n.clone(), self.blank_unseen(value))
+                                    CoreBinding::with_demand(
+                                        b.name.clone(),
+                                        self.blank_unseen(&b.expr),
+                                        demand,
+                                    )
                                 }
                             }
                         })
@@ -478,14 +530,20 @@ impl<'expr> ScopeTracker<'expr> {
         match &*expr.inner {
             Expr::Let(s, scope, LetType::DefaultBlockLet) => {
                 // Convert inner bindings normally
-                let new_bindings: Vec<_> = scope
+                let new_bindings: Vec<CoreBinding<RcExpr>> = scope
                     .pattern
                     .iter()
-                    .map(|(n, value)| {
-                        if value.unseen() {
-                            (n.clone(), RcExpr::from(Expr::ErrEliminated))
+                    .map(|b| {
+                        if b.expr.unseen() {
+                            CoreBinding::new(b.name.clone(), RcExpr::from(Expr::ErrEliminated))
                         } else {
-                            (n.clone(), self.blank_unseen(value))
+                            let use_count = b.expr.data.use_count();
+                            let demand = Self::demand_from_use_count(use_count);
+                            CoreBinding::with_demand(
+                                b.name.clone(),
+                                self.blank_unseen(&b.expr),
+                                demand,
+                            )
                         }
                     })
                     .collect();
@@ -529,6 +587,41 @@ pub mod tests {
     use crate::core::expr::acore::*;
     use crate::core::expr::RcExpr;
 
+    /// Reset all `CoreBinding::demand` fields in `expr` to `Demand::default()`.
+    ///
+    /// Used in structural-equality tests that only care about which bindings
+    /// are pruned (ErrEliminated), not about the demand annotations that the
+    /// prune pass now computes.  Demand correctness is validated separately.
+    fn strip_demands(expr: &RcExpr) -> RcExpr {
+        match &*expr.inner {
+            Expr::Let(s, scope, t) => {
+                let new_pattern = scope
+                    .pattern
+                    .iter()
+                    .map(|b| CoreBinding {
+                        name: b.name.clone(),
+                        expr: strip_demands(&b.expr),
+                        demand: Demand::default(),
+                    })
+                    .collect();
+                let new_body = strip_demands(&scope.body);
+                RcExpr::from(Expr::Let(
+                    *s,
+                    Scope {
+                        pattern: new_pattern,
+                        body: new_body,
+                    },
+                    *t,
+                ))
+            }
+            Expr::Meta(s, inner, meta) => {
+                RcExpr::from(Expr::Meta(*s, strip_demands(inner), strip_demands(meta)))
+            }
+            // All other variants: no bindings to strip
+            _ => expr.clone(),
+        }
+    }
+
     #[test]
     pub fn test_simple() {
         let x = free("x");
@@ -544,7 +637,7 @@ pub mod tests {
             var(x),
         );
 
-        assert_eq!(prune(&simple), expected)
+        assert_eq!(strip_demands(&prune(&simple)), expected)
     }
 
     #[test]
@@ -573,7 +666,7 @@ pub mod tests {
             ),
         );
 
-        assert_eq!(prune(&nested), expected)
+        assert_eq!(strip_demands(&prune(&nested)), expected)
     }
 
     #[test]
@@ -600,7 +693,7 @@ pub mod tests {
             app(bif("BLAH"), vec![var(a), var(b)]),
         );
 
-        assert_eq!(prune(&expr), expected)
+        assert_eq!(strip_demands(&prune(&expr)), expected)
     }
 
     #[test]
@@ -638,7 +731,7 @@ pub mod tests {
             var(a),
         );
 
-        assert_eq!(prune(&expr), expected)
+        assert_eq!(strip_demands(&prune(&expr)), expected)
     }
 
     // Block-level DCE tests
@@ -669,7 +762,7 @@ pub mod tests {
         // Verify the block body is filtered (only "used" member)
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, ref ns_val) = scope.pattern[0];
+                let ns_val = &scope.pattern[0].expr;
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         // Block body should only contain "used"
@@ -710,7 +803,7 @@ pub mod tests {
 
         let pruned = prune(&expr);
         // All members preserved (dynamic access), result used
-        assert_eq!(pruned, expr);
+        assert_eq!(strip_demands(&pruned), strip_demands(&expr));
     }
 
     #[test]
@@ -735,7 +828,7 @@ pub mod tests {
         );
 
         let pruned = prune(&expr);
-        assert_eq!(pruned, expr);
+        assert_eq!(strip_demands(&pruned), strip_demands(&expr));
     }
 
     #[test]
@@ -770,7 +863,7 @@ pub mod tests {
         // Verify block body has only "a" and "c"
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, ref ns_val) = scope.pattern[0];
+                let ns_val = &scope.pattern[0].expr;
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         // Block body should contain "a" and "c" only
@@ -822,7 +915,7 @@ pub mod tests {
         // Verify the block body is filtered (only "used" member)
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, ref ns_val) = scope.pattern[0];
+                let ns_val = &scope.pattern[0].expr;
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         match &*inner_scope.body.inner {
@@ -873,7 +966,7 @@ pub mod tests {
         // "used" is accessed — the fallback references "other", not "ns"
         match &*pruned.inner {
             Expr::Let(_, scope, _) => {
-                let (_, ref ns_val) = scope.pattern[0];
+                let ns_val = &scope.pattern[0].expr;
                 match &*ns_val.inner {
                     Expr::Let(_, inner_scope, LetType::DefaultBlockLet) => {
                         match &*inner_scope.body.inner {
@@ -916,6 +1009,6 @@ pub mod tests {
 
         let pruned = prune(&expr);
         // ns escapes bare in body block, so all members preserved
-        assert_eq!(pruned, expr);
+        assert_eq!(strip_demands(&pruned), strip_demands(&expr));
     }
 }

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -775,10 +775,10 @@ impl Checker {
         match &*expr.inner {
             Expr::Let(_, scope, _) => {
                 // Each binding in the scope corresponds to one alias declaration.
-                for (alias_name, type_str_expr) in &scope.pattern {
-                    if let Some(type_str) = extract_string_literal(type_str_expr) {
+                for b in &scope.pattern {
+                    if let Some(type_str) = extract_string_literal(&b.expr) {
                         if let Ok(ty) = parse::parse_type(&type_str) {
-                            self.register_alias(alias_name.clone(), ty);
+                            self.register_alias(b.name.clone(), ty);
                         }
                     }
                 }
@@ -964,11 +964,11 @@ impl Checker {
                 // Pass 1: pre-seed the frame with annotation schemes (or a
                 // `mono(any)` placeholder for unannotated bindings).
                 let mut frame: HashMap<String, TypeScheme> = HashMap::new();
-                for (name, value) in &scope.pattern {
+                for b in &scope.pattern {
                     let scheme = self
-                        .annotation_scheme_of(value)
+                        .annotation_scheme_of(&b.expr)
                         .unwrap_or(TypeScheme::mono(Type::Any));
-                    frame.insert(name.clone(), scheme);
+                    frame.insert(b.name.clone(), scheme);
                 }
 
                 self.push_scope(frame);
@@ -981,15 +981,15 @@ impl Checker {
                 //
                 // anchored = scope_stack.len() - 1 (the newly-pushed innermost frame).
                 let anchored = self.scope_stack.len() - 1;
-                for (name, value) in &scope.pattern {
-                    let key: BoundKey = (anchored, name.clone());
+                for b in &scope.pattern {
+                    let key: BoundKey = (anchored, b.name.clone());
                     // Tentative `None` entries double as recursion guards: if
                     // classification recurses back to this binding, it sees
                     // "not a brancher/projector" and terminates.
                     self.branch_shapes.insert(key.clone(), None);
                     self.projection_shapes.insert(key.clone(), None);
                     // Store the body for later structural analysis.
-                    let body = peel_meta(value).clone();
+                    let body = peel_meta(&b.expr).clone();
                     self.binding_bodies.insert(key.clone(), body.clone());
                     // Classify and update.
                     let shape = self.classify_binding_shape(&body, self.scope_stack.len());
@@ -1002,7 +1002,9 @@ impl Checker {
                 // checks against any annotations.  For unannotated bindings,
                 // replace the placeholder with the synthesised mono type so
                 // later sibling bindings and the body can use it.
-                for (name, value) in &scope.pattern {
+                for b in &scope.pattern {
+                    let name = &b.name;
+                    let value = &b.expr;
                     let synthesised = self.synthesise_binding_value(value);
                     let placeholder = TypeScheme::mono(Type::Any);
                     if let Some(frame) = self.scope_stack.front_mut() {
@@ -2679,8 +2681,8 @@ fn collect_block_uses(expr: &RcExpr, depth: usize, flags: &mut Vec<bool>) {
 
         // Let binding: values are at the current depth; the body is at depth+1.
         Expr::Let(_, inner_scope, _) => {
-            for (_, val) in &inner_scope.pattern {
-                collect_block_uses(val, depth, flags);
+            for b in &inner_scope.pattern {
+                collect_block_uses(&b.expr, depth, flags);
             }
             collect_block_uses(&inner_scope.body, depth + 1, flags);
         }
@@ -3432,8 +3434,8 @@ impl Checker {
                 self.walk_meta_for_aliases(meta);
             }
             Expr::Let(_, scope, _) => {
-                for (_, value) in &scope.pattern {
-                    self.walk_meta_for_aliases(value);
+                for b in &scope.pattern {
+                    self.walk_meta_for_aliases(&b.expr);
                 }
                 self.walk_meta_for_aliases(&scope.body);
             }

--- a/src/core/verify/binding.rs
+++ b/src/core/verify/binding.rs
@@ -35,9 +35,9 @@ impl ScopeTracker {
         let expr = self.scopes[bound_var.scope as usize].clone();
         match &*expr.inner {
             Expr::Let(_, scope, _) => {
-                if let Some((name, _)) = scope.pattern.get(bound_var.binder as usize) {
+                if let Some(b) = scope.pattern.get(bound_var.binder as usize) {
                     assert_eq!(
-                        Some(name.as_str()),
+                        Some(b.name.as_str()),
                         bound_var.name.as_deref(),
                         "name mismatch for BV scope={} binder={}",
                         bound_var.scope,

--- a/src/core/verify/content.rs
+++ b/src/core/verify/content.rs
@@ -99,10 +99,12 @@ impl Verifier {
             Expr::Let(_, scope, _) => {
                 // Check each binding value for trivial self-assignment before
                 // walking into the scope body.
-                for (binder, (name, value)) in scope.pattern.iter().enumerate() {
-                    if is_trivially_self_referential(value, binder as u32) {
-                        self.errors
-                            .push(CoreError::TrivialSelfAssignment(value.smid(), name.clone()));
+                for (binder, b) in scope.pattern.iter().enumerate() {
+                    if is_trivially_self_referential(&b.expr, binder as u32) {
+                        self.errors.push(CoreError::TrivialSelfAssignment(
+                            b.expr.smid(),
+                            b.name.clone(),
+                        ));
                     }
                 }
                 expr.walk_safe(&mut |x| self.verify(x))

--- a/src/core/verify/deprecation.rs
+++ b/src/core/verify/deprecation.rs
@@ -46,8 +46,8 @@ fn check_expr(
             }
         }
         Expr::Let(_, scope, _) => {
-            for (_, v) in &scope.pattern {
-                check_expr(v, deprecations, warnings);
+            for b in &scope.pattern {
+                check_expr(&b.expr, deprecations, warnings);
             }
             check_expr(&scope.body, deprecations, warnings);
         }

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -493,6 +493,10 @@ fn run_type_checker(opt: &EucalyptOptions) -> Result<PipelineCheckResult, Eucaly
     // Eliminate dead bindings.
     loader.eliminate()?;
 
+    // Extract demand annotations AFTER eliminate so the prune pass has had a
+    // chance to populate `CoreBinding::demand` with cardinality information.
+    loader.extract_demands();
+
     // Run the deprecation reference checker before cook strips metadata.
     let deprecation_warnings =
         check_deprecated_references(&loader.core().expr, &loader.core().deprecations);

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -1109,8 +1109,8 @@ fn extract_top_level_bindings(expr: &crate::core::expr::RcExpr, type_env: &mut T
 
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            for (name, _) in &scope.pattern {
-                type_env.entry(name.clone()).or_insert(Type::Any);
+            for b in &scope.pattern {
+                type_env.entry(b.name.clone()).or_insert(Type::Any);
             }
             // Recurse into the body to capture nested Let scopes.
             extract_top_level_bindings(&scope.body, type_env);

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -716,6 +716,18 @@ impl SourceLoader {
     pub fn extract_visibility(&mut self) {
         let expr = self.core.expr.clone();
         self.unit_interface.extract_visibility_from_expr(&expr);
+    }
+
+    /// Extract demand (cardinality/strictness) annotations for exported bindings
+    /// into `unit_interface.demands`.
+    ///
+    /// Must be called AFTER the prune pass (`eliminate()`) — the prune pass
+    /// populates `CoreBinding::demand` with `Cardinality::AtMostOnce` for
+    /// single-use bindings.  Calling this before prune would always yield
+    /// `Demand::default()` (all `Unknown`) because the cardinality information
+    /// has not yet been written.
+    pub fn extract_demands(&mut self) {
+        let expr = self.core.expr.clone();
         self.unit_interface.extract_demands_from_expr(&expr);
     }
 

--- a/src/driver/unit_interface.rs
+++ b/src/driver/unit_interface.rs
@@ -193,7 +193,11 @@ impl UnitInterface {
     /// The slot starts conservative (all `Unknown`); future analysis passes
     /// (W11 strictness analysis) populate it with richer information.
     ///
-    /// Call at the same pipeline stage as `extract_visibility_from_expr`.
+    /// Must be called AFTER the prune/eliminate pass — the prune pass populates
+    /// `CoreBinding::demand` with cardinality information that this function
+    /// reads.  Calling it before prune would always yield `Demand::default()`
+    /// (all `Unknown`) because the cardinality information has not yet been written.
+    /// Do NOT call alongside `extract_visibility_from_expr`.
     pub fn extract_demands_from_expr(&mut self, expr: &RcExpr) {
         collect_demands(expr, &mut self.demands);
     }

--- a/src/driver/unit_interface.rs
+++ b/src/driver/unit_interface.rs
@@ -221,9 +221,9 @@ impl UnitInterface {
 fn collect_operator_info(expr: &RcExpr, out: &mut HashMap<String, OperatorInfo>) {
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            for (name, value) in &scope.pattern {
-                if let Some(info) = extract_operator_info_from_value(value) {
-                    out.insert(name.clone(), info);
+            for b in &scope.pattern {
+                if let Some(info) = extract_operator_info_from_value(&b.expr) {
+                    out.insert(b.name.clone(), info);
                 }
             }
             collect_operator_info(&scope.body, out);
@@ -286,13 +286,13 @@ fn extract_str_literal(expr: &RcExpr) -> Option<String> {
 fn collect_visibility(expr: &RcExpr, out: &mut HashMap<String, Visibility>) {
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            for (name, value) in &scope.pattern {
-                let vis = if has_internal_export(value) {
+            for b in &scope.pattern {
+                let vis = if has_internal_export(&b.expr) {
                     Visibility::Internal
                 } else {
                     Visibility::Public
                 };
-                out.insert(name.clone(), vis);
+                out.insert(b.name.clone(), vis);
             }
             collect_visibility(&scope.body, out);
         }
@@ -301,17 +301,20 @@ fn collect_visibility(expr: &RcExpr, out: &mut HashMap<String, Visibility>) {
     }
 }
 
-/// Recursively register all exported bindings in `expr` with a conservative
-/// `Demand::default()` annotation.
+/// Recursively collect `Demand` annotations for exported bindings in `expr`.
+///
+/// Reads the `demand` field directly from the `CoreBinding` entries, giving
+/// the value populated by the prune (usage-counting) pass.
 ///
 /// Internal bindings (marked `export: :internal`) are excluded — they are not
 /// part of the cross-unit interface.
 fn collect_demands(expr: &RcExpr, out: &mut HashMap<String, Demand>) {
     match &*expr.inner {
         Expr::Let(_, scope, _) => {
-            for (name, value) in &scope.pattern {
-                if !has_internal_export(value) {
-                    out.entry(name.clone()).or_default();
+            for b in &scope.pattern {
+                if !has_internal_export(&b.expr) {
+                    // Use the annotation from the binding; default if absent.
+                    out.entry(b.name.clone()).or_insert(b.demand);
                 }
             }
             collect_demands(&scope.body, out);

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -767,12 +767,25 @@ impl<'a> LetBinder<'a> {
 
 struct ProtoLet {
     expr: RcExpr,
+    /// Demand from the enclosing binding — propagated so that single-use
+    /// bindings whose values are nested let expressions are compiled as
+    /// `Value` rather than `Thunk`.
+    demand: Demand,
 }
 
 impl ProtoLet {
     pub fn new(expr: RcExpr) -> Self {
         assert!(matches!(&*expr.inner, Expr::Let(_, _, _)));
-        ProtoLet { expr }
+        ProtoLet {
+            expr,
+            demand: Demand::default(),
+        }
+    }
+
+    /// Create a `ProtoLet` with an explicit demand annotation.
+    pub fn with_demand(expr: RcExpr, demand: Demand) -> Self {
+        assert!(matches!(&*expr.inner, Expr::Let(_, _, _)));
+        ProtoLet { expr, demand }
     }
 
     /// Reference the scope inside the let expression
@@ -786,6 +799,10 @@ impl ProtoLet {
 }
 
 impl ProtoSyntax for ProtoLet {
+    fn demand(&self) -> Demand {
+        self.demand
+    }
+
     fn take_syntax(
         &mut self,
         compiler: &Compiler,
@@ -1351,7 +1368,9 @@ impl<'rt> Compiler<'rt> {
                 }
                 Var::Free(name) => self.resolve_free_var(*s, name),
             },
-            Expr::Let(_, _, _) => binder.add_deferred(Box::new(ProtoLet::new(expr))),
+            Expr::Let(_, _, _) => {
+                binder.add_deferred(Box::new(ProtoLet::with_demand(expr, demand)))
+            }
             Expr::Lam(_, _, _) => {
                 binder.add_deferred(Box::new(self.compile_lambda(&expr, annotation)?))
             }
@@ -1553,6 +1572,7 @@ pub mod tests {
         eval::stg::tags::DataConstructor,
     };
 
+
     fn compile(expr: RcExpr) -> Result<Rc<StgSyn>, CompileError> {
         Compiler::new(
             true,
@@ -1699,5 +1719,140 @@ pub mod tests {
         );
 
         assert_eq!(compile(core).unwrap(), syntax);
+    }
+
+    /// A let-body application is compiled as `Value`, not `Thunk` (W9 §3.4).
+    ///
+    /// When the body of a let is an application, it is evaluated exactly once
+    /// (no sharing), so the STG compiler sets `Demand::at_most_once()` on the
+    /// corresponding synthetic binding.  This means the binding wrapping the
+    /// application result uses `value(...)` rather than `thunk(...)`.
+    ///
+    /// Concretely: `let f = λx.x in f(f)` — the body `f(f)` is compiled inside
+    /// a synthetic let.  The app binding within that let should be `Value`.
+    ///
+    /// Note: the outer letrec binding for `f` (a lambda) is always `Value` because
+    /// lambdas are WHNF.  What changes is the inner synthetic let that holds the
+    /// application result: it uses `value(app(...))` not `thunk(app(...))`.
+    #[test]
+    pub fn test_let_body_app_compiles_as_value() {
+        let f = free("f");
+        let x = free("x");
+
+        // let f = λx.x in f(f)
+        // The body `f(f)` is an App → compile_body uses Demand::at_most_once()
+        // for the synthetic binding produced by ProtoAppGroup.
+        let core = acore::let_(
+            vec![(f.clone(), acore::lam(vec![x.clone()], acore::var(x)))],
+            acore::app(acore::var(f.clone()), vec![acore::var(f)]),
+        );
+
+        let syntax = compile(core).unwrap();
+
+        // Walk the compiled STG to confirm no Thunk appears in the synthetic
+        // inner let that holds the application.
+        fn has_thunk(syn: &Rc<StgSyn>) -> bool {
+            match syn.as_ref() {
+                StgSyn::Let { bindings, body } | StgSyn::LetRec { bindings, body } => {
+                    bindings.iter().any(|b| matches!(b, LambdaForm::Thunk { .. }))
+                        || has_thunk(body)
+                }
+                _ => false,
+            }
+        }
+
+        assert!(
+            !has_thunk(&syntax),
+            "let-body application should not produce any Thunk bindings; got:\n{syntax:?}"
+        );
+    }
+
+    /// A single-use binding is compiled as `Value` after prune sets its demand.
+    ///
+    /// The prune pass annotates bindings used exactly once with
+    /// `Cardinality::AtMostOnce`.  The STG compiler then emits `value(...)`
+    /// instead of `thunk(...)` because no Update frame is needed (W9 §8
+    /// criterion 3 — at least one binding previously Thunk is now Value).
+    ///
+    /// We verify this with an expression where a binding holds another
+    /// binding reference — a `var(y)` — which is a bound-variable atom
+    /// (WHNF), but compile it indirectly by constructing a `CoreBinding`
+    /// with explicit demands so that the non-WHNF case can be demonstrated
+    /// without needing a prune-safe inner expression.
+    ///
+    /// Concretely: `let x = λf.f(f)` used once in the body.  Without demand,
+    /// the lambda binding is always `Value` (lambdas are WHNF).  Instead we
+    /// use the prune test helper to confirm that a binding with `Unknown`
+    /// demand (the default) compiles as `Thunk` for a nested let, and with
+    /// `AtMostOnce` it compiles as `Value`.  We build the demand explicitly
+    /// using `CoreBinding::with_demand` so that `ErrEliminated` is not
+    /// introduced.
+    #[test]
+    pub fn test_single_use_binding_compiles_as_value_after_prune() {
+        use crate::core::binding::{CoreBinding, Scope};
+        use crate::core::demand::Demand;
+        use crate::core::expr::{Expr, LetType, RcExpr};
+        use crate::common::sourcemap::Smid;
+
+        // Build `let y = 3 in y` as the binding expression for `x`:
+        //   x = let y = 3 in y      ← not WHNF, so Thunk by default
+        // Outer: let x = ... in var(x)
+        //
+        // We build this using close_let_scope so de Bruijn indices are correct,
+        // then override the demand on `x` to test both paths.
+
+        let y = free("y");
+        let x = free("x");
+
+        // inner: `let y = 3 in var(y)` — this is a nested let, not WHNF.
+        let inner = acore::let_(vec![(y.clone(), acore::num(3))], acore::var(y));
+
+        // outer body uses x once.
+        let outer_body = acore::var(x.clone());
+
+        // Build scope manually so we can set demand.
+        let names = [x.clone()];
+        let name_refs: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
+        let closed_inner = crate::core::expr::close_expr_vars(&name_refs, 0, &inner);
+        let closed_body = crate::core::expr::close_expr_vars(&name_refs, 0, &outer_body);
+
+        let make_let = |demand: Demand| -> RcExpr {
+            RcExpr::from(Expr::Let(
+                Smid::default(),
+                Scope {
+                    pattern: vec![CoreBinding::with_demand(x.clone(), closed_inner.clone(), demand)],
+                    body: closed_body.clone(),
+                },
+                LetType::OtherLet,
+            ))
+        };
+
+        // Without demand (Unknown): nested let is not WHNF → Thunk.
+        let unknown_demand = compile(make_let(Demand::default())).unwrap();
+        let x_is_thunk = match unknown_demand.as_ref() {
+            StgSyn::LetRec { bindings, .. } => {
+                matches!(bindings.first(), Some(LambdaForm::Thunk { .. }))
+            }
+            _ => false,
+        };
+        assert!(
+            x_is_thunk,
+            "with Unknown demand, nested-let binding should be Thunk; got:\n{unknown_demand:?}"
+        );
+
+        // With AtMostOnce demand: prune would set this for a single-use binding.
+        // Compiler should emit Value, not Thunk (W9 §8 criterion 3).
+        let at_most_once = compile(make_let(Demand::at_most_once())).unwrap();
+        let x_is_value = match at_most_once.as_ref() {
+            StgSyn::LetRec { bindings, .. } => {
+                matches!(bindings.first(), Some(LambdaForm::Value { .. }))
+            }
+            _ => false,
+        };
+        assert!(
+            x_is_value,
+            "with AtMostOnce demand (set by prune for single-use bindings), \
+             nested-let binding should be Value; got:\n{at_most_once:?}"
+        );
     }
 }

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -793,14 +793,10 @@ impl ProtoSyntax for ProtoLet {
     ) -> Result<Rc<StgSyn>, CompileError> {
         let scope = self.scope();
         let mut binder = LetBinder::for_scope(self.expr.clone(), context);
-        for (_, value) in scope.pattern.iter() {
-            let annotation = value.smid();
-            let index = compiler.compile_binding(
-                &mut binder,
-                value.clone(),
-                annotation,
-                Demand::default(),
-            )?;
+        for b in scope.pattern.iter() {
+            let annotation = b.expr.smid();
+            let index =
+                compiler.compile_binding(&mut binder, b.expr.clone(), annotation, b.demand)?;
             binder.add_var_index(index);
         }
 

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1572,7 +1572,6 @@ pub mod tests {
         eval::stg::tags::DataConstructor,
     };
 
-
     fn compile(expr: RcExpr) -> Result<Rc<StgSyn>, CompileError> {
         Compiler::new(
             true,
@@ -1754,7 +1753,9 @@ pub mod tests {
         fn has_thunk(syn: &Rc<StgSyn>) -> bool {
             match syn.as_ref() {
                 StgSyn::Let { bindings, body } | StgSyn::LetRec { bindings, body } => {
-                    bindings.iter().any(|b| matches!(b, LambdaForm::Thunk { .. }))
+                    bindings
+                        .iter()
+                        .any(|b| matches!(b, LambdaForm::Thunk { .. }))
                         || has_thunk(body)
                 }
                 _ => false,
@@ -1789,10 +1790,10 @@ pub mod tests {
     /// introduced.
     #[test]
     pub fn test_single_use_binding_compiles_as_value_after_prune() {
+        use crate::common::sourcemap::Smid;
         use crate::core::binding::{CoreBinding, Scope};
         use crate::core::demand::Demand;
         use crate::core::expr::{Expr, LetType, RcExpr};
-        use crate::common::sourcemap::Smid;
 
         // Build `let y = 3 in y` as the binding expression for `x`:
         //   x = let y = 3 in y      ← not WHNF, so Thunk by default
@@ -1820,7 +1821,11 @@ pub mod tests {
             RcExpr::from(Expr::Let(
                 Smid::default(),
                 Scope {
-                    pattern: vec![CoreBinding::with_demand(x.clone(), closed_inner.clone(), demand)],
+                    pattern: vec![CoreBinding::with_demand(
+                        x.clone(),
+                        closed_inner.clone(),
+                        demand,
+                    )],
                     body: closed_body.clone(),
                 },
                 LetType::OtherLet,

--- a/src/import/yaml.rs
+++ b/src/import/yaml.rs
@@ -203,7 +203,11 @@ impl<'smap> Receiver<'smap> {
     ) -> Result<Vec<(String, RcExpr)>, SourceError> {
         match &*expr.inner {
             Expr::Let(_, scope, LetType::DefaultBlockLet) => {
-                let entries: Vec<(String, RcExpr)> = scope.pattern.clone();
+                let entries: Vec<(String, RcExpr)> = scope
+                    .pattern
+                    .iter()
+                    .map(|b| (b.name.clone(), b.expr.clone()))
+                    .collect();
                 Ok(entries)
             }
             Expr::List(_, items) => {


### PR DESCRIPTION
## Summary

- **Phase 2**: Introduces `CoreBinding<T>` struct (fields: `name`, `expr`, `demand`) in `src/core/binding.rs`, replacing `(String, T)` tuples throughout `LetScope`. Updates 18 consumer modules to use named field access.
- **Phase 3**: Extends the prune (dead-code elimination) pass with per-binding usage counting (`use_count: Cell<u32>` on `Tracker`). After marking, `blank_unseen()` computes `Cardinality::AtMostOnce` for single-use bindings and stores it in `CoreBinding::demand`.
- **STG wiring**: `ProtoLet::take_syntax()` in the STG compiler reads `b.demand` directly from `CoreBinding`, so single-use bindings now propagate `skip_update = true` all the way to `take_lambda_form` without any heuristic duplication.
- **UnitInterface**: `collect_demands()` reads actual `b.demand` values instead of always defaulting to `Demand::default()`.

## Key files changed

- `src/core/binding.rs` — new `CoreBinding<T>` struct
- `src/core/expr.rs` — `LetScope<T>` re-typed; `fmap`/`walk`/`try_walk` traversals updated; `pub use CoreBinding`
- `src/core/simplify/prune.rs` — usage counting, `demand_from_use_count()`, demand annotation in `blank_unseen()`
- `src/eval/stg/compiler.rs` — `ProtoLet` reads `b.demand` from core binding

## Test plan

- [x] `cargo fmt --all` — no formatting changes
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --lib` — 1023 tests pass
- [x] `cargo test --test harness_test` — 436 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)