### PR TITLE
feat: print statistics on SIGINT (Ctrl-C) interruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +247,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -530,6 +545,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +583,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -634,6 +672,7 @@ dependencies = [
  "codespan-reporting",
  "criterion",
  "csv",
+ "ctrlc",
  "dirs",
  "edn-format",
  "getrandom 0.2.17",
@@ -1274,6 +1313,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1379,21 @@ checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ serde = { version = "1", features = ["derive"] }
 libc = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ctrlc = "3"
 clap = { version = "4.5", features = ["derive"] }
 dirs = "4.0.0"
 webbrowser = "0.8.0"

--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -29,6 +29,11 @@ const STACK_SIZE: usize = 64 * 1024 * 1024;
 pub fn main() {
     eucalypt::eval::machine::crash::install_crash_handler();
 
+    ctrlc::set_handler(|| {
+        eucalypt::eval::machine::vm::set_interrupted();
+    })
+    .expect("failed to set Ctrl-C handler");
+
     let exit_code = thread::Builder::new()
         .stack_size(STACK_SIZE)
         .spawn(run)
@@ -165,9 +170,10 @@ fn run() -> i32 {
     if opt.run() || opt.dump_stg() || opt.dump_runtime() {
         // run manages error reporting
         match eval::run(&opt, loader) {
-            Ok(run_stats) => {
-                statistics.merge(run_stats);
-                return exit_code(&opt, 0, &statistics);
+            Ok(result) => {
+                statistics.merge(result.stats);
+                let code = result.exit_code.map_or(0, |c| c as i32);
+                return exit_code(&opt, code, &statistics);
             }
             _ => return exit_code(&opt, 1, &statistics),
         }

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -393,7 +393,7 @@ impl<'a> Executor<'a> {
     ) -> Result<Option<u8>, ExecutionError> {
         match result {
             Err(ref e) if e.is_interrupted() => {
-                eprintln!("interrupted");
+                eprintln!("\nInterrupted (Ctrl-C) — partial statistics follow");
                 Ok(Some(130))
             }
             Err(e) => {

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -105,7 +105,16 @@ fn collect_machine_stats(machine: &crate::eval::machine::vm::Machine<'_>, stats:
 }
 
 /// Run the prepared core expression and output to selected emitter
-pub fn run(opt: &EucalyptOptions, mut loader: SourceLoader) -> Result<Statistics, EucalyptError> {
+/// Run result: statistics and an optional process exit code override.
+///
+/// The exit code is `Some(130)` when the program was interrupted by
+/// SIGINT and `None` for normal completion.
+pub struct RunResult {
+    pub stats: Statistics,
+    pub exit_code: Option<u8>,
+}
+
+pub fn run(opt: &EucalyptOptions, mut loader: SourceLoader) -> Result<RunResult, EucalyptError> {
     let format = determine_format(opt, &loader);
     let mut stats = Statistics::default();
     // Extract the blob before the loader is consumed by Executor::from().
@@ -116,10 +125,10 @@ pub fn run(opt: &EucalyptOptions, mut loader: SourceLoader) -> Result<Statistics
     let mut executor = Executor::from(loader);
     #[cfg(not(target_arch = "wasm32"))]
     executor.set_prelude_blob(blob);
-    executor
+    let exit_code = executor
         .execute(opt, &mut stats, format)
         .map_err(|e| EucalyptError::Execution(Box::new(e)))?;
-    Ok(stats)
+    Ok(RunResult { stats, exit_code })
 }
 
 /// Determine the output format from options and targets
@@ -363,11 +372,12 @@ impl<'a> Executor<'a> {
                     }
                 } else {
                     machine.take_emitter().stream_end();
-                    ret?;
-                    Ok(None)
+                    ret.map(|_| None)
                 };
 
-                // Collect machine/GC statistics from all execution phases.
+                // Collect machine/GC statistics from all execution phases,
+                // even on error (e.g. Interrupted) so that -S output is
+                // available.
                 collect_machine_stats(&machine, stats);
 
                 result
@@ -382,6 +392,10 @@ impl<'a> Executor<'a> {
         error_format: &ErrorFormat,
     ) -> Result<Option<u8>, ExecutionError> {
         match result {
+            Err(ref e) if e.is_interrupted() => {
+                eprintln!("interrupted");
+                Ok(Some(130))
+            }
             Err(e) => {
                 match error_format {
                     ErrorFormat::Human => {

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -729,6 +729,9 @@ pub enum ExecutionError {
     HeadOfEmptyList(Smid),
     #[error("tail of empty list")]
     TailOfEmptyList(Smid),
+    /// The program was interrupted by SIGINT (Ctrl-C).
+    #[error("interrupted")]
+    Interrupted,
 }
 
 impl From<bump::AllocError> for ExecutionError {
@@ -1166,6 +1169,17 @@ impl ExecutionError {
                 format!("smid={} {file_part} {span_part} {ann_part}", smid.get())
             }
             None => format!("smid={} (no source info)", smid.get()),
+        }
+    }
+
+    /// Check whether this error represents an interrupt (SIGINT).
+    ///
+    /// Matches both bare `Interrupted` and `Traced(Interrupted, ...)`.
+    pub fn is_interrupted(&self) -> bool {
+        match self {
+            ExecutionError::Interrupted => true,
+            ExecutionError::Traced(inner, _, _) => inner.is_interrupted(),
+            _ => false,
         }
     }
 

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -3,7 +3,26 @@
 //! This is in the process of morphing from something that is clearly
 //! an interpreter to something more like a VM
 
-use std::{cmp::Ordering, convert::TryInto, num::NonZeroUsize};
+use std::{
+    cmp::Ordering,
+    convert::TryInto,
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, Ordering as AtomicOrdering},
+};
+
+/// Global flag set by the SIGINT handler.  Checked by the VM run loop
+/// every 500 steps alongside the GC check.
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+/// Check whether an interrupt has been requested.
+pub fn interrupted() -> bool {
+    INTERRUPTED.load(AtomicOrdering::Relaxed)
+}
+
+/// Set the interrupt flag (called from the signal handler).
+pub fn set_interrupted() {
+    INTERRUPTED.store(true, AtomicOrdering::Relaxed);
+}
 
 use itertools::Itertools;
 use lru::LruCache;
@@ -1298,6 +1317,11 @@ fn evaluate_to_whnf_impl(
         gc_countdown -= 1;
         if gc_countdown == 0 {
             gc_countdown = gc_check_freq;
+
+            if interrupted() {
+                break Err(ExecutionError::Interrupted);
+            }
+
             if core.heap.policy_requires_collection() {
                 collect::collect(
                     state,
@@ -1817,6 +1841,10 @@ impl<'a> Machine<'a> {
             gc_countdown -= 1;
             if gc_countdown == 0 {
                 gc_countdown = gc_check_freq;
+
+                if interrupted() {
+                    return Err(ExecutionError::Interrupted);
+                }
 
                 if self.heap().policy_requires_collection() {
                     self.collect_with_diagnostics();


### PR DESCRIPTION
## Summary

- Install a `ctrlc` handler that sets a global `AtomicBool` interrupt flag
- Check the flag every 500 VM steps (alongside the GC check)
- When set, return `ExecutionError::Interrupted` which propagates to the exit path
- Statistics are always printed on exit, including after interruption
- Exit code 130 (standard SIGINT convention: 128 + signal 2)
- `eval::run` now returns `RunResult` containing both stats and exit code, so partial stats are available even on error
- `collect_machine_stats` is called on both success and error paths, so VM timings are included in interrupted stats
- `ctrlc` dependency gated with `cfg(not(target_arch = "wasm32"))`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — 1121 passed
- [x] `cargo test --test harness_test` — 441 passed
- [x] Manual test: `-S` stats printed on normal exit
- [x] Manual test: `-S` stats printed on error exit
- [ ] CI green on all platforms

Closes eu-z7dh

🤖 Generated with [Claude Code](https://claude.com/claude-code)