### PR TITLE
fix: replace todo!() panic in compile_binding, clean up build.rs comment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,9 +65,7 @@ fn verify_prelude_blob() {
         }
         Ok(blob_bytes) => {
             // The first 32 bytes of the postcard blob are the `source_hash` field
-            // (a `[u8; 32]` is serialised by postcard as its raw bytes with a
-            // 1-byte length prefix for the fixed-size array variant — actually
-            // postcard serialises `[u8; N]` as N raw bytes with no length prefix).
+            // (postcard serialises `[u8; N]` as N raw bytes with no length prefix).
             // We use the `postcard` crate's own deserialiser to avoid parsing
             // the full blob just for the hash.
             match read_blob_source_hash(&blob_bytes) {

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1393,9 +1393,7 @@ impl<'rt> Compiler<'rt> {
                 let lookup = self.compile_lookup(binder, obj, k, d, *s)?;
                 binder.add_deferred(Box::new(lookup))
             }
-            Expr::Name(_, _) => {
-                todo!()
-            }
+            Expr::Name(s, _) => Err(CompileError::UnexpectedExpression(*s)),
             Expr::Meta(s, body, meta) => {
                 let m = self.compile_binding(binder, meta.clone(), *s, Demand::default())?;
                 let b = self.compile_binding(binder, body.clone(), *s, Demand::default())?;


### PR DESCRIPTION
## Summary
- Replace `todo!()` panic for `Expr::Name` in `compile_binding` with `CompileError::UnexpectedExpression` — Name nodes should never survive to the STG compiler, but panicking violates project policy (eu-ewfs)
- Clean up self-contradictory comment in `build.rs` about postcard serialisation of `[u8; N]` arrays (eu-5h47)

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (1056 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)