### PR TITLE
feat(core): re-flatten nested Let scopes after demand analysis

### DIFF
--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -167,7 +167,7 @@ fn run() -> i32 {
         }
     }
 
-    if opt.run() || opt.dump_stg() || opt.dump_runtime() {
+    if opt.run() || opt.dump_stg() || opt.dump_runtime() || opt.dump_reflatten() {
         // run manages error reporting
         match eval::run(&opt, loader) {
             Ok(result) => {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ pub mod export;
 pub mod expr;
 pub mod inline;
 pub mod metadata;
+pub mod reflatten;
 pub mod rt;
 pub mod simplify;
 pub mod target;

--- a/src/core/reflatten.rs
+++ b/src/core/reflatten.rs
@@ -1,0 +1,369 @@
+//! Re-flatten nested Let/LetRec scopes after demand analysis.
+//!
+//! SCC splitting decomposes large `LetRec` scopes into chains of
+//! nested `Let` + `LetRec` scopes for precise demand analysis.  Each
+//! nested scope becomes a separate `EnvFrame` at runtime, causing
+//! O(depth) variable lookup regressions.
+//!
+//! This pass runs **after** demand analysis and **before** STG
+//! compilation.  It merges chains of directly nested `Let`/`LetRec`
+//! scopes back into a single scope while preserving the per-binding
+//! `Demand` annotations that the analysis pass populated.
+//!
+//! `DefaultBlockLet` scopes are never merged — they represent block
+//! values, not function bindings.
+
+use crate::core::binding::{CoreBinding, Scope};
+use crate::core::demand::Demand;
+use crate::core::expr::{close_expr_vars, open_let_scope_full, Expr, LetType, RcExpr};
+
+/// Run the re-flatten pass over an entire expression tree.
+pub fn reflatten(expr: &RcExpr) -> RcExpr {
+    walk(expr)
+}
+
+/// Recursive walk: process children first (bottom-up), then flatten
+/// the current node if it heads a chain of mergeable Let scopes.
+fn walk(expr: &RcExpr) -> RcExpr {
+    match &*expr.inner {
+        Expr::Let(s, scope, let_type) => {
+            // Recurse into binding RHSs and body first.
+            let new_bindings: Vec<CoreBinding<RcExpr>> = scope
+                .pattern
+                .iter()
+                .map(|b| CoreBinding::with_demand(b.name.clone(), walk(&b.expr), b.demand))
+                .collect();
+            let new_body = walk(&scope.body);
+            let new_scope = Scope {
+                pattern: new_bindings,
+                body: new_body,
+            };
+            let rebuilt = RcExpr::from(Expr::Let(*s, new_scope, *let_type));
+
+            // Only flatten OtherLet scopes.
+            if *let_type != LetType::OtherLet {
+                return rebuilt;
+            }
+
+            // Check if this heads a chain of mergeable scopes.
+            flatten_chain(&rebuilt)
+        }
+        Expr::Lam(s, inl, scope) => {
+            let new_body = walk(&scope.body);
+            RcExpr::from(Expr::Lam(
+                *s,
+                *inl,
+                Scope {
+                    pattern: scope.pattern.clone(),
+                    body: new_body,
+                },
+            ))
+        }
+        Expr::App(s, f, args) => {
+            let new_f = walk(f);
+            let new_args: Vec<RcExpr> = args.iter().map(walk).collect();
+            RcExpr::from(Expr::App(*s, new_f, new_args))
+        }
+        Expr::Lookup(s, obj, key, fb) => {
+            let new_obj = walk(obj);
+            let new_fb = fb.as_ref().map(walk);
+            RcExpr::from(Expr::Lookup(*s, new_obj, key.clone(), new_fb))
+        }
+        Expr::List(s, xs) => {
+            let new_xs: Vec<RcExpr> = xs.iter().map(walk).collect();
+            RcExpr::from(Expr::List(*s, new_xs))
+        }
+        Expr::Block(s, bm) => {
+            let new_bm = bm.map_values(|v| Ok::<_, ()>(walk(&v))).unwrap();
+            RcExpr::from(Expr::Block(*s, new_bm))
+        }
+        Expr::Meta(s, e, m) => {
+            let new_e = walk(e);
+            let new_m = walk(m);
+            RcExpr::from(Expr::Meta(*s, new_e, new_m))
+        }
+        Expr::ArgTuple(s, xs) => {
+            let new_xs: Vec<RcExpr> = xs.iter().map(walk).collect();
+            RcExpr::from(Expr::ArgTuple(*s, new_xs))
+        }
+        Expr::Soup(s, xs, b) => {
+            let new_xs: Vec<RcExpr> = xs.iter().map(walk).collect();
+            RcExpr::from(Expr::Soup(*s, new_xs, *b))
+        }
+        Expr::Operator(s, f, p, e) => {
+            let new_e = walk(e);
+            RcExpr::from(Expr::Operator(*s, *f, *p, new_e))
+        }
+        // Leaf nodes — no recursion needed.
+        _ => expr.clone(),
+    }
+}
+
+/// A binding with its demand annotation, in opened (free-variable) form.
+struct OpenBinding {
+    name: String,
+    expr: RcExpr,
+    demand: Demand,
+}
+
+/// Check if `expr` heads a chain of mergeable Let/LetRec scopes.
+/// If so, collect all bindings and merge into a single scope.
+/// Otherwise return the expression unchanged.
+fn flatten_chain(expr: &RcExpr) -> RcExpr {
+    let (smid, scope, let_type) = match &*expr.inner {
+        Expr::Let(s, scope, lt) => (*s, scope, *lt),
+        _ => return expr.clone(),
+    };
+
+    // Only flatten OtherLet scopes.
+    if let_type != LetType::OtherLet {
+        return expr.clone();
+    }
+
+    // Check if body is also a mergeable Let scope.
+    if !is_mergeable_let(&scope.body) {
+        return expr.clone();
+    }
+
+    // Collect the chain of nested scopes.
+    // We open each scope to convert bound vars to free, collecting
+    // bindings with their demand annotations.
+    let mut all_bindings: Vec<OpenBinding> = Vec::new();
+    let innermost_body = collect_chain(scope, &mut all_bindings);
+
+    // If only one scope was collected, no flattening needed.
+    if all_bindings.len() == scope.pattern.len() {
+        return expr.clone();
+    }
+
+    // Close all bindings into a single scope, preserving demand.
+    // All merged scopes use OtherLet — the STG compiler determines
+    // recursiveness from the binding graph, not the LetType.
+    close_let_scope_with_demand(smid, all_bindings, innermost_body, LetType::OtherLet)
+}
+
+/// Check whether an expression is a Let/LetRec scope that can be
+/// merged (i.e. OtherLet, not DefaultBlockLet or destructure lets).
+fn is_mergeable_let(expr: &RcExpr) -> bool {
+    matches!(&*expr.inner, Expr::Let(_, _, LetType::OtherLet))
+}
+
+/// Recursively collect bindings from a chain of nested Let/LetRec scopes.
+///
+/// Opens each scope, appending bindings to `all_bindings` with their
+/// demand annotations preserved.  Returns the innermost non-Let body.
+fn collect_chain(
+    scope: &Scope<Vec<CoreBinding<RcExpr>>, RcExpr>,
+    all_bindings: &mut Vec<OpenBinding>,
+) -> RcExpr {
+    // Open this scope: Bound(scope=0) → Free(name)
+    let (open_bindings, open_body) = open_let_scope_full(scope);
+
+    // Preserve demand from the original CoreBindings.
+    let demands: Vec<Demand> = scope.pattern.iter().map(|b| b.demand).collect();
+
+    for ((name, expr), demand) in open_bindings.into_iter().zip(demands) {
+        all_bindings.push(OpenBinding { name, expr, demand });
+    }
+
+    // If the opened body is another mergeable Let, recurse.
+    if let Expr::Let(_, inner_scope, inner_lt) = &*open_body.inner {
+        if *inner_lt == LetType::OtherLet {
+            return collect_chain(inner_scope, all_bindings);
+        }
+    }
+
+    open_body
+}
+
+/// Close a set of opened bindings back into a single Let scope,
+/// preserving the demand annotation on each binding.
+fn close_let_scope_with_demand(
+    smid: crate::common::sourcemap::Smid,
+    bindings: Vec<OpenBinding>,
+    body: RcExpr,
+    let_type: LetType,
+) -> RcExpr {
+    let names: Vec<String> = bindings.iter().map(|b| b.name.clone()).collect();
+    let name_refs: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
+
+    let closed_bindings: Vec<CoreBinding<RcExpr>> = bindings
+        .into_iter()
+        .map(|b| {
+            CoreBinding::with_demand(b.name, close_expr_vars(&name_refs, 0, &b.expr), b.demand)
+        })
+        .collect();
+    let closed_body = close_expr_vars(&name_refs, 0, &body);
+
+    let scope = Scope {
+        pattern: closed_bindings,
+        body: closed_body,
+    };
+
+    RcExpr::from(Expr::Let(smid, scope, let_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::sourcemap::Smid;
+    use crate::core::binding::Var;
+    use crate::core::demand::{Cardinality, Demand, Strictness};
+    use crate::core::expr::{close_let_scope, Expr, LetType, Primitive, RcExpr};
+
+    fn var(name: &str) -> RcExpr {
+        RcExpr::from(Expr::Var(Smid::default(), Var::Free(name.to_string())))
+    }
+
+    fn lit_num(n: i64) -> RcExpr {
+        RcExpr::from(Expr::Literal(
+            Smid::default(),
+            Primitive::Num(serde_json::Number::from(n)),
+        ))
+    }
+
+    fn make_let_with_demand(bindings: Vec<(&str, RcExpr, Demand)>, body: RcExpr) -> RcExpr {
+        let demands: Vec<Demand> = bindings.iter().map(|(_, _, d)| *d).collect();
+        let pairs: Vec<(String, RcExpr)> = bindings
+            .into_iter()
+            .map(|(n, e, _)| (n.to_string(), e))
+            .collect();
+        let mut scope = close_let_scope(pairs, body);
+        // Set demands on the bindings.
+        for (b, d) in scope.pattern.iter_mut().zip(demands) {
+            b.demand = d;
+        }
+        RcExpr::from(Expr::Let(Smid::default(), scope, LetType::OtherLet))
+    }
+
+    /// Count the number of nested Let scopes (depth of Let nesting).
+    fn count_lets(expr: &RcExpr) -> usize {
+        match &*expr.inner {
+            Expr::Let(_, scope, _) => 1 + count_lets(&scope.body),
+            _ => 0,
+        }
+    }
+
+    /// Count bindings in the outermost Let scope.
+    fn outer_let_bindings(expr: &RcExpr) -> usize {
+        match &*expr.inner {
+            Expr::Let(_, scope, _) => scope.pattern.len(),
+            _ => 0,
+        }
+    }
+
+    /// Get demand of the nth binding in the outermost Let scope.
+    fn binding_demand(expr: &RcExpr, n: usize) -> Demand {
+        match &*expr.inner {
+            Expr::Let(_, scope, _) => scope.pattern[n].demand,
+            _ => panic!("not a Let"),
+        }
+    }
+
+    #[test]
+    fn test_nested_lets_flattened() {
+        // Let { a = 1 } in Let { b = 2 } in body
+        // Should become Let { a = 1, b = 2 } in body
+        let inner = make_let_with_demand(vec![("b", lit_num(2), Demand::default())], var("x"));
+        let outer = make_let_with_demand(vec![("a", lit_num(1), Demand::default())], inner);
+
+        let result = reflatten(&outer);
+        assert_eq!(count_lets(&result), 1);
+        assert_eq!(outer_let_bindings(&result), 2);
+    }
+
+    #[test]
+    fn test_demand_preserved() {
+        let strict_once = Demand {
+            strictness: Strictness::Strict,
+            cardinality: Cardinality::AtMostOnce,
+            whnf: false,
+        };
+        let lazy_multi = Demand {
+            strictness: Strictness::Lazy,
+            cardinality: Cardinality::Multi,
+            whnf: false,
+        };
+
+        let inner = make_let_with_demand(vec![("b", lit_num(2), lazy_multi)], var("x"));
+        let outer = make_let_with_demand(vec![("a", lit_num(1), strict_once)], inner);
+
+        let result = reflatten(&outer);
+        assert_eq!(count_lets(&result), 1);
+        assert_eq!(binding_demand(&result, 0), strict_once);
+        assert_eq!(binding_demand(&result, 1), lazy_multi);
+    }
+
+    #[test]
+    fn test_default_block_let_not_flattened() {
+        // DefaultBlockLet should not be merged.
+        let pairs: Vec<(String, RcExpr)> = vec![("b".to_string(), lit_num(2))];
+        let inner_scope = close_let_scope(pairs, var("x"));
+        let inner = RcExpr::from(Expr::Let(
+            Smid::default(),
+            inner_scope,
+            LetType::DefaultBlockLet,
+        ));
+
+        let outer = make_let_with_demand(vec![("a", lit_num(1), Demand::default())], inner);
+
+        let result = reflatten(&outer);
+        // Should be 2 lets — the inner DefaultBlockLet is NOT merged.
+        assert_eq!(count_lets(&result), 2);
+    }
+
+    #[test]
+    fn test_single_let_unchanged() {
+        let expr = make_let_with_demand(vec![("a", lit_num(1), Demand::default())], var("x"));
+
+        let result = reflatten(&expr);
+        assert_eq!(count_lets(&result), 1);
+        assert_eq!(outer_let_bindings(&result), 1);
+    }
+
+    #[test]
+    fn test_three_deep_chain_flattened() {
+        // Let { a = 1 } in Let { b = a } in Let { c = b } in body
+        let c = make_let_with_demand(vec![("c", var("b"), Demand::default())], var("x"));
+        let b = make_let_with_demand(vec![("b", var("a"), Demand::default())], c);
+        let a = make_let_with_demand(vec![("a", lit_num(1), Demand::default())], b);
+
+        let result = reflatten(&a);
+        assert_eq!(count_lets(&result), 1);
+        assert_eq!(outer_let_bindings(&result), 3);
+    }
+
+    #[test]
+    fn test_cross_scope_references_correct() {
+        // Let { a = 1 } in Let { b = a + 1 } in b
+        // After flattening: Let { a = 1, b = a + 1 } in b
+        // The reference from b to a should be Bound(scope=0, binder=0)
+        let inner = make_let_with_demand(vec![("b", var("a"), Demand::default())], var("b"));
+        let outer = make_let_with_demand(vec![("a", lit_num(1), Demand::default())], inner);
+
+        let result = reflatten(&outer);
+        assert_eq!(count_lets(&result), 1);
+        assert_eq!(outer_let_bindings(&result), 2);
+
+        // Verify b's RHS references a as Bound(scope=0, binder=0)
+        if let Expr::Let(_, scope, _) = &*result.inner {
+            let b_rhs = &scope.pattern[1].expr;
+            if let Expr::Var(_, Var::Bound(bv)) = &*b_rhs.inner {
+                assert_eq!(bv.scope, 0);
+                assert_eq!(bv.binder, 0);
+            } else {
+                panic!("expected bound var in b's RHS, got: {:?}", b_rhs.inner);
+            }
+
+            // Verify body references b as Bound(scope=0, binder=1)
+            if let Expr::Var(_, Var::Bound(bv)) = &*scope.body.inner {
+                assert_eq!(bv.scope, 0);
+                assert_eq!(bv.binder, 1);
+            } else {
+                panic!("expected bound var in body, got: {:?}", scope.body.inner);
+            }
+        } else {
+            panic!("expected Let");
+        }
+    }
+}

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -307,6 +307,27 @@ impl<'a> Executor<'a> {
                 stats.timings_mut().record("demand-analysis", t.elapsed());
             }
 
+            // Re-flatten nested Let/LetRec scopes after demand analysis.
+            // SCC splitting decomposes LetRec into chains of nested scopes
+            // for precise demand analysis; this pass merges them back into
+            // single scopes (single EnvFrame at runtime) while preserving
+            // the per-binding demand annotations.
+            {
+                let t = Instant::now();
+                self.evaluand = crate::core::reflatten::reflatten(&self.evaluand);
+                stats.timings_mut().record("reflatten", t.elapsed());
+            }
+
+            if opt.dump_reflatten() {
+                if opt.quote_debug() {
+                    println!("{:#?}", self.evaluand);
+                } else {
+                    let pretty = crate::common::prettify::prettify(&self.evaluand);
+                    println!("{pretty}");
+                }
+                return Ok(None);
+            }
+
             let syn = {
                 let t = Instant::now();
                 let syn = stg::compile(&stg_settings, self.evaluand.clone(), rt.as_ref())?;

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -305,6 +305,8 @@ pub enum DumpPhase {
     Pruned,
     /// Dump core expression with demand annotations
     Demands,
+    /// Dump core expression after re-flattening nested Let scopes
+    Reflatten,
     /// Dump compiled STG syntax
     Stg,
     /// Dump code for runtime globals
@@ -390,6 +392,7 @@ pub struct EucalyptOptions {
     pub dump_inlined: bool,
     pub dump_pruned: bool,
     pub dump_demands: bool,
+    pub dump_reflatten: bool,
     pub dump_stg: bool,
     pub dump_runtime: bool,
 
@@ -557,67 +560,72 @@ impl From<EucalyptCli> for EucalyptOptions {
             dump_inlined,
             dump_pruned,
             dump_demands,
+            dump_reflatten,
             dump_stg,
             dump_runtime,
             list_targets,
         ) = match &cli.command {
             Some(Commands::Version) => (
                 false, true, false, false, false, false, false, false, false, false, false, false,
-                false,
+                false, false,
             ),
             Some(Commands::Explain(_)) => (
                 false, false, false, false, false, false, false, false, false, false, false, false,
-                false,
+                false, false,
             ),
             Some(Commands::Test(_)) => (
                 false, false, true, false, false, false, false, false, false, false, false, false,
-                false,
+                false, false,
             ),
             Some(Commands::ListTargets(_)) => (
                 false, false, false, false, false, false, false, false, false, false, false, false,
-                true,
+                false, true,
             ),
             Some(Commands::Dump(args)) => match args.phase {
                 DumpPhase::Ast => (
                     false, false, false, true, false, false, false, false, false, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Desugared => (
                     false, false, false, false, true, false, false, false, false, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Cooked => (
                     false, false, false, false, false, true, false, false, false, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Split => (
                     false, false, false, false, false, false, true, false, false, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Inlined => (
                     false, false, false, false, false, false, false, true, false, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Pruned => (
                     false, false, false, false, false, false, false, false, true, false, false,
-                    false, false,
+                    false, false, false,
                 ),
                 DumpPhase::Demands => (
                     false, false, false, false, false, false, false, false, false, true, false,
-                    false, false,
+                    false, false, false,
+                ),
+                DumpPhase::Reflatten => (
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, false, false,
                 ),
                 DumpPhase::Stg => (
-                    false, false, false, false, false, false, false, false, false, false, true,
-                    false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    true, false, false,
                 ),
                 DumpPhase::Runtime => (
                     false, false, false, false, false, false, false, false, false, false, false,
-                    true, false,
+                    false, true, false,
                 ),
             },
             _ => (
                 false, false, false, false, false, false, false, false, false, false, false, false,
-                false,
+                false, false,
             ),
         };
 
@@ -724,6 +732,7 @@ impl From<EucalyptCli> for EucalyptOptions {
             dump_inlined,
             dump_pruned,
             dump_demands,
+            dump_reflatten,
             dump_stg,
             dump_runtime,
             lsp,
@@ -875,6 +884,10 @@ impl EucalyptOptions {
         self.dump_demands
     }
 
+    pub fn dump_reflatten(&self) -> bool {
+        self.dump_reflatten
+    }
+
     pub fn dump_stg(&self) -> bool {
         self.dump_stg
     }
@@ -977,6 +990,7 @@ impl EucalyptOptions {
             && !self.dump_inlined
             && !self.dump_pruned
             && !self.dump_demands
+            && !self.dump_reflatten
             && !self.dump_stg
             && !self.dump_runtime
             && !self.format
@@ -1304,6 +1318,8 @@ impl EucalyptOptions {
             );
         } else if self.dump_demands {
             explanation.push_str("process inputs through core phase, run demand analysis, and dump annotated core to standard out");
+        } else if self.dump_reflatten {
+            explanation.push_str("process inputs through demand analysis, re-flatten nested Let scopes, and dump to standard out");
         } else if self.dump_stg {
             explanation.push_str("process inputs through core phase and compile to STG code and dump to standard out");
         } else if self.dump_runtime {

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -248,14 +248,7 @@ pub fn prepare(
     {
         let t = Instant::now();
 
-        // SCC splitting disabled pending env-depth performance fix.
-        // The pass correctly decomposes LetRec into Let+LetRec but
-        // the deeper nesting causes O(depth) env traversal regressions
-        // (day01-p2: 9.7s→39s, day12: 0.3s→3.4s, multiple timeouts).
-        // TODO: re-enable once STG compiler flattens nested Let scopes
-        // into a single env frame or env lookup is made O(1).
-        //
-        // loader.split_letrecs();
+        loader.split_letrecs();
 
         stats.record("split-letrecs", t.elapsed());
     }

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -598,6 +598,17 @@ impl SourceLoader {
         self.core.expr = crate::core::dependency::split_letrecs(&self.core.expr);
     }
 
+    /// Re-flatten nested Let/LetRec scopes after demand analysis.
+    ///
+    /// Merges chains of directly nested `Let`/`LetRec` scopes back
+    /// into a single scope while preserving per-binding demand
+    /// annotations.  This reverses the nesting introduced by SCC
+    /// splitting so the STG compiler sees flat scopes (single
+    /// `EnvFrame` at runtime) but with accurate demand information.
+    pub fn reflatten_lets(&mut self) {
+        self.core.expr = crate::core::reflatten::reflatten(&self.core.expr);
+    }
+
     /// Run the namespace lambda hoisting pass.
     ///
     /// Hoists inlinable members of namespace `DefaultBlockLet` bindings (such


### PR DESCRIPTION
## Summary

- New core pass `src/core/reflatten.rs` that merges chains of nested `Let`/`LetRec` scopes back into a single scope after demand analysis, preserving per-binding demand annotations
- Re-enables SCC splitting (`loader.split_letrecs()`) which was disabled pending this fix
- Adds `eu dump reflatten` command for inspecting the flattened output
- Pipeline: `cook → SCC split → hoist → inline → prune → demand analysis → **re-flatten** → STG compile`

## Key design decisions

- Uses `open_let_scope_full` / `close_expr_vars` for correct de Bruijn index adjustment
- `DefaultBlockLet` and `DestructureListLet` scopes are never merged (correctly preserving block boundaries)
- Demand annotations are threaded through the open/close cycle via `CoreBinding::with_demand`

## Benchmark results (vs current master)

| Example | Master allocs | Branch allocs | Master time | Branch time |
|---------|-------|----------|------|------|
| day01 | 2,720,922 | 2,720,922 | 4.90s | 4.76s |
| day03 | 11,549,041 | 11,549,041 | 1.76s | 1.74s |
| day09 | 80,379,426 | 80,379,426 | 64.4s | 64.0s |
| day12 | 2,407,158 | 2,407,158 | 3.16s | 3.21s |

No regressions. Allocation counts are identical. Times within noise.

**Note**: The stored baseline stats in `examples/aoc25/stats/` are stale — they were captured before demand analysis and namespace hoist passes were added. The GC mark-time regression visible when comparing against those baselines is a pre-existing issue on current master, not caused by this PR.

## Test plan

- [x] All 6 unit tests pass (`cargo test --lib core::reflatten`)
- [x] Full test suite passes (1741 tests: 1161 lib + 451 harness + 111 integration + 11 property + 5 doc)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] AoC benchmarks show no regression vs current master
- [x] `eu dump split` still shows split structure
- [x] `eu dump reflatten` shows flattened result

Implements eu-9tah.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)