### PR TITLE
fix(dump): honour prelude mode in dump commands

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -259,10 +259,18 @@ impl<'a> Executor<'a> {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(ref b) = self.prelude_blob {
+            // Build a slot-ordered name list from name_to_slot (name → slot index).
+            let mut names = vec![String::new(); b.binding_entries.len()];
+            for (name, &slot) in &b.name_to_slot {
+                if slot < names.len() {
+                    names[slot] = name.clone();
+                }
+            }
             rt.set_prelude_bindings(
                 b.nodes.clone(),
                 b.forms_pool.clone(),
                 b.binding_entries.clone(),
+                names,
             );
         }
 

--- a/src/driver/prepare.rs
+++ b/src/driver/prepare.rs
@@ -84,6 +84,7 @@ pub fn prepare(
             let can_continue = opt.parse_only()
                 || opt.dump_desugared()
                 || opt.dump_cooked()
+                || opt.dump_split()
                 || opt.dump_inlined()
                 || opt.dump_pruned()
                 || opt.dump_demands()

--- a/src/eval/stg/runtime.rs
+++ b/src/eval/stg/runtime.rs
@@ -66,6 +66,11 @@ pub struct StandardRuntime {
     /// Index into `prelude_forms_pool` for each prelude global binding
     /// (one entry per binding, in slot order).
     prelude_binding_entries: Vec<FormIdx>,
+    /// Binding names in slot order (parallel to `prelude_binding_entries`).
+    ///
+    /// Empty string for any slot whose name is not recorded.  Used by
+    /// `dump runtime` to label prelude global slots.
+    prelude_names: Vec<String>,
 }
 
 impl Default for StandardRuntime {
@@ -80,6 +85,7 @@ impl Default for StandardRuntime {
             prelude_nodes: Vec::new(),
             prelude_forms_pool: Vec::new(),
             prelude_binding_entries: Vec::new(),
+            prelude_names: Vec::new(),
         }
     }
 }
@@ -92,16 +98,20 @@ impl StandardRuntime {
     ///
     /// `forms_pool` is the COMPLETE set of lambda forms (entry thunks + all inner
     /// forms from `Let`/`LetRec` nodes).  `binding_entries` contains one `FormIdx`
-    /// per prelude binding pointing into `forms_pool`.
+    /// per prelude binding pointing into `forms_pool`.  `names` contains the
+    /// binding name for each slot (parallel to `binding_entries`), used by
+    /// `dump runtime` to label prelude global slots.
     pub fn set_prelude_bindings(
         &mut self,
         nodes: Vec<ArenaStgSyn>,
         forms_pool: Vec<ArenaLambdaForm>,
         binding_entries: Vec<FormIdx>,
+        names: Vec<String>,
     ) {
         self.prelude_nodes = nodes;
         self.prelude_forms_pool = forms_pool;
         self.prelude_binding_entries = binding_entries;
+        self.prelude_names = names;
     }
 }
 
@@ -119,7 +129,9 @@ impl ToPretty for StandardRuntime {
         D::Doc: Clone,
         A: Clone,
     {
-        let docs = self.lambdas().into_iter().enumerate().map(|(i, lam)| {
+        let intrinsic_count = self.impls.len();
+
+        let intrinsic_docs = self.lambdas().into_iter().enumerate().map(|(i, lam)| {
             let name = intrinsics::intrinsic(i).name();
 
             allocator
@@ -132,7 +144,43 @@ impl ToPretty for StandardRuntime {
                 .append(allocator.line())
         });
 
-        allocator.intersperse(docs, allocator.line())
+        if self.prelude_binding_entries.is_empty() {
+            return allocator.intersperse(intrinsic_docs, allocator.line());
+        }
+
+        // In blob mode, also print prelude globals (slots INTRINSIC_COUNT..).
+        let arena = StgArena {
+            nodes: self.prelude_nodes.clone(),
+            forms: self.prelude_forms_pool.clone(),
+        };
+
+        let prelude_docs =
+            self.prelude_binding_entries
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &entry_idx)| {
+                    let slot = intrinsic_count + i;
+                    let name = self
+                        .prelude_names
+                        .get(i)
+                        .map(|s| s.as_str())
+                        .unwrap_or("<unnamed>");
+                    match arena.reconstruct_form(entry_idx) {
+                        Ok(lam) => Some(
+                            allocator
+                                .text(format!("(⊗{slot}) "))
+                                .append(name)
+                                .append(":")
+                                .append(allocator.space())
+                                .append(allocator.line())
+                                .append(allocator.text(prettify(&lam)))
+                                .append(allocator.line()),
+                        ),
+                        Err(_) => None,
+                    }
+                });
+
+        allocator.intersperse(intrinsic_docs.chain(prelude_docs), allocator.line())
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `dump_split` to the `can_continue` parse-error list in `prepare.rs` so `eu dump split` proceeds with a partial parse tree when source has errors, consistent with `dump cooked` and `dump inlined`
- Fix `eu dump runtime` in blob-prelude mode (the default) to show the complete runtime picture: intrinsics (⊗0..⊗192) **plus** named prelude global slots (⊗193..). Previously both blob and source-prelude modes produced identical output, hiding ~300+ prelude lambdas that the blob injects into the VM runtime

## Details

In blob mode, `StandardRuntime` now stores `prelude_names: Vec<String>` (slot-ordered, derived by inverting `name_to_slot` from the blob). `ToPretty for StandardRuntime` iterates `prelude_binding_entries`, reconstructs each `LambdaForm` from the blob arena, and prints it as `(⊗N) name: <form>` after the intrinsics section.

## Test plan

- [x] All 1155 lib tests pass
- [x] All 451 harness tests pass
- [x] `eu dump <phase> file.eu` exits 0 for all phases in both blob and source-prelude modes
- [x] `eu dump runtime file.eu` shows ~8400 lines in blob mode (intrinsics + prelude globals) vs ~1867 in source-prelude mode (intrinsics only)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)