### PR TITLE
fix(test): use prelude blob in test harness, matching default eu path

### DIFF
--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -375,6 +375,10 @@ pub struct EucalyptOptions {
     pub version: bool,
     pub list_targets: bool,
     pub test: bool,
+    /// When true, `prepare()` returns after desugaring without running
+    /// cook/eliminate/inline.  Set during test *plan analysis* (discovering
+    /// targets) and cleared for test *execution* (running each target).
+    pub plan_only: bool,
     pub parse: bool,
     pub dump_desugared: bool,
     pub dump_cooked: bool,
@@ -693,6 +697,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             version,
             list_targets,
             test,
+            plan_only: test,
             parse,
             dump_desugared,
             dump_cooked,
@@ -869,6 +874,13 @@ impl EucalyptOptions {
         self.test
     }
 
+    /// True during test plan analysis (discovering targets); false during
+    /// test execution.  When true, `prepare()` returns after desugaring
+    /// without running cook/eliminate/inline.
+    pub fn plan_only(&self) -> bool {
+        self.plan_only
+    }
+
     pub fn lsp(&self) -> bool {
         self.lsp
     }
@@ -1036,11 +1048,9 @@ impl EucalyptOptions {
             Some(target)
         };
         self.export_type = Some(format);
-        // Clear the test flag so that prepare() runs the full pipeline
-        // (cook, eliminate, inline) rather than returning early after
-        // desugaring.  The early return is correct for the test *plan*
-        // analysis phase but not for test *execution*.
-        self.test = false;
+        // Clear plan_only so that prepare() runs the full pipeline
+        // (cook, eliminate, inline) for test execution.
+        self.plan_only = false;
         self
     }
 
@@ -1092,13 +1102,6 @@ impl EucalyptOptions {
     /// Enable IO monad operations (shell execution) for this run.
     pub fn with_allow_io(mut self) -> Self {
         self.allow_io = true;
-        self
-    }
-
-    /// The test flag indicates shallow desugaring only for test plan
-    /// analysis. Actual execution requires the flag is reset.
-    pub fn without_test_flag(mut self) -> Self {
-        self.test = false;
         self
     }
 

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -1036,6 +1036,11 @@ impl EucalyptOptions {
             Some(target)
         };
         self.export_type = Some(format);
+        // Clear the test flag so that prepare() runs the full pipeline
+        // (cook, eliminate, inline) rather than returning early after
+        // desugaring.  The early return is correct for the test *plan*
+        // analysis phase but not for test *execution*.
+        self.test = false;
         self
     }
 

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -219,8 +219,9 @@ pub fn prepare(
         return Ok(Command::Exit);
     }
 
-    // Test plan processing only needs desugaring
-    if opt.test() {
+    // Test plan analysis only needs desugaring (to discover targets).
+    // Test *execution* (plan_only = false) continues to cook and beyond.
+    if opt.plan_only() {
         return Ok(Command::Continue);
     }
 

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -626,6 +626,17 @@ impl Tester for InProcessTester {
                     .build();
 
                 let mut loader = SourceLoader::new(test_opts.lib_path().to_vec());
+
+                // Load the prelude blob so the test runner exercises the
+                // same code path as the default `eu` binary.  Without this,
+                // blob-specific bugs (e.g. missing monad specs) are invisible
+                // to the test suite.  EU_SOURCE_PRELUDE=1 still bypasses
+                // the blob (see maybe_load_prelude_blob).
+                #[cfg(not(target_arch = "wasm32"))]
+                if let Some(blob) = eval::maybe_load_prelude_blob(&test_opts) {
+                    loader.set_prelude_blob(blob);
+                }
+
                 let mut statistics = Statistics::default();
 
                 // For error tests, catch preparation failures gracefully
@@ -658,7 +669,11 @@ impl Tester for InProcessTester {
                 let exit_code = {
                     let out = Box::new(&mut outbuf);
                     let err = Box::new(&mut errbuf);
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let blob = loader.take_prelude_blob();
                     let mut executor = eval::Executor::from(loader);
+                    #[cfg(not(target_arch = "wasm32"))]
+                    executor.set_prelude_blob(blob);
                     executor.capture_output(out, err);
                     executor.execute(&test_opts, &mut statistics, f.clone())
                 };

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -179,7 +179,7 @@ pub fn run_plans(opt: &EucalyptOptions, tests: &[TestPlan]) -> Result<i32, Eucal
 
         print!("{}...", test.title());
 
-        let mut execution_opts = test_opts.clone().without_test_flag();
+        let mut execution_opts = test_opts.clone();
         if !test.is_error_test() {
             execution_opts = execution_opts.with_test_mode();
         }

--- a/src/eval/stg/blob.rs
+++ b/src/eval/stg/blob.rs
@@ -179,6 +179,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(prelude_blob_ok)]
+    fn embedded_blob_contains_expect_operators() {
+        let bytes = crate::driver::resources::PRELUDE_BLOB_BYTES;
+        let blob = PreludeBlob::from_bytes(bytes).expect("embedded blob should deserialise");
+        let expect_ops: Vec<&String> = blob.operators.keys().filter(|k| k.contains("//")).collect();
+        eprintln!("Expect operators: {:?}", expect_ops);
+        eprintln!("Total operators: {}", blob.operators.len());
+        assert!(
+            blob.operators.contains_key("//="),
+            "prelude blob must contain //= operator; found: {:?}",
+            expect_ops
+        );
+    }
+
+    #[test]
     fn monad_type_hints_round_trip() {
         let mut blob = minimal_blob();
         blob.monad_type_hints


### PR DESCRIPTION
## Summary

- Test harness ran all tests with source prelude, not the blob — blob-specific regressions were invisible
- The InProcessTester created a fresh SourceLoader without loading the blob
- Additionally, `for_test()` didn't clear the `test` flag, so `prepare()` returned early before cook — operators like `//=` were unresolved on the blob path

## Changes

- Load prelude blob in InProcessTester::run() (respects EU_SOURCE_PRELUDE=1)
- Pass blob through to Executor via take_prelude_blob/set_prelude_blob
- Clear `test` flag in `for_test()` so prepare() runs full pipeline
- Add `embedded_blob_contains_expect_operators` test

## Test plan

- [x] `cargo test --test harness_test` — 440 pass (with blob path)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] EU_SOURCE_PRELUDE=1 still works (source prelude path)

Fixes eu-45w9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)