### PR TITLE
fix(core): extend rendered-block fixup to cover OtherLet scopes

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -433,12 +433,16 @@ impl DemandAnalyser {
 
         // Step 7: Fixup for rendered block scopes.
         //
-        // DefaultBlockLet scopes whose body is a Block constructor will
-        // have their bindings forced by RENDER_DOC after demand analysis.
-        // The render traversal adds invisible uses that the analysis
-        // cannot see, so AtMostOnce is unsound here — force Multi on
-        // any non-absent binding to prevent update elision.
-        if let_type == LetType::DefaultBlockLet && matches!(&*new_body.inner, Expr::Block(_, _)) {
+        // Any Let scope whose body is a Block constructor will have its
+        // bindings forced by RENDER_DOC after demand analysis. The render
+        // traversal adds invisible uses that the analysis cannot see, so
+        // AtMostOnce is unsound here — force Multi on any non-absent
+        // binding to prevent update elision.
+        //
+        // Note: we check the body rather than the LetType because pipeline
+        // transforms (inject_prelude_inline_cores + compress) can convert
+        // DefaultBlockLet scopes to OtherLet while preserving the Block body.
+        if matches!(&*new_body.inner, Expr::Block(_, _)) {
             for d in &mut demands {
                 if d.cardinality == Cardinality::AtMostOnce {
                     d.cardinality = Cardinality::Multi;


### PR DESCRIPTION
## Summary

- Fixes a P1 regression where demand analysis Step 7 (rendered-scope fixup) only checked `DefaultBlockLet` scopes, missing `OtherLet` scopes with Block bodies
- Root cause: `inject_prelude_inline_cores` wraps user expression in `OtherLet`, then `compress` removes intermediate empty scopes, leaving user bindings in `OtherLet` with a Block body — Step 7 missed these
- Fix: check `matches!(&*body.inner, Expr::Block(_, _))` regardless of `LetType`
- Eliminates 2× regression on 008_folds (19,346 ticks → 8,747 ticks with DA on)

## Test plan

- [x] All 111 harness tests pass
- [x] All 11 property tests pass
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [x] 008_folds: DA on matches DA off (8,747 ticks, 1,201 allocs both)
- [x] 010_prelude: DA on matches DA off (228,988 ticks, 118,955 allocs both)
- [x] No test failures or regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)