### PR TITLE
fix(errors): propagate call-site Smid through STG list/num iterators

### DIFF
--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -495,6 +495,7 @@ impl StgIntrinsic for ListDrop {
             num.as_u64().unwrap_or(0) as usize
         };
 
+        let smid = machine.annotation();
         // Navigate through the cons structure, skipping n elements.
         // We traverse the tail links directly so we can return the
         // remaining cons cell (rather than reconstructing the list).
@@ -509,10 +510,7 @@ impl StgIntrinsic for ListDrop {
                     match (*tag).try_into() {
                         Ok(DataConstructor::ListCons) => {
                             let tail_ref = cons_args.get(1).ok_or_else(|| {
-                                ExecutionError::Panic(
-                                    Smid::default(),
-                                    "malformed cons cell".to_string(),
-                                )
+                                ExecutionError::Panic(smid, "malformed cons cell".to_string())
                             })?;
                             closure = closure.navigate_local(&view, tail_ref);
                         }
@@ -521,17 +519,17 @@ impl StgIntrinsic for ListDrop {
                             return machine.set_closure(closure);
                         }
                         _ => {
-                            return Err(ExecutionError::Panic(
-                                Smid::default(),
-                                "LIST.DROP: expected list".to_string(),
+                            return Err(ExecutionError::NotValue(
+                                smid,
+                                "drop: expected a list".to_string(),
                             ));
                         }
                     }
                 }
                 _ => {
-                    return Err(ExecutionError::Panic(
-                        Smid::default(),
-                        "LIST.DROP: expected list".to_string(),
+                    return Err(ExecutionError::NotValue(
+                        smid,
+                        "drop: expected a list".to_string(),
                     ));
                 }
             }

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -238,6 +238,7 @@ pub fn zdt_arg(
 pub struct DataIterator<'scope> {
     closure: SynClosure,
     view: MutatorHeapView<'scope>,
+    smid: Smid,
 }
 
 impl Iterator for DataIterator<'_> {
@@ -251,15 +252,15 @@ impl Iterator for DataIterator<'_> {
                 Ok(DataConstructor::ListCons) => (args.get(0), args.get(1)),
                 Ok(DataConstructor::ListNil) => return None,
                 _ => {
-                    return Some(Err(ExecutionError::Panic(
-                        Smid::default(),
+                    return Some(Err(ExecutionError::NotValue(
+                        self.smid,
                         "expected list data".to_string(),
                     )))
                 }
             },
             _ => {
-                return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                return Some(Err(ExecutionError::NotValue(
+                    self.smid,
                     "expected list data".to_string(),
                 )))
             }
@@ -269,7 +270,7 @@ impl Iterator for DataIterator<'_> {
             Some(h) => self.closure.navigate_local(&self.view, h),
             None => {
                 return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                    self.smid,
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -281,7 +282,7 @@ impl Iterator for DataIterator<'_> {
             }
             None => {
                 return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                    self.smid,
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -298,6 +299,7 @@ pub fn data_list_arg<'scope>(
     arg: Ref,
 ) -> Result<DataIterator<'scope>, ExecutionError> {
     Ok(DataIterator {
+        smid: machine.annotation(),
         closure: machine.nav(view).resolve(&arg)?,
         view,
     })
@@ -308,6 +310,7 @@ pub fn data_list_arg<'scope>(
 pub struct StrListIterator<'scope> {
     closure: SynClosure,
     view: MutatorHeapView<'scope>,
+    smid: Smid,
 }
 
 impl Iterator for StrListIterator<'_> {
@@ -321,15 +324,15 @@ impl Iterator for StrListIterator<'_> {
                 Ok(DataConstructor::ListCons) => (args.get(0), args.get(1)),
                 Ok(DataConstructor::ListNil) => return None,
                 _ => {
-                    return Some(Err(ExecutionError::Panic(
-                        Smid::default(),
+                    return Some(Err(ExecutionError::NotValue(
+                        self.smid,
                         "expected string list data".to_string(),
                     )))
                 }
             },
             _ => {
-                return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                return Some(Err(ExecutionError::NotValue(
+                    self.smid,
                     "expected string list data".to_string(),
                 )))
             }
@@ -339,7 +342,7 @@ impl Iterator for StrListIterator<'_> {
             Some(h) => self.closure.navigate_local_native(&self.view, h),
             None => {
                 return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                    self.smid,
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -351,7 +354,7 @@ impl Iterator for StrListIterator<'_> {
             }
             None => {
                 return Some(Err(ExecutionError::Panic(
-                    Smid::default(),
+                    self.smid,
                     "malformed cons cell".to_string(),
                 )))
             }
@@ -361,7 +364,7 @@ impl Iterator for StrListIterator<'_> {
             Some(Ok((*self.view.scoped(s)).as_str().to_string()))
         } else {
             Some(Err(ExecutionError::TypeMismatch(
-                Smid::default(),
+                self.smid,
                 Box::new(IntrinsicType::String),
                 Box::new(native_type(&native)),
                 None,
@@ -377,6 +380,7 @@ pub fn str_list_arg<'guard>(
     arg: Ref,
 ) -> Result<StrListIterator<'guard>, ExecutionError> {
     Ok(StrListIterator {
+        smid: machine.annotation(),
         closure: machine.nav(view).resolve(&arg)?,
         view,
     })
@@ -694,6 +698,7 @@ pub fn collect_num_list(
     view: MutatorHeapView<'_>,
     list_ref: Ref,
 ) -> Result<Vec<f64>, ExecutionError> {
+    let smid = machine.annotation();
     let iter = data_list_arg(machine, view, list_ref)?;
     let mut numbers = Vec::new();
     for item_result in iter {
@@ -705,8 +710,8 @@ pub fn collect_num_list(
                 match native {
                     Native::Num(n) => numbers.push(n.as_f64().unwrap_or(0.0)),
                     _ => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
+                        return Err(ExecutionError::NotValue(
+                            smid,
                             "non-numeric value in number list".to_string(),
                         ))
                     }
@@ -717,25 +722,22 @@ pub fn collect_num_list(
                 args: cargs,
             } => {
                 let inner_ref = cargs.get(0).ok_or_else(|| {
-                    ExecutionError::Panic(
-                        Smid::default(),
-                        "empty boxed value in number list".to_string(),
-                    )
+                    ExecutionError::Panic(smid, "empty boxed value in number list".to_string())
                 })?;
                 let native = item_closure.navigate_local_native(&view, inner_ref.clone());
                 match native {
                     Native::Num(n) => numbers.push(n.as_f64().unwrap_or(0.0)),
                     _ => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
+                        return Err(ExecutionError::NotValue(
+                            smid,
                             "non-numeric value in number list".to_string(),
                         ))
                     }
                 }
             }
             _ => {
-                return Err(ExecutionError::Panic(
-                    Smid::default(),
+                return Err(ExecutionError::NotValue(
+                    smid,
                     "unexpected value in number list".to_string(),
                 ))
             }

--- a/tests/harness/errors/error_173.eu
+++ b/tests/harness/errors/error_173.eu
@@ -1,0 +1,10 @@
+# Error test: graph.topo-sort with non-numeric edge values.
+#
+# collect_num_list is called internally for graph intrinsics; passing
+# string values in the edge list used to produce a locationless Panic.
+# After the fix it produces a NotValue error with source location.
+#
+# Expected behaviour:
+#   - Exit code 1
+#   - Stderr mentions "non-numeric value"
+result: graph.topo-sort(3, [["a", 1], [1, 2]])

--- a/tests/harness/errors/error_173.eu.expect
+++ b/tests/harness/errors/error_173.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "non-numeric value in number list"

--- a/tests/harness/errors/error_174.eu
+++ b/tests/harness/errors/error_174.eu
@@ -1,0 +1,10 @@
+# Error test: str.join-on on a list of numbers instead of strings.
+#
+# StrListIterator used to emit TypeMismatch with Smid::default() so no
+# source location appeared in the diagnostic.  After the fix the error
+# carries the annotation Smid from the call site.
+#
+# Expected behaviour:
+#   - Exit code 1
+#   - Stderr mentions "type mismatch" and "string"
+result: [1, 2, 3] str.join-on(",")

--- a/tests/harness/errors/error_174.eu.expect
+++ b/tests/harness/errors/error_174.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch.*expected string"

--- a/tests/harness/errors/error_175.eu
+++ b/tests/harness/errors/error_175.eu
@@ -1,0 +1,10 @@
+# Error test: sort-nums on a string instead of a number list.
+#
+# DataIterator used to emit Panic with Smid::default() so no source
+# location appeared in the diagnostic.  After the fix the error carries
+# the annotation Smid from the call site.
+#
+# Expected behaviour:
+#   - Exit code 1
+#   - Stderr mentions the type mismatch
+result: "not_a_list" sort-nums

--- a/tests/harness/errors/error_175.eu.expect
+++ b/tests/harness/errors/error_175.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch.*list"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2457,6 +2457,28 @@ pub fn test_error_169() {
 }
 
 #[test]
+/// graph.topo-sort with non-numeric edge values used to produce a locationless
+/// Panic from collect_num_list; after the fix it emits a NotValue error with
+/// source location.
+pub fn test_error_173() {
+    run_error_test(&error_opts("error_173.eu"));
+}
+
+#[test]
+/// str.join-on on a list of numbers used to emit TypeMismatch with
+/// Smid::default(); after the fix StrListIterator carries the call-site Smid.
+pub fn test_error_174() {
+    run_error_test(&error_opts("error_174.eu"));
+}
+
+#[test]
+/// sort-nums on a string used to produce a locationless type-mismatch error
+/// from DataIterator; after the fix the error carries the call-site Smid.
+pub fn test_error_175() {
+    run_error_test(&error_opts("error_175.eu"));
+}
+
+#[test]
 /// W4p2 integration: valid declarations structurally equivalent to those
 /// that would survive error recovery evaluate correctly end-to-end.
 /// Paired with test_error_164/165 to prove the full recovery story:


### PR DESCRIPTION
## Summary

- **DataIterator**: add `smid` field set from `machine.annotation()` at construction; replace `Smid::default()` in `Panic`/`NotValue` errors
- **StrListIterator**: same pattern; `TypeMismatch` now carries call-site Smid (e.g. `str.join-on` on a number list now shows a source location)
- **`collect_num_list`**: capture `machine.annotation()` before iterating; replace `Smid::default()` in `NotValue` errors (graph/stat intrinsics)
- **`LIST.DROP` (`ListDrop::execute`)**: use `machine.annotation()` instead of `Smid::default()`; convert `Panic` to `NotValue` for type errors

Three error harness tests added (170–172) covering each code path.

## Test plan

- [ ] `cargo test test_error_17` — all three new tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)