### PR TITLE
fix(errors): add call-site Smid to emit and render-to-string errors

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1723,7 +1723,7 @@ impl<'a> Machine<'a> {
                 ExecutionError::Panic(Smid::default(), "no active capture emitter".to_string())
             })?;
             capture.stream_end();
-            let result_str = capture.into_string()?;
+            let result_str = capture.into_string(self.annotation())?;
             let view = MutatorHeapView::new(&self.core.heap);
             let str_ref = view.str_ref(result_str)?;
             let atom = view.alloc(HeapSyn::Atom { evaluand: str_ref })?.as_ptr();

--- a/src/eval/stg/emit.rs
+++ b/src/eval/stg/emit.rs
@@ -1,24 +1,19 @@
 //! Intrinsics for emitting data format events and debug / error
 //! tracing
 
-use crate::{
-    common::sourcemap::Smid,
-    eval::{
-        emit::{Emitter, RenderMetadata},
-        error::ExecutionError,
-        machine::intrinsic::{
-            CallGlobal0, CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic,
-        },
-        memory::{
-            self,
-            mutator::MutatorHeapView,
-            ndarray::HeapNdArray,
-            set::{HeapSet, Primitive as SetPrimitive},
-            syntax::{Ref, RefPtr},
-            vec::HeapVec,
-        },
-        primitive::Primitive,
+use crate::eval::{
+    emit::{Emitter, RenderMetadata},
+    error::ExecutionError,
+    machine::intrinsic::{CallGlobal0, CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic},
+    memory::{
+        self,
+        mutator::MutatorHeapView,
+        ndarray::HeapNdArray,
+        set::{HeapSet, Primitive as SetPrimitive},
+        syntax::{Ref, RefPtr},
+        vec::HeapVec,
     },
+    primitive::Primitive,
 };
 
 use super::support::machine_return_unit;
@@ -252,7 +247,7 @@ impl StgIntrinsic for EmitNative {
             memory::syntax::Native::Index(_)
             | memory::syntax::Native::Prng(_)
             | memory::syntax::Native::Producer(_) => {
-                return Err(ExecutionError::NotScalar(Smid::default()));
+                return Err(ExecutionError::NotScalar(machine.annotation()));
             }
         }
         machine_return_unit(machine, view)
@@ -307,7 +302,7 @@ impl StgIntrinsic for EmitTagNative {
             memory::syntax::Native::Index(_)
             | memory::syntax::Native::Prng(_)
             | memory::syntax::Native::Producer(_) => {
-                return Err(ExecutionError::NotScalar(Smid::default()));
+                return Err(ExecutionError::NotScalar(machine.annotation()));
             }
         }
         machine_return_unit(machine, view)

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -84,13 +84,13 @@ impl OwnedCaptureEmitter {
     }
 
     /// Consume the capture emitter and extract the buffered output as a
-    /// UTF-8 string.
-    pub fn into_string(mut self) -> Result<String, ExecutionError> {
+    /// UTF-8 string.  `annotation` is the call-site Smid from the machine,
+    /// used to point at the source location if the buffer is not valid UTF-8.
+    pub fn into_string(mut self, annotation: Smid) -> Result<String, ExecutionError> {
         // Drop the emitter first to end its borrow on the buffer.
         drop(self.emitter.take());
-        String::from_utf8(*self.buffer).map_err(|e| {
-            ExecutionError::Panic(Smid::default(), format!("capture not valid UTF-8: {e}"))
-        })
+        String::from_utf8(*self.buffer)
+            .map_err(|e| ExecutionError::Panic(annotation, format!("capture not valid UTF-8: {e}")))
     }
 }
 


### PR DESCRIPTION
## Summary

- **`EmitNative` / `EmitTagNative`** (`src/eval/stg/emit.rs`): `NotScalar(Smid::default())` → `NotScalar(machine.annotation())` so the source location of the emit call appears in the diagnostic when a non-scalar native (Index/Prng/Producer) reaches the emit path
- **`OwnedCaptureEmitter::into_string`** (`src/eval/stg/render_to_string.rs`): now accepts an `annotation: Smid` parameter from the call site in `vm.rs`, replacing `Smid::default()` in the UTF-8 capture error

## Notes

No harness test included: both error paths are defensive checks for internal invariant violations that are not reachable from normal user code (the render pipeline consumes Producers via `PRODUCER_NEXT`, not `EmitNative`; UTF-8 errors from the emitter are not ordinarily possible). The improvement is that when these errors do occur (e.g. via a bug), the diagnostic now points at the source location.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo test --lib` — 1137 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)