### PR TITLE
feat(gc): sticky-mark-bit minor collection and write barrier (P3+P4)

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -558,31 +558,29 @@ impl MachineState {
 
     /// Update environment index to point to current closure.
     ///
-    /// This is the single mutation site for the generational nursery.
-    /// The write barrier is currently disabled — see comment in body.
+    /// Includes an eager-promotion write barrier: when a marked (old)
+    /// env frame is updated to point to an unmarked (young) closure,
+    /// the closure's code and environment are immediately marked
+    /// (tenured).  This eliminates old→young edges at mutation time,
+    /// allowing minor collections to skip old objects entirely.
+    ///
+    /// Thunk updates are write-once (each thunk is updated exactly once),
+    /// so the barrier cost is bounded: one branch + two potential marks
+    /// per thunk evaluation.
     fn update(
         &mut self,
         view: MutatorHeapView,
         environment: RefPtr<EnvFrame>,
         index: usize,
     ) -> Result<(), ExecutionError> {
+        // Eager promotion: if the env frame is old (marked), mark the
+        // closure's code and environment to eliminate old→young edges.
+        if view.is_marked(environment) {
+            view.write_barrier_mark_young(self.closure.code());
+            view.write_barrier_mark_young(self.closure.env());
+        }
+
         let cont_env = view.scoped(environment);
-
-        // Write barrier is intentionally disabled.  The current minor
-        // collection does a full trace (visiting all reachable objects
-        // via a visited set), so the barrier is not needed for
-        // correctness.  Enabling the write barrier requires
-        // coordinating with the major collection's mark-state flip:
-        // header marks set during mutation would confuse the next
-        // major's flip-at-end, causing the marked objects to be
-        // skipped (their header bit matches mark_state, so they
-        // appear "already traced").
-        //
-        // A future optimisation can enable the barrier alongside a
-        // selective minor that only traces young objects, once the
-        // flip interaction is resolved (e.g. flip-before-trace with
-        // appropriate new-allocation handling).
-
         cont_env.update(&view, index, self.closure.clone())
     }
 

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -159,16 +159,40 @@ impl<T: GcScannable> GcScannable for Vec<NonNull<T>> {
 /// are skipped; young (unmarked) objects are traced and tenured in place.
 pub struct CollectorHeapView<'guard> {
     heap: &'guard mut Heap,
-    /// When `Some`, this is a major (full) collection.  The visited set
-    /// provides traversal termination — `mark()` unconditionally marks
-    /// headers and lines for all reachable objects.
+    /// When `Some`, this is a major (full) collection or a verification
+    /// pass.  The visited set provides traversal termination — `mark()`
+    /// unconditionally marks headers and lines for all reachable objects.
     ///
     /// When `None`, this is a minor collection.  `is_marked()` provides
     /// both termination and generational skipping.
     visited: Option<HashSet<usize>>,
+    /// Mark count at construction time, used by verify passes to detect
+    /// how many objects were newly marked during traversal.
+    mark_count_at_start: u64,
 }
 
-impl CollectorHeapView<'_> {
+impl<'guard> CollectorHeapView<'guard> {
+    /// Create a verification-mode heap view (visited set, for post-minor
+    /// invariant checking).
+    pub fn new_verify(heap: &'guard mut Heap) -> Self {
+        let mark_count = heap.mark_count();
+        CollectorHeapView {
+            heap,
+            visited: Some(HashSet::with_capacity(64 * 1024)),
+            mark_count_at_start: mark_count,
+        }
+    }
+
+    /// Return the number of objects newly marked since this view was created.
+    pub fn newly_marked_count(&self) -> u64 {
+        self.heap.mark_count() - self.mark_count_at_start
+    }
+
+    /// Return the heap's current mark state.
+    pub fn mark_state(&self) -> bool {
+        self.heap.mark_state()
+    }
+
     pub fn reset(&mut self) {
         self.heap.reset_region_marks();
     }
@@ -445,17 +469,37 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
     }
 }
 
-/// Major collection: full mark-sweep with mark-state flip.
+/// Major collection: full mark-sweep using a visited set.
 ///
 /// Resets all line marks, traces every live object from roots using a
-/// visited set for traversal termination, defers sweep.
+/// `HashSet` visited set for traversal termination, defers sweep.
 ///
-/// The mark state is NOT flipped.  With the visited-set approach, full
-/// collections unconditionally mark all reachable objects regardless of
-/// their prior header mark state.  This avoids the 1-bit mark limitation
-/// where a flip would cause newly-allocated objects (whose mark_bit
-/// happens to equal the post-flip state) to appear already marked and
-/// be skipped — leading to use-after-free.
+/// ## Why visited set instead of mark-state flip
+///
+/// The traditional Immix collector uses a mark-state flip to
+/// distinguish "traced this cycle" from "stale mark from last cycle".
+/// However, the sticky-mark-bit generational design is incompatible
+/// with flipping:
+///
+/// With `mark_state = false`:
+/// - Young objects have `mark_bit = true` (from `new_unmarked(false)`)
+/// - Old objects have `mark_bit = false` (from `mark_with_state(false)`)
+///
+/// If we flip to `mark_state = true` before a major trace:
+/// - Former **young** (mark_bit = true): `is_marked(true)` = true
+///   → appear **marked** → **skipped by trace**
+/// - Former **old** (mark_bit = false): `is_marked(true)` = false
+///   → appear unmarked → traced
+///
+/// The flip **inverts** the generational meaning: unreachable young
+/// garbage appears "marked" and survives, while reachable young objects'
+/// children are never discovered.  This causes both memory leaks and
+/// use-after-free.
+///
+/// The visited set avoids this by providing cycle termination
+/// independent of the mark bit.  All reachable objects are
+/// unconditionally marked with `mark_with_state(mark_state)`,
+/// regardless of their prior mark state.
 ///
 /// Optionally performs selective evacuation of fragmented blocks.
 pub fn collect_major(
@@ -481,7 +525,8 @@ pub fn collect_major(
 
     let mut heap_view = CollectorHeapView {
         heap,
-        visited: Some(HashSet::new()),
+        visited: Some(HashSet::with_capacity(64 * 1024)),
+        mark_count_at_start: 0,
     };
 
     // Clear all line marks — every live object will be re-marked
@@ -525,8 +570,10 @@ pub fn collect_major(
         eprintln!("Heap after defer_sweep:\n\n{:?}", &heap_view.heap)
     }
 
-    // Record major collection.  No mark state flip — the visited-set
-    // approach keeps the mark state constant.
+    // Record major collection.  The mark state is never flipped — it
+    // stays constant so that "marked = old" and "unmarked = young"
+    // remain meaningful for minor collections.  See doc comment above
+    // for why flip is incompatible with sticky-mark-bit.
     heap_view.heap.record_major_collection();
 }
 
@@ -544,10 +591,32 @@ pub fn collect_major(
 /// every young object reachable from old objects has already been
 /// promoted.
 ///
+/// ## No sweep in minor collections
+///
+/// Minor collections do NOT sweep.  Dead young objects occupy space
+/// until the next major collection reclaims them.  This is a deliberate
+/// trade-off:
+///
+/// - **Simplicity**: sweeping requires resetting line marks, which
+///   would erase line marks for old objects.  A selective line reset
+///   (young lines only) would require tracking which lines are young
+///   vs old — complexity that exceeds the benefit.
+/// - **Efficiency**: minor collections are fast precisely because they
+///   skip old objects.  Sweeping would add O(heap) cost regardless of
+///   nursery size.
+/// - **Correctness**: old objects' line marks must be preserved because
+///   they were set during the last major (with full trace).  Resetting
+///   and re-marking only young lines would risk missing old objects
+///   whose lines overlap with young allocations.
+///
+/// The adaptive scheduling policy (`should_collect_major`) escalates
+/// to a major collection when too many minors run without reclaiming
+/// enough space, ensuring dead young objects don't accumulate
+/// indefinitely.
+///
 /// Line marks are NOT reset — old objects retain their line marks from
 /// the last major.  Only newly-marked (tenured) objects get fresh line
-/// marks.  Dead young objects have no line marks and occupy space until
-/// the next major collection reclaims them.
+/// marks.
 pub fn collect_minor(
     roots: &mut dyn GcScannable,
     heap: &mut Heap,
@@ -565,6 +634,7 @@ pub fn collect_minor(
     let mut heap_view = CollectorHeapView {
         heap,
         visited: None,
+        mark_count_at_start: 0,
     };
 
     let mut queue = VecDeque::default();
@@ -586,16 +656,21 @@ pub fn collect_minor(
         eprintln!("Heap after minor mark:\n\n{:?}", &heap_view.heap)
     }
 
+    // Post-minor verification: check the old→young invariant.
+    // Every reachable object should now be marked (old).  If any
+    // reachable object is still unmarked, the minor trace or write
+    // barrier has a bug.
+    let verify = super::gc_debug::verify_level();
+    if verify >= 2 {
+        super::gc_verify::verify_post_minor(roots, heap_view.heap);
+    }
+
     clock.switch(ThreadOccupation::Mutator);
 
     // No sweep in minor — dead young objects' space is reclaimed at
     // the next major collection.  No flip — the mark state stays
     // constant so that the generational invariant holds.
-    //
-    // Reclaim ratio is 0.0 because minors don't sweep.  Adaptive
-    // scheduling will escalate to major if too many minors run
-    // without reclaiming space.
-    heap_view.heap.record_minor_collection(0.0);
+    heap_view.heap.record_minor_collection();
 }
 
 /// Perform a collecting GC cycle with selective evacuation of fragmented blocks.
@@ -633,7 +708,8 @@ pub fn collect_with_evacuation(
     {
         let mut heap_view = CollectorHeapView {
             heap: &mut *heap,
-            visited: Some(HashSet::new()),
+            visited: Some(HashSet::with_capacity(64 * 1024)),
+            mark_count_at_start: 0,
         };
         heap_view.reset();
 
@@ -684,6 +760,7 @@ pub fn collect_with_evacuation(
         let heap_view = CollectorHeapView {
             heap: &mut *heap,
             visited: None,
+            mark_count_at_start: 0,
         };
 
         // Update root pointers (MachineState: globals, closure, stack)
@@ -751,6 +828,7 @@ pub fn collect_with_evacuation(
         let mut heap_view = CollectorHeapView {
             heap,
             visited: None,
+            mark_count_at_start: 0,
         };
         heap_view.defer_sweep();
     }
@@ -782,6 +860,7 @@ fn verify_mark_integrity(roots: &dyn GcScannable, heap: &mut Heap) {
     let mut heap_view = CollectorHeapView {
         heap,
         visited: None,
+        mark_count_at_start: 0,
     };
     let mut queue = VecDeque::default();
     let mut scan_buffer = Vec::new();
@@ -1005,6 +1084,7 @@ pub mod tests {
         let heap_view = CollectorHeapView {
             heap: &mut heap,
             visited: None,
+            mark_count_at_start: 0,
         };
         unsafe {
             let obj_ref: &mut dyn GcScannable =
@@ -1114,6 +1194,7 @@ pub mod tests {
         let mut heap_view = CollectorHeapView {
             heap: &mut heap,
             visited: None,
+            mark_count_at_start: 0,
         };
 
         // Mark the object so evacuation recognises it as live
@@ -1174,6 +1255,7 @@ pub mod tests {
         let mut heap_view = CollectorHeapView {
             heap: &mut heap,
             visited: None,
+            mark_count_at_start: 0,
         };
 
         // Mark and evacuate both

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -149,19 +149,23 @@ impl<T: GcScannable> GcScannable for Vec<NonNull<T>> {
 
 /// View of the heap available to the collector.
 ///
-/// In major mode (default), `mark()` uses the header mark bit to track
-/// visited objects — an already-marked object is skipped.
+/// In major mode (`visited: Some(HashSet)`), `mark()` uses the visited
+/// set for traversal termination and unconditionally marks headers and
+/// lines.  This avoids the 1-bit mark limitation where a flip would
+/// cause newly-allocated objects to appear marked after the state change.
 ///
-/// In minor mode, a `HashSet` tracks visited addresses so that old
-/// (already header-marked) objects are still scanned to discover young
-/// children.  This is necessary because without a complete transitive
-/// write barrier, old→young edges can exist.
+/// In minor mode (`visited: None`), `mark()` uses `is_marked()` for both
+/// termination and generational skipping.  Already-marked (old) objects
+/// are skipped; young (unmarked) objects are traced and tenured in place.
 pub struct CollectorHeapView<'guard> {
     heap: &'guard mut Heap,
-    /// When `Some`, we are in minor mode: the set tracks all objects
-    /// visited during this minor cycle so that old objects are scanned
-    /// exactly once.
-    minor_visited: Option<HashSet<usize>>,
+    /// When `Some`, this is a major (full) collection.  The visited set
+    /// provides traversal termination — `mark()` unconditionally marks
+    /// headers and lines for all reachable objects.
+    ///
+    /// When `None`, this is a minor collection.  `is_marked()` provides
+    /// both termination and generational skipping.
+    visited: Option<HashSet<usize>>,
 }
 
 impl CollectorHeapView<'_> {
@@ -169,12 +173,28 @@ impl CollectorHeapView<'_> {
         self.heap.reset_region_marks();
     }
 
-    /// Mark object if not already marked and return whether it should
-    /// be scanned (queued).
+    /// Check whether an object is newly discovered in this collection cycle.
     ///
-    /// In major mode, this checks the header mark bit.
-    /// In minor mode, this uses the visited set so that old objects are
-    /// scanned once (to discover young children) without re-marking them.
+    /// With a visited set (major): inserts the address and returns true
+    /// if not previously seen.
+    /// Without (minor): returns true if the object is young (unmarked).
+    #[inline(always)]
+    fn is_new<T>(&mut self, ptr: NonNull<T>) -> bool {
+        if let Some(ref mut visited) = self.visited {
+            visited.insert(ptr.as_ptr() as usize)
+        } else {
+            !self.heap.is_marked(ptr)
+        }
+    }
+
+    /// Mark object if newly discovered and return whether it should be
+    /// scanned (queued).
+    ///
+    /// In major mode (visited set active), unconditionally marks the
+    /// object's header and lines, using the visited set for cycle
+    /// termination.
+    /// In minor mode, uses `is_marked()` for generational skipping:
+    /// old objects are skipped, young objects are marked (tenured).
     pub fn mark<T>(&mut self, obj: NonNull<T>) -> bool {
         debug_assert!(obj != NonNull::dangling());
         debug_assert!(obj.as_ptr() as usize != usize::MAX);
@@ -196,11 +216,7 @@ impl CollectorHeapView<'_> {
             }
         }
 
-        if let Some(ref mut visited) = self.minor_visited {
-            return Self::mark_minor_inner(self.heap, obj, visited);
-        }
-
-        if obj != NonNull::dangling() && !self.heap.is_marked(obj) {
+        if obj != NonNull::dangling() && self.is_new(obj) {
             self.heap.mark_object(obj);
             self.heap.mark_line(obj);
 
@@ -224,32 +240,6 @@ impl CollectorHeapView<'_> {
         }
     }
 
-    /// Minor-mode mark: visit every reachable object exactly once,
-    /// re-marking lines for ALL visited objects.
-    ///
-    /// Header mark bits are NOT changed — only lines are marked.
-    /// This avoids conflicts with the major collection's flip-at-end
-    /// semantics.  The major sees all objects as "unmarked" (header
-    /// bit ≠ mark_state after a flip) and re-traces everything,
-    /// which is correct regardless of whether a minor ran in between.
-    ///
-    /// Cannot borrow `self` because `minor_visited` is part of self;
-    /// the caller passes the visited set directly.
-    fn mark_minor_inner<T>(heap: &mut Heap, obj: NonNull<T>, visited: &mut HashSet<usize>) -> bool {
-        let addr = obj.as_ptr() as usize;
-        if !visited.insert(addr) {
-            return false; // already visited this cycle
-        }
-
-        // Mark lines for this object (lines were reset at start)
-        heap.mark_line(obj);
-
-        // Do NOT set the header mark bit — leave it for major
-        // collections which use the flip mechanism.
-
-        true // scan children
-    }
-
     /// Mark a raw byte allocation (e.g. a `RawArray<u8>` backing buffer)
     /// if not already marked, covering all lines spanned by the bytes.
     ///
@@ -258,18 +248,7 @@ impl CollectorHeapView<'_> {
     pub fn mark_raw_bytes(&mut self, ptr: NonNull<u8>) -> bool {
         debug_assert!(ptr != NonNull::dangling());
         debug_assert!(ptr.as_ptr() as usize != usize::MAX);
-
-        if let Some(ref mut visited) = self.minor_visited {
-            let addr = ptr.as_ptr() as usize;
-            if !visited.insert(addr) {
-                return false;
-            }
-            // Lines only — no header mark change in minor mode
-            self.heap.mark_lines_for_bytes(ptr);
-            return true;
-        }
-
-        if !self.heap.is_marked(ptr) {
+        if self.is_new(ptr) {
             self.heap.mark_object(ptr);
             self.heap.mark_lines_for_bytes(ptr);
             true
@@ -278,23 +257,12 @@ impl CollectorHeapView<'_> {
         }
     }
 
-    /// Mark object if not already marked and return whether marked
+    /// Mark array backing store if not already visited and return whether marked
     pub fn mark_array<T: Clone>(&mut self, arr: &Array<T>) -> bool {
         if let Some(ptr) = arr.allocated_data() {
             debug_assert!(ptr != NonNull::dangling());
             debug_assert!(ptr.as_ptr() as usize != usize::MAX);
-
-            if let Some(ref mut visited) = self.minor_visited {
-                let addr = ptr.as_ptr() as usize;
-                if !visited.insert(addr) {
-                    return false;
-                }
-                // Lines only — no header mark change in minor mode
-                self.heap.mark_lines_for_bytes(ptr);
-                return true;
-            }
-
-            if !self.heap.is_marked(ptr) {
+            if self.is_new(ptr) {
                 self.heap.mark_object(ptr);
                 self.heap.mark_lines_for_bytes(ptr);
                 true
@@ -439,6 +407,12 @@ impl CollectorHeapView<'_> {
         let old_header = unsafe { &mut *self.heap.header_ptr_mut(obj) };
         old_header.set_forwarded(new_obj.cast());
 
+        // Register the new copy in the visited set so the traversal
+        // does not re-process it.
+        if let Some(ref mut visited) = self.visited {
+            visited.insert(new_obj.as_ptr() as usize);
+        }
+
         // Mark the new copy as live.
         //
         // Use `mark_lines_for_bytes` rather than `mark_line<T>` so that the
@@ -464,25 +438,24 @@ impl CollectorScope for Scope {}
 /// `collect_minor` or `collect_major` depending on the heap's nursery
 /// scheduling policy.
 pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, dump_heap: bool) {
-    // All collections are currently major.  The allocation-rate
-    // trigger (`policy_requires_collection`) provides more frequent
-    // collection without needing a separate minor path.
-    //
-    // A true minor collection (sticky-mark-bit, skipping old objects)
-    // requires a write barrier that coordinates with the mark-state
-    // flip.  Setting header marks during mutation (eager promotion)
-    // causes those objects to be skipped by the next major's trace
-    // after the flip, since their bit matches mark_state.  The minor
-    // path (`collect_minor`) and its full-trace visited-set approach
-    // are retained below for when this is resolved.
-    collect_major(roots, heap, clock, dump_heap);
+    if heap.should_collect_major() {
+        collect_major(roots, heap, clock, dump_heap);
+    } else {
+        collect_minor(roots, heap, clock, dump_heap);
+    }
 }
 
 /// Major collection: full mark-sweep with mark-state flip.
 ///
-/// Resets all line marks, traces every live object from roots, defers
-/// sweep, then flips the mark state so that all surviving objects are
-/// now "old" (their header mark bit matches the new mark state).
+/// Resets all line marks, traces every live object from roots using a
+/// visited set for traversal termination, defers sweep.
+///
+/// The mark state is NOT flipped.  With the visited-set approach, full
+/// collections unconditionally mark all reachable objects regardless of
+/// their prior header mark state.  This avoids the 1-bit mark limitation
+/// where a flip would cause newly-allocated objects (whose mark_bit
+/// happens to equal the post-flip state) to appear already marked and
+/// be skipped — leading to use-after-free.
 ///
 /// Optionally performs selective evacuation of fragmented blocks.
 pub fn collect_major(
@@ -508,7 +481,7 @@ pub fn collect_major(
 
     let mut heap_view = CollectorHeapView {
         heap,
-        minor_visited: None,
+        visited: Some(HashSet::new()),
     };
 
     // Clear all line marks — every live object will be re-marked
@@ -552,25 +525,29 @@ pub fn collect_major(
         eprintln!("Heap after defer_sweep:\n\n{:?}", &heap_view.heap)
     }
 
-    // Record major collection and flip mark state
+    // Record major collection.  No mark state flip — the visited-set
+    // approach keeps the mark state constant.
     heap_view.heap.record_major_collection();
-    heap_view.heap.flip_mark_state();
 }
 
-/// Minor (nursery) collection: full trace without mark-state flip.
+/// Minor (nursery) collection: trace young objects only.
 ///
-/// Line marks ARE reset so that dead objects (old and young) have their
-/// lines reclaimed.  The trace visits ALL reachable objects (old and
-/// young alike), using a visited set to handle cycle detection for old
-/// objects whose header mark bit would otherwise cause them to be
-/// skipped.  Young objects that are reached are tenured in place (their
-/// header mark bit is set).  The mark state is NOT flipped.
+/// Uses `is_marked()` for generational skipping: already-marked (old)
+/// objects are skipped, and only young (unmarked) objects are traced
+/// and tenured in place (their header mark bit is set via `mark_object`).
 ///
-/// The full trace is necessary because without a transitive write
-/// barrier, old→young edges can exist (an old thunk's result may
-/// reference young objects).  Once the write barrier ensures all
-/// old→young references are eagerly promoted, a future optimisation
-/// can switch to tracing only young objects.
+/// The eager promotion write barrier (`write_barrier_mark_young`) ensures
+/// that all old→young edges are eliminated at mutation time: when an old
+/// (marked) env frame is updated with a value pointing to a young
+/// (unmarked) object, the young object is immediately marked.  This
+/// means the minor does NOT need a remembered set or full trace —
+/// every young object reachable from old objects has already been
+/// promoted.
+///
+/// Line marks are NOT reset — old objects retain their line marks from
+/// the last major.  Only newly-marked (tenured) objects get fresh line
+/// marks.  Dead young objects have no line marks and occupy space until
+/// the next major collection reclaims them.
 pub fn collect_minor(
     roots: &mut dyn GcScannable,
     heap: &mut Heap,
@@ -581,29 +558,22 @@ pub fn collect_minor(
         eprintln!("GC (minor)!");
     }
 
-    let blocks_before = heap.stats().recycled;
-
     clock.switch(ThreadOccupation::CollectorMark);
 
+    // Minor mode: visited = None → is_marked() for generational skip.
+    // No line reset — old objects keep their line marks.
     let mut heap_view = CollectorHeapView {
         heap,
-        minor_visited: Some(HashSet::new()),
+        visited: None,
     };
-
-    // Reset all line marks.  The full trace below will re-mark lines
-    // for every reachable object (old and young).  Dead objects' lines
-    // remain unmarked and are reclaimable by lazy sweep.
-    heap_view.reset();
 
     let mut queue = VecDeque::default();
     let mut scan_buffer = Vec::new();
 
     let scope = Scope();
 
-    // Trace from roots.  In minor mode, mark() uses the visited set
-    // so that old objects are scanned exactly once (discovering young
-    // children) without relying on the header mark bit for cycle
-    // detection.
+    // Trace from roots.  Old (marked) objects are skipped by mark().
+    // Only young (unmarked) objects are traced and tenured.
     roots.scan(&scope, &mut heap_view, &mut scan_buffer);
     queue.extend(scan_buffer.drain(..));
 
@@ -616,34 +586,16 @@ pub fn collect_minor(
         eprintln!("Heap after minor mark:\n\n{:?}", &heap_view.heap)
     }
 
-    // Skip verify_mark_integrity — minor does not change header marks,
-    // so the verify (which checks header marks) would find nothing
-    // meaningful.  The full-trace via visited set guarantees all
-    // reachable objects have their lines marked.
+    clock.switch(ThreadOccupation::Mutator);
 
-    let verify = super::gc_debug::verify_level();
-
-    clock.switch(ThreadOccupation::CollectorSweep);
-
-    // Defer sweep — lazy sweep will reclaim lines with no marks
-    heap_view.defer_sweep();
-
-    if verify >= 2 {
-        super::gc_verify::verify_post_sweep(heap_view.heap);
-    }
-
-    if dump_heap {
-        eprintln!("Heap after minor defer_sweep:\n\n{:?}", &heap_view.heap)
-    }
-
-    // Calculate reclaim ratio for adaptive scheduling
-    let blocks_after = heap_view.heap.stats().recycled;
-    let reclaimed = blocks_after.saturating_sub(blocks_before);
-    let budget = heap_view.heap.nursery_budget().max(1);
-    let reclaim_ratio = reclaimed as f64 / budget as f64;
-
-    // Do NOT flip mark state — header marks are unchanged.
-    heap_view.heap.record_minor_collection(reclaim_ratio);
+    // No sweep in minor — dead young objects' space is reclaimed at
+    // the next major collection.  No flip — the mark state stays
+    // constant so that the generational invariant holds.
+    //
+    // Reclaim ratio is 0.0 because minors don't sweep.  Adaptive
+    // scheduling will escalate to major if too many minors run
+    // without reclaiming space.
+    heap_view.heap.record_minor_collection(0.0);
 }
 
 /// Perform a collecting GC cycle with selective evacuation of fragmented blocks.
@@ -681,7 +633,7 @@ pub fn collect_with_evacuation(
     {
         let mut heap_view = CollectorHeapView {
             heap: &mut *heap,
-            minor_visited: None,
+            visited: Some(HashSet::new()),
         };
         heap_view.reset();
 
@@ -731,7 +683,7 @@ pub fn collect_with_evacuation(
     {
         let heap_view = CollectorHeapView {
             heap: &mut *heap,
-            minor_visited: None,
+            visited: None,
         };
 
         // Update root pointers (MachineState: globals, closure, stack)
@@ -798,7 +750,7 @@ pub fn collect_with_evacuation(
     {
         let mut heap_view = CollectorHeapView {
             heap,
-            minor_visited: None,
+            visited: None,
         };
         heap_view.defer_sweep();
     }
@@ -808,8 +760,8 @@ pub fn collect_with_evacuation(
         super::gc_verify::verify_post_sweep(heap);
     }
 
+    // Record major collection.  No flip — visited-set approach.
     heap.record_major_collection();
-    heap.flip_mark_state();
 }
 
 /// Verify mark integrity after the mark phase.
@@ -829,7 +781,7 @@ fn verify_mark_integrity(roots: &dyn GcScannable, heap: &mut Heap) {
     let scope = Scope();
     let mut heap_view = CollectorHeapView {
         heap,
-        minor_visited: None,
+        visited: None,
     };
     let mut queue = VecDeque::default();
     let mut scan_buffer = Vec::new();
@@ -957,7 +909,7 @@ pub mod tests {
         };
 
         {
-            collect(&mut vec![let_ptr, bif_ptr], &mut heap, &mut clock, true);
+            collect_major(&mut vec![let_ptr, bif_ptr], &mut heap, &mut clock, true);
         }
 
         // Flush lazy sweep so recycled counts are deterministic
@@ -965,7 +917,7 @@ pub mod tests {
         let stats_a = heap.stats();
 
         {
-            collect(&mut vec![bif_ptr], &mut heap, &mut clock, true);
+            collect_major(&mut vec![bif_ptr], &mut heap, &mut clock, true);
         }
 
         heap.flush_unswept();
@@ -998,7 +950,7 @@ pub mod tests {
         };
 
         {
-            collect(&mut vec![let_ptr2], &mut heap, &mut clock, true);
+            collect_major(&mut vec![let_ptr2], &mut heap, &mut clock, true);
         }
 
         heap.flush_unswept();
@@ -1052,7 +1004,7 @@ pub mod tests {
         // nothing is forwarded, but verifies the transmute doesn't crash)
         let heap_view = CollectorHeapView {
             heap: &mut heap,
-            minor_visited: None,
+            visited: None,
         };
         unsafe {
             let obj_ref: &mut dyn GcScannable =
@@ -1161,7 +1113,7 @@ pub mod tests {
         // Manually perform evacuation via CollectorHeapView
         let mut heap_view = CollectorHeapView {
             heap: &mut heap,
-            minor_visited: None,
+            visited: None,
         };
 
         // Mark the object so evacuation recognises it as live
@@ -1221,7 +1173,7 @@ pub mod tests {
 
         let mut heap_view = CollectorHeapView {
             heap: &mut heap,
-            minor_visited: None,
+            visited: None,
         };
 
         // Mark and evacuate both
@@ -1354,24 +1306,30 @@ pub mod tests {
 
     #[test]
     pub fn test_per_heap_mark_state_isolation() {
-        // Test that each heap has its own independent mark state
+        // Test that each heap has its own independent mark state.
+        // With the no-flip visited-set approach, mark state is constant,
+        // so we verify that collection does not affect the other heap's
+        // collection count.
         let mut heap1 = Heap::new();
-        let heap2 = Heap::new();
+        let mut heap2 = Heap::new();
         let mut clock = Clock::default();
         clock.switch(ThreadOccupation::Mutator);
 
-        // Both heaps should start with the same mark state
-        assert_eq!(heap1.mark_state(), heap2.mark_state());
-        let initial_state = heap1.mark_state();
+        let stats1_before = heap1.stats().collections_count;
+        let stats2_before = heap2.stats().collections_count;
 
         // Perform collection on heap1 only
         let mut empty_roots: Vec<NonNull<crate::eval::memory::syntax::HeapSyn>> = vec![];
-        collect(&mut empty_roots, &mut heap1, &mut clock, true);
+        collect_major(&mut empty_roots, &mut heap1, &mut clock, false);
 
-        // heap1's mark state should have flipped, heap2's should remain unchanged
-        assert_ne!(heap1.mark_state(), initial_state);
-        assert_eq!(heap2.mark_state(), initial_state);
-        assert_ne!(heap1.mark_state(), heap2.mark_state());
+        // heap1 should have recorded a collection; heap2 should not
+        assert_eq!(heap1.stats().collections_count, stats1_before + 1);
+        assert_eq!(heap2.stats().collections_count, stats2_before);
+
+        // Collect heap2 — should not affect heap1's count
+        collect_major(&mut empty_roots, &mut heap2, &mut clock, false);
+        assert_eq!(heap1.stats().collections_count, stats1_before + 1);
+        assert_eq!(heap2.stats().collections_count, stats2_before + 1);
     }
 
     #[test]
@@ -1414,7 +1372,7 @@ pub mod tests {
         };
 
         {
-            collect(&mut vec![let_ptr, bif_ptr], &mut heap, &mut clock, true);
+            collect_major(&mut vec![let_ptr, bif_ptr], &mut heap, &mut clock, true);
         }
 
         // Flush lazy sweep so recycled counts are deterministic
@@ -1422,7 +1380,7 @@ pub mod tests {
         let stats_a = heap.stats();
 
         {
-            collect(&mut vec![bif_ptr], &mut heap, &mut clock, true);
+            collect_major(&mut vec![bif_ptr], &mut heap, &mut clock, true);
         }
 
         heap.flush_unswept();
@@ -1454,7 +1412,7 @@ pub mod tests {
         };
 
         {
-            collect(&mut vec![let_ptr2], &mut heap, &mut clock, true);
+            collect_major(&mut vec![let_ptr2], &mut heap, &mut clock, true);
         }
 
         heap.flush_unswept();

--- a/src/eval/memory/gc_verify.rs
+++ b/src/eval/memory/gc_verify.rs
@@ -177,6 +177,62 @@ pub(crate) fn verify_post_update(heap: &Heap) {
     let _ = (mark_state, block_ranges);
 }
 
+/// Post-minor verification: old→young invariant check.
+///
+/// After a minor collection with eager promotion, every reachable
+/// object must be marked (old).  The minor marks all reachable young
+/// objects (tenuring them), and the write barrier marks young objects
+/// pointed to by old objects.  If any reachable object is still
+/// unmarked after the minor, either the trace missed it or the write
+/// barrier failed to promote it.
+///
+/// This traverses from roots using a visited set to visit ALL
+/// reachable objects (not just young ones).  For each discovered
+/// object, it verifies the header is marked.
+///
+/// Enabled by `EU_GC_VERIFY=2`.
+pub(crate) fn verify_post_minor(roots: &dyn super::collect::GcScannable, heap: &mut Heap) {
+    use super::collect::{CollectorHeapView, Scope};
+    use std::collections::VecDeque;
+
+    let scope = Scope();
+    let mut heap_view = CollectorHeapView::new_verify(heap);
+    let mut queue = VecDeque::default();
+    let mut scan_buffer = Vec::new();
+    let mut total = 0usize;
+    let mark_state = heap_view.mark_state();
+
+    // Traverse from roots using the visited set.  mark() will
+    // unconditionally mark objects, but after a correct minor all
+    // reachable objects should already be marked.  We check BEFORE
+    // marking to detect the bug.
+    roots.scan(&scope, &mut heap_view, &mut scan_buffer);
+    queue.extend(scan_buffer.drain(..));
+
+    while let Some(scanptr) = queue.pop_front() {
+        total += 1;
+        // The object was already marked by the visited-set mark().
+        // We check the object's prior state by counting how many
+        // mark_object calls occurred — the mark_count delta tells us.
+        scanptr.get().scan(&scope, &mut heap_view, &mut scan_buffer);
+        queue.extend(scan_buffer.drain(..));
+    }
+
+    // Count objects that were newly marked during this verification
+    // traversal.  These were unmarked (young) after the minor,
+    // meaning the minor trace or write barrier missed them.
+    let newly_marked = heap_view.newly_marked_count();
+    if newly_marked > 0 {
+        panic!(
+            "POST-MINOR old→young invariant violation: {newly_marked} reachable objects \
+             were still unmarked (young) after minor collection \
+             ({total} objects traversed, mark_state={mark_state}). \
+             This indicates either the minor trace missed them or the \
+             write barrier failed to promote them.",
+        );
+    }
+}
+
 /// Post-sweep verification: block list disjointness and rest block
 /// liveness.
 pub(crate) fn verify_post_sweep(heap: &Heap) {

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -53,10 +53,6 @@ const DEFAULT_NURSERY_BUDGET: usize = 256;
 /// After this many consecutive minor collections, force a major collection.
 const MINORS_BEFORE_MAJOR: usize = 8;
 
-/// If a minor collection reclaims less than this fraction of the nursery,
-/// escalate to a major collection next time.
-const MIN_MINOR_RECLAIM_RATIO: f64 = 0.25;
-
 /// Type of garbage collection performed
 #[derive(Debug, Clone, Copy)]
 enum CollectionType {
@@ -1754,6 +1750,10 @@ impl Heap {
 
     pub fn with_limit(limit_mib: usize) -> Self {
         let block_limit = (limit_mib * 1_048_576) / BLOCK_SIZE_BYTES;
+        // Scale nursery budget to the heap limit: at most 1/16 of the
+        // limit, so collections trigger before dead young objects fill
+        // the heap.  Floor at 8 blocks (256 KiB).
+        let budget = (block_limit / 16).clamp(8, DEFAULT_NURSERY_BUDGET);
         Heap {
             state: UnsafeCell::new(HeapState::new()),
             limit: Some(block_limit),
@@ -1764,7 +1764,7 @@ impl Heap {
             pin_counts: UnsafeCell::new(HashMap::new()),
             mark_count: std::cell::Cell::new(0),
 
-            nursery_budget: std::cell::Cell::new(DEFAULT_NURSERY_BUDGET),
+            nursery_budget: std::cell::Cell::new(budget),
             minors_since_major: std::cell::Cell::new(0),
             minor_collection_count: std::cell::Cell::new(0),
             major_collection_count: std::cell::Cell::new(0),
@@ -1865,15 +1865,17 @@ impl Heap {
 
         // Allocation-rate trigger: nursery budget exhausted.
         //
-        // Only active when a heap limit is set, because without a
-        // limit there is no memory pressure and the allocation-rate
-        // trigger would cause unnecessary full collections.  When a
-        // true minor collection (skipping old objects) is available,
-        // this trigger should fire unconditionally.
-        if self.limit.is_some() {
-            let heap_state = unsafe { &*self.state.get() };
-            if heap_state.blocks_replaced_since_gc >= self.nursery_budget.get() {
-                return true;
+        // Only active when the heap is under memory pressure — i.e.
+        // when at least half of the heap limit is in use.  Programs
+        // that never approach the limit (e.g. naive_fib at the
+        // default 32 GiB limit) avoid unnecessary collection overhead.
+        if let Some(limit) = self.limit {
+            let stats = self.stats();
+            if stats.blocks_allocated >= limit / 2 {
+                let heap_state = unsafe { &*self.state.get() };
+                if heap_state.blocks_replaced_since_gc >= self.nursery_budget.get() {
+                    return true;
+                }
             }
         }
 
@@ -1884,9 +1886,10 @@ impl Heap {
     ///
     /// A major collection is chosen when:
     /// - Too many consecutive minors have occurred (> `MINORS_BEFORE_MAJOR`)
-    /// - The heap limit is reached (back-pressure)
     /// - GC stress mode is active (every collection is major to maximise
-    ///   coverage of the flip-and-trace path)
+    ///   coverage of the visited-set trace path)
+    /// - Heap usage exceeds the limit (minors don't sweep, so dead young
+    ///   objects accumulate; a major is needed to reclaim them)
     pub fn should_collect_major(&self) -> bool {
         if self.gc_stress {
             return true;
@@ -1902,10 +1905,15 @@ impl Heap {
             return true;
         }
 
-        // If the heap limit is reached, escalate to major
+        // If the heap exceeds the limit, escalate to major.  Minors
+        // don't sweep, so dead young objects accumulate between majors.
+        // Without this, the heap grows unboundedly at tight limits.
+        // We only check this AFTER at least one minor has run, so the
+        // nursery gets a chance to tenure objects before forcing a
+        // full trace.
         if let Some(limit) = self.limit {
             let stats = self.stats();
-            if stats.blocks_allocated >= limit {
+            if stats.blocks_allocated >= limit && self.minors_since_major.get() > 0 {
                 return true;
             }
         }
@@ -1916,10 +1924,11 @@ impl Heap {
     /// Record that a minor collection completed.
     ///
     /// Updates counters and resets the allocation-rate trigger.
-    /// `reclaim_ratio` is the fraction of nursery blocks reclaimed
-    /// (0.0–1.0); if below `MIN_MINOR_RECLAIM_RATIO` the next
-    /// collection will be escalated to major.
-    pub fn record_minor_collection(&self, reclaim_ratio: f64) {
+    /// Minor collections do not sweep (dead young objects are reclaimed
+    /// at the next major), so there is no reclaim-ratio escalation.
+    /// The count-based `MINORS_BEFORE_MAJOR` threshold handles
+    /// escalation to major when minors accumulate.
+    pub fn record_minor_collection(&self) {
         self.minor_collection_count
             .set(self.minor_collection_count.get() + 1);
         let minors = self.minors_since_major.get() + 1;
@@ -1929,11 +1938,6 @@ impl Heap {
         let heap_state = unsafe { &mut *self.state.get() };
         heap_state.blocks_replaced_since_gc = 0;
         heap_state.record_collection();
-
-        // If minor reclaimed very little, force a major next time
-        if reclaim_ratio < MIN_MINOR_RECLAIM_RATIO {
-            self.minors_since_major.set(MINORS_BEFORE_MAJOR);
-        }
     }
 
     /// Record that a major collection completed.


### PR DESCRIPTION
## Summary

Implements P3 (sticky-mark-bit minor collection) and P4 (write barrier with eager promotion) from the GC nursery spec.

- **No-flip visited-set approach**: Major collections use a `HashSet` visited set for traversal termination instead of mark-state flips. This resolves the fundamental 1-bit mark limitation where eager promotion would cause promoted objects to be skipped after a flip.
- **Minor collections**: Use `is_marked()` for generational skipping — old objects are skipped, young objects are traced and tenured in place. No line reset, no sweep, no flip.
- **Write barrier**: When an old env frame is updated (thunk update), the closure's code and environment pointers are immediately marked if young, eliminating old→young edges at mutation time.
- **Simplified collector**: `CollectorHeapView` uses a single `visited: Option<HashSet>` field — `Some` for major, `None` for minor. The `is_new()` helper unifies termination logic. Removed `mark_minor_inner()` and duplicate minor-mode branches.

## Test plan

- [x] All 1146 lib tests pass
- [x] All 450 harness tests pass
- [x] `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1` — all harness tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] Test 089 (sharing/thunk memoisation) passes under stress

🤖 Generated with [Claude Code](https://claude.com/claude-code)