### PR TITLE
perf(vm): avoid eager ExecutionError construction in HeapNavigator hot path

### DIFF
--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -89,16 +89,18 @@ impl HeapNavigator<'_> {
 
     /// Index into current environment, retrieving pointer
     pub fn get(&self, index: usize) -> Result<SynClosure, ExecutionError> {
-        (*self.locals)
-            .get(&self.view, index)
-            .ok_or(ExecutionError::BadEnvironmentIndex(index))
+        match (*self.locals).get(&self.view, index) {
+            Some(c) => Ok(c),
+            None => Err(ExecutionError::BadEnvironmentIndex(index)),
+        }
     }
 
     /// Index into globals
     pub fn global(&self, index: usize) -> Result<SynClosure, ExecutionError> {
-        (*self.globals)
-            .get(&self.view, index)
-            .ok_or(ExecutionError::BadGlobalIndex(index))
+        match (*self.globals).get(&self.view, index) {
+            Some(c) => Ok(c),
+            None => Err(ExecutionError::BadGlobalIndex(index)),
+        }
     }
 
     /// Resolve a ref to a closure


### PR DESCRIPTION
## Summary

- `HeapNavigator::get` and `HeapNavigator::global` are called on every heap reference resolution — ~14M times for `day05-p1`
- Both previously used `ok_or(ExecutionError::...)`, which eagerly constructs the error value even on the success path, then immediately drops it
- Although `BadEnvironmentIndex(usize)` is cheap to construct, `ExecutionError`'s drop glue is non-trivial (other variants hold `String`/`Vec`/`Box` fields)
- The discriminant check + branch in `drop_in_place<ExecutionError>`, repeated 14M times, was ~20.7% of mutator CPU in macOS `sample` profiles

**Fix:** replace `ok_or` with explicit `match` expressions that only construct `Err` on the `None` (error) path. This is semantically identical but avoids the eager construction and immediate drop on the common success path. Clippy's `unnecessary_lazy_evaluations` lint does not fire on `match` expressions.

## Before/after profiling

**CPU profile (aarch64-apple-darwin, `sample`, `--heap-limit-mib 0`):**

| Symbol | Before | After |
|--------|--------|-------|
| `drop_in_place<ExecutionError>` | ~20.7% mutator CPU | ~0.9% total samples |

**Wall time (`day05-p1`, `--heap-limit-mib 0`, aarch64-apple-darwin):**

| | Before | After | Change |
|-|--------|-------|--------|
| day05 part-1 | 1.47–1.55s user | 1.33–1.38s user | ~9–11% faster |
| day05 part-2 | 0.04s | 0.04s | no change (fast path) |
| day01/03/06/12 | <0.02s | <0.02s | below noise floor |

The improvement is proportional to heap reference density — programmes with many environment lookups (like day05-p1 with ~14M machine ticks) benefit most.

## Test plan

- [x] `cargo test --lib` — 1163 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes
- [x] Post-fix profile confirms `drop_in_place<ExecutionError>` drops from ~20.7% to ~0.9% of samples
- [x] `day05-p1` answer unchanged: 558 (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)