### PR TITLE
test: add demand annotation and prelude blob round-trip tests

### DIFF
--- a/src/core/demand.rs
+++ b/src/core/demand.rs
@@ -92,3 +92,65 @@ pub enum Strictness {
     /// Definitely strict — will be evaluated by context.
     Strict,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_demand_does_not_skip_update() {
+        let d = Demand::default();
+        assert!(!d.skip_update(), "Unknown demand should NOT skip update");
+    }
+
+    #[test]
+    fn at_most_once_skips_update() {
+        let d = Demand::at_most_once();
+        assert!(d.skip_update(), "AtMostOnce should skip update");
+    }
+
+    #[test]
+    fn multi_does_not_skip_update() {
+        let d = Demand {
+            cardinality: Cardinality::Multi,
+            ..Default::default()
+        };
+        assert!(!d.skip_update(), "Multi cardinality should NOT skip update");
+    }
+
+    #[test]
+    fn whnf_skips_update() {
+        let d = Demand::whnf();
+        assert!(d.skip_update(), "WHNF demand should skip update");
+    }
+
+    #[test]
+    fn strict_alone_does_not_skip_update() {
+        let d = Demand::strict();
+        assert!(
+            !d.skip_update(),
+            "Strict-only demand should NOT skip update (strictness is orthogonal)"
+        );
+    }
+
+    #[test]
+    fn whnf_overrides_multi_cardinality() {
+        let d = Demand {
+            cardinality: Cardinality::Multi,
+            whnf: true,
+            ..Default::default()
+        };
+        assert!(
+            d.skip_update(),
+            "WHNF should skip update even with Multi cardinality"
+        );
+    }
+
+    #[test]
+    fn default_demand_is_conservative() {
+        let d = Demand::default();
+        assert_eq!(d.cardinality, Cardinality::Unknown);
+        assert_eq!(d.strictness, Strictness::Unknown);
+        assert!(!d.whnf);
+    }
+}

--- a/src/core/simplify/prune.rs
+++ b/src/core/simplify/prune.rs
@@ -1081,4 +1081,69 @@ pub mod tests {
             other => panic!("expected outer Let, got: {other:?}"),
         }
     }
+
+    /// `demand_from_use_count` maps zero uses to Unknown (eliminated binding)
+    /// and any positive count to Multi (conservative).
+    #[test]
+    pub fn test_demand_from_use_count_zero() {
+        let d = ScopeTracker::demand_from_use_count(0);
+        assert_eq!(
+            d.cardinality,
+            Cardinality::Unknown,
+            "zero-use binding should have Unknown cardinality"
+        );
+    }
+
+    #[test]
+    pub fn test_demand_from_use_count_one() {
+        let d = ScopeTracker::demand_from_use_count(1);
+        assert_eq!(
+            d.cardinality,
+            Cardinality::Multi,
+            "single-use binding should get Multi (conservative from prune)"
+        );
+    }
+
+    #[test]
+    pub fn test_demand_from_use_count_many() {
+        let d = ScopeTracker::demand_from_use_count(5);
+        assert_eq!(
+            d.cardinality,
+            Cardinality::Multi,
+            "multi-use binding should get Multi"
+        );
+    }
+
+    /// Demand annotations survive through nested let scopes.
+    #[test]
+    pub fn test_demand_propagation_in_nested_lets() {
+        use crate::core::demand::Cardinality;
+
+        let x = free("x");
+        let y = free("y");
+
+        // Inner let: `y` used once in body.  Outer let: `x` used twice.
+        let inner = let_(vec![(y.clone(), num(7))], var(y));
+        let expr = let_(
+            vec![(x.clone(), num(1))],
+            app(
+                bif("ADD"),
+                vec![var(x.clone()), app(bif("ADD"), vec![var(x), inner])],
+            ),
+        );
+
+        let pruned = prune(&expr);
+
+        match &*pruned.inner {
+            Expr::Let(_, scope, _) => {
+                let x_binding = &scope.pattern[0];
+                assert_eq!(
+                    x_binding.demand.cardinality,
+                    Cardinality::Multi,
+                    "x (used twice across nested lets) should have Multi"
+                );
+            }
+            other => panic!("expected outer Let, got: {other:?}"),
+        }
+    }
 }

--- a/src/eval/stg/blob.rs
+++ b/src/eval/stg/blob.rs
@@ -222,4 +222,175 @@ mod tests {
             Some(&"IO(a)".to_string())
         );
     }
+
+    #[test]
+    fn empty_blob_round_trip() {
+        let blob = minimal_blob();
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.source_hash, [0u8; 32]);
+        assert!(restored.nodes.is_empty());
+        assert!(restored.forms_pool.is_empty());
+        assert!(restored.binding_entries.is_empty());
+        assert!(restored.name_to_slot.is_empty());
+        assert!(restored.operators.is_empty());
+        assert!(restored.monad_specs.is_empty());
+        assert!(restored.monad_type_hints.is_empty());
+        assert!(restored.inline_cores.is_empty());
+    }
+
+    #[test]
+    fn blob_with_nodes_and_bindings_round_trip() {
+        use crate::common::sourcemap::Smid;
+        use crate::eval::stg::arena::{ArenaLambdaForm, ArenaStgSyn};
+        use crate::eval::stg::syntax::Native;
+
+        let mut blob = minimal_blob();
+        blob.source_hash = [42u8; 32];
+
+        // Add some arena nodes: an Atom containing a symbol
+        blob.nodes.push(ArenaStgSyn::Atom {
+            evaluand: super::super::syntax::Ref::V(Native::Sym("hello".to_string())),
+        });
+
+        // Add a Value lambda form referencing node 0
+        blob.forms_pool.push(ArenaLambdaForm::Value { body: 0 });
+
+        // Add a Thunk lambda form referencing node 0
+        blob.forms_pool.push(ArenaLambdaForm::Thunk { body: 0 });
+
+        // Add a Lambda form
+        blob.forms_pool.push(ArenaLambdaForm::Lambda {
+            bound: 2,
+            body: 0,
+            annotation: Smid::default(),
+        });
+
+        // Binding entries point to forms_pool indices
+        blob.binding_entries.push(0);
+        blob.binding_entries.push(1);
+
+        // Name-to-slot mapping
+        blob.name_to_slot.insert("my-value".to_string(), 0);
+        blob.name_to_slot.insert("my-thunk".to_string(), 1);
+
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.source_hash, [42u8; 32]);
+        assert_eq!(restored.nodes.len(), 1);
+        assert_eq!(restored.forms_pool.len(), 3);
+        assert_eq!(restored.binding_entries.len(), 2);
+        assert_eq!(restored.name_to_slot.get("my-value"), Some(&0));
+        assert_eq!(restored.name_to_slot.get("my-thunk"), Some(&1));
+
+        // Verify the lambda form variants survived
+        assert!(matches!(
+            &restored.forms_pool[0],
+            ArenaLambdaForm::Value { body: 0 }
+        ));
+        assert!(matches!(
+            &restored.forms_pool[1],
+            ArenaLambdaForm::Thunk { body: 0 }
+        ));
+        assert!(matches!(
+            &restored.forms_pool[2],
+            ArenaLambdaForm::Lambda {
+                bound: 2,
+                body: 0,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn blob_with_operators_round_trip() {
+        use crate::common::sourcemap::Smid;
+        use crate::core::expr::Fixity;
+        use crate::driver::unit_interface::OperatorInfo;
+
+        let mut blob = minimal_blob();
+        blob.operators.insert(
+            "+".to_string(),
+            OperatorInfo {
+                smid: Smid::default(),
+                fixity: Fixity::InfixLeft,
+                precedence: 60,
+                type_annotation: None,
+            },
+        );
+        blob.operators.insert(
+            "*".to_string(),
+            OperatorInfo {
+                smid: Smid::default(),
+                fixity: Fixity::InfixLeft,
+                precedence: 70,
+                type_annotation: None,
+            },
+        );
+
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.operators.len(), 2);
+        let plus = restored.operators.get("+").unwrap();
+        assert_eq!(plus.fixity, Fixity::InfixLeft);
+        assert_eq!(plus.precedence, 60);
+        let times = restored.operators.get("*").unwrap();
+        assert_eq!(times.precedence, 70);
+    }
+
+    #[test]
+    fn blob_corrupted_bytes_fail_gracefully() {
+        let result = PreludeBlob::from_bytes(&[0xFF, 0xFE, 0xFD, 0x00]);
+        assert!(
+            result.is_err(),
+            "corrupted bytes should produce a deserialisation error"
+        );
+    }
+
+    #[test]
+    #[cfg(prelude_blob_ok)]
+    fn embedded_blob_has_bindings_and_slots() {
+        let bytes = crate::driver::resources::PRELUDE_BLOB_BYTES;
+        let blob = PreludeBlob::from_bytes(bytes).expect("embedded blob should deserialise");
+
+        assert!(!blob.nodes.is_empty(), "prelude blob must have arena nodes");
+        assert!(
+            !blob.forms_pool.is_empty(),
+            "prelude blob must have lambda forms"
+        );
+        assert!(
+            !blob.binding_entries.is_empty(),
+            "prelude blob must have binding entries"
+        );
+        assert!(
+            !blob.name_to_slot.is_empty(),
+            "prelude blob must have name-to-slot mappings"
+        );
+
+        // Spot-check a few well-known prelude names
+        assert!(
+            blob.name_to_slot.contains_key("map"),
+            "prelude blob must contain 'map'"
+        );
+        assert!(
+            blob.name_to_slot.contains_key("filter"),
+            "prelude blob must contain 'filter'"
+        );
+        assert!(
+            blob.name_to_slot.contains_key("head"),
+            "prelude blob must contain 'head'"
+        );
+
+        // Every binding entry must be a valid index into forms_pool
+        for (i, &entry) in blob.binding_entries.iter().enumerate() {
+            assert!(
+                (entry as usize) < blob.forms_pool.len(),
+                "binding_entries[{i}] = {entry} is out of bounds (forms_pool len = {})",
+                blob.forms_pool.len()
+            );
+        }
+    }
 }

--- a/tests/harness/165_demand_annotation.eu
+++ b/tests/harness/165_demand_annotation.eu
@@ -1,0 +1,37 @@
+#!/usr/bin/env eu
+# Demand annotation smoke test (W9)
+#
+# Tests that bindings with different usage cardinalities produce correct
+# results.  Single-use bindings may compile to Values (skip update frame)
+# while multi-use bindings compile to Thunks (memoised).  Both must give
+# the same answer as if all were Thunks.
+
+# Single-use binding: used exactly once — may become Value
+single-use-ok: { x: 42  result: x }.result = 42
+
+# Multi-use binding: used more than once — should remain Thunk (memoised)
+multi-use-ok: { x: 7 + 3  result: x + x }.result = 20
+
+# Unused binding: should be eliminated but not cause errors
+unused-ok: { x: 99  y: 100  result: x }.result = 99
+
+# Nested single-use: inner binding used once
+nested-ok: { x: 1  y: x + 2  result: y }.result = 3
+
+# Chain of single-use bindings
+chain-ok: { a: 10  b: a + 1  c: b + 1  d: c + 1  result: d }.result = 13
+
+# Multi-use with computation (memoisation is optimisation, not semantic)
+multi-chain-ok: { x: 5 * 3  result: [x, x, x] }.result = [15, 15, 15]
+
+# Mixed: some bindings single-use, some multi-use
+mixed-ok: { a: 1  b: 2  c: a + b  d: c + c  result: d }.result = 6
+
+RESULT: if(
+  and(single-use-ok,
+  and(multi-use-ok,
+  and(unused-ok,
+  and(nested-ok,
+  and(chain-ok,
+  and(multi-chain-ok, mixed-ok)))))),
+  :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -1798,6 +1798,11 @@ pub fn test_harness_164() {
 }
 
 #[test]
+pub fn test_harness_165() {
+    run_test(&opts("165_demand_annotation.eu"));
+}
+
+#[test]
 pub fn test_error_154() {
     run_error_test(&error_opts("154_internal_import_error.eu"));
 }


### PR DESCRIPTION
## Summary

- **Demand annotation (W9)**: 7 unit tests in `demand.rs` for `skip_update` logic, 4 unit tests in `prune.rs` for `demand_from_use_count` and demand propagation, plus harness test 165 verifying end-to-end correctness of single-use/multi-use/unused bindings
- **Prelude blob (W6)**: 5 new round-trip tests in `blob.rs` covering empty blobs, blobs with arena nodes and lambda forms, operator metadata serialisation, corrupted-bytes error handling, and embedded blob structural validation

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib -- demand` — 11 tests pass
- [x] `cargo test --lib -- blob` — 10 tests pass  
- [x] `cargo test --test harness_test test_harness_165` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)