### PR TITLE
feat: namespace lambda hoisting pass (eu-398r)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Eucalypt is a Rust-based tool and language for generating, templating, rendering
 - `cook/` - Operator precedence and fixity resolution
 - `verify/` - Binding and content verification
 - `simplify/` - Expression simplification and optimization
-- `transform/` - Various AST transformations
+- `transform/` - Various AST transformations including namespace lambda hoisting (`hoist.rs`)
 - `inline/` - Inlining and reduction passes
 - `typecheck/` - Gradual type system: type representation, parser, subtyping, bidirectional checker, polymorphic instantiation
 
@@ -108,7 +108,7 @@ Use `eu dump <phase>` to inspect intermediate representations at each pipeline s
 | `eu dump ast <file>` | Parsed syntax tree |
 | `eu dump desugared <file>` | Core expression after desugaring |
 | `eu dump cooked <file>` | Core expression after operator precedence resolution |
-| `eu dump inlined <file>` | Core expression after inlining |
+| `eu dump inlined <file>` | Core expression after namespace hoisting + inlining |
 | `eu dump pruned <file>` | Core expression after dead code elimination |
 | `eu dump stg <file>` | Compiled STG syntax |
 | `eu dump runtime <file>` | Runtime globals |

--- a/src/core/transform/hoist.rs
+++ b/src/core/transform/hoist.rs
@@ -1,0 +1,391 @@
+//! Namespace lambda hoisting pass.
+//!
+//! Many namespaces (e.g. `str`, `cal`, `vec`) are desugared as nested
+//! `DefaultBlockLet` bindings whose members are inlinable lambdas (`Lam(_, true,
+//! _)`) or intrinsics.  Before this pass the inliner must distribute `str` as a
+//! whole block to every call site before individual lookups like `str.upper` can
+//! be simplified.  This is expensive.
+//!
+//! This pass hoists the individual members to top-level `Let` bindings named
+//! `__<namespace>_<member>` (e.g. `__str_upper`) and rewrites
+//! `Lookup(Var(Free("str")), "upper", _)` to `Var(Free("__str_upper"))`.  The
+//! inliner can then work directly with the individual functions without ever
+//! distributing the namespace block.
+//!
+//! # Algorithm
+//!
+//! 1. Walk the expression tree.  For every `Let` binding whose value is a
+//!    `DefaultBlockLet`, treat the binding name as a namespace candidate.
+//!
+//! 2. Open the inner `DefaultBlockLet` scope.  For each member that is a
+//!    `Lam(_, true, _)` or `Intrinsic(_, _)` **and** whose free variables do
+//!    not intersect with the set of sibling member names (i.e. it is
+//!    self-contained), record it as hoistable with the generated name
+//!    `__<namespace>_<member>`.
+//!
+//! 3. Add the hoistable bindings as an `OtherLet` scope wrapping the entire
+//!    expression.
+//!
+//! 4. Rewrite all `Lookup(Var(Free(ns)), member, _)` nodes where
+//!    `__<ns>_<member>` was hoisted to `Var(Free("__<ns>_<member>"))`.  The
+//!    original namespace blocks are preserved so they can still be used as
+//!    values (e.g. passed to a higher-order function).
+
+use std::collections::{HashMap, HashSet};
+
+use crate::common::sourcemap::Smid;
+use crate::core::binding::{CoreBinding, Var};
+use crate::core::error::CoreError;
+use crate::core::expr::{close_let_scope, free_vars, open_let_scope_full, Expr, LetType, RcExpr};
+
+/// A hoistable member: namespace name, member name, and the open (free-var)
+/// expression to bind at the top level.
+struct Hoistable {
+    ns: String,
+    member: String,
+    expr: RcExpr,
+}
+
+/// Strip `Meta` wrappers to get the inner expression.
+///
+/// Namespace members in the prelude are often wrapped in a `Meta` node that
+/// carries documentation and type annotations.  We strip those to examine the
+/// underlying expression kind when deciding what is hoistable.
+fn strip_meta(expr: &RcExpr) -> &RcExpr {
+    match &*expr.inner {
+        Expr::Meta(_, inner, _) => strip_meta(inner),
+        _ => expr,
+    }
+}
+
+/// True iff `expr` (after stripping metadata) is an inlinable lambda or
+/// an intrinsic reference — the kinds of expressions that the inline pass
+/// can beta-reduce once hoisted to a top-level binding.
+fn is_hoistable_kind(expr: &RcExpr) -> bool {
+    matches!(
+        &*strip_meta(expr).inner,
+        Expr::Lam(_, true, _) | Expr::Intrinsic(_, _)
+    )
+}
+
+/// Collect hoistable members from a single `DefaultBlockLet` binding value.
+///
+/// `ns_name` is the name of the binding (e.g. `"str"`).  `ns_expr` is the
+/// binding's value, which may be a `DefaultBlockLet` optionally wrapped in
+/// one or more `Meta` nodes (the desugarer adds metadata wrappers for doc
+/// and type annotations).
+///
+/// Returns `None` if `ns_expr` (after stripping metadata) is not a
+/// `DefaultBlockLet`.  Returns `Some(vec)` with the members safe to hoist.
+fn collect_hoistable_from_ns(ns_name: &str, ns_expr: &RcExpr) -> Option<Vec<Hoistable>> {
+    // Strip any metadata wrapper added by the desugarer before checking the
+    // expression kind — namespace bindings in the prelude are often
+    // `Meta(smid, Let(..., DefaultBlockLet), doc_block)`.
+    let inner = strip_meta(ns_expr);
+    let Expr::Let(_, inner_scope, LetType::DefaultBlockLet) = &*inner.inner else {
+        return None;
+    };
+
+    // Open the inner scope so members are in free-variable form.
+    let (open_bindings, _body) = open_let_scope_full(inner_scope);
+
+    // The sibling names are all binding names in this scope.
+    let sibling_names: HashSet<&str> = open_bindings.iter().map(|(n, _)| n.as_str()).collect();
+
+    let mut hoistable = Vec::new();
+
+    for (member_name, member_expr) in &open_bindings {
+        // Only hoist inlinable lambdas and intrinsics (stripping any metadata
+        // wrappers that the desugarer adds for doc/type annotations).
+        if !is_hoistable_kind(member_expr) {
+            continue;
+        }
+
+        // Skip members whose free variables include any sibling name —
+        // these are self-referential and cannot be lifted without also
+        // rewriting their bodies.
+        let fvs = free_vars(member_expr);
+        let self_referential = fvs.iter().any(|fv| sibling_names.contains(fv.as_str()));
+        if self_referential {
+            continue;
+        }
+
+        // Strip metadata wrappers from the hoisted expression: the hoisted
+        // binding should be the raw lambda or intrinsic so that the inliner's
+        // `inlinable()` check recognises it and distributes it to call sites.
+        hoistable.push(Hoistable {
+            ns: ns_name.to_string(),
+            member: member_name.clone(),
+            expr: strip_meta(member_expr).clone(),
+        });
+    }
+
+    Some(hoistable)
+}
+
+/// Walk `expr` and collect all hoistable namespace members.
+///
+/// The result maps `(ns_name, member_name)` → generated hoisted name.
+fn collect_all_hoistable(expr: &RcExpr) -> Vec<Hoistable> {
+    let mut result = Vec::new();
+    collect_all_hoistable_rec(expr, &mut result);
+    result
+}
+
+fn collect_all_hoistable_rec(expr: &RcExpr, result: &mut Vec<Hoistable>) {
+    match &*expr.inner {
+        Expr::Let(_, scope, LetType::DefaultBlockLet) => {
+            // Open the outer scope to inspect binding values.
+            let (open_bindings, _body) = open_let_scope_full(scope);
+
+            for (ns_name, ns_expr) in &open_bindings {
+                if let Some(members) = collect_hoistable_from_ns(ns_name, ns_expr) {
+                    result.extend(members);
+                }
+                // Recurse into the binding value (handles nesting).
+                collect_all_hoistable_rec(ns_expr, result);
+            }
+
+            // Recurse into the body too.
+            collect_all_hoistable_rec(&scope.body, result);
+        }
+        Expr::Let(_, scope, _) => {
+            for b in &scope.pattern {
+                collect_all_hoistable_rec(&b.expr, result);
+            }
+            collect_all_hoistable_rec(&scope.body, result);
+        }
+        Expr::Lam(_, _, scope) => {
+            collect_all_hoistable_rec(&scope.body, result);
+        }
+        Expr::Lookup(_, target, _, fallback) => {
+            collect_all_hoistable_rec(target, result);
+            if let Some(fb) = fallback {
+                collect_all_hoistable_rec(fb, result);
+            }
+        }
+        Expr::App(_, f, xs) => {
+            collect_all_hoistable_rec(f, result);
+            for x in xs {
+                collect_all_hoistable_rec(x, result);
+            }
+        }
+        Expr::List(_, xs) | Expr::ArgTuple(_, xs) => {
+            for x in xs {
+                collect_all_hoistable_rec(x, result);
+            }
+        }
+        Expr::Block(_, bm) => {
+            for (_, v) in bm.iter() {
+                collect_all_hoistable_rec(v, result);
+            }
+        }
+        Expr::Meta(_, e, m) => {
+            // Walk through metadata wrappers — namespace bindings in the
+            // prelude are wrapped as `Meta(smid, DefaultBlockLet, doc)`.
+            collect_all_hoistable_rec(e, result);
+            collect_all_hoistable_rec(m, result);
+        }
+        Expr::Soup(_, xs, _) => {
+            for x in xs {
+                collect_all_hoistable_rec(x, result);
+            }
+        }
+        // Leaves — nothing to recurse into.
+        _ => {}
+    }
+}
+
+/// The generated name for a hoisted namespace member.
+fn hoisted_name(ns: &str, member: &str) -> String {
+    format!("__{ns}_{member}")
+}
+
+/// Rewrite `Lookup(Var(Free(ns)), member, fallback)` to
+/// `Var(Free("__<ns>_<member>"))` where the hoisted name is known.
+///
+/// Also rewrites `Var(Free(ns))` in positions where the namespace is used
+/// purely for its member lookups — but the dispatch says to preserve
+/// the original block so we only rewrite the Lookup nodes.
+fn rewrite_lookups(
+    expr: &RcExpr,
+    hoisted: &HashMap<(String, String), String>,
+) -> Result<RcExpr, CoreError> {
+    match &*expr.inner {
+        Expr::Lookup(s, target, member, _fallback) => {
+            // Check if target is Var(Free(ns)) and (ns, member) is hoisted.
+            if let Expr::Var(_, Var::Free(ns_name)) = &*target.inner {
+                let key = (ns_name.clone(), member.clone());
+                if let Some(generated) = hoisted.get(&key) {
+                    return Ok(RcExpr::from(Expr::Var(*s, Var::Free(generated.clone()))));
+                }
+            }
+            // Recurse — target may itself be a complex expression.
+            expr.try_walk_safe(&mut |e| rewrite_lookups(e, hoisted))
+        }
+        _ => expr.try_walk_safe(&mut |e| rewrite_lookups(e, hoisted)),
+    }
+}
+
+/// Run the namespace lambda hoisting pass.
+///
+/// Returns the expression with hoisted namespace members added as top-level
+/// `OtherLet` bindings and all eligible `Lookup` nodes rewritten to
+/// direct `Var` references.
+pub fn hoist(expr: &RcExpr) -> Result<RcExpr, CoreError> {
+    let hoistable = collect_all_hoistable(expr);
+
+    if hoistable.is_empty() {
+        return Ok(expr.clone());
+    }
+
+    // Build lookup map: (ns, member) → generated name.
+    let mut hoisted_map: HashMap<(String, String), String> = HashMap::new();
+    let mut bindings: Vec<CoreBinding<RcExpr>> = Vec::new();
+
+    for h in hoistable {
+        let gen_name = hoisted_name(&h.ns, &h.member);
+        hoisted_map.entry((h.ns, h.member)).or_insert_with(|| {
+            bindings.push(CoreBinding::new(gen_name.clone(), h.expr));
+            gen_name.clone()
+        });
+    }
+
+    // Rewrite Lookup nodes in the expression.
+    let rewritten = rewrite_lookups(expr, &hoisted_map)?;
+
+    // Wrap with an OtherLet binding all hoisted members.
+    //
+    // We use OtherLet (not DefaultBlockLet) so the prune pass treats these
+    // as regular definitions and the inliner distributes them normally.
+    //
+    // IMPORTANT: We must close the scope via `close_let_scope` so that
+    // `Var::Free("__str_to-upper")` references in the body become
+    // `Var::Bound(scope=0, binder=k)`.  The prune pass only follows
+    // `Var::Bound` references, so without closing the free references
+    // would be invisible and the bindings would be pruned as dead code.
+    let binding_pairs: Vec<(String, RcExpr)> =
+        bindings.into_iter().map(|b| (b.name, b.expr)).collect();
+    Ok(RcExpr::from(Expr::Let(
+        Smid::default(),
+        close_let_scope(binding_pairs, rewritten),
+        LetType::OtherLet,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::expr::acore;
+    use crate::core::expr::{close_lam_scope, Primitive};
+
+    fn make_inline_lam(params: Vec<String>, body: RcExpr) -> RcExpr {
+        RcExpr::from(Expr::Lam(
+            Smid::default(),
+            true, // inlinable
+            close_lam_scope(params, body),
+        ))
+    }
+
+    fn make_identity_lam() -> RcExpr {
+        make_inline_lam(
+            vec!["x".to_string()],
+            RcExpr::from(Expr::Var(Smid::default(), Var::Free("x".to_string()))),
+        )
+    }
+
+    #[test]
+    fn test_hoist_simple_namespace() {
+        // Build: let str = DefaultBlockLet { upper: Lam } in Block { str: str }
+        let ns_expr = acore::default_let(vec![("upper".to_string(), make_identity_lam())]);
+        let outer = acore::default_let(vec![("str".to_string(), ns_expr)]);
+
+        let result = hoist(&outer).expect("hoist failed");
+
+        // The result should be an OtherLet with a binding named __str_upper.
+        match &*result.inner {
+            Expr::Let(_, scope, LetType::OtherLet) => {
+                let has_hoisted = scope.pattern.iter().any(|b| b.name == "__str_upper");
+                assert!(has_hoisted, "expected __str_upper binding");
+            }
+            other => panic!("expected OtherLet, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_lookup_to_var() {
+        // Build a Lookup node: str.upper
+        let lookup = RcExpr::from(Expr::Lookup(
+            Smid::default(),
+            RcExpr::from(Expr::Var(Smid::default(), Var::Free("str".to_string()))),
+            "upper".to_string(),
+            None,
+        ));
+
+        let mut hoisted_map = HashMap::new();
+        hoisted_map.insert(
+            ("str".to_string(), "upper".to_string()),
+            "__str_upper".to_string(),
+        );
+
+        let result = rewrite_lookups(&lookup, &hoisted_map).expect("rewrite failed");
+        match &*result.inner {
+            Expr::Var(_, Var::Free(name)) => {
+                assert_eq!(name, "__str_upper");
+            }
+            other => panic!("expected Var(Free(__str_upper)), got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_skip_self_referential_member() {
+        // A member that references a sibling should not be hoisted.
+        // "upper" body contains Var(Free("lower")) — a sibling ref.
+        let upper_body = RcExpr::from(Expr::Var(Smid::default(), Var::Free("lower".to_string())));
+        let upper_lam = make_inline_lam(vec![], upper_body);
+        // "lower" is a plain identity lambda — no sibling refs.
+        let lower_lam = make_identity_lam();
+
+        let inner = acore::default_let(vec![
+            ("upper".to_string(), upper_lam),
+            ("lower".to_string(), lower_lam),
+        ]);
+        let ns_members = collect_hoistable_from_ns("str", &inner).expect("expected Some");
+        // "upper" references "lower" (sibling) → skip.
+        // "lower" references only "x" (its own param) → hoist.
+        let names: Vec<&str> = ns_members.iter().map(|h| h.member.as_str()).collect();
+        assert!(
+            !names.contains(&"upper"),
+            "self-referential upper should be skipped"
+        );
+        assert!(names.contains(&"lower"), "plain lower should be hoisted");
+    }
+
+    #[test]
+    fn test_idempotent_on_no_namespace() {
+        // An expression with no DefaultBlockLet namespaces should be returned unchanged.
+        let expr = RcExpr::from(Expr::Literal(Smid::default(), Primitive::Num(42.into())));
+        let result = hoist(&expr).expect("hoist failed");
+        // With no hoistable members, the result is a clone of the input.
+        assert_eq!(result, expr);
+    }
+
+    #[test]
+    fn test_no_hoist_non_inlinable_member() {
+        // A member that is not Lam(_, true, _) or Intrinsic should not be hoisted.
+        let non_inline = RcExpr::from(Expr::Lam(
+            Smid::default(),
+            false, // NOT inlinable
+            close_lam_scope(
+                vec!["x".to_string()],
+                RcExpr::from(Expr::Var(Smid::default(), Var::Free("x".to_string()))),
+            ),
+        ));
+        let inner = acore::default_let(vec![("apply".to_string(), non_inline)]);
+        let ns_members = collect_hoistable_from_ns("ns", &inner).expect("expected Some");
+        assert!(
+            ns_members.is_empty(),
+            "non-inlinable member should not be hoisted"
+        );
+    }
+}

--- a/src/core/transform/mod.rs
+++ b/src/core/transform/mod.rs
@@ -1,3 +1,4 @@
 pub mod dynamise;
 pub mod fuse;
+pub mod hoist;
 pub mod succ;

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -240,6 +240,21 @@ pub fn prepare(
         return Ok(Command::Exit);
     }
 
+    // Hoist inlinable namespace members to top-level bindings.
+    //
+    // This pass lifts `Lam(_, true, _)` and `Intrinsic` members of namespace
+    // `DefaultBlockLet` bindings (e.g. `str.upper`) to named top-level bindings
+    // (`__str_upper`) and rewrites `Lookup(Var(ns), member)` to direct `Var`
+    // references.  The inliner can then work on individual functions without
+    // distributing the whole namespace block.
+    {
+        let t = Instant::now();
+
+        loader.hoist_namespaces()?;
+
+        stats.record("hoist", t.elapsed());
+    }
+
     // Prune unused bindings to reduce inline overhead
     if !opt.no_dce() {
         let t = Instant::now();

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -11,6 +11,7 @@ use crate::core::inline::tag;
 use crate::core::simplify::compress;
 use crate::core::simplify::prune;
 use crate::core::transform::fuse;
+use crate::core::transform::hoist;
 use crate::core::unit::TranslationUnit;
 use crate::core::verify::content;
 use crate::driver::error::EucalyptError;
@@ -564,6 +565,20 @@ impl SourceLoader {
             return Ok(());
         }
         self.core.expr = cook::cook(self.core.expr.clone())?;
+        Ok(())
+    }
+
+    /// Run the namespace lambda hoisting pass.
+    ///
+    /// Hoists inlinable members of namespace `DefaultBlockLet` bindings (such
+    /// as `str`, `cal`, `vec`) to top-level `OtherLet` bindings named
+    /// `__<namespace>_<member>` and rewrites `Lookup(Var(ns), member)` to
+    /// `Var(__<namespace>_<member>)`.  This lets the inline pass work directly
+    /// on individual functions without distributing the namespace block.
+    ///
+    /// The pass is a no-op when no hoistable members are found.
+    pub fn hoist_namespaces(&mut self) -> Result<(), EucalyptError> {
+        self.core.expr = hoist::hoist(&self.core.expr)?;
         Ok(())
     }
 

--- a/tests/harness/167_namespace_hoisting.eu
+++ b/tests/harness/167_namespace_hoisting.eu
@@ -1,0 +1,37 @@
+#!/usr/bin/env eu
+# Tests for namespace lambda hoisting pass (eu-398r)
+#
+# The hoist pass lifts inlinable members of namespace DefaultBlockLet
+# bindings (e.g. str, cal, vec) to top-level OtherLet bindings named
+# __<namespace>_<member> and rewrites Lookup(Var(ns), member) to direct
+# Var references.  These tests exercise the hoisted paths via ordinary
+# namespace calls.
+
+# str.to-upper — intrinsic hoisted as __str_to-upper
+upper-got: "hello" str.to-upper
+upper-ok: upper-got = "HELLO"
+
+# str.to-lower — intrinsic hoisted as __str_to-lower
+lower-got: "WORLD" str.to-lower
+lower-ok: lower-got = "world"
+
+# str.of — intrinsic hoisted as __str_of
+of-got: str.of(42)
+of-ok: of-got = "42"
+
+# str.split: split(s, re) — string first, regex second
+# Using str.split-on which takes regex first (pipeline-idiomatic)
+split-got: "a,b,c" str.split-on("[,]")
+split-ok: split-got = ["a", "b", "c"]
+
+# Chained namespace calls: the result of one is passed to another
+chained-got: "hello world" str.to-upper str.to-lower
+chained-ok: chained-got = "hello world"
+
+# Namespace used as a value (block) — must still work even though
+# hoisting adds direct Var references for member calls above
+ns-is-block-ok: block?(str)
+
+RESULT: if(
+  and(upper-ok, and(lower-ok, and(of-ok, and(split-ok, and(chained-ok, ns-is-block-ok))))),
+  :PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2447,6 +2447,15 @@ pub fn test_166_error_recovery_eval() {
 }
 
 #[test]
+/// Namespace lambda hoisting pass (eu-398r): verifies that inlinable
+/// namespace members (str.to-upper, str.to-lower, str.of) are correctly
+/// hoisted to top-level OtherLet bindings and their call sites rewritten,
+/// while the namespace block itself remains usable as a value.
+pub fn test_167_namespace_hoisting() {
+    run_test(&opts("167_namespace_hoisting.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }


### PR DESCRIPTION
## Summary

- Add `src/core/transform/hoist.rs`: a new core pass that hoists inlinable namespace members (`Lam(_, true, _)` and `Intrinsic`) from `DefaultBlockLet` bindings (e.g. `str`, `cal`, `vec`) to top-level `OtherLet` bindings named `__<namespace>_<member>`
- Rewrite all `Lookup(Var(Free(ns)), member)` nodes to `Var(Free("__<ns>_<member>"))` so the inline pass can beta-reduce individual functions directly
- Insert the pass between cook and the first DCE eliminate pass in `src/driver/prepare.rs`
- Add harness test `167_namespace_hoisting.eu` verifying `str.to-upper`, `str.to-lower`, `str.of`, `str.split-on`, chained calls, and namespace-as-value

## Key design notes

- **Meta stripping**: namespace binding values and member expressions are wrapped in `Meta` nodes (doc/type annotations). The pass strips these before checking kinds and before storing hoisted expressions, so the inliner's `inlinable()` check fires correctly.
- **Scope closing**: the hoisted `OtherLet` is closed via `close_let_scope` so that `Var::Free("__str_to-upper")` references become `Var::Bound`. The prune (DCE) pass only follows `Var::Bound` edges; without this, hoisted bindings would be silently eliminated.
- **Self-referential skipping**: members whose free variables overlap with sibling names (e.g. `split-on` referencing `split`) are not hoisted to avoid dangling references.
- **Block preservation**: original namespace blocks are kept in place so they remain usable as values (e.g. `block?(str)` still returns `true`).

## Test plan

- [x] `cargo test` — all 1696 tests pass (lib, harness, LSP, property, doc-tests)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all` — no formatting changes required
- [x] Manual: `EU_SOURCE_PRELUDE=1 eu /tmp/test_str2.eu` returns `HELLO` for `"hello" str.to-upper`
- [x] Manual: `eu dump inlined` shows `UPPER("hello")` after hoisting (Lookup rewritten and intrinsic distributed by inliner)
- [x] New harness test `test_167_namespace_hoisting` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)