### PR TITLE
perf(import): cache YAML timestamp regex in lazy_static

### DIFF
--- a/src/import/yaml.rs
+++ b/src/import/yaml.rs
@@ -569,6 +569,12 @@ lazy_static! {
         r"^\.nan|\.NaN|\.NAN$",
     ])
     .expect("YAML scalar patterns should compile");
+
+    /// Compiled regex for YAML timestamp detection.
+    /// Compiled once and reused for all plain scalar processing.
+    static ref YAML_TIMESTAMP_PATTERN: Regex =
+        Regex::new(r"^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$")
+            .expect("YAML timestamp pattern should compile");
 }
 
 /// If tags aren't explicit, infer from value
@@ -597,16 +603,7 @@ fn infer_tag_for_plain_scalar(text: &str) -> Tag {
 /// - Space separator: 2023-01-15 10:30:00 (UTC)
 /// - Fractional seconds: 2023-01-15T10:30:00.123456Z
 fn is_timestamp(text: &str) -> bool {
-    // YAML timestamp pattern - matches formats like:
-    // YYYY-MM-DD
-    // YYYY-MM-DD[T ]HH:MM:SS
-    // YYYY-MM-DD[T ]HH:MM:SS.fraction
-    // YYYY-MM-DD[T ]HH:MM:SS[Z|±HH:MM|±HHMM|±HH]
-    let timestamp_regex =
-        Regex::new(r"^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}(:\d{2})?)?)?$")
-            .unwrap();
-
-    if !timestamp_regex.is_match(text) {
+    if !YAML_TIMESTAMP_PATTERN.is_match(text) {
         return false;
     }
 


### PR DESCRIPTION
## Summary

- `is_timestamp()` in `src/import/yaml.rs` called `Regex::new()` on every invocation, compiling the full NFA (including Unicode ranges and capture groups) for each plain scalar encountered during YAML source loading
- `YAML_SCALAR_PATTERNS` was correctly in `lazy_static!` but the timestamp pattern was missed
- Move timestamp regex into the same `lazy_static!` block as `YAML_TIMESTAMP_PATTERN`

## Profiling evidence

CPU profile of `day05-p1 --heap-limit-mib 0` (aarch64-apple-darwin, macOS `sample`):

| Symbol | Before | After |
|--------|--------|-------|
| `regex_automata::Compiler::c` + `c_cap` (self-time) | 22 samples (5.1%) | 1 sample (one-time init) |

Call chain that was hot:
```
prepare → SourceLoader::load_simple → read_yaml → load_mapping
  → on_event → is_timestamp → Regex::new
    → build_one_string → meta::regex::Builder::build
      → meta::strategy::new → build_many_from_hir → Compiler::c  ← self-time
```

Wall time improvement is within noise for day05-p1 (the regex overhead is ~65ms in a 1.3s run), but is most significant for programs that load YAML source files with many plain scalars.

## Test plan

- [x] `cargo test --lib` — 1163 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes
- [x] Post-fix profile confirms `regex_automata::Compiler` drops from 5.1% to one-time init sample

🤖 Generated with [Claude Code](https://claude.com/claude-code)