### PR TITLE
fix(errors): convert io_run Panic variants to proper IoFail errors

### DIFF
--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -776,14 +776,18 @@ fn evaluate_spec_block(
     let is_shell = tag_name == "io-shell";
     let is_exec = tag_name == "io-exec";
 
+    // Capture the call-site annotation before the branching so closures below
+    // can reference it without re-borrowing `machine`.
+    let call_smid = machine.annotation();
+
     if is_shell {
         let cmd = eval_fields
             .get("cmd")
             .and_then(|opt| opt.clone())
             .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::Panic(
-                    Smid::default(),
-                    "io-shell spec missing 'cmd'".to_string(),
+                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+                    call_smid,
+                    "io.shell: 'cmd' field is required in the action spec".to_string(),
                 )))
             })?;
         Ok(ActionSpec::Shell {
@@ -796,9 +800,9 @@ fn evaluate_spec_block(
             .get("cmd")
             .and_then(|opt| opt.clone())
             .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::Panic(
-                    Smid::default(),
-                    "io-exec spec missing 'cmd'".to_string(),
+                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+                    call_smid,
+                    "io.exec: 'cmd' field is required in the action spec".to_string(),
                 )))
             })?;
         let args = eval_fields
@@ -825,9 +829,9 @@ fn evaluate_spec_block(
             .unwrap_or_else(|| "io.fail".to_string());
         Err(IoRunError::Fail(message))
     } else {
-        Err(IoRunError::MachineError(Box::new(ExecutionError::Panic(
-            Smid::default(),
-            format!("unrecognised IO action tag: {tag_name}"),
+        Err(IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+            call_smid,
+            format!("unknown IO action tag '{tag_name}'"),
         ))))
     }
 }

--- a/tests/harness/errors/168_io_shell_missing_cmd.eu
+++ b/tests/harness/errors/168_io_shell_missing_cmd.eu
@@ -1,0 +1,3 @@
+# io.shell with no cmd field should produce a clear error, not a panic
+` { target: :main requires-io: true }
+main: io.shell({ stdin: "ignored" })

--- a/tests/harness/errors/168_io_shell_missing_cmd.eu.expect
+++ b/tests/harness/errors/168_io_shell_missing_cmd.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "io.shell: 'cmd' field is required"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2445,6 +2445,12 @@ pub fn test_error_167() {
 }
 
 #[test]
+/// io.shell without a cmd field should produce a proper IoFail error, not a panic.
+pub fn test_error_168() {
+    run_error_test(&io_error_opts("168_io_shell_missing_cmd.eu"));
+}
+
+#[test]
 /// Importing a malformed JSONL stream should produce a clear error, not a panic.
 pub fn test_error_169() {
     run_error_test(&error_opts("169_malformed_jsonl_stream.eu"));


### PR DESCRIPTION
## Summary

Three `ExecutionError::Panic(Smid::default(), ...)` instances in `evaluate_spec_block()` were reached via user-reachable code paths and would display as raw panics rather than structured diagnostics:

- `io.shell` with no `cmd` field → `"io-shell spec missing 'cmd'"`
- `io.exec` with no `cmd` field → `"io-exec spec missing 'cmd'"`
- Unrecognised IO action tag → `"unrecognised IO action tag: ..."`

These are now `ExecutionError::IoFail` with:
- `machine.annotation()` as the source location (points at the call site)
- Clear, user-facing messages explaining what is required

## Before

```
thread 'main' panicked at 'io-shell spec missing 'cmd''
```

## After

```
error: io.shell: 'cmd' field is required in the action spec
  --> example.eu:3:8
```

## Test plan

- [x] `test_error_168` — `io.shell({stdin: "..."})` without a `cmd` field produces a proper error message, not a panic
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)