### PR TITLE
perf(gc): skip unnecessary collections + refactor CLI options

### DIFF
--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -90,6 +90,10 @@ pub struct EucalyptCli {
     #[arg(long = "type-check")]
     pub type_check: bool,
 
+    /// Limit managed heap to SIZE MiB (default: 32768, i.e. 32 GiB; use 0 for unbounded)
+    #[arg(long = "heap-limit-mib", default_value = "32768")]
+    pub heap_limit_mib: usize,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 
@@ -637,14 +641,15 @@ impl From<EucalyptCli> for EucalyptOptions {
                 _ => (false, false, DocFormat::default(), false, None),
             };
 
-        // Extract heap limit and no-dce from Run command
-        // 0 means unbounded; any other value is the limit in MiB
-        let heap_limit_mib = match &cli.command {
-            Some(Commands::Run(run_args)) => match run_args.heap_limit_mib {
-                0 => None,
-                n => Some(n),
-            },
-            _ => None,
+        // Extract heap limit: prefer the Run subcommand value when present,
+        // otherwise use the top-level CLI flag.  0 means unbounded.
+        let heap_limit_raw = match &cli.command {
+            Some(Commands::Run(run_args)) => run_args.heap_limit_mib,
+            _ => cli.heap_limit_mib,
+        };
+        let heap_limit_mib = match heap_limit_raw {
+            0 => None,
+            n => Some(n),
         };
 
         let no_dce = match &cli.command {

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -1472,4 +1472,40 @@ mod tests {
         let opts = parse_opts(&["run", "file.eu"]);
         assert_eq!(opts.explicit_inputs.len(), 1);
     }
+
+    #[test]
+    fn test_heap_limit_default() {
+        let opts = parse_opts(&["test", "file.eu"]);
+        assert_eq!(opts.stg_settings.heap_limit_mib, Some(32768));
+    }
+
+    #[test]
+    fn test_heap_limit_zero_is_unbounded() {
+        let opts = parse_opts(&["test", "--heap-limit-mib=0", "file.eu"]);
+        assert_eq!(opts.stg_settings.heap_limit_mib, None);
+    }
+
+    #[test]
+    fn test_debug_flag() {
+        let opts = parse_opts(&["test", "-d", "file.eu"]);
+        assert!(opts.debug);
+    }
+
+    #[test]
+    fn test_statistics_flag() {
+        let opts = parse_opts(&["test", "-S", "file.eu"]);
+        assert!(opts.statistics);
+    }
+
+    #[test]
+    fn test_no_prelude_flag() {
+        let opts = parse_opts(&["test", "-Q", "file.eu"]);
+        assert!(opts.no_prelude);
+    }
+
+    #[test]
+    fn test_lib_path_flag() {
+        let opts = parse_opts(&["test", "-L", "/some/path", "file.eu"]);
+        assert_eq!(opts.lib_path, vec![std::path::PathBuf::from("/some/path")]);
+    }
 }

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -56,12 +56,9 @@ pub enum DocFormat {
     Json,
 }
 
-/// Eucalypt - A functional language for structured data
-#[derive(Parser, Debug, Clone)]
-#[command(name = "eu")]
-#[command(about = "A functional language for structured data")]
-#[command(version)]
-pub struct EucalyptCli {
+/// Flags shared between `run` and `test` subcommands.
+#[derive(Args, Debug, Clone)]
+pub struct CommonArgs {
     /// Add directory to lib path
     #[arg(short = 'L', long = "lib-path", action = clap::ArgAction::Append)]
     pub lib_path: Vec<PathBuf>,
@@ -69,10 +66,6 @@ pub struct EucalyptCli {
     /// Don't load the standard prelude
     #[arg(short = 'Q', long = "no-prelude")]
     pub no_prelude: bool,
-
-    /// Force source-prelude pipeline even when pre-compiled blob is available
-    #[arg(long = "source-prelude")]
-    pub source_prelude: bool,
 
     /// Turn on debug features
     #[arg(short = 'd', long = "debug")]
@@ -93,6 +86,27 @@ pub struct EucalyptCli {
     /// Limit managed heap to SIZE MiB (default: 32768, i.e. 32 GiB; use 0 for unbounded)
     #[arg(long = "heap-limit-mib", default_value = "32768")]
     pub heap_limit_mib: usize,
+}
+
+impl CommonArgs {
+    /// Convert `heap_limit_mib` (0 = unbounded) to `Option<usize>`.
+    fn heap_limit(&self) -> Option<usize> {
+        match self.heap_limit_mib {
+            0 => None,
+            n => Some(n),
+        }
+    }
+}
+
+/// Eucalypt - A functional language for structured data
+#[derive(Parser, Debug, Clone)]
+#[command(name = "eu")]
+#[command(about = "A functional language for structured data")]
+#[command(version)]
+pub struct EucalyptCli {
+    /// Force source-prelude pipeline even when pre-compiled blob is available
+    #[arg(long = "source-prelude")]
+    pub source_prelude: bool,
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -162,6 +176,9 @@ pub struct DocCliArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct RunArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
     /// Target to run (identified by target metadata in eucalypt source)
     #[arg(short = 't', long = "target")]
     pub target: Option<String>,
@@ -190,30 +207,6 @@ pub struct RunArgs {
     #[arg(short = 'N', long = "name-inputs")]
     pub name_inputs: bool,
 
-    /// Add directory to lib path
-    #[arg(short = 'L', long = "lib-path", action = clap::ArgAction::Append)]
-    pub lib_path: Vec<PathBuf>,
-
-    /// Don't load the standard prelude
-    #[arg(short = 'Q', long = "no-prelude")]
-    pub no_prelude: bool,
-
-    /// Turn on debug features
-    #[arg(short = 'd', long = "debug")]
-    pub debug: bool,
-
-    /// Print metrics to stderr before exiting
-    #[arg(short = 'S', long = "statistics")]
-    pub statistics: bool,
-
-    /// Write statistics as JSON to a file
-    #[arg(long = "statistics-file")]
-    pub statistics_file: Option<PathBuf>,
-
-    /// Run the type checker before evaluation, reporting warnings to stderr
-    #[arg(long = "type-check")]
-    pub type_check: bool,
-
     /// With --type-check: treat type warnings as errors and abort before evaluation
     #[arg(long = "strict")]
     pub strict: bool,
@@ -230,10 +223,6 @@ pub struct RunArgs {
     #[arg(long = "error-format", default_value = "human")]
     pub error_format: ErrorFormat,
 
-    /// Limit managed heap to SIZE MiB (default: 32768, i.e. 32 GiB; use 0 for unbounded)
-    #[arg(long = "heap-limit-mib", default_value = "32768")]
-    pub heap_limit_mib: usize,
-
     /// Allow IO monad operations (shell execution)
     #[arg(short = 'I', long = "allow-io")]
     pub allow_io: bool,
@@ -249,6 +238,9 @@ pub struct RunArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct TestArgs {
+    #[command(flatten)]
+    pub common: CommonArgs,
+
     /// Target to test (identified by target metadata in eucalypt source)
     #[arg(short = 't', long = "target")]
     pub target: Option<String>,
@@ -448,8 +440,29 @@ pub struct EucalyptOptions {
     pub strict: bool,
 }
 
+/// Extract `CommonArgs` from whatever subcommand is active, falling
+/// back to defaults for subcommands that don't carry them.
+fn common_args(command: &Option<Commands>) -> CommonArgs {
+    match command {
+        Some(Commands::Run(args)) => args.common.clone(),
+        Some(Commands::Test(args)) => args.common.clone(),
+        _ => CommonArgs {
+            lib_path: vec![],
+            no_prelude: false,
+            debug: false,
+            statistics: false,
+            statistics_file: None,
+            type_check: false,
+            heap_limit_mib: 32768,
+        },
+    }
+}
+
 impl From<EucalyptCli> for EucalyptOptions {
     fn from(cli: EucalyptCli) -> Self {
+        // Extract common args once
+        let common = common_args(&cli.command);
+
         // Convert files to inputs
         let mut explicit_inputs = Vec::new();
         let files = match &cli.command {
@@ -471,7 +484,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             }
         }
 
-        // Extract command-specific options and override global settings
+        // Extract command-specific options
         let (
             target,
             output,
@@ -483,11 +496,6 @@ impl From<EucalyptCli> for EucalyptOptions {
             quote_embed,
             quote_debug,
             open_browser,
-            cmd_lib_path,
-            cmd_no_prelude,
-            cmd_debug,
-            cmd_statistics,
-            cmd_statistics_file,
         ) = match &cli.command {
             Some(Commands::Run(args)) => (
                 args.target.clone(),
@@ -500,11 +508,6 @@ impl From<EucalyptCli> for EucalyptOptions {
                 false,
                 false,
                 false,
-                Some(args.lib_path.clone()),
-                Some(args.no_prelude),
-                Some(args.debug),
-                Some(args.statistics),
-                args.statistics_file.clone(),
             ),
             Some(Commands::Test(args)) => (
                 args.target.clone(),
@@ -517,11 +520,6 @@ impl From<EucalyptCli> for EucalyptOptions {
                 false,
                 false,
                 args.open_browser,
-                None,
-                None,
-                None,
-                None,
-                None,
             ),
             Some(Commands::Dump(args)) => (
                 args.target.clone(),
@@ -534,20 +532,8 @@ impl From<EucalyptCli> for EucalyptOptions {
                 args.quote_embed,
                 args.quote_debug,
                 false,
-                None,
-                None,
-                None,
-                None,
-                None,
             ),
-            Some(Commands::ListTargets(_)) => (
-                None, None, None, None, false, None, false, false, false, false, None, None, None,
-                None, None,
-            ),
-            _ => (
-                None, None, None, None, false, None, false, false, false, false, None, None, None,
-                None, None,
-            ),
+            _ => (None, None, None, None, false, None, false, false, false, false),
         };
 
         // Set command type flags for backward compatibility
@@ -624,7 +610,7 @@ impl From<EucalyptCli> for EucalyptOptions {
         // Extract check mode
         let (check, check_strict) = match &cli.command {
             Some(Commands::Check(args)) => (true, args.strict),
-            Some(Commands::Run(run_args)) => (false, run_args.strict),
+            Some(Commands::Run(args)) => (false, args.strict),
             _ => (false, false),
         };
 
@@ -641,31 +627,23 @@ impl From<EucalyptCli> for EucalyptOptions {
                 _ => (false, false, DocFormat::default(), false, None),
             };
 
-        // Extract heap limit: prefer the Run subcommand value when present,
-        // otherwise use the top-level CLI flag.  0 means unbounded.
-        let heap_limit_raw = match &cli.command {
-            Some(Commands::Run(run_args)) => run_args.heap_limit_mib,
-            _ => cli.heap_limit_mib,
-        };
-        let heap_limit_mib = match heap_limit_raw {
-            0 => None,
-            n => Some(n),
-        };
+        // Heap limit from common args (0 = unbounded)
+        let heap_limit_mib = common.heap_limit();
 
         let no_dce = match &cli.command {
-            Some(Commands::Run(run_args)) => run_args.no_dce,
+            Some(Commands::Run(args)) => args.no_dce,
             _ => false,
         };
 
         // Extract seed from Run command
         let seed = match &cli.command {
-            Some(Commands::Run(run_args)) => run_args.seed,
+            Some(Commands::Run(args)) => args.seed,
             _ => None,
         };
 
         // Extract error format from Run command
         let error_format = match &cli.command {
-            Some(Commands::Run(run_args)) => run_args.error_format.clone(),
+            Some(Commands::Run(args)) => args.error_format.clone(),
             _ => ErrorFormat::default(),
         };
 
@@ -683,11 +661,11 @@ impl From<EucalyptCli> for EucalyptOptions {
         };
 
         EucalyptOptions {
-            lib_path: cmd_lib_path.unwrap_or(cli.lib_path),
-            no_prelude: cmd_no_prelude.unwrap_or(cli.no_prelude),
-            debug: cmd_debug.unwrap_or(cli.debug),
-            statistics: cmd_statistics.unwrap_or(cli.statistics),
-            statistics_file: cmd_statistics_file.or(cli.statistics_file),
+            lib_path: common.lib_path,
+            no_prelude: common.no_prelude,
+            debug: common.debug,
+            statistics: common.statistics,
+            statistics_file: common.statistics_file,
             target,
             output,
             evaluate,
@@ -718,10 +696,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             doc_format,
             doc_coverage_check,
             doc_output_dir,
-            type_check: match &cli.command {
-                Some(Commands::Run(run_args)) => run_args.type_check || cli.type_check,
-                _ => cli.type_check,
-            },
+            type_check: common.type_check,
             format,
             format_width,
             format_write,

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -1354,3 +1354,147 @@ impl EucalyptOptions {
         explanation
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_cli(args: &[&str]) -> EucalyptCli {
+        let mut full = vec!["eu"];
+        full.extend_from_slice(args);
+        EucalyptCli::try_parse_from(full).expect("should parse")
+    }
+
+    fn parse_opts(args: &[&str]) -> EucalyptOptions {
+        let cli = parse_cli(args);
+        EucalyptOptions::from(cli)
+    }
+
+    #[test]
+    fn run_with_file() {
+        let cli = parse_cli(&["run", "file.eu"]);
+        assert!(matches!(cli.command, Some(Commands::Run(_))));
+        if let Some(Commands::Run(args)) = cli.command {
+            assert_eq!(args.files, vec!["file.eu"]);
+        }
+    }
+
+    #[test]
+    fn run_with_eval() {
+        let cli = parse_cli(&["run", "-e", "1+1"]);
+        if let Some(Commands::Run(args)) = cli.command {
+            assert_eq!(args.evaluate.as_deref(), Some("1+1"));
+        }
+    }
+
+    #[test]
+    fn run_heap_limit_default() {
+        let opts = parse_opts(&["run", "file.eu"]);
+        assert_eq!(opts.stg_settings.heap_limit_mib, Some(32768));
+    }
+
+    #[test]
+    fn run_heap_limit_zero_is_unbounded() {
+        let opts = parse_opts(&["run", "--heap-limit-mib=0", "file.eu"]);
+        assert_eq!(opts.stg_settings.heap_limit_mib, None);
+    }
+
+    #[test]
+    fn run_heap_limit_custom() {
+        let opts = parse_opts(&["run", "--heap-limit-mib=100", "file.eu"]);
+        assert_eq!(opts.stg_settings.heap_limit_mib, Some(100));
+    }
+
+    #[test]
+    fn run_statistics_flag() {
+        let opts = parse_opts(&["run", "-S", "file.eu"]);
+        assert!(opts.statistics);
+    }
+
+    #[test]
+    fn run_debug_flag() {
+        let opts = parse_opts(&["run", "-d", "file.eu"]);
+        assert!(opts.debug);
+    }
+
+    #[test]
+    fn run_no_prelude_flag() {
+        let opts = parse_opts(&["run", "-Q", "file.eu"]);
+        assert!(opts.no_prelude);
+    }
+
+    #[test]
+    fn run_allow_io_flag() {
+        let opts = parse_opts(&["run", "-I", "file.eu"]);
+        assert!(opts.allow_io);
+    }
+
+    #[test]
+    fn run_multiple_flags() {
+        let opts = parse_opts(&["run", "-d", "-S", "--heap-limit-mib=100", "file.eu"]);
+        assert!(opts.debug);
+        assert!(opts.statistics);
+        assert_eq!(opts.stg_settings.heap_limit_mib, Some(100));
+    }
+
+    #[test]
+    fn run_export_json_shortcut() {
+        let opts = parse_opts(&["run", "-j", "file.eu"]);
+        assert!(opts.json);
+    }
+
+    #[test]
+    fn run_seed() {
+        let opts = parse_opts(&["run", "--seed=42", "file.eu"]);
+        assert_eq!(opts.seed, Some(42));
+    }
+
+    #[test]
+    fn run_no_dce() {
+        let opts = parse_opts(&["run", "--no-dce", "file.eu"]);
+        assert!(opts.no_dce);
+    }
+
+    #[test]
+    fn test_subcommand() {
+        let cli = parse_cli(&["test", "file.eu"]);
+        assert!(matches!(cli.command, Some(Commands::Test(_))));
+    }
+
+    #[test]
+    fn test_allow_io() {
+        let opts = parse_opts(&["test", "-I", "file.eu"]);
+        assert!(opts.allow_io);
+    }
+
+    #[test]
+    fn test_mode_flags() {
+        let opts = parse_opts(&["test", "file.eu"]);
+        assert!(opts.test);
+    }
+
+    #[test]
+    fn dump_stg() {
+        let opts = parse_opts(&["dump", "stg", "file.eu"]);
+        assert!(opts.dump_stg);
+    }
+
+    #[test]
+    fn check_strict() {
+        let opts = parse_opts(&["check", "--strict", "file.eu"]);
+        assert!(opts.check);
+        assert!(opts.check_strict);
+    }
+
+    #[test]
+    fn lsp_mode() {
+        let opts = parse_opts(&["lsp"]);
+        assert!(opts.lsp);
+    }
+
+    #[test]
+    fn options_from_run_has_correct_inputs() {
+        let opts = parse_opts(&["run", "file.eu"]);
+        assert_eq!(opts.explicit_inputs.len(), 1);
+    }
+}

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -533,7 +533,9 @@ impl From<EucalyptCli> for EucalyptOptions {
                 args.quote_debug,
                 false,
             ),
-            _ => (None, None, None, None, false, None, false, false, false, false),
+            _ => (
+                None, None, None, None, false, None, false, false, false, false,
+            ),
         };
 
         // Set command type flags for backward compatibility

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1827,10 +1827,14 @@ impl<'a> Machine<'a> {
             self.step()?;
         }
 
-        // Skip the final collection when the heap is unbounded — there is
-        // no memory pressure and the process is about to exit, so the
-        // mark/sweep work is pure overhead.
-        if self.heap().is_bounded() {
+        // Only collect at the end of a run() call if the heap is under
+        // memory pressure.  run() is called multiple times for IO programs
+        // (once per IO step) and also once for rendering; an unconditional
+        // collection here was the dominant source of GC overhead since it
+        // ran a full mark/sweep on every call even when no reclamation was
+        // needed.  The periodic in-loop check (every 500 steps) still
+        // triggers collection when the policy demands it.
+        if self.heap().policy_requires_collection() {
             self.collect_with_diagnostics();
         }
 

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1827,7 +1827,12 @@ impl<'a> Machine<'a> {
             self.step()?;
         }
 
-        self.collect_with_diagnostics();
+        // Skip the final collection when the heap is unbounded — there is
+        // no memory pressure and the process is about to exit, so the
+        // mark/sweep work is pure overhead.
+        if self.heap().is_bounded() {
+            self.collect_with_diagnostics();
+        }
 
         self.core.clock.stop();
 

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1768,6 +1768,13 @@ impl Heap {
         heap_state.finalise_evacuation();
     }
 
+    /// Whether this heap has a finite block limit (i.e. was created with
+    /// `with_limit`).  An unbounded heap never requires policy-driven
+    /// collection.
+    pub fn is_bounded(&self) -> bool {
+        self.limit.is_some()
+    }
+
     pub fn policy_requires_collection(&self) -> bool {
         if let Some(limit) = self.limit {
             let stats = self.stats();


### PR DESCRIPTION
## Summary

### GC performance fix
- `machine.run()` ended with an **unconditional** `collect_with_diagnostics()` — a full mark/sweep after every `run()` call. Since `run()` is called multiple times (once for evaluation, once for rendering, once per IO step), this was the dominant source of GC overhead.
- Guard the end-of-run collection with `policy_requires_collection()` so it only runs when the heap is actually under memory pressure.
- Add `Heap::is_bounded()` predicate.
- Before: `eu -S -e '1+1'` → GC Collections: 2, Mark Time: ~1.7ms
- After: `eu -S -e '1+1'` → GC Collections: 0, Mark Time: 0

### CLI options refactor
- `--heap-limit-mib` was only available on the `run` subcommand; `eu file.eu` (no subcommand) silently used a different default. Investigation revealed `parse_with_fallback()` already normalises absent subcommands to `run`, making duplicated fields on `EucalyptCli` dead code.
- Extract 7 shared flags (`-L`, `-Q`, `-d`, `-S`, `--statistics-file`, `--type-check`, `--heap-limit-mib`) into `CommonArgs` struct, flattened into both `RunArgs` and `TestArgs`.
- Remove duplicated fields from `EucalyptCli` (net -25 lines).
- Simplify `From<EucalyptCli>` — eliminate the `cmd_foo.unwrap_or(cli.foo)` reconciliation pattern.
- `--heap-limit-mib`, `-d`, `-S`, `-Q`, `-L`, `--type-check` now all work in `eu test` mode.
- 26 new unit tests for CLI argument parsing.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 1098 passed (including 26 new CLI tests)
- [x] `cargo test --test harness_test` — 441 passed
- [ ] CI green on all platforms

Closes eu-ez9d

🤖 Generated with [Claude Code](https://claude.com/claude-code)