### PR TITLE
fix(core): disable AtMostOnce → Value update elision (3× regression)

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -980,8 +980,10 @@ mod tests {
     }
 
     #[test]
-    fn absent_demand_skips_update() {
-        assert!(Demand::absent().skip_update());
+    fn absent_demand_does_not_skip_update() {
+        // Absent → Value is disabled (same reason as AtMostOnce — see
+        // Demand::skip_update doc comment).
+        assert!(!Demand::absent().skip_update());
     }
 
     #[test]

--- a/src/core/demand.rs
+++ b/src/core/demand.rs
@@ -40,10 +40,18 @@ pub struct Demand {
 impl Demand {
     /// Returns `true` when the STG compiler should skip the Update frame
     /// (i.e. emit `Value` rather than `Thunk`).
+    ///
+    /// Currently only fires for bindings already in WHNF. The
+    /// `AtMostOnce` and `Absent` cardinality paths are disabled because
+    /// demand analysis counts `Var::Bound` references but cannot account
+    /// for runtime block lookups (`.key`) or the post-analysis rendering
+    /// wrapper — both of which re-enter closures that the analysis
+    /// considers single-use, causing cascading re-evaluation and a 3×
+    /// allocation regression.  The cardinality computation is retained
+    /// in the analysis for future use once a sound update-elision
+    /// strategy is in place.
     pub fn skip_update(self) -> bool {
         self.whnf
-            || self.cardinality == Cardinality::AtMostOnce
-            || self.cardinality == Cardinality::Absent
     }
 
     /// Convenience: a demand marking a binding as used at most once.
@@ -233,9 +241,15 @@ mod tests {
     }
 
     #[test]
-    fn at_most_once_skips_update() {
+    fn at_most_once_does_not_skip_update() {
+        // AtMostOnce → Value is disabled: runtime block lookups and
+        // post-analysis rendering re-enter closures that the analysis
+        // considers single-use, causing cascading re-evaluation.
         let d = Demand::at_most_once();
-        assert!(d.skip_update(), "AtMostOnce should skip update");
+        assert!(
+            !d.skip_update(),
+            "AtMostOnce should NOT skip update (disabled — unsound with rendering)"
+        );
     }
 
     #[test]

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1795,28 +1795,18 @@ pub mod tests {
         );
     }
 
-    /// A single-use binding is compiled as `Value` after prune sets its demand.
+    /// AtMostOnce demand does NOT elide update frames (disabled).
     ///
-    /// The prune pass annotates bindings used exactly once with
-    /// `Cardinality::AtMostOnce`.  The STG compiler then emits `value(...)`
-    /// instead of `thunk(...)` because no Update frame is needed (W9 §8
-    /// criterion 3 — at least one binding previously Thunk is now Value).
+    /// `AtMostOnce → Value` was disabled because demand analysis counts
+    /// `Var::Bound` references but cannot account for runtime block
+    /// lookups (`.key`) or the post-analysis rendering wrapper — both
+    /// re-enter closures the analysis considers single-use, causing
+    /// cascading re-evaluation and a 3× allocation regression.
     ///
-    /// We verify this with an expression where a binding holds another
-    /// binding reference — a `var(y)` — which is a bound-variable atom
-    /// (WHNF), but compile it indirectly by constructing a `CoreBinding`
-    /// with explicit demands so that the non-WHNF case can be demonstrated
-    /// without needing a prune-safe inner expression.
-    ///
-    /// Concretely: `let x = λf.f(f)` used once in the body.  Without demand,
-    /// the lambda binding is always `Value` (lambdas are WHNF).  Instead we
-    /// use the prune test helper to confirm that a binding with `Unknown`
-    /// demand (the default) compiles as `Thunk` for a nested let, and with
-    /// `AtMostOnce` it compiles as `Value`.  We build the demand explicitly
-    /// using `CoreBinding::with_demand` so that `ErrEliminated` is not
-    /// introduced.
+    /// This test verifies both `Unknown` and `AtMostOnce` compile as
+    /// `Thunk` for a non-WHNF binding.
     #[test]
-    pub fn test_single_use_binding_compiles_as_value_after_prune() {
+    pub fn test_at_most_once_does_not_elide_update() {
         use crate::common::sourcemap::Smid;
         use crate::core::binding::{CoreBinding, Scope};
         use crate::core::demand::Demand;
@@ -1872,19 +1862,18 @@ pub mod tests {
             "with Unknown demand, nested-let binding should be Thunk; got:\n{unknown_demand:?}"
         );
 
-        // With AtMostOnce demand: prune would set this for a single-use binding.
-        // Compiler should emit Value, not Thunk (W9 §8 criterion 3).
+        // With AtMostOnce demand: update elision is disabled, so still Thunk.
         let at_most_once = compile(make_let(Demand::at_most_once())).unwrap();
-        let x_is_value = match at_most_once.as_ref() {
+        let x_is_thunk_too = match at_most_once.as_ref() {
             StgSyn::LetRec { bindings, .. } => {
-                matches!(bindings.first(), Some(LambdaForm::Value { .. }))
+                matches!(bindings.first(), Some(LambdaForm::Thunk { .. }))
             }
             _ => false,
         };
         assert!(
-            x_is_value,
-            "with AtMostOnce demand (set by prune for single-use bindings), \
-             nested-let binding should be Value; got:\n{at_most_once:?}"
+            x_is_thunk_too,
+            "with AtMostOnce demand, nested-let binding should still be Thunk \
+             (update elision disabled); got:\n{at_most_once:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Disables `AtMostOnce` and `Absent` cardinality paths in `Demand::skip_update()` — only WHNF bindings now get `Value`
- Fixes a 3× allocation regression (369K → 119K allocs on `010_prelude`) introduced by demand analysis + SCC splitting

## Root cause

Demand analysis counts `Var::Bound` references but cannot account for:
1. **Runtime block lookups** (`.key`) — enter block element closures that the analysis considers single-use
2. **Post-analysis rendering wrapper** — iterates all block elements, re-entering closures independently

When `AtMostOnce` bindings are compiled as `Value` (no update frame), they re-evaluate on every entry instead of being memoised. This causes cascading re-evaluation through nested block structures.

## What's preserved

The cardinality computation in `analyse_demand.rs` is unchanged — `AtMostOnce` and `Absent` are still computed correctly. Only their USE in `skip_update()` for update elision is disabled. The infrastructure remains for future work once a sound update-elision strategy is in place.

## Files changed

- `src/core/demand.rs` — `skip_update()` now only checks `whnf`
- `src/core/analyse_demand.rs` — Updated test assertion
- `src/eval/stg/compiler.rs` — Updated test to verify AtMostOnce → Thunk

## Verification

```
# Before (master):  DA=369,212 allocs  |  No-DA=118,955 allocs (3× regression)
# After (this PR):  DA=118,955 allocs  |  No-DA=118,955 allocs (regression gone)
```

## Test plan

- [x] `cargo test` — all tests pass (1735+)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Allocation counts verified identical with/without DA
- [x] Updated `at_most_once_skips_update` → `at_most_once_does_not_skip_update`
- [x] Updated `test_single_use_binding_compiles_as_value_after_prune` → `test_at_most_once_does_not_elide_update`
- [x] Updated `absent_demand_skips_update` → `absent_demand_does_not_skip_update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)