### PR TITLE
fix(errors): convert stream producer panics to proper error returns

### DIFF
--- a/src/eval/stg/stream.rs
+++ b/src/eval/stg/stream.rs
@@ -8,16 +8,24 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::eval::error::ExecutionError;
+
 use super::syntax::StgSyn;
 
 /// A lazy producer of STG values, accessed via a handle in ProducerTable.
 ///
 /// Each call to `next()` advances the underlying source (file cursor,
 /// CSV parser, etc.) and returns the next value as pre-compiled STG
-/// syntax, or `None` when the source is exhausted.
+/// syntax, `None` when the source is exhausted, or `Some(Err(_))` when
+/// a read or parse error occurs.
 pub trait LazyProducer {
-    /// Produce the next value as STG syntax, or `None` if exhausted.
-    fn next(&mut self) -> Option<Rc<StgSyn>>;
+    /// Produce the next value as STG syntax.
+    ///
+    /// - `Some(Ok(v))` — the next value
+    /// - `None` — producer exhausted
+    /// - `Some(Err(e))` — an IO or parse error; the producer should be
+    ///   considered failed and not advanced further
+    fn next(&mut self) -> Option<Result<Rc<StgSyn>, ExecutionError>>;
 
     /// Whether this producer is pure (same state → same output).
     /// Pure producers can safely be forked/shared in future.
@@ -76,29 +84,36 @@ pub fn register_producer(producer: Box<dyn LazyProducer>) -> u32 {
 /// Drain all remaining values from a producer.
 ///
 /// Returns a vector of all STG syntax values, consuming the
-/// producer to exhaustion.
-pub fn producer_drain(handle: u32) -> Vec<Rc<StgSyn>> {
+/// producer to exhaustion. Stops and returns an error if the
+/// producer yields `Some(Err(_))`.
+pub fn producer_drain(handle: u32) -> Result<Vec<Rc<StgSyn>>, ExecutionError> {
     PRODUCER_TABLE.with(|table| {
         let table = table.borrow();
         match table.get(handle) {
             Some(producer) => {
                 let mut values = Vec::new();
                 let mut producer = producer.borrow_mut();
-                while let Some(v) = producer.next() {
-                    values.push(v);
+                loop {
+                    match producer.next() {
+                        Some(Ok(v)) => values.push(v),
+                        Some(Err(e)) => return Err(e),
+                        None => break,
+                    }
                 }
-                values
+                Ok(values)
             }
-            None => Vec::new(),
+            None => Ok(Vec::new()),
         }
     })
 }
 
 /// Advance a producer by a single step.
 ///
-/// Returns `Some(value)` if the producer yielded an element, or
-/// `None` if the producer is exhausted or the handle is invalid.
-pub fn producer_next(handle: u32) -> Option<Rc<StgSyn>> {
+/// Returns:
+/// - `Some(Ok(value))` if the producer yielded an element
+/// - `Some(Err(e))` if the producer encountered an error
+/// - `None` if the producer is exhausted or the handle is invalid
+pub fn producer_next(handle: u32) -> Option<Result<Rc<StgSyn>, ExecutionError>> {
     PRODUCER_TABLE.with(|table| {
         let table = table.borrow();
         match table.get(handle) {

--- a/src/eval/stg/stream_intrinsic.rs
+++ b/src/eval/stg/stream_intrinsic.rs
@@ -66,7 +66,8 @@ impl StgIntrinsic for ProducerNext {
 
         // Advance the producer by one element
         let value_stg = match producer_next(handle) {
-            Some(v) => v,
+            Some(Ok(v)) => v,
+            Some(Err(e)) => return Err(e),
             None => {
                 // Producer exhausted — return Nil
                 let nil = view.nil()?;

--- a/src/import/stream.rs
+++ b/src/import/stream.rs
@@ -8,6 +8,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::rc::Rc;
 
+use crate::common::sourcemap::Smid;
+use crate::eval::error::ExecutionError;
 use crate::eval::stg::json_to_stg::json_to_stg;
 use crate::eval::stg::stream::LazyProducer;
 use crate::eval::stg::syntax::dsl;
@@ -32,7 +34,7 @@ impl JsonlProducer {
 }
 
 impl LazyProducer for JsonlProducer {
-    fn next(&mut self) -> Option<Rc<StgSyn>> {
+    fn next(&mut self) -> Option<Result<Rc<StgSyn>, ExecutionError>> {
         loop {
             self.line_buf.clear();
             match self.reader.read_line(&mut self.line_buf) {
@@ -42,11 +44,18 @@ impl LazyProducer for JsonlProducer {
                     if trimmed.is_empty() {
                         continue; // skip blank lines
                     }
-                    let value: serde_json::Value = serde_json::from_str(trimmed)
-                        .unwrap_or_else(|e| panic!("malformed JSON on stream line: {e}"));
-                    return Some(json_to_stg(&value));
+                    return Some(
+                        serde_json::from_str(trimmed)
+                            .map(|v: serde_json::Value| json_to_stg(&v))
+                            .map_err(|e| {
+                                ExecutionError::Panic(
+                                    Smid::default(),
+                                    format!("malformed JSON in stream: {e}"),
+                                )
+                            }),
+                    );
                 }
-                Err(e) => panic!("IO error reading JSONL stream: {e}"),
+                Err(e) => return Some(Err(ExecutionError::Io(e))),
             }
         }
     }
@@ -73,10 +82,15 @@ impl CsvProducer {
 }
 
 impl LazyProducer for CsvProducer {
-    fn next(&mut self) -> Option<Rc<StgSyn>> {
+    fn next(&mut self) -> Option<Result<Rc<StgSyn>, ExecutionError>> {
         let record = match self.reader.records().next() {
             Some(Ok(rec)) => rec,
-            Some(Err(e)) => panic!("CSV parse error on stream: {e}"),
+            Some(Err(e)) => {
+                return Some(Err(ExecutionError::Panic(
+                    Smid::default(),
+                    format!("CSV parse error in stream: {e}"),
+                )));
+            }
             None => return None,
         };
 
@@ -88,7 +102,7 @@ impl LazyProducer for CsvProducer {
                 serde_json::Value::String(value.to_string()),
             );
         }
-        Some(json_to_stg(&serde_json::Value::Object(map)))
+        Some(Ok(json_to_stg(&serde_json::Value::Object(map))))
     }
 }
 
@@ -114,16 +128,16 @@ impl TextProducer {
 }
 
 impl LazyProducer for TextProducer {
-    fn next(&mut self) -> Option<Rc<StgSyn>> {
+    fn next(&mut self) -> Option<Result<Rc<StgSyn>, ExecutionError>> {
         self.line_buf.clear();
         match self.reader.read_line(&mut self.line_buf) {
             Ok(0) => None, // EOF
             Ok(_) => {
                 // Strip trailing newline
                 let line = self.line_buf.trim_end_matches('\n').trim_end_matches('\r');
-                Some(dsl::box_str(line))
+                Some(Ok(dsl::box_str(line)))
             }
-            Err(e) => panic!("IO error reading text stream: {e}"),
+            Err(e) => Some(Err(ExecutionError::Io(e))),
         }
     }
 }

--- a/tests/harness/errors/169_malformed_jsonl_stream.eu
+++ b/tests/harness/errors/169_malformed_jsonl_stream.eu
@@ -1,0 +1,3 @@
+# Importing a malformed JSONL stream should produce a clear error, not a panic
+{ import: ["data=jsonl-stream@testdata/malformed.jsonl"] }
+main: data count

--- a/tests/harness/errors/169_malformed_jsonl_stream.eu.expect
+++ b/tests/harness/errors/169_malformed_jsonl_stream.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "malformed JSON in stream"

--- a/tests/harness/errors/testdata/malformed.jsonl
+++ b/tests/harness/errors/testdata/malformed.jsonl
@@ -1,0 +1,3 @@
+{"valid": 1}
+{not valid json
+{"valid": 3}

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2445,6 +2445,12 @@ pub fn test_error_167() {
 }
 
 #[test]
+/// Importing a malformed JSONL stream should produce a clear error, not a panic.
+pub fn test_error_169() {
+    run_error_test(&error_opts("169_malformed_jsonl_stream.eu"));
+}
+
+#[test]
 /// W4p2 integration: valid declarations structurally equivalent to those
 /// that would survive error recovery evaluate correctly end-to-end.
 /// Paired with test_error_164/165 to prove the full recovery story:


### PR DESCRIPTION
## Summary

`LazyProducer::next()` previously returned `Option<Rc<StgSyn>>` with no error channel, so all three streaming import producers (`JsonlProducer`, `CsvProducer`, `TextProducer`) called `panic!()` on malformed input or IO errors.

This PR changes the trait signature to `Option<Result<Rc<StgSyn>, ExecutionError>>` and updates all implementations and callers.

## Changes

- **`src/eval/stg/stream.rs`**: `LazyProducer::next()` signature changed; `producer_next()` and `producer_drain()` updated accordingly
- **`src/import/stream.rs`**: All three producers return `Some(Err(...))` instead of panicking
  - `JsonlProducer`: malformed JSON → `ExecutionError::Panic` with clear message; IO error → `ExecutionError::Io`
  - `CsvProducer`: CSV parse error → `ExecutionError::Panic` with clear message
  - `TextProducer`: IO error → `ExecutionError::Io`
- **`src/eval/stg/stream_intrinsic.rs`**: `PRODUCER_NEXT` intrinsic propagates `Err` to the STG machine

## Before

```
thread 'main' panicked at 'malformed JSON on stream line: expected value at line 1 column 2'
```

## After

```
error: malformed JSON in stream: expected value at line 1 column 2
```

## Test plan

- [x] `test_error_169` — importing a file with an invalid JSON line produces a clean error
- [x] `test_harness_079` — existing stream tests (JSONL, CSV, text) still pass
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)