### PR TITLE
feat(gc): nursery v3 — sticky-mark-bit minor with remembered set

### DIFF
--- a/src/eval/machine/env.rs
+++ b/src/eval/machine/env.rs
@@ -343,6 +343,51 @@ where
         }
     }
 
+    /// Find the specific frame in the chain that owns the slot at `idx`.
+    ///
+    /// Used by the GC write barrier to record the ACTUAL frame whose backing
+    /// array was written, rather than always recording the top-of-chain frame.
+    /// Without this, a thunk update at index `idx >= self.logical_len()` writes
+    /// to a parent frame but the write barrier would record `self` (the top),
+    /// causing the parent's young closure to be missed by dirty-frame scanning.
+    ///
+    /// Returns `None` if `idx` is out of range.
+    ///
+    /// # Safety
+    ///
+    /// `start` must be a valid, live pointer to a heap-allocated `EnvironmentFrame`
+    /// and all `next` pointers reachable from it must be similarly valid.  This is
+    /// upheld by the invariant that frames are GC-managed heap objects.
+    pub fn find_frame_for_index(
+        start: std::ptr::NonNull<EnvironmentFrame<C>>,
+        idx: usize,
+    ) -> Option<std::ptr::NonNull<EnvironmentFrame<C>>> {
+        let frame = unsafe { start.as_ref() };
+        let len = frame.logical_len();
+        if idx < len {
+            Some(start)
+        } else {
+            match frame.next {
+                Some(next_ref) => {
+                    let next_ptr = unsafe { std::ptr::NonNull::new_unchecked(next_ref.as_ptr()) };
+                    Self::find_frame_for_index(next_ptr, idx - len)
+                }
+                None => None,
+            }
+        }
+    }
+
+    /// Iterate all physical binding slots in this frame.
+    ///
+    /// Used by the GC dirty-frame scanning pass to find young closures in
+    /// old frames without going through `mark_array()`.  Unlike `GcScannable::scan`,
+    /// this iterates every slot unconditionally — the frame and its backing array
+    /// are already marked (old), so `mark_array` would return false and skip them,
+    /// causing live young closures written via thunk updates to be missed.
+    pub fn iter_bindings(&self) -> std::slice::Iter<'_, C> {
+        self.bindings.iter()
+    }
+
     /// Zero-based closure access (from top of environment)
     ///
     /// Uses guard for scoping derefs during navigation but then

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -561,6 +561,12 @@ impl MachineState {
     /// Write barrier: if the frame being updated is old (already marked),
     /// record it in the remembered set so the next minor collection scans
     /// it as an extra root and finds the newly-written young closure.
+    ///
+    /// The write barrier records the ACTUAL frame that owns the updated slot,
+    /// not necessarily `environment` (the top of the chain).  When `index >=
+    /// environment.logical_len()`, the update traverses to a parent frame and
+    /// we must record that parent — otherwise dirty-frame scanning would iterate
+    /// the wrong frame's bindings and miss the young closure.
     fn update(
         &mut self,
         view: MutatorHeapView,
@@ -569,9 +575,13 @@ impl MachineState {
     ) -> Result<(), ExecutionError> {
         let cont_env = view.scoped(environment);
         cont_env.update(&view, index, self.closure.clone())?;
+        // Find the specific frame that owns the updated slot so the write
+        // barrier records exactly where the young closure was written.
+        let actual_frame =
+            EnvFrame::find_frame_for_index(environment, index).unwrap_or(environment);
         // Write barrier: record old frames updated with new (possibly young) closures.
-        if view.is_marked(environment) {
-            view.record_dirty_frame(environment);
+        if view.is_marked(actual_frame) {
+            view.record_dirty_frame(actual_frame);
         }
         Ok(())
     }
@@ -1821,16 +1831,13 @@ impl<'a> Machine<'a> {
             self.step()?;
         }
 
-        // Only collect at the end of a run() call if the heap is under
-        // memory pressure.  run() is called multiple times for IO programs
-        // (once per IO step) and also once for rendering; an unconditional
-        // collection here was the dominant source of GC overhead since it
-        // ran a full mark/sweep on every call even when no reclamation was
-        // needed.  The periodic in-loop check (every 500 steps) still
-        // triggers collection when the policy demands it.
-        if self.heap().policy_requires_collection() {
-            self.collect_with_diagnostics();
-        }
+        // Unconditional end-of-run collection: ensures GC has a chance to
+        // establish mark state and reclaim dead objects after each evaluation
+        // phase.  run() is called once for STG eval and once for rendering,
+        // giving exactly 2 collections for non-IO programs — matching the
+        // pre-nursery baseline.  The nursery budget trigger is disabled so
+        // this is the primary trigger for programs that fit comfortably in RAM.
+        self.collect_with_diagnostics();
 
         self.core.clock.stop();
 

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -558,9 +558,9 @@ impl MachineState {
 
     /// Update environment index to point to current closure.
     ///
-    /// No write barrier is needed: the minor collection uses a HashSet to trace
-    /// ALL reachable objects (old and young alike), so old→young edges created
-    /// by thunk updates are discovered naturally without any special treatment.
+    /// Write barrier: if the frame being updated is old (already marked),
+    /// record it in the remembered set so the next minor collection scans
+    /// it as an extra root and finds the newly-written young closure.
     fn update(
         &mut self,
         view: MutatorHeapView,
@@ -569,6 +569,10 @@ impl MachineState {
     ) -> Result<(), ExecutionError> {
         let cont_env = view.scoped(environment);
         cont_env.update(&view, index, self.closure.clone())?;
+        // Write barrier: record old frames updated with new (possibly young) closures.
+        if view.is_marked(environment) {
+            view.record_dirty_frame(environment);
+        }
         Ok(())
     }
 

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -4,13 +4,12 @@
 //! tracing, marking and potentially, in future, moving.
 //!
 
-use std::{
-    collections::{HashSet, VecDeque},
-    mem::size_of,
-    ptr::NonNull,
-};
+use std::{collections::VecDeque, mem::size_of, ptr::NonNull};
 
-use crate::eval::machine::metrics::{Clock, ThreadOccupation};
+use crate::eval::machine::{
+    env::EnvFrame,
+    metrics::{Clock, ThreadOccupation},
+};
 
 use super::{array::Array, header::AllocHeader, heap::Heap};
 
@@ -157,13 +156,11 @@ impl<T: GcScannable> GcScannable for Vec<NonNull<T>> {
 ///   `mark()` is a no-op, so minor collections naturally skip old objects.
 /// - Young objects (mark_bit != mark_state) return `is_marked() = NO` →
 ///   `mark()` marks them (tenures them) in place.
+///
+/// There is no longer a separate minor-mode `visited` set.  The header
+/// mark bit IS the visited set for both minor and major collections.
 pub struct CollectorHeapView<'guard> {
     heap: &'guard mut Heap,
-    /// Minor-collection visited set.  When `Some`, the collector is in minor
-    /// mode: cycle detection uses the HashSet rather than header mark bits,
-    /// and only line marks are written (header marks are NOT touched).
-    /// When `None`, the collector is in major mode (header + line marks).
-    visited: Option<HashSet<usize>>,
 }
 
 impl CollectorHeapView<'_> {
@@ -174,14 +171,14 @@ impl CollectorHeapView<'_> {
     /// Mark an object for the current collection and return whether it should
     /// be scanned (queued for child traversal).
     ///
-    /// **Major mode** (`visited = None`): uses the header mark bit for cycle
-    /// detection; marks both header and line.  Old objects (`is_marked() =
-    /// YES`) are skipped; young objects are tenured in place.
+    /// Uses the header mark bit for cycle detection and marks both header
+    /// and line.  This works for both minor and major collections:
     ///
-    /// **Minor mode** (`visited = Some(HashSet)`): uses the HashSet for cycle
-    /// detection; marks lines ONLY (header mark bits are NOT touched).  All
-    /// reachable objects (old and young) are visited, so old→young edges are
-    /// discovered naturally without a write barrier.
+    /// - Old objects (`is_marked() = YES`) → `mark()` is a no-op → returns
+    ///   false → trace skips them.  Minor collections naturally skip old
+    ///   objects without any special mode.
+    /// - Young objects (`is_marked() = NO`) → marked in place (tenured) →
+    ///   returns true → children are traced.
     pub fn mark<T>(&mut self, obj: NonNull<T>) -> bool {
         debug_assert!(obj != NonNull::dangling());
         debug_assert!(obj.as_ptr() as usize != usize::MAX);
@@ -203,41 +200,27 @@ impl CollectorHeapView<'_> {
             }
         }
 
-        if let Some(visited) = &mut self.visited {
-            // Minor mode: HashSet cycle detection, line marks only.
-            // Header marks are intentionally left untouched so the major
-            // can still distinguish old from young objects.
-            let addr = obj.as_ptr() as usize;
-            if visited.insert(addr) {
-                self.heap.mark_line(obj);
-                true
-            } else {
-                false
+        if !self.heap.is_marked(obj) {
+            self.heap.mark_object(obj);
+            self.heap.mark_line(obj);
+
+            let verify = super::gc_debug::verify_level();
+            if verify >= 2 {
+                // Level 2: full header + line consistency check
+                super::gc_verify::verify_marked_object(self.heap, obj);
+            } else if verify >= 1 {
+                // Level 1: just verify mark persisted
+                debug_assert!(
+                    self.heap.is_marked(obj),
+                    "GC BUG: mark_object({:p}) did not persist! mark_state={}",
+                    obj.as_ptr(),
+                    self.heap.mark_state(),
+                );
             }
+
+            true
         } else {
-            // Major mode: header mark for cycle detection, header + line marks.
-            if !self.heap.is_marked(obj) {
-                self.heap.mark_object(obj);
-                self.heap.mark_line(obj);
-
-                let verify = super::gc_debug::verify_level();
-                if verify >= 2 {
-                    // Level 2: full header + line consistency check
-                    super::gc_verify::verify_marked_object(self.heap, obj);
-                } else if verify >= 1 {
-                    // Level 1: just verify mark persisted
-                    debug_assert!(
-                        self.heap.is_marked(obj),
-                        "GC BUG: mark_object({:p}) did not persist! mark_state={}",
-                        obj.as_ptr(),
-                        self.heap.mark_state(),
-                    );
-                }
-
-                true
-            } else {
-                false
-            }
+            false
         }
     }
 
@@ -247,57 +230,35 @@ impl CollectorHeapView<'_> {
     /// Returns `true` if the object was newly visited (i.e. it should be
     /// pushed onto the scan queue as an `OpaqueHeapBytes` object).
     ///
-    /// In minor mode: uses HashSet for cycle detection, marks lines only.
-    /// In major mode: uses header mark for cycle detection, marks header + lines.
+    /// Uses the header mark bit for cycle detection (same as `mark()`).
     pub fn mark_raw_bytes(&mut self, ptr: NonNull<u8>) -> bool {
         debug_assert!(ptr != NonNull::dangling());
         debug_assert!(ptr.as_ptr() as usize != usize::MAX);
 
-        if let Some(visited) = &mut self.visited {
-            let addr = ptr.as_ptr() as usize;
-            if visited.insert(addr) {
-                self.heap.mark_lines_for_bytes(ptr);
-                true
-            } else {
-                false
-            }
+        if !self.heap.is_marked(ptr) {
+            self.heap.mark_object(ptr);
+            self.heap.mark_lines_for_bytes(ptr);
+            true
         } else {
-            if !self.heap.is_marked(ptr) {
-                self.heap.mark_object(ptr);
-                self.heap.mark_lines_for_bytes(ptr);
-                true
-            } else {
-                false
-            }
+            false
         }
     }
 
     /// Mark array backing storage if not already visited and return whether
     /// newly visited.
     ///
-    /// In minor mode: uses HashSet for cycle detection, marks lines only.
-    /// In major mode: uses header mark for cycle detection, marks header + lines.
+    /// Uses the header mark bit for cycle detection (same as `mark()`).
     pub fn mark_array<T: Clone>(&mut self, arr: &Array<T>) -> bool {
         if let Some(ptr) = arr.allocated_data() {
             debug_assert!(ptr != NonNull::dangling());
             debug_assert!(ptr.as_ptr() as usize != usize::MAX);
 
-            if let Some(visited) = &mut self.visited {
-                let addr = ptr.as_ptr() as usize;
-                if visited.insert(addr) {
-                    self.heap.mark_lines_for_bytes(ptr);
-                    true
-                } else {
-                    false
-                }
+            if !self.heap.is_marked(ptr) {
+                self.heap.mark_object(ptr);
+                self.heap.mark_lines_for_bytes(ptr);
+                true
             } else {
-                if !self.heap.is_marked(ptr) {
-                    self.heap.mark_object(ptr);
-                    self.heap.mark_lines_for_bytes(ptr);
-                    true
-                } else {
-                    false
-                }
+                false
             }
         } else {
             false
@@ -462,12 +423,14 @@ impl CollectorScope for Scope {}
 /// `collect_minor` or `collect_major` depending on the heap's nursery
 /// scheduling policy (`should_collect_major()`).
 ///
-/// Minor collections use a HashSet for cycle detection and mark only line
-/// marks (not header marks), tracing from ALL roots including old objects.
-/// Old→young edges are discovered naturally — no write barrier is needed.
+/// Minor collections use sticky-mark-bit + remembered set.  Old objects
+/// are skipped (they're already marked).  Young objects are tenured in
+/// place.  Dirty frames (the remembered set) are traced as extra roots.
 ///
-/// Major collections reset all line marks, do a full trace marking both
-/// headers and lines, defer sweep, then flip the mark state at the end.
+/// Major collections run a preliminary minor, flip the mark state, reset
+/// line marks, do a full trace, and defer sweep.  The flip is at the
+/// START so that after the flip everything appears unmarked and the full
+/// trace re-discovers all live objects.
 pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, dump_heap: bool) {
     if heap.should_collect_major() {
         collect_major(roots, heap, clock, dump_heap);
@@ -476,21 +439,23 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
     }
 }
 
-/// Major collection: full mark-sweep with mark-state flip at END.
+/// Major collection: preliminary minor + flip at START + full trace + sweep.
 ///
 /// ## Algorithm (non-evacuating path)
 ///
-/// 1. **Reset line marks**: all line marks are cleared; every live object
-///    will be re-marked during the trace.
-/// 2. **Full trace from roots**: every reachable object is marked (both
-///    header mark and line marks).  Objects appear unmarked because their
-///    mark bits are from the PREVIOUS cycle's mark state (which is now the
-///    opposite of the current `mark_state` after the last flip).
-/// 3. **Defer sweep**: objects with no line marks are lazily reclaimed.
-/// 4. **Flip mark state at END**: after flipping, survivors' mark bits equal
-///    the OLD `mark_state`, which is now `!new_mark_state`.  The next major
-///    cycle starts with all survivors appearing unmarked, ready to be
-///    re-discovered from scratch.
+/// 1. **Preliminary minor**: tenure all currently reachable young objects
+///    so that after the flip every live object appears marked.
+/// 2. **Flip mark state at START**: after flip, all objects appear unmarked
+///    (mark_bit == old_state, is_marked(new_state) == NO).
+/// 3. **Drain dirty frames**: not needed after flip, but cleared for
+///    hygiene so they don't influence the next minor.
+/// 4. **Reset line marks**: all line marks are cleared.
+/// 5. **Full trace from roots**: every reachable object is re-marked.
+/// 6. **Defer sweep**: objects with no line marks are lazily reclaimed.
+///
+/// Note: the flip is at START, not END.  The first minor after a major
+/// traces everything (expected — all objects appear unmarked after flip).
+/// Subsequent minors only trace young objects + dirty frames.
 ///
 /// Optionally performs selective evacuation of fragmented blocks.
 pub fn collect_major(
@@ -513,12 +478,24 @@ pub fn collect_major(
 
     clock.switch(ThreadOccupation::CollectorMark);
 
-    let mut heap_view = CollectorHeapView {
-        heap,
-        visited: None,
-    };
+    // Step 1: Preliminary minor — tenure all reachable young objects.
+    // This ensures that after the flip, all currently-live objects are
+    // marked with the OLD mark state and will appear unmarked (→ new state).
+    collect_minor(roots, heap, clock, false);
 
-    // Step 1: Clear all line marks — every live object will be re-marked.
+    // Step 2: Flip mark state at START.
+    // After flip, every object's mark_bit == old_mark_state, so
+    // is_marked(new_mark_state) == NO for ALL objects.
+    heap.flip_mark_state();
+
+    // Step 3: Drain dirty frames (cleared — major retraces everything).
+    heap.drain_dirty_frames();
+
+    clock.switch(ThreadOccupation::CollectorMark);
+
+    let mut heap_view = CollectorHeapView { heap };
+
+    // Step 4: Reset line marks — every live object will be re-marked.
     heap_view.reset();
 
     let mut queue = VecDeque::default();
@@ -526,7 +503,7 @@ pub fn collect_major(
 
     let scope = Scope();
 
-    // Step 2: Full trace from roots.
+    // Step 5: Full trace from roots.
     roots.scan(&scope, &mut heap_view, &mut scan_buffer);
     queue.extend(scan_buffer.drain(..));
 
@@ -547,7 +524,7 @@ pub fn collect_major(
 
     clock.switch(ThreadOccupation::CollectorSweep);
 
-    // Step 3: Defer sweep to allocation time (lazy sweeping).
+    // Step 6: Defer sweep to allocation time (lazy sweeping).
     heap_view.defer_sweep();
 
     // Post-sweep verification (level 2)
@@ -559,32 +536,27 @@ pub fn collect_major(
         eprintln!("Heap after defer_sweep:\n\n{:?}", &heap_view.heap)
     }
 
-    // Step 4: Flip mark state at END.
-    // After flip, this cycle's survivors have mark_bit = !new_mark_state,
-    // so they appear unmarked to the next major and are correctly re-traced.
-    heap_view.heap.flip_mark_state();
-
+    // NO flip at end — flip was at start.
     heap_view.heap.record_major_collection();
 }
 
-/// Minor (nursery) collection: HashSet-based trace with line-only marking.
+/// Minor (nursery) collection: sticky-mark-bit with remembered set.
 ///
-/// Traces from ALL roots using a `HashSet<usize>` for cycle detection.
-/// Unlike major collection, the minor does NOT touch header mark bits —
-/// only line marks are refreshed.  This means:
+/// Uses the header mark bit as the visited set (no HashSet needed):
 ///
-/// - Old objects ARE visited (via HashSet); their line marks are refreshed
-///   but their header marks are left unchanged.
-/// - Young objects are also visited; their line marks are set.
-/// - Old→young edges are discovered naturally since the trace follows ALL
-///   reachable objects without stopping at old boundaries.
-/// - No write barrier is required.
+/// - Old objects (`is_marked() = YES`) → `mark()` is a no-op → skipped.
+/// - Young objects (`is_marked() = NO`) → tenured in place (header + line
+///   marks written) → children are traced.
 ///
-/// Key differences from major collection:
-/// - NO `reset()` — old objects' line marks are preserved between minors
-/// - NO `flip_mark_state()` — not needed; no header marks are written
-/// - NO sweep — dead objects are reclaimed at the next major collection
-/// - Uses `HashSet<usize>` for visited tracking instead of header mark bits
+/// Old→young edges are found via the remembered set: frames recorded by
+/// the write barrier are scanned as extra roots, exposing young objects
+/// that are only reachable through updated old frames.
+///
+/// Key properties:
+/// - NO `reset()` — old objects' line marks are preserved between minors.
+/// - NO `flip_mark_state()` — not needed; survivors remain marked.
+/// - NO sweep — dead objects are reclaimed at the next major collection.
+/// - NO HashSet — the header mark bit IS the visited set.
 pub fn collect_minor(
     roots: &mut dyn GcScannable,
     heap: &mut Heap,
@@ -597,25 +569,44 @@ pub fn collect_minor(
 
     clock.switch(ThreadOccupation::CollectorMark);
 
-    // Minor mode: HashSet cycle detection, line marks only, no header marks.
-    let mut heap_view = CollectorHeapView {
-        heap,
-        visited: Some(HashSet::new()),
-    };
+    // Drain dirty frames BEFORE creating heap_view to avoid aliasing.
+    let dirty_addrs = heap.drain_dirty_frames();
+
+    // Sticky-mark-bit mode: header mark bit for cycle detection.
+    // Old objects are already marked → mark() is a no-op → skipped.
+    // Young objects are unmarked → mark() tenures them.
+    let mut heap_view = CollectorHeapView { heap };
 
     // DO NOT call reset() — preserve old objects' line marks.
-    // DO NOT call flip_mark_state() — not needed for line-only marking.
+    // DO NOT call flip_mark_state() — mark bit sticky across minors.
 
-    // Trace from ALL roots (old and young alike).
-    // HashSet prevents revisiting the same object twice.
-    // For each object: mark_line() is called (via mark()), no mark_object().
     let mut queue = VecDeque::default();
     let mut scan_buffer = Vec::new();
     let scope = Scope();
 
+    // 1. Trace from regular roots (stacks, globals, current closure).
     roots.scan(&scope, &mut heap_view, &mut scan_buffer);
     queue.extend(scan_buffer.drain(..));
 
+    // 2. Trace dirty frames (remembered set) as extra roots.
+    //    Each dirty frame is an old EnvFrame that was updated since
+    //    the last collection.  Scanning its closures finds young
+    //    objects reachable through old→young edges.
+    for frame_addr in dirty_addrs {
+        // SAFETY: frame_addr was stored by record_dirty_frame() from a live
+        // NonNull<EnvFrame>.  The frame is still live (it's old / marked) and
+        // cannot have been reclaimed between barrier and collection.
+        if let Some(frame_ptr) = NonNull::new(frame_addr as *mut EnvFrame) {
+            unsafe {
+                frame_ptr
+                    .as_ref()
+                    .scan(&scope, &mut heap_view, &mut scan_buffer);
+            }
+            queue.extend(scan_buffer.drain(..));
+        }
+    }
+
+    // 3. Trace reachable objects (mark bit terminates cycles).
     while let Some(scanptr) = queue.pop_front() {
         scanptr.get().scan(&scope, &mut heap_view, &mut scan_buffer);
         queue.extend(scan_buffer.drain(..));
@@ -625,8 +616,8 @@ pub fn collect_minor(
         eprintln!("Heap after minor mark:\n\n{:?}", &heap_view.heap)
     }
 
-    // Record minor collection (no flip, no sweep)
-    heap_view.heap.record_minor_collection(0.0);
+    // Record minor collection (no flip, no sweep).
+    heap_view.heap.record_minor_collection();
 }
 
 /// Public entry point for evacuating collection (called directly from tests).
@@ -645,12 +636,18 @@ pub fn collect_with_evacuation(
 
 /// Inner evacuating collection.
 ///
-/// This extends the basic mark-sweep with Immix-style opportunistic evacuation:
-/// 1. Reset line marks and full trace from roots (marking headers + lines)
-/// 2. Evacuate phase: copy marked objects from candidate blocks to target blocks
-/// 3. Update phase: rewrite all pointers to forwarded objects
-/// 4. Sweep phase: defer sweep; candidate blocks are fully dead after evacuation
-/// 5. Flip mark state at END
+/// Uses the same flip-at-START design as the non-evacuating major:
+/// 1. Preliminary minor — tenure all reachable young objects
+/// 2. Flip mark state at START — everything appears unmarked
+/// 3. Drain dirty frames (cleared — major retraces everything)
+/// 4. Reset line marks
+/// 5. Full trace from roots (marking headers + lines)
+/// 6. Evacuate phase: copy marked objects from candidate blocks to target blocks
+/// 7. Update phase: rewrite all pointers to forwarded objects
+/// 8. Sweep phase: defer sweep; candidate blocks are fully dead after evacuation
+///
+/// After this call, all live objects have mark_bit = current_mark_state.
+/// The flip is at START, not END.
 ///
 /// Objects are evacuated via `CollectorHeapView::evacuate()` which does a
 /// byte-level copy (header + payload) and sets a forwarding pointer in the
@@ -667,6 +664,15 @@ fn collect_with_evacuation_inner(
         eprintln!("GC (evacuating)!");
     }
 
+    // Step 1: Preliminary minor — tenure all reachable young objects.
+    collect_minor(roots, heap, clock, false);
+
+    // Step 2: Flip mark state at START.
+    heap.flip_mark_state();
+
+    // Step 3: Drain dirty frames (major retraces everything from roots).
+    heap.drain_dirty_frames();
+
     clock.switch(ThreadOccupation::CollectorMark);
 
     // --- Mark phase ---
@@ -677,10 +683,7 @@ fn collect_with_evacuation_inner(
     let mut live_heap_objects: Vec<(*const u8, *const ())> = Vec::new();
 
     {
-        let mut heap_view = CollectorHeapView {
-            heap: &mut *heap,
-            visited: None,
-        };
+        let mut heap_view = CollectorHeapView { heap: &mut *heap };
         heap_view.reset();
 
         let mut queue = VecDeque::default();
@@ -727,10 +730,7 @@ fn collect_with_evacuation_inner(
     // --- Update phase ---
     // Rewrite forwarded pointers in roots and all live heap objects.
     {
-        let heap_view = CollectorHeapView {
-            heap: &mut *heap,
-            visited: None,
-        };
+        let heap_view = CollectorHeapView { heap: &mut *heap };
 
         // Update root pointers (MachineState: globals, closure, stack)
         roots.scan_and_update(&heap_view);
@@ -794,10 +794,7 @@ fn collect_with_evacuation_inner(
 
     // Defer sweep to allocation time (lazy sweeping)
     {
-        let mut heap_view = CollectorHeapView {
-            heap,
-            visited: None,
-        };
+        let mut heap_view = CollectorHeapView { heap };
         heap_view.defer_sweep();
     }
 
@@ -806,11 +803,7 @@ fn collect_with_evacuation_inner(
         super::gc_verify::verify_post_sweep(heap);
     }
 
-    // Flip mark state at END.
-    // After flip, this cycle's survivors have mark_bit = !new_mark_state,
-    // so they appear unmarked to the next major cycle.
-    heap.flip_mark_state();
-
+    // NO flip at end — flip was at start.
     heap.record_major_collection();
 }
 
@@ -829,10 +822,7 @@ fn collect_with_evacuation_inner(
 /// Enabled by `EU_GC_VERIFY=1`.
 fn verify_mark_integrity(roots: &dyn GcScannable, heap: &mut Heap) {
     let scope = Scope();
-    let mut heap_view = CollectorHeapView {
-        heap,
-        visited: None,
-    };
+    let mut heap_view = CollectorHeapView { heap };
     let mut queue = VecDeque::default();
     let mut scan_buffer = Vec::new();
     let mut total = 0usize;
@@ -1052,10 +1042,7 @@ pub mod tests {
 
         // Reconstruct via transmute and call scan_and_update (no-op since
         // nothing is forwarded, but verifies the transmute doesn't crash)
-        let heap_view = CollectorHeapView {
-            heap: &mut heap,
-            visited: None,
-        };
+        let heap_view = CollectorHeapView { heap: &mut heap };
         unsafe {
             let obj_ref: &mut dyn GcScannable =
                 std::mem::transmute::<[usize; 2], &mut dyn GcScannable>([
@@ -1161,10 +1148,7 @@ pub mod tests {
         let original_addr = atom_ptr.as_ptr() as usize;
 
         // Manually perform evacuation via CollectorHeapView
-        let mut heap_view = CollectorHeapView {
-            heap: &mut heap,
-            visited: None,
-        };
+        let mut heap_view = CollectorHeapView { heap: &mut heap };
 
         // Mark the object so evacuation recognises it as live
         heap_view.mark(atom_ptr);
@@ -1221,10 +1205,7 @@ pub mod tests {
             .unwrap()
             .as_ptr();
 
-        let mut heap_view = CollectorHeapView {
-            heap: &mut heap,
-            visited: None,
-        };
+        let mut heap_view = CollectorHeapView { heap: &mut heap };
 
         // Mark and evacuate both
         heap_view.mark(atom_ptr);

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -592,15 +592,20 @@ pub fn collect_minor(
     //    Each dirty frame is an old EnvFrame that was updated since
     //    the last collection.  Scanning its closures finds young
     //    objects reachable through old→young edges.
+    //
+    //    IMPORTANT: We must NOT use EnvFrame::scan() here.  scan() calls
+    //    mark_array() on the backing array, which returns false (already
+    //    marked from the last major), causing all bindings to be skipped.
+    //    Instead we iterate bindings directly via iter_bindings() so that
+    //    young closures written via thunk updates are discovered and tenured.
     for frame_addr in dirty_addrs {
         // SAFETY: frame_addr was stored by record_dirty_frame() from a live
         // NonNull<EnvFrame>.  The frame is still live (it's old / marked) and
         // cannot have been reclaimed between barrier and collection.
         if let Some(frame_ptr) = NonNull::new(frame_addr as *mut EnvFrame) {
-            unsafe {
-                frame_ptr
-                    .as_ref()
-                    .scan(&scope, &mut heap_view, &mut scan_buffer);
+            let frame = unsafe { frame_ptr.as_ref() };
+            for binding in frame.iter_bindings() {
+                binding.scan(&scope, &mut heap_view, &mut scan_buffer);
             }
             queue.extend(scan_buffer.drain(..));
         }

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -1870,16 +1870,15 @@ impl Heap {
             }
         }
 
-        // Allocation-rate trigger: nursery budget exhausted.
+        // NOTE: The allocation-rate (nursery budget) trigger is intentionally
+        // disabled.  For programs that fit comfortably in RAM the budget fired
+        // too frequently (e.g. 35+ minor collections for AoC day04 vs. the
+        // pre-nursery baseline of 2), causing regressions of 2-14×.
         //
-        // Only active when a heap limit is set — without memory
-        // pressure, collections would be unnecessary overhead.
-        if self.limit.is_some() {
-            let heap_state = unsafe { &*self.state.get() };
-            if heap_state.blocks_replaced_since_gc >= self.nursery_budget.get() {
-                return true;
-            }
-        }
+        // The primary GC trigger is the unconditional end-of-run collection in
+        // vm.rs (called after STG eval and after rendering).  Back-pressure
+        // collection remains as a safety valve for programs that exhaust the
+        // heap limit before completing.
 
         false
     }

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -47,15 +47,13 @@ use super::{
 
 /// Default nursery budget in blocks.  When this many blocks have been
 /// allocated since the last collection, a collection is triggered.
-/// 256 blocks = 8 MiB with 32 KiB blocks.
-const DEFAULT_NURSERY_BUDGET: usize = 256;
+/// 2048 blocks = 64 MiB with 32 KiB blocks.  The previous value of 256
+/// (8 MiB) was too aggressive, triggering hundreds of minor collections
+/// on programs that fit comfortably in RAM and causing 2-14x regressions.
+const DEFAULT_NURSERY_BUDGET: usize = 2048;
 
 /// After this many consecutive minor collections, force a major collection.
 const MINORS_BEFORE_MAJOR: usize = 8;
-
-/// If a minor collection reclaims less than this fraction of the nursery,
-/// escalate to a major collection next time.
-const MIN_MINOR_RECLAIM_RATIO: f64 = 0.25;
 
 /// Type of garbage collection performed
 #[derive(Debug, Clone, Copy)]
@@ -423,6 +421,10 @@ pub struct HeapState {
     /// Counter of block replacements since last collection.
     /// Incremented by replace_head / replace_head_targeted / replace_overflow.
     blocks_replaced_since_gc: usize,
+    /// Remembered set: addresses of old EnvFrame objects that have been
+    /// updated since the last collection (write barrier records).
+    /// Drained at the start of each minor and major collection.
+    dirty_frames: Vec<usize>,
 }
 
 impl Default for HeapState {
@@ -476,6 +478,7 @@ impl HeapState {
             evacuation_target: None,
             filled_evacuation_blocks: Vec::new(),
             blocks_replaced_since_gc: 0,
+            dirty_frames: Vec::new(),
         }
     }
 
@@ -1917,10 +1920,10 @@ impl Heap {
     /// Record that a minor collection completed.
     ///
     /// Updates counters and resets the allocation-rate trigger.
-    /// `reclaim_ratio` is the fraction of nursery blocks reclaimed
-    /// (0.0–1.0); if below `MIN_MINOR_RECLAIM_RATIO` the next
-    /// collection will be escalated to major.
-    pub fn record_minor_collection(&self, reclaim_ratio: f64) {
+    /// Does NOT escalate to major based on reclaim ratio — the minor
+    /// collector does not sweep, so no meaningful ratio is available.
+    /// Major escalation is handled by the `MINORS_BEFORE_MAJOR` counter.
+    pub fn record_minor_collection(&self) {
         self.minor_collection_count
             .set(self.minor_collection_count.get() + 1);
         let minors = self.minors_since_major.get() + 1;
@@ -1930,11 +1933,6 @@ impl Heap {
         let heap_state = unsafe { &mut *self.state.get() };
         heap_state.blocks_replaced_since_gc = 0;
         heap_state.record_collection();
-
-        // If minor reclaimed very little, force a major next time
-        if reclaim_ratio < MIN_MINOR_RECLAIM_RATIO {
-            self.minors_since_major.set(MINORS_BEFORE_MAJOR);
-        }
     }
 
     /// Record that a major collection completed.
@@ -1947,6 +1945,27 @@ impl Heap {
         let heap_state = unsafe { &mut *self.state.get() };
         heap_state.blocks_replaced_since_gc = 0;
         heap_state.record_collection();
+    }
+
+    /// Record an old EnvFrame as dirty (write barrier).
+    ///
+    /// Called when a thunk update writes a new closure into an old
+    /// (already-marked) frame.  The frame's address is added to the
+    /// remembered set so that the next minor collection scans it as
+    /// an extra root, finding any young objects reachable through it.
+    pub fn record_dirty_frame<T>(&self, ptr: NonNull<T>) {
+        let heap_state = unsafe { &mut *self.state.get() };
+        heap_state.dirty_frames.push(ptr.as_ptr() as usize);
+    }
+
+    /// Drain and return the remembered set of dirty frame addresses.
+    ///
+    /// Called at the start of each minor and major collection.
+    /// Clears the dirty list so new barriers recorded during the pause
+    /// (none, since we're stop-the-world) don't accumulate.
+    pub fn drain_dirty_frames(&self) -> Vec<usize> {
+        let heap_state = unsafe { &mut *self.state.get() };
+        std::mem::take(&mut heap_state.dirty_frames)
     }
 
     /// Current nursery budget in blocks.

--- a/src/eval/memory/mutator.rs
+++ b/src/eval/memory/mutator.rs
@@ -112,6 +112,22 @@ impl<'guard> MutatorHeapView<'guard> {
             heap: self.heap,
         }
     }
+
+    /// Return whether `ptr` is already marked (i.e. is an old object).
+    ///
+    /// Used by the write barrier to determine whether a frame is old
+    /// and should be added to the remembered set.
+    pub fn is_marked<T>(&self, ptr: std::ptr::NonNull<T>) -> bool {
+        self.heap_ref().is_marked(ptr)
+    }
+
+    /// Record a dirty frame in the remembered set (write barrier).
+    ///
+    /// Called when a thunk update writes into an old (marked) frame,
+    /// so that the next minor collection scans it as an extra root.
+    pub fn record_dirty_frame<T>(&self, ptr: std::ptr::NonNull<T>) {
+        self.heap_ref().record_dirty_frame(ptr)
+    }
 }
 
 /// Allow allocation in a mutator scope


### PR DESCRIPTION
## Summary

Implements the nursery v3 design from `docs/superpowers/specs/2026-06-21-nursery-remembered-set.md` (bead eu-9tah.1).

Replaces the HashSet full-trace minor (PR #875) with a correct sticky-mark-bit minor that traces only young objects via a remembered set.

## Root cause of SIGBUS (0x300000001)

Two bugs in the previous implementation caused use-after-free → SIGBUS:

**Bug 1 — dirty-frame scanning skipped young bindings**

`collect_minor()` called `frame.scan()` which internally calls `mark_array()` on the backing `Array`. For OLD backing arrays (already marked from the last major), `mark_array()` returns `false` and all bindings are skipped. Young closures written into those slots via thunk updates were therefore never tenured during the preliminary minor. After the mark-state flip, they appeared OLD, were not re-marked during the full trace, and lazy sweep reclaimed their lines → use-after-free → garbage read as a code pointer → SIGBUS at `0x300000001` (which is a valid `InfoFlags` value, not a heap pointer).

Fix: added `EnvFrame::iter_bindings()` and iterate bindings directly in the dirty-frame scanning loop, bypassing the `mark_array` shortcut.

**Bug 2 — write barrier recorded the wrong frame**

`MachineState::update()` recorded `environment` (top of env chain) as dirty. But when `index >= environment.logical_len()`, the actual write happened in a parent frame further up the chain. Dirty-frame scanning then scanned the wrong frame, missing the updated slot.

Fix: added `EnvFrame::find_frame_for_index()` which traverses the env chain to find the frame that actually owns a given logical index. The write barrier records that frame.

## Scheduling fix

The allocation-rate (nursery budget) trigger is disabled. With a 2048-block budget and day04 allocating 72,339 blocks, it was firing ~35 times (vs 2 in the baseline), causing 12× regressions. Collections now occur at the unconditional end-of-run checkpoint in `vm.rs` (matching the pre-nursery baseline of 2 collections per non-IO program).

## Performance results

All 19 AoC programs that completed at baseline continue to complete, all within 1.2× of baseline:

| Program | Baseline | New | Ratio |
|---------|----------|-----|-------|
| day01-part-1 | 3.541s | 0.478s | 0.13× |
| day01-part-2 | 9.746s | 0.512s | 0.05× |
| day02-part-1 | 0.016s | 0.016s | 1.03× |
| day02-part-2 | 0.060s | 0.062s | 1.03× |
| day03-part-1 | 1.060s | 1.238s | 1.17× |
| day03-part-2 | 2.295s | 2.468s | 1.08× |
| day04-part-1 | 2.476s | 2.618s | 1.06× |
| day05-part-1 | 2.210s | 2.225s | 1.01× |
| day05-part-2 | 0.054s | 0.055s | 1.01× |
| day06-part-1 | 0.648s | 0.678s | 1.05× |
| day06-part-2 | 4.842s | 4.605s | 0.95× |
| day07-part-1 | 1.822s | 1.895s | 1.04× |
| day07-part-2 | 2.456s | 2.818s | 1.15× |
| day08-part-1 | 10.945s | 11.881s | 1.09× |
| day09-part-1 | 8.331s | 8.884s | 1.07× |
| day10-part-1 | 22.114s | 24.953s | 1.13× |
| day11-part-1 | 1.467s | 1.514s | 1.03× |
| day11-part-2 | 144.906s | 150.710s | 1.04× |
| day12-part-1 | 0.287s | 0.338s | 1.18× |

(Day01 improvements are from earlier AoC head-retention fixes unrelated to this PR.)

## Verification

- `cargo test` — all 1163 tests pass
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 cargo test --lib` — all tests pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)