### PR TITLE
refactor(aoc): foldl over map+aggregate to reduce head retention

### DIFF
--- a/examples/aoc25/day01.eu
+++ b/examples/aoc25/day01.eu
@@ -8,17 +8,15 @@ Part 2: Count the total number of zero crossings — times the
 cumulative position crosses a multiple of 100 between consecutive
 steps.
 
-Approach: scanl to build cumulative positions, then filter (part 1)
-or window-and-sum (part 2) to count crossings.
+Approach: single foldl per part accumulates position and result in
+one pass, avoiding intermediate lists that cause head retention.
 
 Notable eucalypt techniques:
-- `scanl` for running totals
+- `foldl` with tuple accumulator for single-pass aggregation
 - sections `(% 100 = 0)` for divisibility predicates
-- `window(2, 1)` for consecutive-pair analysis
-- juxtaposed call syntax in `to-offset[dir, mag]:` and `zeros[a, b]:`
+- list destructuring in fold step functions
+- juxtaposed call syntax in `to-offset[dir, mag]:`
 - scoped imports with target metadata
-
-Running time: ~3s (part 1), ~10s (part 2)
 "
 
 ` "Convert Lxx / Rxx instructions to numeric offsets."
@@ -26,15 +24,25 @@ to-offset[dir, mag]: ((dir = "L") then(-1, 1)) * (mag num)
 
 parse-instruction(s): s str.match-with("([LR])([0-9]+)") tail to-offset
 
-solve(data): data map(parse-instruction) scanl(+, 50) filter(% 100 = 0) count
+` "Fold step for part 1: parse instruction, update position, count multiples of 100."
+count-step([pos, cnt], line): {
+  p: pos + parse-instruction(line)
+}.[p, (p % 100 = 0) then(cnt + 1, cnt)]
+
+solve(data): foldl(count-step, [50, 0], data) second
 
 ` "Count zero crossings between consecutive positions. Shift by 1 when
 moving left so that starting on a multiple of 100 is not counted."
-zeros[a, b]: {
+crossing(a, b): {
   s: (b < a) then(1, 0)
 }.(abs((b - s) / 100 - (a - s) / 100))
 
-solve2(data): data map(parse-instruction) scanl(+, 50) window(2, 1) map(zeros) sum
+` "Fold step for part 2: parse instruction, update position, accumulate crossings."
+crossing-step([prev, total], line): {
+  p: prev + parse-instruction(line)
+}.[p, total + crossing(prev, p)]
+
+solve2(data): foldl(crossing-step, [50, 0], data) second
 
 ` { target: :test
     import: "ex1=inputs/day01-ex1.txt" }

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -8,14 +8,14 @@ Find the largest rectangle using two red tiles as corners that fits
 entirely within the red/green region.
 
 Approach: Part 1 is brute-force over all tile pairs via `tails` and
-`max-of-by`. Part 2 builds polygon 'levels' (cross-sections at each
+`foldl` to find the maximum area without intermediate lists. Part 2
+builds polygon 'levels' (cross-sections at each
 y-coordinate), then sweeps all start/end level pairs with corridor
 narrowing and area-based pruning to find the maximum inscribed
 rectangle.
 
 Notable eucalypt techniques:
-- `tails` for generating all suffix pairs
-- `max-of-by` for finding best pair without explicit recursion
+- `tails` with `foldl` for pairwise maximum without intermediate lists
 - `product` for 2D area from dimension list
 - block-scoped modules (`levels`, `search`) for organising complex logic
 - `cross` for Cartesian product of tile x-coords
@@ -34,11 +34,13 @@ area(a, b): zip-with(-, a, b) map(abs ; (+ 1)) product
 ` "Max area from head of a list to any later element."
 best-from(ps): ps tail map(area(ps head)) max-of
 
-` "Max area over all distinct pairs of points."
-best-area(pts):
-  tails(pts)
-    filter(count ; (> 1))
-    max-map(best-from)
+` "Max area over all distinct pairs of points.
+Uses foldl instead of max-map to avoid materialising an intermediate
+list of areas — each tail is processed and discarded in turn."
+best-area(pts): {
+  step(best, suffix): max(best, best-from(suffix))
+  tls: tails(pts) filter(count ; (> 1))
+}.(foldl(step, 0, tls))
 
 parse(data): data filter(!= "") map(parse-coord)
 


### PR DESCRIPTION
## Summary

- **day01**: Replace `scanl+filter/count` (part-1) and `scanl+window+map/sum` (part-2) pipelines with single-pass `foldl` using `[pos, count]` tuple accumulators. Eliminates intermediate lists that keep all elements reachable, preventing GC from reclaiming consumed data.
- **day09-p1**: Replace `max-map(best-from)` with `foldl(step, 0, tails)` so each suffix is processed and discarded rather than materialising an intermediate list of all area values.

## Before/after statistics

### day01 part-1
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Ticks | 48.3M | 13.0M | **-73%** |
| Allocs | 2.72M | 2.25M | -17% |
| Mark Time | 2.86s | 1.18s | **-59%** |
| Mutator | 2.27s | 0.42s | **-81%** |

### day01 part-2
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Ticks | 188.4M | 13.4M | **-93%** |
| Allocs | 4.80M | 2.37M | **-51%** |
| Mark Time | 42.84s | 1.64s | **-96%** |
| Mutator | 5.08s | 0.45s | **-91%** |

### Correctness
- day01 test: PASS (part-1: 1180, part-2: 6892 — unchanged)
- day09 test: PASS (part-1: 50 — unchanged)
- Full `cargo test`: all passing
- `cargo clippy --all-targets -- -D warnings`: clean

## Test plan
- [x] day01 `-t test` passes (both parts)
- [x] day01 `-t part-1` and `-t part-2` produce same output as before
- [x] day09 `-t test` passes
- [x] Full `cargo test` passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)