### PR TITLE
feat(stats): enhance readability of statistics output

### DIFF
--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -180,9 +180,9 @@ fn run() -> i32 {
 pub fn exit_code(opts: &EucalyptOptions, code: i32, stats: &Statistics) -> i32 {
     if opts.statistics() {
         eprintln!();
-        eprintln!("~~~~~~~~~~");
+        eprintln!("══════════════════════════════════════════════════════");
         eprintln!("STATISTICS");
-        eprintln!("~~~~~~~~~~");
+        eprintln!("══════════════════════════════════════════════════════");
         eprintln!();
         eprintln!("{stats}");
     }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -9,7 +9,12 @@ pub struct Timings {
     timings: IndexMap<String, Duration>,
 }
 
-pub(crate) type TimingPartition = (Vec<(String, Duration)>, Vec<(String, Duration)>);
+/// Pipeline, IO, and VM timing groups.
+pub(crate) struct TimingPartition {
+    pub pipeline: Vec<(String, Duration)>,
+    pub io: Vec<(String, Duration)>,
+    pub vm: Vec<(String, Duration)>,
+}
 
 impl Timings {
     pub fn record<T: AsRef<str>>(&mut self, name: T, elapsed: Duration) {
@@ -20,20 +25,25 @@ impl Timings {
         self.timings.extend(other.timings);
     }
 
-    /// Partition timings into pipeline entries and VM entries.
+    /// Partition timings into pipeline, IO, and VM entries.
     ///
     /// VM entries have keys starting with `"VM-"`.
+    /// IO entries have the key `"io-run"`.
+    /// Everything else is a pipeline phase.
     pub(crate) fn partition(&self) -> TimingPartition {
         let mut pipeline = Vec::new();
+        let mut io = Vec::new();
         let mut vm = Vec::new();
         for (k, v) in &self.timings {
             if k.starts_with("VM-") {
                 vm.push((k.clone(), *v));
+            } else if k == "io-run" {
+                io.push((k.clone(), *v));
             } else {
                 pipeline.push((k.clone(), *v));
             }
         }
-        (pipeline, vm)
+        TimingPartition { pipeline, io, vm }
     }
 }
 
@@ -211,10 +221,10 @@ impl Statistics {
 
 impl Display for Statistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (pipeline, vm) = self.timings.partition();
+        let parts = self.timings.partition();
 
         // Summary bar
-        let summary = render_summary_bar(&pipeline, &vm);
+        let summary = render_summary_bar(&parts.pipeline, &parts.io, &parts.vm);
         if !summary.is_empty() {
             writeln!(f, "{summary}")?;
             writeln!(f)?;
@@ -288,16 +298,23 @@ impl Display for Statistics {
         writeln!(f)?;
 
         // Pipeline timings
-        if !pipeline.is_empty() {
+        if !parts.pipeline.is_empty() {
             writeln!(f, "{}", section_header("Pipeline"))?;
-            write!(f, "{}", render_timing_section(&pipeline))?;
+            write!(f, "{}", render_timing_section(&parts.pipeline))?;
+            writeln!(f)?;
+        }
+
+        // IO timings
+        if !parts.io.is_empty() {
+            writeln!(f, "{}", section_header("IO"))?;
+            write!(f, "{}", render_timing_section(&parts.io))?;
             writeln!(f)?;
         }
 
         // VM timings
-        if !vm.is_empty() {
+        if !parts.vm.is_empty() {
             writeln!(f, "{}", section_header("VM"))?;
-            write!(f, "{}", render_timing_section(&vm))?;
+            write!(f, "{}", render_timing_section(&parts.vm))?;
         }
 
         Ok(())
@@ -344,12 +361,19 @@ pub(crate) fn render_bar(value: f64, max_value: f64) -> String {
 /// Render a top-level summary bar showing where total time was spent.
 pub(crate) fn render_summary_bar(
     pipeline: &[(String, Duration)],
+    io: &[(String, Duration)],
     vm: &[(String, Duration)],
 ) -> String {
     let mut fractions: Vec<(String, f64)> = Vec::new();
 
     for (name, dur) in pipeline {
         fractions.push((name.clone(), dur.as_secs_f64()));
+    }
+
+    // Add IO as a single "IO" entry
+    let io_total: f64 = io.iter().map(|(_, v)| v.as_secs_f64()).sum();
+    if io_total > 0.0 {
+        fractions.push(("IO".to_string(), io_total));
     }
 
     // Add VM as a single entry (exclude the VM-Total synthetic key)
@@ -435,6 +459,13 @@ pub(crate) fn render_timing_section(entries: &[(String, Duration)]) -> String {
         .map(|(_, v)| v.as_secs_f64())
         .fold(0.0_f64, f64::max);
 
+    // Pre-compute the width of the widest formatted time so bars align.
+    let time_width = entries
+        .iter()
+        .map(|(_, v)| format!("{:.6}", v.as_secs_f64()).len())
+        .max()
+        .unwrap_or(8);
+
     let mut total = Duration::ZERO;
     let mut out = String::new();
 
@@ -447,20 +478,23 @@ pub(crate) fn render_timing_section(entries: &[(String, Duration)]) -> String {
             format!("  {bar}")
         };
         out.push_str(&format!(
-            "{:width$}  :    {:.6}s{}\n",
+            "{:name_w$}  :  {:>time_w$.6}s{}\n",
             display_names[i],
             dur.as_secs_f64(),
             bar_suffix,
-            width = display_width,
+            name_w = display_width,
+            time_w = time_width,
         ));
     }
 
-    // Subtotal right-aligned
+    // Subtotal right-aligned to match the timing column
+    let total_str = format!("{:.6}", total.as_secs_f64());
     out.push_str(&format!(
-        "{:>width$} {:.6}s\n",
+        "{:>name_w$}  {:>time_w$}s\n",
         "Total:",
-        total.as_secs_f64(),
-        width = display_width + 8,
+        total_str,
+        name_w = display_width + 2,
+        time_w = time_width,
     ));
 
     out
@@ -519,21 +553,21 @@ mod tests {
     #[test]
     fn summary_bar_single_entry() {
         let pipeline = vec![("parse".to_string(), Duration::from_millis(100))];
-        let bar = render_summary_bar(&pipeline, &[]);
+        let bar = render_summary_bar(&pipeline, &[], &[]);
         assert!(bar.contains("Total: 0.100s"));
         assert!(bar.contains("parse 100%"));
     }
 
     #[test]
     fn summary_bar_empty() {
-        assert_eq!(render_summary_bar(&[], &[]), "");
+        assert_eq!(render_summary_bar(&[], &[], &[]), "");
     }
 
     #[test]
     fn summary_bar_with_vm() {
         let pipeline = vec![("parse".to_string(), Duration::from_millis(80))];
         let vm = vec![("VM-Mutator".to_string(), Duration::from_millis(20))];
-        let bar = render_summary_bar(&pipeline, &vm);
+        let bar = render_summary_bar(&pipeline, &[], &vm);
         assert!(bar.contains("parse 80%"));
         assert!(bar.contains("VM 20%"));
     }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -297,27 +297,27 @@ impl Display for Statistics {
         )?;
         writeln!(f)?;
 
-        // Compute global time column width so bars align across all sections
-        let tw = max_time_width(&[&parts.pipeline, &parts.io, &parts.vm]);
+        // Compute global column widths so entries and totals align across all sections
+        let widths = timing_column_widths(&[&parts.pipeline, &parts.io, &parts.vm]);
 
         // Pipeline timings
         if !parts.pipeline.is_empty() {
             writeln!(f, "{}", section_header("Pipeline"))?;
-            write!(f, "{}", render_timing_section(&parts.pipeline, tw))?;
+            write!(f, "{}", render_timing_section(&parts.pipeline, &widths))?;
             writeln!(f)?;
         }
 
         // IO timings
         if !parts.io.is_empty() {
             writeln!(f, "{}", section_header("IO"))?;
-            write!(f, "{}", render_timing_section(&parts.io, tw))?;
+            write!(f, "{}", render_timing_section(&parts.io, &widths))?;
             writeln!(f)?;
         }
 
         // VM timings
         if !parts.vm.is_empty() {
             writeln!(f, "{}", section_header("VM"))?;
-            write!(f, "{}", render_timing_section(&parts.vm, tw))?;
+            write!(f, "{}", render_timing_section(&parts.vm, &widths))?;
         }
 
         Ok(())
@@ -443,24 +443,41 @@ pub(crate) fn section_header(title: &str) -> String {
     format!("{}{}", prefix, "─".repeat(padding))
 }
 
-/// Compute the width needed to format the widest time value across all
-/// entries (excluding `"VM-Total"`).
-pub(crate) fn max_time_width(groups: &[&[(String, Duration)]]) -> usize {
-    groups
+/// Column widths computed globally across all timing sections.
+pub(crate) struct TimingColumnWidths {
+    pub name: usize,
+    pub time: usize,
+}
+
+/// Compute column widths across all timing groups so entries and totals
+/// align globally, not just within each section.
+pub(crate) fn timing_column_widths(groups: &[&[(String, Duration)]]) -> TimingColumnWidths {
+    let all_entries = groups
         .iter()
         .flat_map(|g| g.iter())
-        .filter(|(k, _)| k != "VM-Total")
-        .map(|(_, v)| format!("{:.6}", v.as_secs_f64()).len())
-        .max()
-        .unwrap_or(8)
+        .filter(|(k, _)| k != "VM-Total");
+
+    let mut max_name: usize = 0;
+    let mut max_time: usize = 8;
+
+    for (k, v) in all_entries {
+        let display = k.strip_prefix("VM-").unwrap_or(k);
+        max_name = max_name.max(display.len());
+        max_time = max_time.max(format!("{:.6}", v.as_secs_f64()).len());
+    }
+
+    TimingColumnWidths {
+        name: max_name,
+        time: max_time,
+    }
 }
 
 /// Render a group of timings with bar charts and a subtotal.
 ///
-/// `global_time_width` ensures bars align across sections.
+/// `widths` ensures entries and totals align across all sections.
 pub(crate) fn render_timing_section(
     entries: &[(String, Duration)],
-    global_time_width: usize,
+    widths: &TimingColumnWidths,
 ) -> String {
     let entries: Vec<_> = entries.iter().filter(|(k, _)| k != "VM-Total").collect();
 
@@ -472,14 +489,11 @@ pub(crate) fn render_timing_section(
         .iter()
         .map(|(k, _)| k.strip_prefix("VM-").unwrap_or(k).to_string())
         .collect();
-    let display_width = display_names.iter().map(|n| n.len()).max().unwrap_or(0);
 
     let max_secs = entries
         .iter()
         .map(|(_, v)| v.as_secs_f64())
         .fold(0.0_f64, f64::max);
-
-    let time_width = global_time_width;
 
     let mut total = Duration::ZERO;
     let mut out = String::new();
@@ -497,21 +511,20 @@ pub(crate) fn render_timing_section(
             display_names[i],
             dur.as_secs_f64(),
             bar_suffix,
-            name_w = display_width,
-            time_w = time_width,
+            name_w = widths.name,
+            time_w = widths.time,
         ));
     }
 
     // Subtotal right-aligned to match the timing column.
     // Entry format is: "{name:name_w}  :  {time:>time_w.6}s"
     // so total needs:  "{label:>name_w+4}  {:>time_w.6}s"
-    //                   (name_w + "  : " = name_w + 4 to reach the time column)
     out.push_str(&format!(
         "{:>label_w$}  {:>time_w$.6}s\n",
         "Total:",
         total.as_secs_f64(),
-        label_w = display_width + 4,
-        time_w = time_width,
+        label_w = widths.name + 4,
+        time_w = widths.time,
     ));
 
     out
@@ -602,8 +615,8 @@ mod tests {
             ("parse".to_string(), Duration::from_millis(100)),
             ("cook".to_string(), Duration::from_millis(10)),
         ];
-        let tw = max_time_width(&[&entries]);
-        let rendered = render_timing_section(&entries, tw);
+        let w = timing_column_widths(&[&entries]);
+        let rendered = render_timing_section(&entries, &w);
         assert!(rendered.contains("parse"));
         assert!(rendered.contains("cook"));
         assert!(rendered.contains("Total:"));
@@ -616,8 +629,8 @@ mod tests {
             ("VM-Mutator".to_string(), Duration::from_millis(50)),
             ("VM-Total".to_string(), Duration::from_millis(50)),
         ];
-        let tw = max_time_width(&[&entries]);
-        let rendered = render_timing_section(&entries, tw);
+        let w = timing_column_widths(&[&entries]);
+        let rendered = render_timing_section(&entries, &w);
         assert!(rendered.contains("Mutator"));
         assert!(!rendered.contains("VM-Mutator"));
         assert!(!rendered.contains("VM-Total"));
@@ -625,6 +638,7 @@ mod tests {
 
     #[test]
     fn timing_section_empty() {
-        assert_eq!(render_timing_section(&[], 8), "");
+        let w = TimingColumnWidths { name: 8, time: 8 };
+        assert_eq!(render_timing_section(&[], &w), "");
     }
 }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -297,24 +297,27 @@ impl Display for Statistics {
         )?;
         writeln!(f)?;
 
+        // Compute global time column width so bars align across all sections
+        let tw = max_time_width(&[&parts.pipeline, &parts.io, &parts.vm]);
+
         // Pipeline timings
         if !parts.pipeline.is_empty() {
             writeln!(f, "{}", section_header("Pipeline"))?;
-            write!(f, "{}", render_timing_section(&parts.pipeline))?;
+            write!(f, "{}", render_timing_section(&parts.pipeline, tw))?;
             writeln!(f)?;
         }
 
         // IO timings
         if !parts.io.is_empty() {
             writeln!(f, "{}", section_header("IO"))?;
-            write!(f, "{}", render_timing_section(&parts.io))?;
+            write!(f, "{}", render_timing_section(&parts.io, tw))?;
             writeln!(f)?;
         }
 
         // VM timings
         if !parts.vm.is_empty() {
             writeln!(f, "{}", section_header("VM"))?;
-            write!(f, "{}", render_timing_section(&parts.vm))?;
+            write!(f, "{}", render_timing_section(&parts.vm, tw))?;
         }
 
         Ok(())
@@ -440,8 +443,25 @@ pub(crate) fn section_header(title: &str) -> String {
     format!("{}{}", prefix, "─".repeat(padding))
 }
 
+/// Compute the width needed to format the widest time value across all
+/// entries (excluding `"VM-Total"`).
+pub(crate) fn max_time_width(groups: &[&[(String, Duration)]]) -> usize {
+    groups
+        .iter()
+        .flat_map(|g| g.iter())
+        .filter(|(k, _)| k != "VM-Total")
+        .map(|(_, v)| format!("{:.6}", v.as_secs_f64()).len())
+        .max()
+        .unwrap_or(8)
+}
+
 /// Render a group of timings with bar charts and a subtotal.
-pub(crate) fn render_timing_section(entries: &[(String, Duration)]) -> String {
+///
+/// `global_time_width` ensures bars align across sections.
+pub(crate) fn render_timing_section(
+    entries: &[(String, Duration)],
+    global_time_width: usize,
+) -> String {
     let entries: Vec<_> = entries.iter().filter(|(k, _)| k != "VM-Total").collect();
 
     if entries.is_empty() {
@@ -459,12 +479,7 @@ pub(crate) fn render_timing_section(entries: &[(String, Duration)]) -> String {
         .map(|(_, v)| v.as_secs_f64())
         .fold(0.0_f64, f64::max);
 
-    // Pre-compute the width of the widest formatted time so bars align.
-    let time_width = entries
-        .iter()
-        .map(|(_, v)| format!("{:.6}", v.as_secs_f64()).len())
-        .max()
-        .unwrap_or(8);
+    let time_width = global_time_width;
 
     let mut total = Duration::ZERO;
     let mut out = String::new();
@@ -585,7 +600,8 @@ mod tests {
             ("parse".to_string(), Duration::from_millis(100)),
             ("cook".to_string(), Duration::from_millis(10)),
         ];
-        let rendered = render_timing_section(&entries);
+        let tw = max_time_width(&[&entries]);
+        let rendered = render_timing_section(&entries, tw);
         assert!(rendered.contains("parse"));
         assert!(rendered.contains("cook"));
         assert!(rendered.contains("Total:"));
@@ -598,7 +614,8 @@ mod tests {
             ("VM-Mutator".to_string(), Duration::from_millis(50)),
             ("VM-Total".to_string(), Duration::from_millis(50)),
         ];
-        let rendered = render_timing_section(&entries);
+        let tw = max_time_width(&[&entries]);
+        let rendered = render_timing_section(&entries, tw);
         assert!(rendered.contains("Mutator"));
         assert!(!rendered.contains("VM-Mutator"));
         assert!(!rendered.contains("VM-Total"));
@@ -606,6 +623,6 @@ mod tests {
 
     #[test]
     fn timing_section_empty() {
-        assert_eq!(render_timing_section(&[]), "");
+        assert_eq!(render_timing_section(&[], 8), "");
     }
 }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -230,8 +230,12 @@ impl Display for Statistics {
             writeln!(f)?;
         }
 
+        // Compute global column widths early so all headers share the same width
+        let widths = timing_column_widths(&[&parts.pipeline, &parts.io, &parts.vm]);
+        let header_width = widths.name + 5 + widths.time + 1 + 2 + BAR_WIDTH;
+
         // Machine counters
-        writeln!(f, "{}", section_header("Machine"))?;
+        writeln!(f, "{}", section_header("Machine", header_width))?;
         writeln!(
             f,
             "Ticks          : {:>14}",
@@ -250,7 +254,7 @@ impl Display for Statistics {
         writeln!(f)?;
 
         // Heap counters
-        writeln!(f, "{}", section_header("Heap"))?;
+        writeln!(f, "{}", section_header("Heap", header_width))?;
         writeln!(
             f,
             "Blocks Allocated  : {:>10}",
@@ -279,7 +283,7 @@ impl Display for Statistics {
         writeln!(f)?;
 
         // GC counters
-        writeln!(f, "{}", section_header("GC"))?;
+        writeln!(f, "{}", section_header("GC", header_width))?;
         writeln!(
             f,
             "Collections    : {:>14}",
@@ -297,26 +301,23 @@ impl Display for Statistics {
         )?;
         writeln!(f)?;
 
-        // Compute global column widths so entries and totals align across all sections
-        let widths = timing_column_widths(&[&parts.pipeline, &parts.io, &parts.vm]);
-
         // Pipeline timings
         if !parts.pipeline.is_empty() {
-            writeln!(f, "{}", section_header("Pipeline"))?;
+            writeln!(f, "{}", section_header("Pipeline", header_width))?;
             write!(f, "{}", render_timing_section(&parts.pipeline, &widths))?;
             writeln!(f)?;
         }
 
         // IO timings
         if !parts.io.is_empty() {
-            writeln!(f, "{}", section_header("IO"))?;
+            writeln!(f, "{}", section_header("IO", header_width))?;
             write!(f, "{}", render_timing_section(&parts.io, &widths))?;
             writeln!(f)?;
         }
 
         // VM timings
         if !parts.vm.is_empty() {
-            writeln!(f, "{}", section_header("VM"))?;
+            writeln!(f, "{}", section_header("VM", header_width))?;
             write!(f, "{}", render_timing_section(&parts.vm, &widths))?;
         }
 
@@ -436,10 +437,10 @@ pub(crate) fn render_summary_bar(
     format!("Total: {:.3}s  [{}] {}", total, bar, labels.join(" │ "))
 }
 
-/// Render a section header line.
-pub(crate) fn section_header(title: &str) -> String {
+/// Render a section header line extending to `width` characters.
+pub(crate) fn section_header(title: &str, width: usize) -> String {
     let prefix = format!("── {title} ");
-    let padding = 54_usize.saturating_sub(prefix.len());
+    let padding = width.saturating_sub(prefix.len());
     format!("{}{}", prefix, "─".repeat(padding))
 }
 
@@ -607,7 +608,7 @@ mod tests {
 
     #[test]
     fn section_header_format() {
-        let h = section_header("Pipeline");
+        let h = section_header("Pipeline", 60);
         assert!(h.starts_with("── Pipeline "));
         assert!(h.contains("─────"));
     }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -517,13 +517,16 @@ pub(crate) fn render_timing_section(
     }
 
     // Subtotal right-aligned to match the timing column.
-    // Entry format is: "{name:name_w}  :  {time:>time_w.6}s"
-    // so total needs:  "{label:>name_w+4}  {:>time_w.6}s"
+    // Entry format: "{name:name_w}  :  {time:>time_w.6}s"
+    //               name_w + 2 + 1 + 2 = name_w + 5 chars before time
+    // Total format: "{label:>label_w}  {time:>time_w.6}s"
+    //               label_w + 2 chars before time
+    // So label_w = name_w + 3 to get name_w + 5 total.
     out.push_str(&format!(
         "{:>label_w$}  {:>time_w$.6}s\n",
         "Total:",
         total.as_secs_f64(),
-        label_w = widths.name + 4,
+        label_w = widths.name + 3,
         time_w = widths.time,
     ));
 

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -9,6 +9,8 @@ pub struct Timings {
     timings: IndexMap<String, Duration>,
 }
 
+pub(crate) type TimingPartition = (Vec<(String, Duration)>, Vec<(String, Duration)>);
+
 impl Timings {
     pub fn record<T: AsRef<str>>(&mut self, name: T, elapsed: Duration) {
         self.timings.insert(name.as_ref().to_string(), elapsed);
@@ -16,6 +18,22 @@ impl Timings {
 
     pub fn merge(&mut self, other: Timings) {
         self.timings.extend(other.timings);
+    }
+
+    /// Partition timings into pipeline entries and VM entries.
+    ///
+    /// VM entries have keys starting with `"VM-"`.
+    pub(crate) fn partition(&self) -> TimingPartition {
+        let mut pipeline = Vec::new();
+        let mut vm = Vec::new();
+        for (k, v) in &self.timings {
+            if k.starts_with("VM-") {
+                vm.push((k.clone(), *v));
+            } else {
+                pipeline.push((k.clone(), *v));
+            }
+        }
+        (pipeline, vm)
     }
 }
 
@@ -193,26 +211,367 @@ impl Statistics {
 
 impl Display for Statistics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Machine Ticks          : {:10}", self.machine_ticks)?;
-        writeln!(f, "Machine Allocs         : {:10}", self.machine_allocs)?;
-        writeln!(f, "Machine Max Stack      : {:10}", self.machine_max_stack)?;
-        writeln!(f, "Heap Blocks Allocated  : {:10}", self.blocks_allocated)?;
-        writeln!(f, "Heap LOBs Allocated    : {:10}", self.lobs_allocated)?;
-        writeln!(f, "Heap Blocks Used       : {:10}", self.blocks_used)?;
-        writeln!(f, "Heap Blocks Recycled   : {:10}", self.blocks_recycled)?;
-        writeln!(f, "Heap Peak Blocks       : {:10}", self.peak_heap_blocks)?;
-        writeln!(f, "GC Collections         : {:10}", self.collections_count)?;
+        let (pipeline, vm) = self.timings.partition();
+
+        // Summary bar
+        let summary = render_summary_bar(&pipeline, &vm);
+        if !summary.is_empty() {
+            writeln!(f, "{summary}")?;
+            writeln!(f)?;
+        }
+
+        // Machine counters
+        writeln!(f, "{}", section_header("Machine"))?;
         writeln!(
             f,
-            "GC Mark Time           : {:14.9}s",
+            "Ticks          : {:>14}",
+            fmt_thousands(self.machine_ticks)
+        )?;
+        writeln!(
+            f,
+            "Allocs         : {:>14}",
+            fmt_thousands(self.machine_allocs)
+        )?;
+        writeln!(
+            f,
+            "Max Stack      : {:>14}",
+            fmt_thousands_usize(self.machine_max_stack)
+        )?;
+        writeln!(f)?;
+
+        // Heap counters
+        writeln!(f, "{}", section_header("Heap"))?;
+        writeln!(
+            f,
+            "Blocks Allocated  : {:>10}",
+            fmt_thousands_usize(self.blocks_allocated)
+        )?;
+        writeln!(
+            f,
+            "LOBs Allocated    : {:>10}",
+            fmt_thousands_usize(self.lobs_allocated)
+        )?;
+        writeln!(
+            f,
+            "Blocks Used       : {:>10}",
+            fmt_thousands_usize(self.blocks_used)
+        )?;
+        writeln!(
+            f,
+            "Blocks Recycled   : {:>10}",
+            fmt_thousands_usize(self.blocks_recycled)
+        )?;
+        writeln!(
+            f,
+            "Peak Blocks       : {:>10}",
+            fmt_thousands_usize(self.peak_heap_blocks)
+        )?;
+        writeln!(f)?;
+
+        // GC counters
+        writeln!(f, "{}", section_header("GC"))?;
+        writeln!(
+            f,
+            "Collections    : {:>14}",
+            fmt_thousands(self.collections_count)
+        )?;
+        writeln!(
+            f,
+            "Mark Time      : {:>11.6}s",
             self.total_mark_time.as_secs_f64()
         )?;
         writeln!(
             f,
-            "GC Sweep Time          : {:14.9}s",
+            "Sweep Time     : {:>11.6}s",
             self.total_sweep_time.as_secs_f64()
         )?;
         writeln!(f)?;
-        writeln!(f, "{}", self.timings)
+
+        // Pipeline timings
+        if !pipeline.is_empty() {
+            writeln!(f, "{}", section_header("Pipeline"))?;
+            write!(f, "{}", render_timing_section(&pipeline))?;
+            writeln!(f)?;
+        }
+
+        // VM timings
+        if !vm.is_empty() {
+            writeln!(f, "{}", section_header("VM"))?;
+            write!(f, "{}", render_timing_section(&vm))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Format an integer with comma thousands separators.
+pub(crate) fn fmt_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result
+}
+
+/// Format a usize with comma thousands separators.
+pub(crate) fn fmt_thousands_usize(n: usize) -> String {
+    fmt_thousands(n as u64)
+}
+
+pub(crate) const BAR_WIDTH: usize = 30;
+pub(crate) const BAR_FILLED: char = '█';
+pub(crate) const BAR_EMPTY: char = '░';
+
+/// Render a bar of `BAR_WIDTH` characters proportional to `value / max_value`.
+pub(crate) fn render_bar(value: f64, max_value: f64) -> String {
+    if max_value <= 0.0 {
+        return String::new();
+    }
+    let filled = ((value / max_value) * BAR_WIDTH as f64).round() as usize;
+    let filled = filled.min(BAR_WIDTH);
+    let empty = BAR_WIDTH - filled;
+    format!(
+        "{}{}",
+        BAR_FILLED.to_string().repeat(filled),
+        BAR_EMPTY.to_string().repeat(empty),
+    )
+}
+
+/// Render a top-level summary bar showing where total time was spent.
+pub(crate) fn render_summary_bar(
+    pipeline: &[(String, Duration)],
+    vm: &[(String, Duration)],
+) -> String {
+    let mut fractions: Vec<(String, f64)> = Vec::new();
+
+    for (name, dur) in pipeline {
+        fractions.push((name.clone(), dur.as_secs_f64()));
+    }
+
+    // Add VM as a single entry (exclude the VM-Total synthetic key)
+    let vm_total: f64 = vm
+        .iter()
+        .filter(|(k, _)| k != "VM-Total")
+        .map(|(_, v)| v.as_secs_f64())
+        .sum();
+    if vm_total > 0.0 {
+        fractions.push(("VM".to_string(), vm_total));
+    }
+
+    let total: f64 = fractions.iter().map(|(_, s)| s).sum();
+    if total <= 0.0 {
+        return String::new();
+    }
+
+    // Sort descending, collapse entries < 5% into "other"
+    fractions.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let mut shown = Vec::new();
+    let mut other = 0.0;
+    for (label, secs) in &fractions {
+        let pct = secs / total * 100.0;
+        if pct >= 5.0 && shown.len() < 4 {
+            shown.push((label.clone(), pct));
+        } else {
+            other += pct;
+        }
+    }
+    if other > 0.5 {
+        shown.push(("other".to_string(), other));
+    }
+
+    // Build the proportional bar (first entry filled, rest empty)
+    let mut bar = String::with_capacity(BAR_WIDTH * 4);
+    let mut chars_used = 0;
+    for (i, (_, pct)) in shown.iter().enumerate() {
+        let chars = if i == shown.len() - 1 {
+            BAR_WIDTH - chars_used
+        } else {
+            ((pct / 100.0) * BAR_WIDTH as f64).round() as usize
+        };
+        let chars = chars.min(BAR_WIDTH - chars_used);
+        let ch = if i == 0 { BAR_FILLED } else { BAR_EMPTY };
+        for _ in 0..chars {
+            bar.push(ch);
+        }
+        chars_used += chars;
+    }
+
+    let labels: Vec<String> = shown
+        .iter()
+        .map(|(name, pct)| format!("{name} {pct:.0}%"))
+        .collect();
+
+    format!("Total: {:.3}s  [{}] {}", total, bar, labels.join(" │ "))
+}
+
+/// Render a section header line.
+pub(crate) fn section_header(title: &str) -> String {
+    let prefix = format!("── {title} ");
+    let padding = 54_usize.saturating_sub(prefix.len());
+    format!("{}{}", prefix, "─".repeat(padding))
+}
+
+/// Render a group of timings with bar charts and a subtotal.
+pub(crate) fn render_timing_section(entries: &[(String, Duration)]) -> String {
+    let entries: Vec<_> = entries.iter().filter(|(k, _)| k != "VM-Total").collect();
+
+    if entries.is_empty() {
+        return String::new();
+    }
+
+    let display_names: Vec<String> = entries
+        .iter()
+        .map(|(k, _)| k.strip_prefix("VM-").unwrap_or(k).to_string())
+        .collect();
+    let display_width = display_names.iter().map(|n| n.len()).max().unwrap_or(0);
+
+    let max_secs = entries
+        .iter()
+        .map(|(_, v)| v.as_secs_f64())
+        .fold(0.0_f64, f64::max);
+
+    let mut total = Duration::ZERO;
+    let mut out = String::new();
+
+    for (i, (_, dur)) in entries.iter().enumerate() {
+        total += *dur;
+        let bar = render_bar(dur.as_secs_f64(), max_secs);
+        let bar_suffix = if bar.is_empty() {
+            String::new()
+        } else {
+            format!("  {bar}")
+        };
+        out.push_str(&format!(
+            "{:width$}  :    {:.6}s{}\n",
+            display_names[i],
+            dur.as_secs_f64(),
+            bar_suffix,
+            width = display_width,
+        ));
+    }
+
+    // Subtotal right-aligned
+    out.push_str(&format!(
+        "{:>width$} {:.6}s\n",
+        "Total:",
+        total.as_secs_f64(),
+        width = display_width + 8,
+    ));
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thousands_separator_small() {
+        assert_eq!(fmt_thousands(0), "0");
+        assert_eq!(fmt_thousands(1), "1");
+        assert_eq!(fmt_thousands(999), "999");
+    }
+
+    #[test]
+    fn thousands_separator_medium() {
+        assert_eq!(fmt_thousands(1_000), "1,000");
+        assert_eq!(fmt_thousands(12_345), "12,345");
+        assert_eq!(fmt_thousands(999_999), "999,999");
+    }
+
+    #[test]
+    fn thousands_separator_large() {
+        assert_eq!(fmt_thousands(1_000_000), "1,000,000");
+        assert_eq!(fmt_thousands(1_234_567_890), "1,234,567,890");
+    }
+
+    #[test]
+    fn bar_chart_full() {
+        let bar = render_bar(100.0, 100.0);
+        assert_eq!(bar.chars().filter(|&c| c == '█').count(), BAR_WIDTH);
+        assert_eq!(bar.chars().filter(|&c| c == '░').count(), 0);
+    }
+
+    #[test]
+    fn bar_chart_empty() {
+        let bar = render_bar(0.0, 100.0);
+        assert_eq!(bar.chars().filter(|&c| c == '█').count(), 0);
+        assert_eq!(bar.chars().filter(|&c| c == '░').count(), BAR_WIDTH);
+    }
+
+    #[test]
+    fn bar_chart_half() {
+        let bar = render_bar(50.0, 100.0);
+        assert_eq!(bar.chars().filter(|&c| c == '█').count(), 15);
+        assert_eq!(bar.chars().filter(|&c| c == '░').count(), 15);
+    }
+
+    #[test]
+    fn bar_chart_zero_max() {
+        assert_eq!(render_bar(0.0, 0.0), "");
+    }
+
+    #[test]
+    fn summary_bar_single_entry() {
+        let pipeline = vec![("parse".to_string(), Duration::from_millis(100))];
+        let bar = render_summary_bar(&pipeline, &[]);
+        assert!(bar.contains("Total: 0.100s"));
+        assert!(bar.contains("parse 100%"));
+    }
+
+    #[test]
+    fn summary_bar_empty() {
+        assert_eq!(render_summary_bar(&[], &[]), "");
+    }
+
+    #[test]
+    fn summary_bar_with_vm() {
+        let pipeline = vec![("parse".to_string(), Duration::from_millis(80))];
+        let vm = vec![("VM-Mutator".to_string(), Duration::from_millis(20))];
+        let bar = render_summary_bar(&pipeline, &vm);
+        assert!(bar.contains("parse 80%"));
+        assert!(bar.contains("VM 20%"));
+    }
+
+    #[test]
+    fn section_header_format() {
+        let h = section_header("Pipeline");
+        assert!(h.starts_with("── Pipeline "));
+        assert!(h.contains("─────"));
+    }
+
+    #[test]
+    fn timing_section_with_entries() {
+        let entries = vec![
+            ("parse".to_string(), Duration::from_millis(100)),
+            ("cook".to_string(), Duration::from_millis(10)),
+        ];
+        let rendered = render_timing_section(&entries);
+        assert!(rendered.contains("parse"));
+        assert!(rendered.contains("cook"));
+        assert!(rendered.contains("Total:"));
+        assert!(rendered.contains("█"));
+    }
+
+    #[test]
+    fn timing_section_strips_vm_prefix() {
+        let entries = vec![
+            ("VM-Mutator".to_string(), Duration::from_millis(50)),
+            ("VM-Total".to_string(), Duration::from_millis(50)),
+        ];
+        let rendered = render_timing_section(&entries);
+        assert!(rendered.contains("Mutator"));
+        assert!(!rendered.contains("VM-Mutator"));
+        assert!(!rendered.contains("VM-Total"));
+    }
+
+    #[test]
+    fn timing_section_empty() {
+        assert_eq!(render_timing_section(&[]), "");
     }
 }

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -440,7 +440,7 @@ pub(crate) fn render_summary_bar(
 /// Render a section header line extending to `width` characters.
 pub(crate) fn section_header(title: &str, width: usize) -> String {
     let prefix = format!("── {title} ");
-    let padding = width.saturating_sub(prefix.len());
+    let padding = width.saturating_sub(prefix.chars().count());
     format!("{}{}", prefix, "─".repeat(padding))
 }
 

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -502,13 +502,15 @@ pub(crate) fn render_timing_section(
         ));
     }
 
-    // Subtotal right-aligned to match the timing column
-    let total_str = format!("{:.6}", total.as_secs_f64());
+    // Subtotal right-aligned to match the timing column.
+    // Entry format is: "{name:name_w}  :  {time:>time_w.6}s"
+    // so total needs:  "{label:>name_w+4}  {:>time_w.6}s"
+    //                   (name_w + "  : " = name_w + 4 to reach the time column)
     out.push_str(&format!(
-        "{:>name_w$}  {:>time_w$}s\n",
+        "{:>label_w$}  {:>time_w$.6}s\n",
         "Total:",
-        total_str,
-        name_w = display_width + 2,
+        total.as_secs_f64(),
+        label_w = display_width + 4,
         time_w = time_width,
     ));
 


### PR DESCRIPTION
## Summary

- **Sectioned layout**: Machine, Heap, GC, Pipeline, and VM in distinct sections with `──` headers
- **Thousands separators**: Large integers formatted as `1,234,567`
- **Inline bar charts**: 30-char `█░` bars per timing entry, scaled per-section to that section's max
- **Section subtotals**: `Total:` line at the bottom of each timing section
- **Summary bar**: Top-level percentage breakdown of total wall time across categories, with entries < 5% collapsed into "other"
- **Reduced precision**: 6 decimal places (µs) instead of 9 (ns noise)
- **Updated header**: Double-line `══` style instead of tildes
- 14 new unit tests for formatting helpers

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 1086 passed (including 14 new)
- [x] `cargo test --test harness_test` — 441 passed
- [ ] CI green on all platforms

Closes eu-j9nt

🤖 Generated with [Claude Code](https://claude.com/claude-code)