### PR TITLE
fix: cons demand must be lazy to prevent divergence on infinite lists

### DIFF
--- a/src/core/analyse_demand.rs
+++ b/src/core/analyse_demand.rs
@@ -169,8 +169,10 @@ pub fn build_prelude_signatures() -> HashMap<String, DemandSignature> {
     sigs.insert("sum".into(), vec![sm()]);
     // product(l): list traversed
     sigs.insert("product".into(), vec![sm()]);
-    // cons(h, t): both needed to construct
-    sigs.insert("cons".into(), vec![sm(), sm()]);
+    // cons(h, t): lazy in both — wraps __CONS which does not force args.
+    // Strictness here would cause infinite forcing for recursive list
+    // construction (iterate, map, scanl, etc.) over infinite lists.
+    sigs.insert("cons".into(), vec![lm(), lm()]);
     // snoc(x, l): both needed
     sigs.insert("snoc".into(), vec![sm(), sm()]);
     // mapcat(f, l): catenation applied via compose, but f is strict


### PR DESCRIPTION
## Summary

- **P0 release blocker**: `tests/harness/033_scans.eu` hung in blob-prelude mode (CI release builds)
- Root cause: `build_prelude_signatures()` marked `cons` as strict in both arguments (`[sm(), sm()]`), but the `CONS` intrinsic has `strict: vec![]` — neither argument should be forced
- During blob compilation, these signatures apply to intra-prelude calls. With `cons` strict in its tail, recursive list constructors (`iterate`, `map`, `scanl`) had their recursive calls Seq-wrapped, causing infinite forcing on infinite lists
- Fix: change `cons` signature to `[lm(), lm()]` (lazy multi), matching the `CONS` intrinsic

## Test plan

- [x] `timeout 10 ./target/release/eu test tests/harness/033_scans.eu` — PASS (was hanging)
- [x] `EU_SOURCE_PRELUDE=1` mode — still passes
- [x] `cargo test --lib` — 1163 passed
- [x] `cargo test --test harness_test` — 454 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] Infinite list operations verified: `iterate(inc,1) take(3)`, `repeat(1) map(inc) take(3)`

**Note**: The prelude blob must be regenerated after this change (`cargo run --package xtask -- prelude-compile`). CI should handle this if the blob is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)