### PR TITLE
feat(stg): strict eager eval for prelude globals in blob mode

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -216,7 +216,7 @@ pub fn build_prelude_signatures() -> HashMap<String, DemandSignature> {
     sigs.insert("apply".into(), vec![sm(), sm()]);
 
     // Conditionals — condition strict, branches lazy
-    sigs.insert("then".into(), vec![sm(), lm(), sm()]);
+    sigs.insert("then".into(), vec![lm(), lm(), sm()]);
     sigs.insert("when".into(), vec![sm(), sm(), sm()]);
 
     // Lookup functions — strict in key/object args

--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -120,6 +120,140 @@ pub fn build_intrinsic_signatures() -> HashMap<String, DemandSignature> {
     sigs
 }
 
+/// Build demand signatures for common prelude functions.
+///
+/// In blob-prelude mode, the prelude is pre-compiled and its functions
+/// appear as globals (`Ref::G`) with no demand analysis.  This table
+/// provides conservative strictness information for the most common
+/// prelude functions so that the STG compiler can apply strict-arg
+/// optimisation (Seq wrapping) to complex arguments at call sites.
+///
+/// We use `sm()` (Strict + Multi) for strict arguments
+/// because we do not know the exact cardinality within the prelude
+/// function body.  Multi ensures the binding becomes a Thunk (with
+/// Update/memoisation) and Strict triggers Seq wrapping for eager
+/// evaluation.
+pub fn build_prelude_signatures() -> HashMap<String, DemandSignature> {
+    let mut sigs = HashMap::new();
+    let sm = Demand::strict_multi;
+    let lm = Demand::lazy_multi;
+
+    // List operations — strict in all arguments
+    // map(f, l): f applied to each element, l traversed
+    sigs.insert("map".into(), vec![sm(), sm()]);
+    // map2(f, l, m): zip-with
+    sigs.insert("map2".into(), vec![sm(), sm(), sm()]);
+    // filter(p?, l): predicate applied, list traversed
+    sigs.insert("filter".into(), vec![sm(), sm()]);
+    // foldl(op, i, l): all args needed
+    sigs.insert("foldl".into(), vec![sm(), sm(), sm()]);
+    // foldr(op, i, l): all args needed
+    sigs.insert("foldr".into(), vec![sm(), sm(), sm()]);
+    // take(n, l): count and list both needed
+    sigs.insert("take".into(), vec![sm(), sm()]);
+    // drop(n, l): count and list both needed
+    sigs.insert("drop".into(), vec![sm(), sm()]);
+    // nth(n, l): index and list both needed
+    sigs.insert("nth".into(), vec![sm(), sm()]);
+    // reverse(l): list needed
+    sigs.insert("reverse".into(), vec![sm()]);
+    // append(l1, l2): both lists needed
+    sigs.insert("append".into(), vec![sm(), sm()]);
+    // zip-with(f, a, b): all needed
+    sigs.insert("zip-with".into(), vec![sm(), sm(), sm()]);
+    // zip(a, b): both needed (zip = zip-with(pair))
+    sigs.insert("zip".into(), vec![sm(), sm()]);
+    // count(l): list traversed
+    sigs.insert("count".into(), vec![sm()]);
+    // sum(l): list traversed
+    sigs.insert("sum".into(), vec![sm()]);
+    // product(l): list traversed
+    sigs.insert("product".into(), vec![sm()]);
+    // cons(h, t): both needed to construct
+    sigs.insert("cons".into(), vec![sm(), sm()]);
+    // snoc(x, l): both needed
+    sigs.insert("snoc".into(), vec![sm(), sm()]);
+    // mapcat(f, l): catenation applied via compose, but f is strict
+    sigs.insert("mapcat".into(), vec![sm()]);
+    // cross(f, xs, ys): all needed
+    sigs.insert("cross".into(), vec![sm(), sm(), sm()]);
+    // interleave(a, b): both needed
+    sigs.insert("interleave".into(), vec![sm(), sm()]);
+
+    // take-while / drop-while: predicate and list both strict
+    sigs.insert("take-while".into(), vec![sm(), sm()]);
+    sigs.insert("drop-while".into(), vec![sm(), sm()]);
+
+    // Sorting
+    sigs.insert("sort-by".into(), vec![sm(), sm(), sm()]);
+    sigs.insert("sort-by-num".into(), vec![sm()]);
+    sigs.insert("sort-by-str".into(), vec![sm()]);
+    sigs.insert("sort-nums".into(), vec![sm()]);
+    sigs.insert("sort-strs".into(), vec![sm()]);
+
+    // Grouping
+    sigs.insert("group-by".into(), vec![sm(), sm()]);
+    sigs.insert("discriminate".into(), vec![sm(), sm()]);
+    sigs.insert("group-consecutive-by".into(), vec![sm(), sm()]);
+
+    // Numeric — strict in all args
+    sigs.insert("abs".into(), vec![sm()]);
+    sigs.insert("negate".into(), vec![sm()]);
+    sigs.insert("max".into(), vec![sm(), sm()]);
+    sigs.insert("min".into(), vec![sm(), sm()]);
+    sigs.insert("max-of".into(), vec![sm()]);
+    sigs.insert("min-of".into(), vec![sm()]);
+    sigs.insert("pow".into(), vec![sm(), sm()]);
+    sigs.insert("div".into(), vec![sm(), sm()]);
+    sigs.insert("mod".into(), vec![sm(), sm()]);
+    sigs.insert("quot".into(), vec![sm(), sm()]);
+    sigs.insert("rem".into(), vec![sm(), sm()]);
+
+    // Combinators — strict in function arg, lazy in data args
+    sigs.insert("compose".into(), vec![sm(), sm(), sm()]);
+    sigs.insert("flip".into(), vec![sm(), sm(), sm()]);
+    sigs.insert("identity".into(), vec![sm()]);
+    sigs.insert("apply".into(), vec![sm(), sm()]);
+
+    // Conditionals — condition strict, branches lazy
+    sigs.insert("then".into(), vec![sm(), lm(), sm()]);
+    sigs.insert("when".into(), vec![sm(), sm(), sm()]);
+
+    // Lookup functions — strict in key/object args
+    sigs.insert("has".into(), vec![sm(), sm()]);
+    sigs.insert("lookup".into(), vec![sm(), sm()]);
+    sigs.insert("lookup-in".into(), vec![sm(), sm()]);
+    sigs.insert("lookup-or".into(), vec![sm(), lm(), sm()]);
+
+    // Deep operations — strict in key/pattern and block
+    sigs.insert("deep-find".into(), vec![sm(), sm()]);
+    sigs.insert("deep-transform".into(), vec![sm(), sm()]);
+    sigs.insert("deep-query".into(), vec![sm(), sm()]);
+
+    // Head/tail — strict in list
+    sigs.insert("head-or".into(), vec![sm(), sm()]);
+    sigs.insert("tail-or".into(), vec![sm(), sm()]);
+
+    // Rendering
+    sigs.insert("render".into(), vec![sm()]);
+    sigs.insert("render-as".into(), vec![sm(), sm()]);
+    sigs.insert("parse-as".into(), vec![sm(), sm()]);
+
+    // Iterate — strict in initial value, function
+    sigs.insert("iterate".into(), vec![sm(), sm()]);
+    // range(b, e)
+    sigs.insert("range".into(), vec![sm(), sm()]);
+    // iota(n)
+    sigs.insert("iota".into(), vec![sm()]);
+    // repeat(i)
+    sigs.insert("repeat".into(), vec![sm()]);
+
+    // Sliding / windowing
+    sigs.insert("over-sliding-pairs".into(), vec![sm(), sm()]);
+
+    sigs
+}
+
 /// Return the indices of strict arguments for the named intrinsic,
 /// derived from the demand signature table.
 ///

--- a/src/core/demand.rs
+++ b/src/core/demand.rs
@@ -174,6 +174,15 @@ impl Demand {
         }
     }
 
+    /// A demand marking a binding as strict and used multiple times.
+    pub fn strict_multi() -> Self {
+        Self {
+            strictness: Strictness::Strict,
+            cardinality: Cardinality::Multi,
+            ..Default::default()
+        }
+    }
+
     /// A demand marking a binding as lazy and used multiple times.
     pub fn lazy_multi() -> Self {
         Self {

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -521,6 +521,13 @@ pub struct Compiler<'rt> {
     /// Maps binding name → per-argument demand vector. Used when
     /// compiling `App(user_function, args)` to set per-argument demands.
     user_demand_sigs: crate::core::analyse_demand::NamedSignatureTable,
+    /// Per-prelude-function demand signatures for blob-mode globals.
+    ///
+    /// Maps prelude function name → per-argument demand vector. Used as
+    /// a third fallback (after intrinsic and user sigs) when compiling
+    /// `App(global, args)` to set per-argument demands for eager Seq
+    /// wrapping of strict arguments.
+    prelude_demand_sigs: HashMap<String, Vec<crate::core::demand::Demand>>,
 }
 
 /// An item which can be converted to STG syntax once the context in known
@@ -1063,13 +1070,19 @@ impl ProtoSyntax for ProtoAppGroup {
         };
 
         // Look up per-argument demands.  Try intrinsic signatures first,
-        // then fall back to user function signatures from the demand analysis.
+        // then user function signatures from demand analysis, then
+        // prelude function signatures for blob-mode globals.
         let arg_demands: Option<&[crate::core::demand::Demand]> = intrinsic_name
             .and_then(|name| compiler.intrinsic_demand_sigs.get(name))
             .map(|v| v.as_slice())
             .or_else(|| {
                 callee_name
                     .and_then(|name| compiler.user_demand_sigs.get(name))
+                    .map(|v| v.as_slice())
+            })
+            .or_else(|| {
+                callee_name
+                    .and_then(|name| compiler.prelude_demand_sigs.get(name))
                     .map(|v| v.as_slice())
             });
 
@@ -1310,6 +1323,11 @@ impl<'rt> Compiler<'rt> {
         prelude_globals: Option<HashMap<String, usize>>,
     ) -> Self {
         let intrinsic_demand_sigs = crate::core::analyse_demand::build_intrinsic_signatures();
+        let prelude_demand_sigs = if prelude_globals.is_some() {
+            crate::core::analyse_demand::build_prelude_signatures()
+        } else {
+            HashMap::new()
+        };
         Compiler {
             generate_annotations,
             render_type,
@@ -1320,6 +1338,7 @@ impl<'rt> Compiler<'rt> {
             intrinsic_demand_sigs,
             prelude_globals,
             user_demand_sigs: Default::default(),
+            prelude_demand_sigs,
         }
     }
 

--- a/tests/harness/171_strict_prelude_args.eu
+++ b/tests/harness/171_strict_prelude_args.eu
@@ -1,0 +1,60 @@
+#!/usr/bin/env eu
+# Strict prelude args: Seq forces strict args at global call sites
+#
+# In blob-prelude mode, prelude functions are globals (Ref::G) with no
+# demand analysis. The prelude demand signature table provides
+# conservative strictness for common prelude functions, enabling Seq
+# wrapping of complex arguments at call sites.
+
+# nth with complex index arg — forces (2 + 1) eagerly
+nth-ok: nth(2 + 1, [10, 20, 30, 40]) = 40
+
+# take with computed count
+take-ok: take(1 + 1, [10, 20, 30]) = [10, 20]
+
+# drop with computed count
+drop-ok: drop(2 - 1, [10, 20, 30]) = [20, 30]
+
+# foldl with complex initial accumulator
+foldl-ok: foldl(+, 10 + 5, [1, 2, 3]) = 21
+
+# map with complex function (lambda is WHNF, so no seq needed,
+# but the list arg via catenation is separate)
+map-ok: ([1, 2, 3] map(_ + (5 * 2))) = [11, 12, 13]
+
+# filter with result used in further computation
+filter-ok: ([1, 2, 3, 4, 5] filter(_ > (1 + 1))) = [3, 4, 5]
+
+# Nested prelude calls with complex args
+nested-ok: nth(0, take(1 + 1, [10, 20, 30])) = 10
+
+# range with computed bounds
+range-ok: range(2 * 1, 2 + 3) = [2, 3, 4]
+
+# reverse preserves values
+reverse-ok: reverse([1, 2, 3]) = [3, 2, 1]
+
+# sum / product with list
+sum-ok: sum([1, 2, 3, 4]) = 10
+product-ok: product([1, 2, 3, 4]) = 24
+
+# max / min with computed args
+max-ok: max(3 + 1, 2 + 1) = 4
+min-ok: min(3 + 1, 2 + 1) = 3
+
+# abs with complex arg
+abs-ok: abs(0 - (3 + 2)) = 5
+
+# Chained prelude calls
+chain-ok: ([5, 3, 1, 4, 2] sort-nums reverse head) = 5
+
+# compose with complex args
+compose-ok: compose(_ + 1, _ * 2, 3) = 7
+
+RESULT: if(
+  [nth-ok, take-ok, drop-ok, foldl-ok, map-ok, filter-ok,
+   nested-ok, range-ok, reverse-ok, sum-ok, product-ok,
+   max-ok, min-ok, abs-ok, chain-ok, compose-ok] all-true?,
+  :PASS,
+  :FAIL
+)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2533,6 +2533,12 @@ pub fn test_170_strict_eager_eval() {
 }
 
 #[test]
+/// Strict prelude args: Seq forces strict args at global call sites
+pub fn test_171_strict_prelude_args() {
+    run_test(&opts("171_strict_prelude_args.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }


### PR DESCRIPTION
## Summary

- Adds a prelude demand signature table (`build_prelude_signatures()`) mapping ~60 common prelude functions to conservative strictness demands
- In blob-prelude mode, prelude functions are pre-compiled globals with no demand analysis — this table provides strictness info as a third fallback after intrinsic and user demand signatures
- Complex arguments to prelude functions marked strict now get Seq-wrapped for eager evaluation at call sites

## Measurements

Benchmarks show no regression. The impact on current benchmarks is minimal because most prelude function calls use catenation style (`list map(f)`) where arguments are simple variable references that don't create synthetic bindings:

| Benchmark | Master (Ticks/Allocs) | Branch (Ticks/Allocs) | Delta |
|-----------|----------------------|----------------------|-------|
| 010_prelude | 152,171 / 73,592 | 152,204 / 73,592 | +0.02% / 0% |
| 008_folds | 4,645 / 579 | 4,645 / 579 | 0% / 0% |
| day05 p1 | 62,627,333 / 14,067,690 | 62,627,339 / 14,067,690 | ~0% / 0% |
| day12 p1 | — | 6,654,987 / 2,407,158 | baseline |

The optimisation applies when complex expressions (e.g. `nth(2 + 1, list)`, `foldl(+, base + offset, data)`) are passed directly as arguments. STG dump confirms Seq forms are emitted: `seq ✳0 in ⊗456(✳0)`.

## Test plan

- [x] Full `cargo test` — all tests pass
- [x] `EU_SOURCE_PRELUDE=1 cargo test --test harness_test` — 453 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] New harness test `171_strict_prelude_args.eu` covers nth, take, drop, foldl, map, filter, range, reverse, sum, product, max, min, abs, compose with complex args

🤖 Generated with [Claude Code](https://claude.com/claude-code)