### PR TITLE
docs: remove stale git imports 'not implemented' callouts

### DIFF
--- a/docs/guide/imports-and-modules.md
+++ b/docs/guide/imports-and-modules.md
@@ -181,12 +181,6 @@ projects that rely on `-L` continue to work without modification.
 
 ## Git Imports
 
-> **Note — not currently implemented.** Git imports were available in the
-> original (Haskell) eucalypt but are **not yet supported** by the current
-> implementation: a `{ git: … }` import block is presently ignored rather than
-> fetched. Restoration is planned and prioritised; the form below documents the
-> intended design.
-
 Import eucalypt code directly from a git repository. This is useful
 for sharing libraries without manually managing local copies:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,7 +50,7 @@ Inputs specify text data from:
  - files
  - stdin
  - internal resources (ignored for now)
- - (in future) HTTPS URLs or Git refs
+ - git repository files (via `{ git: … }` import blocks — see [Import Formats](import-formats.md#git-imports))
 
 ...of which the first two are the common case. In the simplest case,
 file inputs are specified by file name, stdin is specified by `-`.

--- a/docs/reference/import-formats.md
+++ b/docs/reference/import-formats.md
@@ -86,11 +86,6 @@ it has already been specified in the command line or another unit.
 
 ### Git imports
 
-> **Note — not currently implemented.** Git imports were available in the
-> original (Haskell) eucalypt but are **not yet supported** by the current
-> implementation; a `{ git: … }` import block is presently ignored. The format
-> below documents the intended design, pending restoration.
-
 Git imports allow you to import eucalypt direct from a git repository
 at a specified commit, combining the convenience of not having to
 explicitly manage a git working copy and a library path with the


### PR DESCRIPTION
## Summary

Git imports are now implemented (PR #848). Removes the "not currently implemented" blockquote callouts that remained in two documentation files, and updates the CLI reference input list which described git imports as a future feature.

Changes:
- **`docs/reference/import-formats.md`** — delete 4-line blockquote (lines 89–92)
- **`docs/guide/imports-and-modules.md`** — delete 5-line blockquote (lines 184–188)
- **`docs/reference/cli.md`** — replace `(in future) HTTPS URLs or Git refs` with the actual git import syntax reference

## Test plan

- [ ] Verify `docs/reference/import-formats.md` git imports section reads cleanly without the callout
- [ ] Verify `docs/guide/imports-and-modules.md` git imports section reads cleanly
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)