### PR TITLE
feat(core): wire demand signature table into STG compiler

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -36,6 +36,14 @@ pub type DemandSignature = Vec<Demand>;
 /// data, mapping to per-argument demand vectors.
 pub type SignatureTable = HashMap<SigKey, DemandSignature>;
 
+/// Name-keyed demand signature table for user function calls.
+///
+/// Maps binding names to per-argument demand vectors. Built during
+/// `analyse_let` by recording the signature of each Let binding whose
+/// RHS is a Lam with a known signature. Used by the STG compiler to
+/// apply per-argument demands at user function call sites.
+pub type NamedSignatureTable = HashMap<String, DemandSignature>;
+
 /// Build intrinsic seed signatures from the INTRINSICS catalogue.
 ///
 /// For each intrinsic, strict arguments get `(Strict, AtMostOnce)` per
@@ -157,6 +165,8 @@ pub struct DemandAnalyser {
     intrinsic_sigs: HashMap<String, DemandSignature>,
     /// Signatures discovered during analysis (keyed by Lam body pointer).
     signatures: SignatureTable,
+    /// Name-keyed signatures for user function calls.
+    named_signatures: NamedSignatureTable,
 }
 
 impl Default for DemandAnalyser {
@@ -170,14 +180,16 @@ impl DemandAnalyser {
         DemandAnalyser {
             intrinsic_sigs: build_intrinsic_signatures(),
             signatures: HashMap::new(),
+            named_signatures: HashMap::new(),
         }
     }
 
     /// Run the demand analysis on the given expression, returning the
-    /// annotated expression and the signature side-table.
-    pub fn analyse(mut self, expr: &RcExpr) -> (RcExpr, SignatureTable) {
+    /// annotated expression, the pointer-keyed signature table, and the
+    /// name-keyed signature table for user function calls.
+    pub fn analyse(mut self, expr: &RcExpr) -> (RcExpr, SignatureTable, NamedSignatureTable) {
         let (new_expr, _env) = self.analyse_expr(expr);
-        (new_expr, self.signatures)
+        (new_expr, self.signatures, self.named_signatures)
     }
 
     /// Analyse an expression, returning the annotated expression and
@@ -434,6 +446,16 @@ impl DemandAnalyser {
                 outer_env = merge_envs(&outer_env, &shifted);
             }
 
+            // If the binding's RHS is a Lam with a known signature, record
+            // the signature under the binding name for STG compiler use.
+            if let Expr::Lam(_, _, ref lam_scope) = &*new_rhs_exprs[i].inner {
+                let key = Rc::as_ptr(&lam_scope.body.inner) as usize;
+                if let Some(sig) = self.signatures.get(&key) {
+                    self.named_signatures
+                        .insert(binding.name.clone(), sig.clone());
+                }
+            }
+
             new_bindings.push(CoreBinding::with_demand(
                 binding.name.clone(),
                 new_rhs_exprs[i].clone(),
@@ -545,7 +567,7 @@ impl DemandAnalyser {
 /// Run the demand analysis pass on a core expression.
 ///
 /// Returns the annotated expression and the signature side-table.
-pub fn analyse_demands(expr: &RcExpr) -> (RcExpr, SignatureTable) {
+pub fn analyse_demands(expr: &RcExpr) -> (RcExpr, SignatureTable, NamedSignatureTable) {
     let analyser = DemandAnalyser::new();
     analyser.analyse(expr)
 }
@@ -624,7 +646,7 @@ mod tests {
         // in any cycle and can safely skip the Update frame.
         let x = free("x");
         let expr = let_(vec![(x.clone(), num(1))], var(x));
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -646,7 +668,7 @@ mod tests {
             vec![(x.clone(), app(bif("ADD"), vec![var(x.clone()), num(1)]))],
             var(x),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -670,7 +692,7 @@ mod tests {
             ],
             app(bif("ADD"), vec![var(x), var(y)]),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -699,7 +721,7 @@ mod tests {
             ],
             var(x),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -717,7 +739,7 @@ mod tests {
         let x = free("x");
         let y = free("y");
         let expr = let_(vec![(x.clone(), num(1)), (y.clone(), num(2))], var(x));
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -734,7 +756,7 @@ mod tests {
             vec![(x.clone(), num(1))],
             app(bif("ADD"), vec![var(x.clone()), var(x)]),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -761,7 +783,7 @@ mod tests {
             ],
             app(bif("ADD"), vec![var(y), var(z)]),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -789,7 +811,7 @@ mod tests {
             ],
             app(bif("ADD"), vec![var(x), var(y)]),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -822,7 +844,7 @@ mod tests {
                 ],
             ),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -860,7 +882,7 @@ mod tests {
                 vec![num(0), app(bif("ADD"), vec![num(0), var(x)])],
             ),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -896,7 +918,7 @@ mod tests {
                 )],
             ),
         );
-        let (result, _sigs) = analyse_demands(&expr);
+        let (result, _sigs, _named_sigs) = analyse_demands(&expr);
 
         match &*result.inner {
             Expr::Let(_, scope, _) => {
@@ -925,7 +947,7 @@ mod tests {
         let x = free("x");
         // \x y -> x (y is unused)
         let lam_expr = lam(vec!["x".to_string(), "y".to_string()], var(x.clone()));
-        let (result, sigs) = analyse_demands(&lam_expr);
+        let (result, sigs, _named_sigs) = analyse_demands(&lam_expr);
 
         assert!(!sigs.is_empty(), "signature table should not be empty");
 
@@ -938,6 +960,23 @@ mod tests {
         } else {
             panic!("expected Lam");
         }
+    }
+
+    #[test]
+    fn named_signature_recorded_for_let_bound_lam() {
+        let x = free("x");
+        // let f = \x y -> x in f
+        let lam_body = lam(vec!["x".to_string(), "y".to_string()], var(x.clone()));
+        let f = free("f");
+        let expr = let_(vec![(f.clone(), lam_body)], var(f));
+        let (_result, _sigs, named_sigs) = analyse_demands(&expr);
+
+        let sig = named_sigs
+            .get("f")
+            .expect("named signature should exist for let-bound lambda");
+        assert_eq!(sig.len(), 2);
+        assert_eq!(sig[0].cardinality, Cardinality::AtMostOnce); // x used once
+        assert_eq!(sig[1].cardinality, Cardinality::Absent); // y unused
     }
 
     #[test]
@@ -988,7 +1027,7 @@ mod tests {
             var(x.clone()),
         );
 
-        let (unsplit_result, _) = analyse_demands(&unsplit);
+        let (unsplit_result, _, _) = analyse_demands(&unsplit);
         match &*unsplit_result.inner {
             Expr::Let(_, scope, _) => {
                 assert_eq!(
@@ -1002,7 +1041,7 @@ mod tests {
 
         // After SCC splitting: a is in its own Let scope
         let split = split_letrecs(&unsplit);
-        let (split_result, _) = analyse_demands(&split);
+        let (split_result, _, _) = analyse_demands(&split);
 
         // The outermost Let should be `a` (independent, placed outermost)
         match &*split_result.inner {

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -301,9 +301,10 @@ impl<'a> Executor<'a> {
             // Run demand analysis on the core expression before STG compile
             if !stg_settings.suppress_demand_analysis {
                 let t = Instant::now();
-                let (annotated, _signatures) =
+                let (annotated, _signatures, named_signatures) =
                     crate::core::analyse_demand::analyse_demands(&self.evaluand);
                 self.evaluand = annotated;
+                stg_settings.user_demand_sigs = named_signatures;
                 stats.timings_mut().record("demand-analysis", t.elapsed());
             }
 

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -356,7 +356,7 @@ pub fn prepare(
 
     if opt.dump_demands() {
         let c = loader.core();
-        let (annotated, sigs) = crate::core::analyse_demand::analyse_demands(&c.expr);
+        let (annotated, sigs, named_sigs) = crate::core::analyse_demand::analyse_demands(&c.expr);
         dump_core(annotated.clone(), opt);
         // Print demand annotations for all let-bound names.
         println!("\n-- demand annotations --");
@@ -369,6 +369,18 @@ pub fn prepare(
                 .map(|d| format!("({:?},{:?})", d.strictness, d.cardinality))
                 .collect();
             println!("  {:016x}: [{}]", key, demands.join(", "));
+        }
+        // Print named signature table.
+        println!(
+            "\n-- named signature table ({} entries) --",
+            named_sigs.len()
+        );
+        for (name, sig) in &named_sigs {
+            let demands: Vec<String> = sig
+                .iter()
+                .map(|d| format!("({:?},{:?})", d.strictness, d.cardinality))
+                .collect();
+            println!("  {}: [{}]", name, demands.join(", "));
         }
         return Ok(Command::Exit);
     }

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -516,6 +516,11 @@ pub struct Compiler<'rt> {
     /// This is how user code compiled independently of the prelude references
     /// the pre-loaded prelude global slots.
     prelude_globals: Option<HashMap<String, usize>>,
+    /// Per-user-function demand signatures from the analysis pass.
+    ///
+    /// Maps binding name → per-argument demand vector. Used when
+    /// compiling `App(user_function, args)` to set per-argument demands.
+    user_demand_sigs: crate::core::analyse_demand::NamedSignatureTable,
 }
 
 /// An item which can be converted to STG syntax once the context in known
@@ -962,13 +967,21 @@ impl ProtoSyntax for ProtoAppGroup {
     ) -> Result<Rc<StgSyn>, CompileError> {
         let mut intrinsic_index = None;
         let mut intrinsic_name: Option<&str> = None;
+        let mut callee_name: Option<&str> = None;
         let mut local_binder = LetBinder::synthetic_let(context);
 
         // Find a reference for the function
         let f_index: Box<dyn ProtoReference> = match &*self.f.inner {
             Expr::Var(s, v) => match v {
-                Var::Bound(bv) => Box::new(ProtoVar::new(bv.clone())),
-                Var::Free(name) => Box::new(ProtoRef::new(compiler.resolve_free_var(*s, name)?)),
+                Var::Bound(bv) => {
+                    // Preserve the binding name for user demand signature lookup.
+                    callee_name = bv.name.as_deref();
+                    Box::new(ProtoVar::new(bv.clone()))
+                }
+                Var::Free(name) => {
+                    callee_name = Some(name.as_str());
+                    Box::new(ProtoRef::new(compiler.resolve_free_var(*s, name)?))
+                }
             },
             Expr::Intrinsic(_, bif) => {
                 intrinsic_index = intrinsics::index(bif);
@@ -985,13 +998,16 @@ impl ProtoSyntax for ProtoAppGroup {
             )?)),
         };
 
-        // Look up per-argument demands from the intrinsic seed signatures.
-        // These were built by the demand analysis pass (build_intrinsic_signatures)
-        // and encode the blanket rule: strict args → (Strict, AtMostOnce), with
-        // special refinements for IF, AND/OR, LOOKUPOR, IO_BIND.
+        // Look up per-argument demands.  Try intrinsic signatures first,
+        // then fall back to user function signatures from the demand analysis.
         let arg_demands: Option<&[crate::core::demand::Demand]> = intrinsic_name
             .and_then(|name| compiler.intrinsic_demand_sigs.get(name))
-            .map(|v| v.as_slice());
+            .map(|v| v.as_slice())
+            .or_else(|| {
+                callee_name
+                    .and_then(|name| compiler.user_demand_sigs.get(name))
+                    .map(|v| v.as_slice())
+            });
 
         let mut arg_indexes: Vec<Box<dyn ProtoReference>> = vec![];
         for (i, arg) in self.args.iter().enumerate() {
@@ -1233,7 +1249,17 @@ impl<'rt> Compiler<'rt> {
             intrinsics,
             intrinsic_demand_sigs,
             prelude_globals,
+            user_demand_sigs: Default::default(),
         }
+    }
+
+    /// Set the user function demand signature table.
+    pub fn with_user_demand_sigs(
+        mut self,
+        sigs: crate::core::analyse_demand::NamedSignatureTable,
+    ) -> Self {
+        self.user_demand_sigs = sigs;
+        self
     }
 
     /// Resolve a free variable name to a global slot reference.

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -316,6 +316,11 @@ pub struct StgSettings {
     pub prelude_globals: Option<HashMap<String, usize>>,
     /// Suppress the demand analysis pass (all demands remain at Unknown).
     pub suppress_demand_analysis: bool,
+    /// Per-user-function demand signatures discovered by the analysis pass.
+    ///
+    /// Maps binding name → per-argument demand vector. Used by the STG
+    /// compiler to apply per-argument demands at user function call sites.
+    pub user_demand_sigs: crate::core::analyse_demand::NamedSignatureTable,
 }
 
 /// Compile core syntax to STG ready for execution
@@ -334,6 +339,7 @@ pub fn compile(
         settings.suppress_optimiser,
         runtime.intrinsics(),
         settings.prelude_globals.clone(),
-    );
+    )
+    .with_user_demand_sigs(settings.user_demand_sigs.clone());
     compiler.compile(expr)
 }

--- a/src/eval/stg/testing.rs
+++ b/src/eval/stg/testing.rs
@@ -31,6 +31,7 @@ lazy_static! {
         test_mode: false,
         prelude_globals: None,
         suppress_demand_analysis: false,
+        user_demand_sigs: Default::default(),
     };
 }
 


### PR DESCRIPTION
## Summary

- Threads the named demand signature table from `analyse_demand` through `StgSettings` into the STG `Compiler`
- `App(user_function, args)` call sites now use the callee's per-argument demand signature as a fallback when no intrinsic signature exists
- Adds `NamedSignatureTable` type alias populated during `analyse_let` for let-bound lambdas with known signatures
- Adds dump output for named signature tables via `eu dump demands`

## Bead

eu-9tah.9

## Acceptance criteria status

1. **Named signature table populated** — verified via `eu dump demands` showing populated table
2. **STG compiler uses signatures** — `ProtoAppGroup::take_syntax` looks up callee name in `user_demand_sigs` as fallback after intrinsic sigs
3. **Allocation reduction on AoC** — not yet measurable; requires SCC splitting (eu-9tah.11 / PR #874) to produce precise per-binding signatures. The spec explicitly notes "This is why eu-9tah.10 should land first."
4. **No test regressions** — all 1735 tests pass
5. **Clippy and fmt clean** — verified

## Test plan

- [x] `cargo test --lib` — 1156 tests pass
- [x] `cargo test` — all 1735 tests pass (including harness)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Unit test `named_signature_recorded_for_let_bound_lam` added
- [x] Verified `eu dump demands` shows named signatures for test inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)