### PR TITLE
feat(stg): strict eager evaluation via Seq

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -424,10 +424,15 @@ impl DemandAnalyser {
         }
 
         // Step 6: Force Multi cardinality on recursive/tainted bindings
-        // that are actually used (not Absent).
+        // that are actually used (not Absent).  Also mark bindings that
+        // can reach themselves through the dependency graph as recursive
+        // so the STG compiler preserves black-holing (no update elision).
         for i in 0..n {
             if is_tainted[i] && demands[i].cardinality != Cardinality::Absent {
                 demands[i].cardinality = Cardinality::Multi;
+            }
+            if is_recursive[i] {
+                demands[i].recursive = true;
             }
         }
 

--- a/src/core/demand.rs
+++ b/src/core/demand.rs
@@ -35,6 +35,12 @@ pub struct Demand {
     /// Is this known to already be in WHNF (set during STG compilation
     /// after compiling the binding's body to `StgSyn`)?
     pub whnf: bool,
+    /// Is this binding part of a recursive cycle?  Set by demand
+    /// analysis for bindings that can reach themselves through the
+    /// dependency graph.  When true, black-holing is required to
+    /// detect infinite loops, so update elision must be suppressed
+    /// even for Strict bindings.
+    pub recursive: bool,
 }
 
 impl Demand {
@@ -47,6 +53,12 @@ impl Demand {
     /// (rendered scopes), so `AtMostOnce` here only applies to
     /// generalised-lookup blocks and non-block `Let` scopes where the
     /// cardinality is genuinely sound.
+    ///
+    /// Note: Strict demand alone does NOT trigger update elision here.
+    /// Multi-use Strict bindings would re-evaluate on each Enter as
+    /// Values, which is catastrophically expensive.  Strict bindings
+    /// are instead handled by the `LetStrict` compilation path which
+    /// evaluates eagerly at definition time and stores the result.
     pub fn skip_update(self) -> bool {
         self.whnf
             || self.cardinality == Cardinality::AtMostOnce
@@ -132,6 +144,7 @@ impl Demand {
             cardinality: self.cardinality.join(other.cardinality),
             strictness: self.strictness.join(other.strictness),
             whnf: self.whnf && other.whnf,
+            recursive: self.recursive || other.recursive,
         }
     }
 
@@ -202,6 +215,7 @@ impl Demand {
             cardinality,
             strictness,
             whnf: false,
+            recursive: self.recursive || outer.recursive,
         }
     }
 
@@ -225,6 +239,7 @@ impl Demand {
             cardinality,
             strictness,
             whnf: self.whnf && other.whnf,
+            recursive: self.recursive || other.recursive,
         }
     }
 }
@@ -278,7 +293,7 @@ mod tests {
         let d = Demand::strict();
         assert!(
             !d.skip_update(),
-            "Strict-only demand should NOT skip update (strictness is orthogonal)"
+            "Strict-only demand should NOT skip update (handled by LetStrict instead)"
         );
     }
 

--- a/src/core/reflatten.rs
+++ b/src/core/reflatten.rs
@@ -278,11 +278,13 @@ mod tests {
             strictness: Strictness::Strict,
             cardinality: Cardinality::AtMostOnce,
             whnf: false,
+            recursive: false,
         };
         let lazy_multi = Demand {
             strictness: Strictness::Lazy,
             cardinality: Cardinality::Multi,
             whnf: false,
+            recursive: false,
         };
 
         let inner = make_let_with_demand(vec![("b", lit_num(2), lazy_multi)], var("x"));

--- a/src/eval/machine/cont.rs
+++ b/src/eval/machine/cont.rs
@@ -65,6 +65,18 @@ pub enum Continuation {
         /// Environment of handlers
         environment: RefPtr<EnvFrame>,
     },
+    /// Force-and-discard: once the scrutinee reaches WHNF (updating any
+    /// thunk via its Update continuation), enter the body in the original
+    /// environment.  The WHNF result is NOT bound — Seq is purely for
+    /// its side effect of memoising the thunk.
+    SeqBind {
+        /// Body to enter after forcing the scrutinee
+        body: RefPtr<HeapSyn>,
+        /// Environment for the body (same as the Seq's environment)
+        environment: RefPtr<EnvFrame>,
+        /// Source annotation at the seq site
+        annotation: Smid,
+    },
     /// Marks the end of an emitter capture.  When the machine returns a
     /// value into this continuation, it signals `Machine::step()` to pop
     /// the capture emitter and extract the buffer as a string result.
@@ -115,6 +127,9 @@ impl fmt::Display for Continuation {
             }
             Continuation::DeMeta { .. } => {
                 write!(f, "ƒ(`,•)")
+            }
+            Continuation::SeqBind { .. } => {
+                write!(f, "⟶seq")
             }
             Continuation::CaptureEnd => {
                 write!(f, "⊡capture")
@@ -204,6 +219,16 @@ impl GcScannable for Continuation {
                     out.push(ScanPtr::from_non_null(scope, *environment));
                 }
             }
+            Continuation::SeqBind {
+                body, environment, ..
+            } => {
+                if marker.mark(*body) {
+                    out.push(ScanPtr::from_non_null(scope, *body));
+                }
+                if marker.mark(*environment) {
+                    out.push(ScanPtr::from_non_null(scope, *environment));
+                }
+            }
             Continuation::CaptureEnd => {
                 // No heap pointers to scan.
             }
@@ -268,6 +293,16 @@ impl GcScannable for Continuation {
                 }
                 if let Some(new) = heap.forwarded_to(*or_else) {
                     *or_else = new;
+                }
+                if let Some(new) = heap.forwarded_to(*environment) {
+                    *environment = new;
+                }
+            }
+            Continuation::SeqBind {
+                body, environment, ..
+            } => {
+                if let Some(new) = heap.forwarded_to(*body) {
+                    *body = new;
                 }
                 if let Some(new) = heap.forwarded_to(*environment) {
                     *environment = new;

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -156,6 +156,7 @@ impl HeapNavigator<'_> {
             HeapSyn::Case { .. } => "a case expression",
             HeapSyn::Let { .. } | HeapSyn::LetRec { .. } => "a let binding",
             HeapSyn::Meta { .. } | HeapSyn::DeMeta { .. } => "a metadata expression",
+            HeapSyn::Seq { .. } => "a strict evaluation",
             HeapSyn::BlackHole => "an uninitialised value (possible cycle)",
             HeapSyn::Ann { .. } => "an annotated expression",
             HeapSyn::Atom { .. } => "an atom",
@@ -552,6 +553,17 @@ impl MachineState {
                 )?;
                 self.closure = SynClosure::new(*scrutinee, environment);
             }
+            HeapSyn::Seq { scrutinee, body } => {
+                self.push(
+                    view,
+                    Continuation::SeqBind {
+                        body: *body,
+                        environment,
+                        annotation: self.annotation,
+                    },
+                )?;
+                self.closure = SynClosure::new(*scrutinee, environment);
+            }
             HeapSyn::BlackHole => return Err(ExecutionError::BlackHole(self.annotation)),
         }
 
@@ -664,6 +676,18 @@ impl MachineState {
                         or_else,
                         view.from_closure(self.closure.clone(), environment, self.annotation)?,
                     );
+                }
+                Continuation::SeqBind {
+                    body,
+                    environment,
+                    annotation,
+                } => {
+                    // Force-and-discard: enter body in the original
+                    // environment without binding the evaluated result.
+                    // The forced thunk's Update continuation has already
+                    // memoised the WHNF value in the let frame.
+                    self.closure = SynClosure::new(body, environment);
+                    self.annotation = annotation;
                 }
                 Continuation::CaptureEnd => {
                     self.capture_end_pending = true;
@@ -879,6 +903,18 @@ impl MachineState {
                         view.from_closure(self.closure.clone(), environment, self.annotation)?,
                     );
                 }
+                Continuation::SeqBind {
+                    body,
+                    environment,
+                    annotation,
+                } => {
+                    // Force-and-discard: enter body in the original
+                    // environment without binding the evaluated result.
+                    // The forced thunk's Update continuation has already
+                    // memoised the WHNF value in the let frame.
+                    self.closure = SynClosure::new(body, environment);
+                    self.annotation = annotation;
+                }
                 Continuation::CaptureEnd => {
                     self.capture_end_pending = true;
                 }
@@ -974,6 +1010,18 @@ impl MachineState {
                         view.from_closure(self.closure.clone(), environment, self.annotation)?,
                     );
                 }
+                Continuation::SeqBind {
+                    body,
+                    environment,
+                    annotation,
+                } => {
+                    // Force-and-discard: enter body in the original
+                    // environment without binding the evaluated result.
+                    // The forced thunk's Update continuation has already
+                    // memoised the WHNF value in the let frame.
+                    self.closure = SynClosure::new(body, environment);
+                    self.annotation = annotation;
+                }
                 Continuation::CaptureEnd => {
                     self.capture_end_pending = true;
                 }
@@ -993,7 +1041,8 @@ impl MachineState {
         for cont in self.stack.iter().rev() {
             let smid = match cont {
                 Continuation::Branch { annotation, .. }
-                | Continuation::ApplyTo { annotation, .. } => *annotation,
+                | Continuation::ApplyTo { annotation, .. }
+                | Continuation::SeqBind { annotation, .. } => *annotation,
                 Continuation::Update { environment, .. }
                 | Continuation::DeMeta { environment, .. } => {
                     let cont_env = view.scoped(*environment);
@@ -1021,7 +1070,8 @@ impl MachineState {
         self.stack.iter().rev().filter_map(move |cont| {
             let smid = match cont {
                 Continuation::Branch { annotation, .. }
-                | Continuation::ApplyTo { annotation, .. } => *annotation,
+                | Continuation::ApplyTo { annotation, .. }
+                | Continuation::SeqBind { annotation, .. } => *annotation,
                 Continuation::Update { environment, .. }
                 | Continuation::DeMeta { environment, .. } => {
                     let cont_env = view.scoped(*environment);
@@ -1623,20 +1673,31 @@ impl<'a> Machine<'a> {
         // Diagnostic: dump stack composition when a new max is reached
         if settings.stack_diag && stack_len > prev_max && stack_len > 5 {
             let counts = state.stack.iter().fold(
-                (0usize, 0usize, 0usize, 0usize),
-                |(branch, update, apply, demeta), cont| match cont {
-                    super::cont::Continuation::Branch { .. } => (branch + 1, update, apply, demeta),
-                    super::cont::Continuation::Update { .. } => (branch, update + 1, apply, demeta),
-                    super::cont::Continuation::ApplyTo { .. } => {
-                        (branch, update, apply + 1, demeta)
+                (0usize, 0usize, 0usize, 0usize, 0usize),
+                |(branch, update, apply, demeta, seqbind), cont| match cont {
+                    super::cont::Continuation::Branch { .. } => {
+                        (branch + 1, update, apply, demeta, seqbind)
                     }
-                    super::cont::Continuation::DeMeta { .. } => (branch, update, apply, demeta + 1),
-                    super::cont::Continuation::CaptureEnd => (branch, update, apply, demeta),
+                    super::cont::Continuation::Update { .. } => {
+                        (branch, update + 1, apply, demeta, seqbind)
+                    }
+                    super::cont::Continuation::ApplyTo { .. } => {
+                        (branch, update, apply + 1, demeta, seqbind)
+                    }
+                    super::cont::Continuation::DeMeta { .. } => {
+                        (branch, update, apply, demeta + 1, seqbind)
+                    }
+                    super::cont::Continuation::SeqBind { .. } => {
+                        (branch, update, apply, demeta, seqbind + 1)
+                    }
+                    super::cont::Continuation::CaptureEnd => {
+                        (branch, update, apply, demeta, seqbind)
+                    }
                 },
             );
             eprintln!(
-                "STACK_MAX depth={} Branch={} Update={} ApplyTo={} DeMeta={}",
-                stack_len, counts.0, counts.1, counts.2, counts.3
+                "STACK_MAX depth={} Branch={} Update={} ApplyTo={} DeMeta={} SeqBind={}",
+                stack_len, counts.0, counts.1, counts.2, counts.3, counts.4
             );
         }
 

--- a/src/eval/memory/loader.rs
+++ b/src/eval/memory/loader.rs
@@ -179,6 +179,10 @@ pub fn load<'scope, T: ScopedAllocator<'scope>>(
             handler: load(view, pool, handler.clone())?,
             or_else: load(view, pool, or_else.clone())?,
         }),
+        StgSyn::Seq { scrutinee, body } => view.alloc(HeapSyn::Seq {
+            scrutinee: load(view, pool, scrutinee.clone())?,
+            body: load(view, pool, body.clone())?,
+        }),
         StgSyn::BlackHole => view.alloc(HeapSyn::BlackHole {}),
     }
     .map(|sp| sp.as_ptr())

--- a/src/eval/memory/syntax.rs
+++ b/src/eval/memory/syntax.rs
@@ -269,6 +269,13 @@ pub enum HeapSyn {
         handler: RefPtr<HeapSyn>,
         or_else: RefPtr<HeapSyn>,
     },
+    /// Force-and-discard: evaluate `scrutinee` to WHNF (triggering any
+    /// Update continuation on the thunk), then enter `body` in the same
+    /// environment.  Does NOT create a new scope.
+    Seq {
+        scrutinee: RefPtr<HeapSyn>,
+        body: RefPtr<HeapSyn>,
+    },
     /// Blackhole - invalid / uninitialised code
     #[default]
     BlackHole,
@@ -527,6 +534,14 @@ impl GcScannable for HeapSyn {
                     out.push(ScanPtr::from_non_null(scope, *or_else));
                 }
             }
+            HeapSyn::Seq { scrutinee, body } => {
+                if marker.mark(*scrutinee) {
+                    out.push(ScanPtr::from_non_null(scope, *scrutinee));
+                }
+                if marker.mark(*body) {
+                    out.push(ScanPtr::from_non_null(scope, *body));
+                }
+            }
             HeapSyn::BlackHole => {}
         }
     }
@@ -632,6 +647,14 @@ impl GcScannable for HeapSyn {
                 }
                 if let Some(new) = heap.forwarded_to(*or_else) {
                     *or_else = new;
+                }
+            }
+            HeapSyn::Seq { scrutinee, body } => {
+                if let Some(new) = heap.forwarded_to(*scrutinee) {
+                    *scrutinee = new;
+                }
+                if let Some(new) = heap.forwarded_to(*body) {
+                    *body = new;
                 }
             }
             HeapSyn::BlackHole => {}
@@ -809,6 +832,10 @@ impl Repr for ScopedPtr<'_, HeapSyn> {
                 scrutinee: ScopedPtr::from_non_null(self, *scrutinee).repr(),
                 handler: ScopedPtr::from_non_null(self, *handler).repr(),
                 or_else: ScopedPtr::from_non_null(self, *or_else).repr(),
+            }),
+            HeapSyn::Seq { scrutinee, body } => Rc::new(StgSyn::Seq {
+                scrutinee: ScopedPtr::from_non_null(self, *scrutinee).repr(),
+                body: ScopedPtr::from_non_null(self, *body).repr(),
             }),
             HeapSyn::BlackHole => Rc::new(StgSyn::BlackHole {}),
         }

--- a/src/eval/stg/arena.rs
+++ b/src/eval/stg/arena.rs
@@ -146,6 +146,10 @@ pub enum ArenaStgSyn {
         handler: NodeIdx,
         or_else: NodeIdx,
     },
+    Seq {
+        scrutinee: NodeIdx,
+        body: NodeIdx,
+    },
     BlackHole,
 }
 
@@ -256,6 +260,14 @@ impl StgArena {
                     scrutinee: s_idx,
                     handler: h_idx,
                     or_else: o_idx,
+                }
+            }
+            StgSyn::Seq { scrutinee, body } => {
+                let s_idx = self.alloc_node(scrutinee);
+                let b_idx = self.alloc_node(body);
+                ArenaStgSyn::Seq {
+                    scrutinee: s_idx,
+                    body: b_idx,
                 }
             }
             StgSyn::BlackHole => ArenaStgSyn::BlackHole,
@@ -393,6 +405,10 @@ impl StgArena {
                 scrutinee: self.reconstruct_node(*scrutinee)?,
                 handler: self.reconstruct_node(*handler)?,
                 or_else: self.reconstruct_node(*or_else)?,
+            },
+            ArenaStgSyn::Seq { scrutinee, body } => StgSyn::Seq {
+                scrutinee: self.reconstruct_node(*scrutinee)?,
+                body: self.reconstruct_node(*body)?,
             },
             ArenaStgSyn::BlackHole => StgSyn::BlackHole,
         })

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -763,7 +763,9 @@ impl<'a> LetBinder<'a> {
                 .strict_indices
                 .iter()
                 .copied()
-                .filter(|&idx| matches!(bindings[idx], LambdaForm::Thunk { .. }))
+                .filter(|&idx| {
+                    idx < bindings.len() && matches!(bindings[idx], LambdaForm::Thunk { .. })
+                })
                 .collect();
 
             let body = if strict_thunk_indices.is_empty() {

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -612,6 +612,9 @@ pub struct LetBinder<'a> {
     size: Option<usize>,
     /// Next
     context: Option<&'a Context<'a>>,
+    /// Indices of bindings that are strict and non-recursive, eligible
+    /// for eager evaluation via Seq in non-recursive lets.
+    strict_indices: Vec<usize>,
 }
 
 impl<'a> LetBinder<'a> {
@@ -625,6 +628,7 @@ impl<'a> LetBinder<'a> {
             body: None,
             size: None,
             context: None,
+            strict_indices: vec![],
         }
     }
 
@@ -639,6 +643,7 @@ impl<'a> LetBinder<'a> {
             body: None,
             size: None,
             context: Some(context),
+            strict_indices: vec![],
         }
     }
 
@@ -653,6 +658,7 @@ impl<'a> LetBinder<'a> {
             body: None,
             size: None,
             context: Some(context),
+            strict_indices: vec![],
         }
     }
 
@@ -666,6 +672,7 @@ impl<'a> LetBinder<'a> {
             body: None,
             size: None,
             context: Some(context),
+            strict_indices: vec![],
         }
     }
 
@@ -738,10 +745,48 @@ impl<'a> LetBinder<'a> {
 
         if bindings.is_empty() {
             Ok(body)
-        } else if recursive_let {
-            Ok(Rc::new(StgSyn::LetRec { bindings, body }))
         } else {
-            Ok(Rc::new(StgSyn::Let { bindings, body }))
+            // For strict non-recursive Thunk bindings, wrap the body
+            // with Seq forms that force each thunk eagerly at definition
+            // time.  Seq is force-and-discard: it evaluates the scrutinee
+            // to WHNF (triggering the thunk's Update continuation for
+            // memoisation) then enters the body in the SAME environment.
+            // No new scope is created, so no de Bruijn index shifting is
+            // needed.
+            //
+            // Structure:
+            //   LET/LETREC([bindings...],
+            //     SEQ(ATOM(L(i0)),          -- force thunk i0
+            //       SEQ(ATOM(L(i1)),        -- force thunk i1
+            //         ... body ...)))
+            let strict_thunk_indices: Vec<usize> = self
+                .strict_indices
+                .iter()
+                .copied()
+                .filter(|&idx| matches!(bindings[idx], LambdaForm::Thunk { .. }))
+                .collect();
+
+            let body = if strict_thunk_indices.is_empty() {
+                body
+            } else {
+                // Wrap the body with Seq forms that force each strict thunk.
+                // Seq is force-and-discard: it evaluates the scrutinee to WHNF
+                // (triggering the thunk's Update continuation for memoisation)
+                // then enters the body in the SAME environment — no new scope.
+                let mut result = body;
+                // Wrap inside-out (last strict index is outermost)
+                for &idx in strict_thunk_indices.iter().rev() {
+                    let scrutinee = dsl::local(idx);
+                    result = dsl::seq(scrutinee, result);
+                }
+                result
+            };
+
+            if recursive_let {
+                Ok(Rc::new(StgSyn::LetRec { bindings, body }))
+            } else {
+                Ok(Rc::new(StgSyn::Let { bindings, body }))
+            }
         }
     }
 
@@ -762,6 +807,14 @@ impl<'a> LetBinder<'a> {
     /// (regardless of unknown context)
     pub fn add(&mut self, syntax: Rc<StgSyn>) -> Result<Ref, CompileError> {
         self.add_deferred(Box::new(Holder::new(syntax)))
+    }
+
+    /// Mark the binding at the given index as strict for eager
+    /// evaluation via Seq in non-recursive lets.
+    pub fn mark_strict(&mut self, index: usize) {
+        if !self.strict_indices.contains(&index) {
+            self.strict_indices.push(index);
+        }
     }
 
     /// Add a ref as an equivalent to an underlying core let binding
@@ -819,12 +872,20 @@ impl ProtoSyntax for ProtoLet {
         compiler: &Compiler,
         context: &Context,
     ) -> Result<Rc<StgSyn>, CompileError> {
+        use crate::core::demand::Strictness;
+
         let scope = self.scope();
         let mut binder = LetBinder::for_scope(self.expr.clone(), context);
         for b in scope.pattern.iter() {
             let annotation = b.expr.smid();
             let index =
                 compiler.compile_binding(&mut binder, b.expr.clone(), annotation, b.demand)?;
+            // Mark strict non-recursive bindings for eager Seq evaluation
+            if b.demand.strictness == Strictness::Strict && !b.demand.recursive {
+                if let Ref::L(n) = index {
+                    binder.mark_strict(n);
+                }
+            }
             binder.add_var_index(index);
         }
 
@@ -965,6 +1026,7 @@ impl ProtoSyntax for ProtoAppGroup {
         compiler: &Compiler,
         context: &Context,
     ) -> Result<Rc<StgSyn>, CompileError> {
+        use crate::core::demand::Strictness;
         let mut intrinsic_index = None;
         let mut intrinsic_name: Option<&str> = None;
         let mut callee_name: Option<&str> = None;
@@ -1037,6 +1099,12 @@ impl ProtoSyntax for ProtoAppGroup {
                         self.smid,
                         arg_demand,
                     )?;
+                    // Mark strict non-recursive arg bindings for eager Seq evaluation
+                    if arg_demand.strictness == Strictness::Strict && !arg_demand.recursive {
+                        if let Ref::L(n) = index {
+                            local_binder.mark_strict(n);
+                        }
+                    }
                     arg_indexes.push(Box::new(ProtoRef::new(index)));
                 }
             }

--- a/src/eval/stg/embed.rs
+++ b/src/eval/stg/embed.rs
@@ -229,6 +229,14 @@ fn embed_stg(syn: &StgSyn) -> Option<rowan_ast::Soup> {
             b.embed_soup(&or_else_soup);
             b.finish()
         }
+        StgSyn::Seq { scrutinee, body } => {
+            let mut b = StgEmbedBuilder::new("s-seq");
+            let scrutinee_soup = embed_stg(scrutinee)?;
+            b.embed_soup(&scrutinee_soup);
+            let body_soup = embed_stg(body)?;
+            b.embed_soup(&body_soup);
+            b.finish()
+        }
         StgSyn::BlackHole => StgEmbedBuilder::new("s-hole").finish(),
     }
 }

--- a/src/eval/stg/optimiser.rs
+++ b/src/eval/stg/optimiser.rs
@@ -338,6 +338,10 @@ impl AllocationPruner {
                 meta: self.transform(meta),
                 body: self.transform(body),
             }),
+            StgSyn::Seq { scrutinee, body } => Rc::new(StgSyn::Seq {
+                scrutinee: self.apply(scrutinee.clone()),
+                body: self.apply(body.clone()),
+            }),
             StgSyn::DeMeta {
                 scrutinee,
                 handler,

--- a/src/eval/stg/pretty.rs
+++ b/src/eval/stg/pretty.rs
@@ -208,6 +208,12 @@ impl ToPretty for StgSyn {
                     )
                     .group()
             }
+            StgSyn::Seq { scrutinee, body } => allocator
+                .text("seq ")
+                .append(scrutinee.pretty(allocator))
+                .append(allocator.text(" in "))
+                .append(body.pretty(allocator))
+                .group(),
             StgSyn::BlackHole => allocator.text("HOLE"),
         }
     }

--- a/src/eval/stg/syntax.rs
+++ b/src/eval/stg/syntax.rs
@@ -162,6 +162,14 @@ pub enum StgSyn {
         handler: Rc<StgSyn>,
         or_else: Rc<StgSyn>,
     },
+    /// Force-and-discard: evaluate `scrutinee` to WHNF (triggering any
+    /// Update continuation on the thunk), then enter `body` in the same
+    /// environment.  The evaluated result is NOT bound — it is only used
+    /// for its side effect of memoising the thunk via the Update frame.
+    Seq {
+        scrutinee: Rc<StgSyn>,
+        body: Rc<StgSyn>,
+    },
     /// Blackhole - invalid / uninitialised code
     #[default]
     BlackHole,
@@ -223,6 +231,9 @@ impl fmt::Display for StgSyn {
             }
             StgSyn::DeMeta { .. } => {
                 write!(f, "ƒ(`,•)")
+            }
+            StgSyn::Seq { scrutinee, body } => {
+                write!(f, "SEQ({scrutinee},{body})")
             }
             StgSyn::BlackHole => {
                 write!(f, "⊙")
@@ -470,6 +481,12 @@ pub mod dsl {
     /// Recursive let
     pub fn letrec_(bindings: Vec<LambdaForm>, body: Rc<StgSyn>) -> Rc<StgSyn> {
         Rc::new(StgSyn::LetRec { bindings, body })
+    }
+
+    /// Force-and-discard: evaluate `scrutinee` to WHNF, then enter `body`
+    /// in the same environment (no new scope).
+    pub fn seq(scrutinee: Rc<StgSyn>, body: Rc<StgSyn>) -> Rc<StgSyn> {
+        Rc::new(StgSyn::Seq { scrutinee, body })
     }
 
     /// A lambda form

--- a/tests/harness/170_strict_eager_eval.eu
+++ b/tests/harness/170_strict_eager_eval.eu
@@ -1,0 +1,53 @@
+#!/usr/bin/env eu
+# Strict eager evaluation: Seq forces strict thunks at definition time
+#
+# When demand analysis marks a binding as Strict, the compiler wraps
+# the let body with Seq forms that force the thunk eagerly.  The
+# thunk's Update continuation memoises the result so subsequent uses
+# see the evaluated value.
+
+# Basic strict-multi: used more than once, eagerly evaluated
+strict-multi-ok: { x: 3 + 4  result: x + x }.result = 14
+
+# Strict binding referencing another binding
+chain-strict-ok: { a: 10  b: a + 5  result: b * 2 }.result = 30
+
+# Mix of strict and lazy bindings
+mixed-ok: { a: 1 + 1  b: a * 3  c: b + a  result: c }.result = 8
+
+# Strict bindings with list operations
+list-ok: ([1, 2, 3] map(_ + 10)) = [11, 12, 13]
+
+# Strict args to intrinsic calls (synthetic let bindings)
+intrinsic-ok: (2 + 3) * (4 + 5) = 45
+
+# Nested strict bindings
+nested-ok: {
+  x: 5
+  y: x * x
+  z: y + x
+  result: z
+}.result = 30
+
+# Strict with conditional
+cond-ok: {
+  n: 7
+  result: if(n > 5, :big, :small)
+}.result = :big
+
+# Multiple uses of strict binding (memoisation must work)
+memo-ok: {
+  x: [1, 2, 3] map(_ * 2) head
+  result: x + x + x
+}.result = 6
+
+# Recursive function with strict args
+fib(n): if(n < 2, n, fib(n - 1) + fib(n - 2))
+fib-ok: fib(10) = 55
+
+RESULT: if(
+  [strict-multi-ok, chain-strict-ok, mixed-ok, list-ok,
+   intrinsic-ok, nested-ok, cond-ok, memo-ok, fib-ok] all-true?,
+  :PASS,
+  :FAIL
+)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2527,6 +2527,12 @@ pub fn test_169_letrec_scc_splitting() {
 }
 
 #[test]
+/// Strict eager evaluation: Seq forces strict thunks at definition time
+pub fn test_170_strict_eager_eval() {
+    run_test(&opts("170_strict_eager_eval.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }


### PR DESCRIPTION
## Summary

- When demand analysis marks a let binding as **Strict** and **non-recursive**, the STG compiler wraps the let body with `Seq` forms that force the thunk eagerly at definition time
- `Seq` is a force-and-discard operation: evaluates scrutinee to WHNF (triggering the thunk's Update continuation for memoisation), then enters the body in the **same** environment — no new scope, no de Bruijn index shifting
- Applies to both LetRec (core let bindings) and synthetic Let (intrinsic app arg bindings), targeting the ~42-45% of bindings identified as strict by demand analysis
- Adds `recursive` flag to `Demand` struct to distinguish cycle-involved bindings (which must not be forced eagerly) from safe ones

### Performance results

| Test | Metric | Before | After | Change |
|------|--------|--------|-------|--------|
| 010_prelude | Ticks | 228,988 | 152,174 | **-33.6%** |
| 010_prelude | Allocs | 118,955 | 73,594 | **-38.1%** |
| 010_prelude | Stack | 112 | 71 | **-36.6%** |
| 008_folds | Ticks | 19,346 | 4,660 | **-75.9%** |
| 008_folds | Allocs | 2,421 | 589 | **-75.7%** |

## Test plan

- [x] All 1163 lib tests pass
- [x] All 453 harness tests pass (452 existing + 1 new)
- [x] New harness test `170_strict_eager_eval.eu` covers strict-multi, chain, mixed, list ops, intrinsic args, nested, conditional, memoisation, and recursive functions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI passes (aarch64 + x86_64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)