### PR TITLE
fix(core): re-enable AtMostOnce update elision with rendered-block fixup

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -431,6 +431,21 @@ impl DemandAnalyser {
             }
         }
 
+        // Step 7: Fixup for rendered block scopes.
+        //
+        // DefaultBlockLet scopes whose body is a Block constructor will
+        // have their bindings forced by RENDER_DOC after demand analysis.
+        // The render traversal adds invisible uses that the analysis
+        // cannot see, so AtMostOnce is unsound here — force Multi on
+        // any non-absent binding to prevent update elision.
+        if let_type == LetType::DefaultBlockLet && matches!(&*new_body.inner, Expr::Block(_, _)) {
+            for d in &mut demands {
+                if d.cardinality == Cardinality::AtMostOnce {
+                    d.cardinality = Cardinality::Multi;
+                }
+            }
+        }
+
         // Build annotated bindings and propagate demands to the outer scope.
         let mut outer_env = unshift_env(&body_env);
         let mut new_bindings = Vec::with_capacity(n);
@@ -980,10 +995,9 @@ mod tests {
     }
 
     #[test]
-    fn absent_demand_does_not_skip_update() {
-        // Absent → Value is disabled (same reason as AtMostOnce — see
-        // Demand::skip_update doc comment).
-        assert!(!Demand::absent().skip_update());
+    fn absent_demand_skips_update() {
+        // Absent bindings are never evaluated, so skipping update is safe.
+        assert!(Demand::absent().skip_update());
     }
 
     #[test]

--- a/src/core/demand.rs
+++ b/src/core/demand.rs
@@ -41,17 +41,16 @@ impl Demand {
     /// Returns `true` when the STG compiler should skip the Update frame
     /// (i.e. emit `Value` rather than `Thunk`).
     ///
-    /// Currently only fires for bindings already in WHNF. The
-    /// `AtMostOnce` and `Absent` cardinality paths are disabled because
-    /// demand analysis counts `Var::Bound` references but cannot account
-    /// for runtime block lookups (`.key`) or the post-analysis rendering
-    /// wrapper — both of which re-enter closures that the analysis
-    /// considers single-use, causing cascading re-evaluation and a 3×
-    /// allocation regression.  The cardinality computation is retained
-    /// in the analysis for future use once a sound update-elision
-    /// strategy is in place.
+    /// Fires for bindings already in WHNF, bindings used at most once,
+    /// and absent bindings.  The demand analysis fixup pass forces Multi
+    /// on `DefaultBlockLet` bindings whose body is a `Block` constructor
+    /// (rendered scopes), so `AtMostOnce` here only applies to
+    /// generalised-lookup blocks and non-block `Let` scopes where the
+    /// cardinality is genuinely sound.
     pub fn skip_update(self) -> bool {
         self.whnf
+            || self.cardinality == Cardinality::AtMostOnce
+            || self.cardinality == Cardinality::Absent
     }
 
     /// Convenience: a demand marking a binding as used at most once.
@@ -241,15 +240,22 @@ mod tests {
     }
 
     #[test]
-    fn at_most_once_does_not_skip_update() {
-        // AtMostOnce → Value is disabled: runtime block lookups and
-        // post-analysis rendering re-enter closures that the analysis
-        // considers single-use, causing cascading re-evaluation.
+    fn at_most_once_skips_update() {
+        // AtMostOnce → Value is now sound: the demand analysis fixup
+        // forces Multi on rendered block scopes (DefaultBlockLet with
+        // Block body), so AtMostOnce only survives for genuinely
+        // single-use bindings.
         let d = Demand::at_most_once();
         assert!(
-            !d.skip_update(),
-            "AtMostOnce should NOT skip update (disabled — unsound with rendering)"
+            d.skip_update(),
+            "AtMostOnce should skip update (sound after rendered-block fixup)"
         );
+    }
+
+    #[test]
+    fn absent_skips_update() {
+        let d = Demand::absent();
+        assert!(d.skip_update(), "Absent demand should skip update");
     }
 
     #[test]

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1797,16 +1797,12 @@ pub mod tests {
 
     /// AtMostOnce demand does NOT elide update frames (disabled).
     ///
-    /// `AtMostOnce → Value` was disabled because demand analysis counts
-    /// `Var::Bound` references but cannot account for runtime block
-    /// lookups (`.key`) or the post-analysis rendering wrapper — both
-    /// re-enter closures the analysis considers single-use, causing
-    /// cascading re-evaluation and a 3× allocation regression.
-    ///
-    /// This test verifies both `Unknown` and `AtMostOnce` compile as
-    /// `Thunk` for a non-WHNF binding.
+    /// After the rendered-block fixup in demand analysis, `AtMostOnce`
+    /// only survives for genuinely single-use bindings (non-rendered
+    /// scopes).  The STG compiler should now emit `Value` for
+    /// `AtMostOnce` and `Thunk` for `Unknown`.
     #[test]
-    pub fn test_at_most_once_does_not_elide_update() {
+    pub fn test_at_most_once_elides_update() {
         use crate::common::sourcemap::Smid;
         use crate::core::binding::{CoreBinding, Scope};
         use crate::core::demand::Demand;
@@ -1862,18 +1858,18 @@ pub mod tests {
             "with Unknown demand, nested-let binding should be Thunk; got:\n{unknown_demand:?}"
         );
 
-        // With AtMostOnce demand: update elision is disabled, so still Thunk.
+        // With AtMostOnce demand: update elision is now enabled → Value.
         let at_most_once = compile(make_let(Demand::at_most_once())).unwrap();
-        let x_is_thunk_too = match at_most_once.as_ref() {
+        let x_is_value = match at_most_once.as_ref() {
             StgSyn::LetRec { bindings, .. } => {
-                matches!(bindings.first(), Some(LambdaForm::Thunk { .. }))
+                matches!(bindings.first(), Some(LambdaForm::Value { .. }))
             }
             _ => false,
         };
         assert!(
-            x_is_thunk_too,
-            "with AtMostOnce demand, nested-let binding should still be Thunk \
-             (update elision disabled); got:\n{at_most_once:?}"
+            x_is_value,
+            "with AtMostOnce demand, nested-let binding should be Value \
+             (update elision enabled after rendered-block fixup); got:\n{at_most_once:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add post-analysis fixup in `analyse_demand.rs` that forces `Multi` cardinality on `DefaultBlockLet` scopes whose body is a `Block` constructor — these are rendered by `RENDER_DOC` which adds invisible uses the analysis cannot see
- Re-enable `AtMostOnce` and `Absent` cardinality in `Demand::skip_update()` so the STG compiler can emit `Value` (skip update frame) for genuinely single-use bindings
- Update tests in `demand.rs`, `analyse_demand.rs`, and `compiler.rs` to match the new behaviour

## Before/after

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| 010_prelude | 118,955 allocs | 118,955 allocs | No change (fixup prevents regression) |
| 010_prelude (EU_SOURCE_PRELUDE=1) | 49,097 allocs | 49,217 allocs | +0.2% (noise) |
| AoC day01 test | 32,689 allocs | 19,713 allocs | **−40%** |

## Test plan

- [x] `cargo test --lib` — 1163 passed
- [x] `cargo test --test harness_test` — 451 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] 010_prelude allocs ~119K (not 369K regression)
- [x] AoC day01 still passes with allocation improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)