### PR TITLE
fix(perf): stop prune pass emitting AtMostOnce for core bindings

### DIFF
--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -424,15 +424,18 @@ impl<'expr> ScopeTracker<'expr> {
 
     /// Compute the demand annotation for a binding after the mark phase.
     ///
-    /// - A binding used exactly once gets `Cardinality::AtMostOnce` (W9 Phase 3):
-    ///   no memoisation benefit, so the STG compiler can skip the Update frame.
-    /// - A binding used more than once gets `Cardinality::Multi`.
-    /// - A binding not reached (use_count == 0) keeps `Unknown` (it will be
-    ///   eliminated, so the annotation is moot).
+    /// All core bindings live in recursive scopes, so syntactic reference
+    /// counting cannot soundly determine cardinality: a binding referenced
+    /// once may be evaluated many times through recursion.  We therefore
+    /// only emit `Multi` (informational) or `Unknown` (default).
+    ///
+    /// `AtMostOnce` is NOT emitted here — it is only set by the STG
+    /// compiler for genuinely single-use synthetic bindings (IF branches,
+    /// intermediate results) where the compiler has semantic knowledge
+    /// that the binding is non-recursive.
     fn demand_from_use_count(use_count: u32) -> Demand {
         match use_count {
             0 => Demand::default(),
-            1 => Demand::at_most_once(),
             _ => Demand {
                 cardinality: Cardinality::Multi,
                 ..Default::default()
@@ -1014,12 +1017,13 @@ pub mod tests {
 
     /// A single-use binding receives `Cardinality::AtMostOnce` after pruning.
     ///
-    /// The prune pass counts references; a binding used exactly once gets
-    /// `Demand::at_most_once()`, which later causes the STG compiler to emit
-    /// a `Value` instead of a `Thunk` (W9 §3.4).
+    /// The prune pass counts references but does not emit `AtMostOnce`
+    /// because core scopes are recursive — syntactic single-use does not
+    /// guarantee runtime single-use.  Both used and unused bindings get
+    /// conservative cardinality (`Multi` or `Unknown`).
     #[test]
-    pub fn test_single_use_binding_gets_at_most_once_cardinality() {
-        use crate::core::demand::{Cardinality, Demand};
+    pub fn test_prune_does_not_emit_at_most_once() {
+        use crate::core::demand::Cardinality;
 
         let x = free("x");
         let y = free("y");
@@ -1033,9 +1037,9 @@ pub mod tests {
             Expr::Let(_, scope, _) => {
                 let x_binding = &scope.pattern[0];
                 assert_eq!(
-                    x_binding.demand,
-                    Demand::at_most_once(),
-                    "single-use binding should have AtMostOnce cardinality after pruning"
+                    x_binding.demand.cardinality,
+                    Cardinality::Multi,
+                    "used binding should have Multi cardinality (conservative)"
                 );
 
                 // The unused binding keeps the default demand.


### PR DESCRIPTION
## Summary

- Prune pass marked single-use bindings as `AtMostOnce`, causing STG compiler to skip thunk updates
- Eucalypt's core scopes are all recursive — syntactic single-use doesn't guarantee runtime single-use
- Result: naive_fib 6s → 60s+, thunk_updates 1s → 4s, several benchmarks 4-5x slower
- Fix: prune emits `Multi` (not `AtMostOnce`) for all used bindings
- STG compiler's own `AtMostOnce` for IF branches and synthetic lets is preserved

## Benchmarks (before/after this fix)

| Bench | 0.8.1 | Before | After |
|-------|-------|--------|-------|
| naive_fib | 6.2s | 61s+ | 10.5s |
| thunk_updates | 0.96s | 3.9s | 0.95s |
| drop_cons | 0.17s | 0.95s | 0.21s |
| short_lived | 0.22s | 1.0s | 0.29s |

Remaining naive_fib gap (6.2s → 10.5s) is from a separate earlier regression, not this commit.

## Test plan

- [x] `cargo test --lib` — 1045 pass
- [x] `cargo test --test harness_test` — 440 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)