### PR TITLE
fix: re-enable demand analysis by default

### DIFF
--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -215,15 +215,9 @@ pub struct RunArgs {
     #[arg(long = "no-dce")]
     pub no_dce: bool,
 
-    /// Suppress demand analysis pass (all demands remain at Unknown).
-    /// Currently the default — demand analysis is disabled pending
-    /// correctness fixes. Use --demand-analysis to opt in.
-    #[arg(long = "suppress-demand-analysis", default_value_t = true)]
+    /// Suppress demand analysis pass (all demands remain at Unknown)
+    #[arg(long = "suppress-demand-analysis")]
     pub suppress_demand_analysis: bool,
-
-    /// Enable the demand analysis pass (experimental — may cause regressions)
-    #[arg(long = "demand-analysis")]
-    pub demand_analysis: bool,
 
     /// Seed for random number generation (for reproducible results)
     #[arg(long = "seed")]
@@ -660,14 +654,8 @@ impl From<EucalyptCli> for EucalyptOptions {
         };
 
         let suppress_demand_analysis = match &cli.command {
-            Some(Commands::Run(args)) => {
-                if args.demand_analysis {
-                    false // explicit opt-in overrides default suppression
-                } else {
-                    args.suppress_demand_analysis
-                }
-            }
-            _ => true, // suppressed by default outside Run
+            Some(Commands::Run(args)) => args.suppress_demand_analysis,
+            _ => false,
         };
 
         // Extract seed from Run command

--- a/src/eval/stg/testing.rs
+++ b/src/eval/stg/testing.rs
@@ -30,7 +30,7 @@ lazy_static! {
         heap_dump_at_gc: false,
         test_mode: false,
         prelude_globals: None,
-        suppress_demand_analysis: true,
+        suppress_demand_analysis: false,
     };
 }
 


### PR DESCRIPTION
## Summary

- Remove `default_value_t = true` from `--suppress-demand-analysis` (reverts to default `false`)
- Remove the `--demand-analysis` opt-in flag added as a temporary workaround
- Simplify the match block in options resolution
- Re-enable demand analysis in test settings

Regressions were fixed in PR #868 (lub→plus, argument scaling). The analysis now matches baseline allocations on all AoC examples.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all tests pass with demand analysis enabled
- [x] `EU_GC_VERIFY=2 EU_GC_STRESS=1` smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)