### PR TITLE
refactor(eval): remove suppress_update runtime hack, use demand analysis

### DIFF
--- a/src/eval/machine/cont.rs
+++ b/src/eval/machine/cont.rs
@@ -45,9 +45,6 @@ pub enum Continuation {
         environment: RefPtr<EnvFrame>,
         /// Source annotation at the point the case was pushed
         annotation: Smid,
-        /// When true, suppress the next Update push if the branch body
-        /// is a bare local atom. See StgSyn::Case::suppress_update.
-        suppress_update: bool,
     },
     /// Update thunk in environment at index i
     Update {
@@ -97,7 +94,6 @@ impl fmt::Display for Continuation {
                 min_tag,
                 branch_table,
                 fallback,
-                suppress_update,
                 ..
             } => {
                 let mut tags: Vec<String> = branch_table
@@ -109,8 +105,7 @@ impl fmt::Display for Continuation {
                     tags.push("…".to_string());
                 }
                 let desc = &tags.join(",");
-                let marker = if *suppress_update { "!" } else { "" };
-                write!(f, "⑂{marker}<{desc}>")
+                write!(f, "⑂<{desc}>")
             }
             Continuation::Update { index, .. } => {
                 write!(f, "☇[ρ,{index}]")

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -289,13 +289,6 @@ pub struct MachineState {
     rcache: LruCache<String, Regex>,
     /// Interned symbol pool for fast symbol comparison
     symbol_pool: SymbolPool,
-    /// When set, suppress the next Update continuation push.
-    ///
-    /// Set by `return_data` when processing a Branch with
-    /// `suppress_update=true` and a branch body that is a bare local
-    /// atom. Prevents O(N) Update accumulation in tail-recursive
-    /// conditional loops such as countdown(n) = if(n=0, 0, countdown(n-1)).
-    suppress_next_update: bool,
     /// Stash of closures kept alive across `machine.run()` calls.
     ///
     /// The io-run driver holds closures (e.g. `cont` and `world` from an
@@ -348,7 +341,6 @@ impl Default for MachineState {
                 NonZeroUsize::new(100).expect("regex cache size must be non-zero"),
             ),
             symbol_pool: SymbolPool::new(),
-            suppress_next_update: false,
             stash: Vec::new(),
             suspended_stacks: Vec::new(),
             capture_end_pending: false,
@@ -428,29 +420,11 @@ impl MachineState {
 
         match code {
             HeapSyn::Atom { evaluand } => {
-                // Consume suppress_next_update flag set by return_data
-                // when processing a suppress_update Branch continuation.
-                let suppress_update = std::mem::replace(&mut self.suppress_next_update, false);
                 match evaluand {
                     Ref::L(i) => {
                         self.closure = self.nav(view).get(*i)?;
                         let is_thunk = self.closure.update();
-                        let updateable = is_thunk && !suppress_update;
-                        // When suppress_update is active but the loaded closure is
-                        // not itself a thunk (e.g. a synthetic value-Atom closure
-                        // created by create_arg_array), propagate the flag to the
-                        // next Atom step so the full indirection chain is covered.
-                        //
-                        // This handles the two-level case that arises when IF args
-                        // are passed via App (not inlined): the Branch body is
-                        // Atom{L(i)} in IF's arg env → value closure → Atom{L(j)}
-                        // in the caller's let env → actual thunk.  Without
-                        // propagation, only the first hop is suppressed and the
-                        // second hop pushes an unwanted Update continuation.
-                        if suppress_update && !is_thunk {
-                            self.suppress_next_update = true;
-                        }
-                        if updateable {
+                        if is_thunk {
                             // Overwrite the env slot with a BlackHole
                             // closure to catch cyclic thunk re-entry.
                             // The Update continuation will replace it
@@ -482,7 +456,6 @@ impl MachineState {
                 min_tag,
                 branch_table,
                 fallback,
-                suppress_update: case_suppress,
             } => {
                 self.push(
                     view,
@@ -492,7 +465,6 @@ impl MachineState {
                         fallback: *fallback,
                         environment,
                         annotation: self.annotation,
-                        suppress_update: *case_suppress,
                     },
                 )?;
                 self.closure = SynClosure::new(*scrutinee, environment);
@@ -501,7 +473,6 @@ impl MachineState {
                 self.return_data(view, *tag, args.as_slice())?;
             }
             HeapSyn::App { callable, args } => {
-                let suppress_update = std::mem::replace(&mut self.suppress_next_update, false);
                 let array = view.create_arg_array(args.as_slice(), environment)?;
                 self.push(
                     view,
@@ -519,8 +490,7 @@ impl MachineState {
                 if let Ref::L(i) = callable {
                     let callee = self.nav(view).get(*i)?;
                     let is_thunk = callee.update();
-                    let updateable = is_thunk && !suppress_update;
-                    if updateable {
+                    if is_thunk {
                         let hole = view.alloc(HeapSyn::BlackHole)?;
                         let black_hole = SynClosure::new(hole.as_ptr(), environment);
                         let cont_env = view.scoped(environment);
@@ -833,7 +803,6 @@ impl MachineState {
                     fallback,
                     environment,
                     annotation,
-                    suppress_update,
                 } => {
                     if let Some(body) = match_tag(tag, min_tag, branch_table.as_slice()) {
                         let env = if args.is_empty() {
@@ -842,18 +811,6 @@ impl MachineState {
                         } else {
                             self.env_from_data_args(view, args, environment)?
                         };
-                        // When suppress_update is set on this Branch and the
-                        // branch body is a bare local atom, suppress the next
-                        // Update push. This prevents O(N) Update accumulation
-                        // in tail-recursive conditionals (e.g. IF branches).
-                        if suppress_update {
-                            if let HeapSyn::Atom {
-                                evaluand: Ref::L(_),
-                            } = &*view.scoped(body)
-                            {
-                                self.suppress_next_update = true;
-                            }
-                        }
                         self.closure = SynClosure::new(body, env);
                     } else if let Some(body) = fallback {
                         self.closure = SynClosure::new(

--- a/src/eval/memory/loader.rs
+++ b/src/eval/memory/loader.rs
@@ -130,7 +130,6 @@ pub fn load<'scope, T: ScopedAllocator<'scope>>(
             scrutinee,
             branches,
             fallback,
-            suppress_update,
         } => {
             let (min_tag, branch_table) = load_branches(view, pool, branches)?;
             view.alloc(HeapSyn::Case {
@@ -141,7 +140,6 @@ pub fn load<'scope, T: ScopedAllocator<'scope>>(
                     Some(f) => Some(load(view, pool, f.clone())?),
                     None => None,
                 },
-                suppress_update: *suppress_update,
             })
         }
         StgSyn::Cons { tag, args } => view.alloc(HeapSyn::Cons {

--- a/src/eval/memory/mutator.rs
+++ b/src/eval/memory/mutator.rs
@@ -313,7 +313,6 @@ impl<'guard> StgBuilder<'guard> for MutatorHeapView<'guard> {
             min_tag,
             branch_table,
             fallback: Some(fallback.as_ptr()),
-            suppress_update: false,
         })
     }
 
@@ -329,7 +328,6 @@ impl<'guard> StgBuilder<'guard> for MutatorHeapView<'guard> {
             min_tag,
             branch_table,
             fallback: None,
-            suppress_update: false,
         })
     }
 

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -238,9 +238,6 @@ pub enum HeapSyn {
         branch_table: Array<Option<RefPtr<HeapSyn>>>,
         /// Default handler
         fallback: Option<RefPtr<HeapSyn>>,
-        /// When true, suppress the next Update push after entering a
-        /// branch whose body is a bare local atom. See StgSyn::Case.
-        suppress_update: bool,
     },
     /// Saturated data constructor
     Cons { tag: Tag, args: Array<Ref> },
@@ -768,14 +765,13 @@ impl Repr for ScopedPtr<'_, HeapSyn> {
                 min_tag,
                 branch_table,
                 fallback,
-                suppress_update,
+                ..
             } => Rc::new(StgSyn::Case {
                 scrutinee: ScopedPtr::from_non_null(self, *scrutinee).repr(),
                 branches: repr::repr_branch_table(self, *min_tag, branch_table.clone()),
                 fallback: fallback
                     .as_ref()
                     .map(|f| ScopedPtr::from_non_null(self, *f).repr()),
-                suppress_update: *suppress_update,
             }),
             HeapSyn::Cons { tag, args } => Rc::new(StgSyn::Cons {
                 tag: *tag,

--- a/src/eval/stg/arena.rs
+++ b/src/eval/stg/arena.rs
@@ -112,7 +112,6 @@ pub enum ArenaStgSyn {
         scrutinee: NodeIdx,
         branches: Vec<(Tag, NodeIdx)>,
         fallback: Option<NodeIdx>,
-        suppress_update: bool,
     },
     Cons {
         tag: Tag,
@@ -191,7 +190,6 @@ impl StgArena {
                 scrutinee,
                 branches,
                 fallback,
-                suppress_update,
             } => {
                 let s_idx = self.alloc_node(scrutinee);
                 let b_idxs: Vec<(Tag, NodeIdx)> = branches
@@ -203,7 +201,6 @@ impl StgArena {
                     scrutinee: s_idx,
                     branches: b_idxs,
                     fallback: fb_idx,
-                    suppress_update: *suppress_update,
                 }
             }
             StgSyn::Cons { tag, args } => ArenaStgSyn::Cons {
@@ -348,7 +345,6 @@ impl StgArena {
                 scrutinee,
                 branches,
                 fallback,
-                suppress_update,
             } => StgSyn::Case {
                 scrutinee: self.reconstruct_node(*scrutinee)?,
                 branches: branches
@@ -356,7 +352,6 @@ impl StgArena {
                     .map(|(tag, idx)| Ok((*tag, self.reconstruct_node(*idx)?)))
                     .collect::<Result<_, BlobReconstructError>>()?,
                 fallback: fallback.map(|idx| self.reconstruct_node(idx)).transpose()?,
-                suppress_update: *suppress_update,
             },
             ArenaStgSyn::Cons { tag, args } => StgSyn::Cons {
                 tag: *tag,
@@ -477,7 +472,6 @@ mod tests {
             scrutinee: atom(Reference::L(0)),
             branches: vec![(1u8, body)],
             fallback: Some(fallback),
-            suppress_update: false,
         });
         let arena = flatten(&original);
         let reconstructed = arena.reconstruct(0).unwrap();

--- a/src/eval/stg/boolean.rs
+++ b/src/eval/stg/boolean.rs
@@ -141,7 +141,7 @@ impl StgIntrinsic for If {
     fn wrapper(&self, _annotation: Smid) -> LambdaForm {
         lambda(
             3,
-            dsl::switch_suppress(
+            dsl::switch(
                 local(0),
                 vec![
                     (DataConstructor::BoolTrue.tag(), local(1)),

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1001,8 +1001,9 @@ impl ProtoSyntax for ProtoAppGroup {
                 }
                 _ => {
                     let arg_demand = if strict_args.contains(&i) {
-                        // Strict argument: will definitely be evaluated.
-                        Demand::strict()
+                        // Strict intrinsic argument: evaluated exactly once.
+                        // AtMostOnce cardinality skips the Update frame.
+                        Demand::strict_once()
                     } else {
                         Demand::default()
                     };

--- a/src/eval/stg/optimiser.rs
+++ b/src/eval/stg/optimiser.rs
@@ -245,7 +245,6 @@ impl AllocationPruner {
                 scrutinee,
                 branches,
                 fallback,
-                suppress_update,
             } => {
                 // Single-branch case elimination for 0-arity constructors:
                 // case scrutinee of { Tag -> body } (no fallback, arity 0)
@@ -317,7 +316,6 @@ impl AllocationPruner {
                     scrutinee,
                     branches,
                     fallback,
-                    suppress_update: *suppress_update,
                 })
             }
             StgSyn::Cons { tag, args } => Rc::new(StgSyn::Cons {

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -126,11 +126,6 @@ pub enum StgSyn {
         branches: Vec<(Tag, Rc<StgSyn>)>,
         /// Default handler
         fallback: Option<Rc<StgSyn>>,
-        /// When true, suppress the next Update push after entering a
-        /// branch whose body is a local atom. Set by the boolean IF
-        /// intrinsic to prevent Update accumulation during
-        /// tail-recursive conditionals.
-        suppress_update: bool,
     },
     /// Saturated data constructor
     Cons { tag: Tag, args: Vec<Ref> },
@@ -515,7 +510,6 @@ pub mod dsl {
             scrutinee,
             branches,
             fallback: Some(fallback),
-            suppress_update: false,
         })
     }
 
@@ -534,21 +528,6 @@ pub mod dsl {
             scrutinee,
             branches,
             fallback: None,
-            suppress_update: false,
-        })
-    }
-
-    /// Case statement without default, with update suppression.
-    ///
-    /// When the branch body is a bare local atom, the next Update push
-    /// is suppressed. Used by the boolean IF intrinsic to prevent
-    /// O(N) Update accumulation during tail-recursive conditionals.
-    pub fn switch_suppress(scrutinee: Rc<StgSyn>, branches: Vec<(Tag, Rc<StgSyn>)>) -> Rc<StgSyn> {
-        Rc::new(StgSyn::Case {
-            scrutinee,
-            branches,
-            fallback: None,
-            suppress_update: true,
         })
     }
 


### PR DESCRIPTION
## Summary

Removes the bespoke IF-only `suppress_update`/`suppress_next_update` update-suppression mechanism, replacing it with compile-time demand annotations from the demand analysis pass (W11, PR #857).

### What was deleted

- `StgSyn::Case::suppress_update` field (`syntax.rs`)
- `HeapSyn::Case::suppress_update` field (`memory/syntax.rs`)
- `ArenaStgSyn::Case::suppress_update` field (`arena.rs`)
- `Continuation::Branch::suppress_update` field (`cont.rs`)
- `switch_suppress()` DSL function (`syntax.rs`)
- `MachineState::suppress_next_update` flag and all related runtime logic (`vm.rs`)
- `suppress_update` propagation in `loader.rs`, `mutator.rs`, `optimiser.rs`

### What changed

- IF wrapper now uses `switch()` instead of `switch_suppress()` (`boolean.rs`)
- Strict intrinsic args now get `Demand::strict_once()` (AtMostOnce + Strict) in `compile_bif_application()`, applying the demand analysis blanket rule at the STG compiler level

### How Update accumulation is now prevented

The demand analysis pass (PR #857) marks IF branch arguments with `(Lazy, AtMostOnce)` via intrinsic seed signatures. The STG compiler's `take_lambda_form()` sees `AtMostOnce` cardinality → emits a `value` lambda form rather than a `thunk`. A value form has no Update continuation — so Update accumulation cannot occur. This is equivalent to the old runtime `suppress_update` mechanism but expressed through compile-time demand information.

### Note on strict vectors

`strict_args()` in `intrinsics.rs` is retained for two uses:
1. `wrap.rs` — STG wrapper code generation (runtime forcing, correctness-critical)
2. `analyse_demand.rs` — seeds the intrinsic signature table

Full removal of the `strict` field would require wiring the demand signature side-table into the STG compiler as a replacement for both uses. Deferred to a follow-up.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 1134 passed
- [x] `cargo test --test harness_test` — 444 passed
- [x] Pre-existing GC stress test failures (3 tests) confirmed present on master before these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)