### PR TITLE
fix(blob): override stale __args/__io globals at runtime

### DIFF
--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -381,7 +381,7 @@ fn type_check_path_with_seed(
     let core_expr = loader.core().expr.clone();
     let mut warnings = type_check_with_seed(&core_expr, &ui.type_summary);
     warnings.extend(deprecation_warnings);
-    let (_, source_map, _) = loader.complete();
+    let (_, source_map, _, _, _) = loader.complete();
     PathCheckResult {
         warnings,
         types: std::collections::HashMap::new(),
@@ -426,7 +426,7 @@ fn type_check_path_merged(
     let core_expr = loader.core().expr.clone();
     let mut result = type_check_full(&core_expr);
     result.warnings.extend(deprecation_warnings);
-    let (_, source_map, _) = loader.complete();
+    let (_, source_map, _, _, _) = loader.complete();
     PathCheckResult {
         warnings: result.warnings,
         types: result.types,
@@ -513,7 +513,7 @@ fn run_type_checker(opt: &EucalyptOptions) -> Result<PipelineCheckResult, Eucaly
     // Run content verifier to catch static errors (e.g. trivial self-assignment).
     let core_errors = loader.verify().unwrap_or_default();
 
-    let (files, source_map, _) = loader.complete();
+    let (files, source_map, _, _, _) = loader.complete();
     Ok(PipelineCheckResult {
         warnings,
         core_errors,

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -174,12 +174,27 @@ pub struct Executor<'a> {
     /// prelude free variables to `Ref::G` rather than raising `CompileError::FreeVar`.
     #[cfg(not(target_arch = "wasm32"))]
     prelude_blob: Option<crate::eval::stg::blob::PreludeBlob>,
+
+    /// Command-line arguments passed after `--`.
+    ///
+    /// Used to override the stale `__args` global baked into the blob at
+    /// compile time with the actual runtime argument list.
+    args: Vec<String>,
+
+    /// Random seed from `--seed`, if provided.
+    ///
+    /// Used to override the stale `__io` global baked into the blob at
+    /// compile time with fresh runtime environment data.
+    seed: Option<i64>,
 }
 
 impl From<SourceLoader> for Executor<'_> {
     fn from(loader: SourceLoader) -> Self {
-        let (files, source_map, evaluand) = loader.complete();
-        Self::new(files, source_map, evaluand)
+        let (files, source_map, evaluand, args, seed) = loader.complete();
+        let mut executor = Self::new(files, source_map, evaluand);
+        executor.args = args;
+        executor.seed = seed;
+        executor
     }
 }
 
@@ -199,6 +214,8 @@ impl<'a> Executor<'a> {
             err: None,
             #[cfg(not(target_arch = "wasm32"))]
             prelude_blob: None,
+            args: Vec::new(),
+            seed: None,
         }
     }
 
@@ -270,6 +287,40 @@ impl<'a> Executor<'a> {
                 b.binding_entries.clone(),
                 names,
             );
+
+            // Override the stale __args and __io globals baked into the blob
+            // at compile time with freshly-constructed runtime values.
+            //
+            // The blob compiles these pseudoblocks once with empty/default
+            // values.  At runtime the actual argument list and environment must
+            // be substituted so that `io.args`, `io.RANDOM_SEED`,
+            // `io.epoch-time`, and `io.env` reflect the current invocation.
+            let override_settings = stg::StgSettings {
+                generate_annotations: false,
+                suppress_updates: false,
+                suppress_inlining: true,
+                suppress_optimiser: false,
+                render_type: stg::RenderType::Headless,
+                prelude_globals: Some(b.name_to_slot.clone()),
+                ..Default::default()
+            };
+
+            if let Some(&args_slot) = b.name_to_slot.get("__args") {
+                let args_expr = crate::driver::io::create_args_pseudoblock(&self.args);
+                if let Ok(stg_syn) = stg::compile(&override_settings, args_expr, rt.as_ref()) {
+                    rt.set_prelude_slot_override(
+                        args_slot,
+                        stg::syntax::LambdaForm::thunk(stg_syn),
+                    );
+                }
+            }
+
+            if let Some(&io_slot) = b.name_to_slot.get("__io") {
+                let io_expr = crate::driver::io::create_io_pseudoblock(self.seed);
+                if let Ok(stg_syn) = stg::compile(&override_settings, io_expr, rt.as_ref()) {
+                    rt.set_prelude_slot_override(io_slot, stg::syntax::LambdaForm::thunk(stg_syn));
+                }
+            }
         }
 
         if opt.dump_runtime() {

--- a/src/driver/lsp/mod.rs
+++ b/src/driver/lsp/mod.rs
@@ -1346,7 +1346,7 @@ fn run_pipeline(
         }
     }
 
-    let (_, source_map, _) = loader.complete();
+    let (_, source_map, _, _, _) = loader.complete();
 
     // Merge pre-elimination aliases with post-elimination aliases.
     // Post-elimination aliases (from the type-check pass) take priority

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -861,9 +861,24 @@ impl SourceLoader {
     }
 
     /// Declare source manipulation complete and take ownership of
-    /// reporting resources
-    pub fn complete(self) -> (SimpleFiles<String, String>, SourceMap, RcExpr) {
-        (self.files, self.source_map, self.core.expr)
+    /// reporting resources, along with the runtime environment data
+    /// needed to override stale blob globals at execution time.
+    pub fn complete(
+        self,
+    ) -> (
+        SimpleFiles<String, String>,
+        SourceMap,
+        RcExpr,
+        Vec<String>,
+        Option<i64>,
+    ) {
+        (
+            self.files,
+            self.source_map,
+            self.core.expr,
+            self.args,
+            self.seed,
+        )
     }
 
     /// Read text from the filesystem, using lib-path to resolve the

--- a/src/eval/stg/runtime.rs
+++ b/src/eval/stg/runtime.rs
@@ -71,6 +71,26 @@ pub struct StandardRuntime {
     /// Empty string for any slot whose name is not recorded.  Used by
     /// `dump runtime` to label prelude global slots.
     prelude_names: Vec<String>,
+
+    /// Per-slot overrides for pre-compiled prelude globals, stored in arena form.
+    ///
+    /// Each entry is `(slot, nodes, forms, entry_form_idx)` where:
+    /// - `slot` is the zero-based prelude slot index (the index into
+    ///   `prelude_binding_entries`, *not* the full `Ref::G` slot number)
+    /// - `nodes` / `forms` / `entry_form_idx` are a self-contained arena for
+    ///   the override `LambdaForm` (reconstructed on demand in `globals()`)
+    ///
+    /// Arena form (`ArenaStgSyn` / `ArenaLambdaForm`) does not contain `Rc`
+    /// and is therefore `Sync`, satisfying the `Runtime: Sync` bound.
+    ///
+    /// Used to replace stale `__args` / `__io` blob globals with freshly-
+    /// constructed runtime values.
+    prelude_slot_overrides: Vec<(
+        usize,
+        Vec<crate::eval::stg::arena::ArenaStgSyn>,
+        Vec<crate::eval::stg::arena::ArenaLambdaForm>,
+        crate::eval::stg::arena::FormIdx,
+    )>,
 }
 
 impl Default for StandardRuntime {
@@ -86,6 +106,7 @@ impl Default for StandardRuntime {
             prelude_forms_pool: Vec::new(),
             prelude_binding_entries: Vec::new(),
             prelude_names: Vec::new(),
+            prelude_slot_overrides: Vec::new(),
         }
     }
 }
@@ -119,6 +140,27 @@ impl StandardRuntime {
     pub fn add(&mut self, imp: Box<dyn StgIntrinsic>) {
         let index = imp.index();
         self.impls[index] = imp;
+    }
+
+    /// Override a single pre-compiled prelude global with a freshly-compiled
+    /// `LambdaForm`.
+    ///
+    /// `slot` is the zero-based prelude slot index (i.e. the value stored in
+    /// `blob.name_to_slot`, *not* the full `Ref::G` index).  When `globals()`
+    /// iterates `prelude_binding_entries`, it checks this list first and uses
+    /// the override if present.
+    ///
+    /// The `LambdaForm` is immediately flattened into an arena so that the
+    /// `StandardRuntime` remains `Sync` (arena types contain no `Rc`).
+    ///
+    /// This is used to replace stale `__args` / `__io` blob globals with
+    /// forms that reflect the actual runtime argument list and environment.
+    pub fn set_prelude_slot_override(&mut self, slot: usize, form: LambdaForm) {
+        use crate::eval::stg::arena::StgArena;
+        let mut arena = StgArena::default();
+        let entry_idx = arena.flatten_form(&form);
+        self.prelude_slot_overrides
+            .push((slot, arena.nodes, arena.forms, entry_idx));
     }
 }
 
@@ -221,7 +263,33 @@ impl Runtime for StandardRuntime {
                 nodes: self.prelude_nodes.clone(),
                 forms: self.prelude_forms_pool.clone(),
             };
-            for &entry_idx in &self.prelude_binding_entries {
+            for (i, &entry_idx) in self.prelude_binding_entries.iter().enumerate() {
+                // Use the runtime override when present (e.g. for `__args` /
+                // `__io` whose blob-baked values are stale at runtime).
+                if let Some(override_form) = self
+                    .prelude_slot_overrides
+                    .iter()
+                    .find(|(slot, _, _, _)| *slot == i)
+                {
+                    let (_, ref nodes, ref forms, entry) = *override_form;
+                    let override_arena = StgArena {
+                        nodes: nodes.clone(),
+                        forms: forms.clone(),
+                    };
+                    match override_arena.reconstruct_form(entry) {
+                        Ok(form) => {
+                            gs.push(form);
+                            continue;
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "warning: corrupt override for prelude slot {i} ({}), \
+                                 using blob value",
+                                e
+                            );
+                        }
+                    }
+                }
                 match arena.reconstruct_form(entry_idx) {
                     Ok(form) => gs.push(form),
                     Err(e) => {

--- a/tests/io_args_test.rs
+++ b/tests/io_args_test.rs
@@ -1,0 +1,147 @@
+//! Integration tests for `io.args`, `io.RANDOM_SEED`, `io.epoch-time`, and
+//! `io.env` when using the pre-compiled prelude blob.
+//!
+//! The blob bakes `__args` and `__io` with empty/default values at compile
+//! time.  These tests verify that the executor overrides them at runtime so
+//! the actual argument list and environment are visible to eucalypt programs.
+
+use std::path::Path;
+
+/// Path to the `eu` binary built by cargo for this test run.
+fn eu_binary() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_eu"))
+}
+
+/// Run `eu -e <expr> [extra_args]` and return the trimmed stdout.
+///
+/// Panics if the process exits with a non-zero status.
+fn eu_eval(expr: &str, extra_args: &[&str]) -> String {
+    let output = std::process::Command::new(eu_binary())
+        .arg("-e")
+        .arg(expr)
+        .args(extra_args)
+        .output()
+        .expect("failed to run eu binary");
+
+    assert!(
+        output.status.success(),
+        "eu exited with status {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// `io.args` should return the arguments passed after `--`.
+#[test]
+fn test_io_args_returns_runtime_args() {
+    let out = eu_eval("io.args", &["--", "hello", "world"]);
+    // YAML list output
+    assert!(
+        out.contains("hello"),
+        "expected 'hello' in io.args output, got: {out}"
+    );
+    assert!(
+        out.contains("world"),
+        "expected 'world' in io.args output, got: {out}"
+    );
+}
+
+/// `io.args` should return an empty list when no args are passed.
+#[test]
+fn test_io_args_empty_when_no_args() {
+    let out = eu_eval("io.args", &[]);
+    // YAML renders an empty list as `[]`, which may appear on its own line.
+    assert!(
+        out.contains("[]"),
+        "expected empty list for io.args, got: {out}"
+    );
+}
+
+/// `io.args` count should match the number of arguments provided.
+#[test]
+fn test_io_args_count() {
+    let out = eu_eval("io.args count", &["--", "a", "b", "c"]);
+    assert!(out.contains('3'), "expected 3 args, got: {out}");
+}
+
+/// `io.RANDOM_SEED` should reflect `--seed` when provided.
+#[test]
+fn test_io_random_seed_with_explicit_seed() {
+    let out = eu_eval("io.RANDOM_SEED", &["--seed", "12345"]);
+    assert!(
+        out.contains("12345"),
+        "expected seed 12345 in output, got: {out}"
+    );
+}
+
+/// `io.RANDOM_SEED` with a different seed value.
+#[test]
+fn test_io_random_seed_different_value() {
+    let out = eu_eval("io.RANDOM_SEED", &["--seed", "99"]);
+    assert!(out.contains("99"), "expected seed 99 in output, got: {out}");
+}
+
+/// `io.env` should be a non-empty block (environment variables are always set).
+#[test]
+fn test_io_env_is_nonempty() {
+    let out = eu_eval("io.env elements non-nil?", &[]);
+    assert!(
+        out.contains("true"),
+        "expected io.env to have environment variables, got: {out}"
+    );
+}
+
+/// `io.epoch-time` should be a positive integer.
+#[test]
+fn test_io_epoch_time_is_positive() {
+    // The prelude exposes this as `io.epoch-time`.
+    let out = eu_eval("io.epoch-time", &[]);
+    // Strip the YAML document marker and parse.
+    let stripped = out
+        .lines()
+        .find(|l| !l.trim_start().starts_with("---"))
+        .unwrap_or("")
+        .trim();
+    let epoch: i64 = stripped
+        .parse()
+        .unwrap_or_else(|_| panic!("expected integer epoch time, got: {out}"));
+    assert!(epoch > 0, "expected positive epoch time, got: {epoch}");
+}
+
+/// `__args` direct access should also reflect runtime args (regression test).
+#[test]
+fn test_direct_args_access() {
+    let out = eu_eval("__args", &["--", "foo", "bar"]);
+    assert!(
+        out.contains("foo"),
+        "expected 'foo' in __args output, got: {out}"
+    );
+    assert!(
+        out.contains("bar"),
+        "expected 'bar' in __args output, got: {out}"
+    );
+}
+
+/// `io.args` first element should be accessible.
+#[test]
+fn test_io_args_first_element() {
+    let out = eu_eval("io.args head", &["--", "first", "second"]);
+    assert!(
+        out.contains("first"),
+        "expected first arg 'first', got: {out}"
+    );
+}
+
+/// Verify two seeds produce different `io.RANDOM_SEED` values.
+#[test]
+fn test_io_random_seed_values_differ_per_seed() {
+    let out42 = eu_eval("io.RANDOM_SEED", &["--seed", "42"]);
+    let out99 = eu_eval("io.RANDOM_SEED", &["--seed", "99"]);
+    assert_ne!(
+        out42, out99,
+        "different --seed flags must produce different io.RANDOM_SEED values"
+    );
+}


### PR DESCRIPTION
## Summary

- The pre-compiled prelude blob baked `__args` and `__io` globals with empty/default values at compile time, causing `io.args`, `io.RANDOM_SEED`, `io.epoch-time`, and `io.env` to return stale values at runtime
- Fix adds per-slot override capability to `StandardRuntime`: after loading blob prelude bindings, the executor compiles fresh `LambdaForm`s for `__args` and `__io` from the actual runtime argument list and seed, then installs them as overrides
- Overrides are stored in arena form (`ArenaStgSyn`/`ArenaLambdaForm`) so `StandardRuntime` remains `Sync`
- `SourceLoader::complete()` is extended to return `args` and `seed` alongside the existing fields; all call sites updated

## Test plan

- [ ] `cargo test --test io_args_test` — 10 new integration tests pass (io.args, io.RANDOM_SEED, io.epoch-time, io.env)
- [ ] `cargo test --lib` — 1170 lib tests pass (no regressions)
- [ ] Manual: `timeout 30 ./target/release/eu -e 'io.args' -- x y z` → returns `x`, `y`, `z`
- [ ] Manual: `timeout 30 ./target/release/eu --seed 42 -e 'io.RANDOM_SEED'` → returns `42`
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)