### PR TITLE
fix(errors): show actual string value and clean location in assertion failures

### DIFF
--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -880,12 +880,31 @@ impl ExecutionError {
             }
         };
 
+        // For assertion failures, suppress a non-user-file primary label.
+        //
+        // When `//=` fails, the env and stack traces often contain only
+        // prelude frames (the `//=` wrapper body's internal evaluation).
+        // Showing the prelude's `//=` definition as the primary error site
+        // is confusing — users want to see their own code.  If we cannot
+        // find a user-file location, it is less misleading to show no
+        // primary label than to show prelude internals.
+        let primary_file_span = if matches!(inner, ExecutionError::AssertionFailed(..)) {
+            primary_file_span.filter(|(file, _)| source_map.is_user_file(*file))
+        } else {
+            primary_file_span
+        };
+
         // Apply the primary label.  We clear any label that source_map.diagnostic()
         // may have set (which could be a prelude location) and replace it with the
         // best location determined above.
         if let Some((file, span)) = primary_file_span {
             diag.labels.clear();
             diag.labels.push(Label::primary(file, span));
+        } else if matches!(inner, ExecutionError::AssertionFailed(..)) {
+            // No user-file location found: clear any prelude label that
+            // source_map.diagnostic() may have placed, so the diagnostic
+            // shows only the error message without a confusing prelude pointer.
+            diag.labels.clear();
         }
 
         // Add secondary labels from the env trace for call-chain context.
@@ -893,13 +912,20 @@ impl ExecutionError {
         // We collect env trace entries that have real source locations and differ
         // from the primary label (to avoid redundant markers).  Limited to 3
         // secondary labels to keep output readable.
+        //
+        // For assertion failures without a user-file primary label, skip
+        // secondary labels entirely: they would only show prelude internals
+        // (the `//=` wrapper body), which adds noise rather than insight.
+        let show_secondary =
+            !matches!(inner, ExecutionError::AssertionFailed(..)) || primary_file_span.is_some();
+
         {
             let mut secondary_labels: Vec<Label<usize>> = vec![];
             let mut seen_spans: Vec<(usize, codespan::Span)> = vec![];
 
             // Skip the first env_trace entry if it matches the fallback primary (already shown)
             for &smid in env_trace.iter() {
-                if secondary_labels.len() >= 3 {
+                if !show_secondary || secondary_labels.len() >= 3 {
                     break;
                 }
                 let info = match source_map.source_info_for_smid(smid) {

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -202,6 +202,162 @@ fn extract_native(
     }
 }
 
+/// Extract a native value from a ref, forcing unevaluated thunks via
+/// `evaluate_to_whnf` when the cheap path fails.
+///
+/// This is the forcing variant of `extract_native`, used when rendering
+/// actual values in assertion failure messages.  It evaluates inner thunks
+/// that `extract_native` cannot reach — for example, the string
+/// concatenation BIF application inside an interpolated `BoxedString`.
+fn extract_native_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<Native> {
+    // Fast path: cheap extraction succeeds.
+    if let Some(n) = extract_native(view, env, r) {
+        return Some(n);
+    }
+
+    // Slow path: resolve the closure and force it to WHNF.
+    let closure = match r {
+        Ref::L(idx) => env.get(&view, *idx)?,
+        Ref::G(idx) => machine.nav(view).global(*idx).ok()?,
+        Ref::V(_) => return None, // already tried in fast path
+    };
+
+    let forced = machine.evaluate_to_whnf(closure).ok()?;
+    let forced_code = view.scoped(forced.code());
+    match &*forced_code {
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => Some(n.clone()),
+        _ => None,
+    }
+}
+
+/// Render an inner argument ref as a debug string, forcing thunks if needed.
+fn render_inner_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native_forced(machine, view, env, r)?;
+    Some(render_native(&native, view, machine))
+}
+
+/// Render an inner string arg with surrounding double quotes, forcing thunks.
+fn render_inner_quoted_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native_forced(machine, view, env, r)?;
+    match &native {
+        Native::Str(s) => {
+            let scoped = view.scoped(*s);
+            Some(format!("{:?}", (*scoped).as_str()))
+        }
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Render an inner symbol arg with `:` prefix, forcing thunks.
+fn render_inner_symbol_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    env: &crate::eval::machine::env::EnvFrame,
+    r: &Ref,
+) -> Option<String> {
+    let native = extract_native_forced(machine, view, env, r)?;
+    match &native {
+        Native::Sym(id) => Some(format!(":{}", machine.symbol_pool().resolve(*id))),
+        _ => Some(render_native(&native, view, machine)),
+    }
+}
+
+/// Render a eucalypt value from a resolved closure, forcing inner thunks.
+///
+/// Unlike `render_debug_repr_closure`, this variant evaluates unevaluated
+/// inner refs (e.g. the string concat thunk inside a `BoxedString` produced
+/// by string interpolation) via `evaluate_to_whnf`.  Use this in contexts
+/// where `&mut dyn IntrinsicMachine` is available (intrinsic `execute` methods).
+fn render_debug_repr_closure_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    closure: crate::eval::machine::env::SynClosure,
+) -> String {
+    let code = view.scoped(closure.code());
+    let env = view.scoped(closure.env());
+
+    match &*code {
+        HeapSyn::Cons { tag, args } => {
+            let dc: Result<DataConstructor, _> = (*tag).try_into();
+            match dc {
+                Ok(DataConstructor::BoolTrue) => "true".to_string(),
+                Ok(DataConstructor::BoolFalse) => "false".to_string(),
+                Ok(DataConstructor::Unit) => "null".to_string(),
+                Ok(DataConstructor::ListNil) => "[]".to_string(),
+                Ok(DataConstructor::ListCons) => "[list]".to_string(),
+                Ok(DataConstructor::Block)
+                | Ok(DataConstructor::BlockPair)
+                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
+                Ok(DataConstructor::BoxedNumber) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_forced(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<number>".to_string()),
+                Ok(DataConstructor::BoxedString) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted_forced(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<string>".to_string()),
+                Ok(DataConstructor::BoxedSymbol) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_symbol_forced(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<symbol>".to_string()),
+                Ok(DataConstructor::BoxedZdt) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_forced(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<datetime>".to_string()),
+                Ok(DataConstructor::BoxedTypeData) => args
+                    .get(0)
+                    .and_then(|inner| render_inner_quoted_forced(machine, view, &env, &inner))
+                    .unwrap_or_else(|| "<type-data>".to_string()),
+                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
+                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
+                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
+                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
+                Ok(DataConstructor::Clause) => "<clause>".to_string(),
+                Err(_) => "<value>".to_string(),
+            }
+        }
+        HeapSyn::Atom {
+            evaluand: Ref::V(n),
+        } => render_native(n, view, machine),
+        _ => "<unevaluated>".to_string(),
+    }
+}
+
+/// Render a eucalypt value to a compact debug string, forcing inner thunks.
+///
+/// This is the forcing variant of `render_debug_repr`, suitable for use in
+/// intrinsic `execute` methods (which have `&mut dyn IntrinsicMachine` access).
+/// It evaluates lazy inner refs (e.g. string interpolation results inside a
+/// `BoxedString`) via `evaluate_to_whnf`, so the rendered output is accurate
+/// rather than showing `<string>` or `<number>` for lazy scalar values.
+pub fn render_debug_repr_forced(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    match machine.nav(view).resolve(r) {
+        Ok(closure) => render_debug_repr_closure_forced(machine, view, closure),
+        Err(_) => "<error>".to_string(),
+    }
+}
+
 /// `__DBG_REPR(value)` — render any value to a compact debug string.
 ///
 /// Used as the shared foundation by both debug tracing functions and

--- a/src/eval/stg/expect.rs
+++ b/src/eval/stg/expect.rs
@@ -17,7 +17,7 @@ use crate::eval::{
     stg::support::{machine_return_bool, str_arg},
 };
 
-use super::{debug::render_debug_repr, tags::DataConstructor};
+use super::{debug::render_debug_repr_forced, tags::DataConstructor};
 
 /// Resolve a strict bool argument to a Rust bool.
 ///
@@ -85,7 +85,7 @@ impl StgIntrinsic for Expect {
             machine.set_closure(closure)
         } else {
             let expected_repr = str_arg(machine, view, &args[1])?;
-            let actual_repr = render_debug_repr(machine, view, &args[0]);
+            let actual_repr = render_debug_repr_forced(machine, view, &args[0]);
             eprintln!("EXPECT FAILED: expected {expected_repr}, got {actual_repr}");
 
             if machine.test_mode() {

--- a/tests/harness/errors/error_176.eu
+++ b/tests/harness/errors/error_176.eu
@@ -1,0 +1,19 @@
+# Error test: assertion failure on interpolated string shows actual value.
+#
+# eu-kw67: when the actual value in `//=` is a string produced by
+# interpolation (or any non-trivial expression whose BoxedString inner
+# ref is an unevaluated thunk), the error message used to show `<string>`
+# instead of the actual string content.
+#
+# After the fix, `render_debug_repr_forced` evaluates the inner thunk
+# via `evaluate_to_whnf` and shows the real string.
+#
+# Expected behaviour:
+#   - Exit code 1
+#   - Stderr "EXPECT FAILED" line shows a quoted string, not `<string>`
+#   - Stderr "assertion failed" diagnostic shows a quoted string
+
+make-greeting(name): "hello {name}"
+
+` :target
+result: make-greeting("world") //= "goodbye world"

--- a/tests/harness/errors/error_176.eu.expect
+++ b/tests/harness/errors/error_176.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "got \"hello world\""

--- a/tests/harness/errors/error_177.eu
+++ b/tests/harness/errors/error_177.eu
@@ -1,0 +1,17 @@
+# Error test: assertion failure diagnostic does not show prelude internals.
+#
+# eu-4qy4: when `//=` fails, the error diagnostic used to show the
+# prelude's `//=` definition (e.g. `[prelude]:1253`) as the primary
+# source location — confusing users who want to see their own code.
+#
+# After the fix, when no user-file source location is available in the
+# env/stack traces, the assertion failure diagnostic suppresses the
+# prelude label entirely, showing only the clear error message.
+#
+# Expected behaviour:
+#   - Exit code 1
+#   - Stderr does NOT mention "prelude" as a location
+#   - Stderr contains the "assertion failed" message with expected/got values
+
+` :target
+result: "hello" //= "goodbye"

--- a/tests/harness/errors/error_177.eu.expect
+++ b/tests/harness/errors/error_177.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "assertion failed.*expected \"goodbye\".*got \"hello\""

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2479,6 +2479,23 @@ pub fn test_error_175() {
 }
 
 #[test]
+/// Assertion failure on an interpolated string used to show `<string>` instead
+/// of the actual string value in the EXPECT FAILED message (eu-kw67).
+/// After the fix, `render_debug_repr_forced` evaluates the inner thunk and
+/// shows the real string.
+pub fn test_error_176() {
+    run_error_test(&error_opts("error_176.eu"));
+}
+
+#[test]
+/// Assertion failure diagnostic used to show the prelude `//=` definition
+/// as the primary source location (eu-4qy4).  After the fix, when no
+/// user-file source location is available, the prelude label is suppressed.
+pub fn test_error_177() {
+    run_error_test(&error_opts("error_177.eu"));
+}
+
+#[test]
 /// Exporting a JSON u64 value exceeding i64::MAX to YAML should produce an
 /// informative panic message including the value, not a bare "unrenderable number".
 pub fn test_error_171() {


### PR DESCRIPTION
## Summary

- **eu-kw67**: `//=` failure on an interpolated string showed `<string>` instead of the actual string content. The `BoxedString` inner ref is an unevaluated BIF thunk that `extract_native` cannot reach without forcing. Added `render_debug_repr_forced` (and supporting helpers) which uses `evaluate_to_whnf` on the inner ref when the fast path fails. `Expect::execute` now uses this forcing variant.

- **eu-4qy4**: `//=` failure showed the prelude's `//=` definition (`[prelude]:1253`) as the primary source location. The user call-site annotation is overwritten by prelude body evaluation before `execute()` runs — it is genuinely unavailable in env/stack traces. Rather than show confusing prelude internals, suppress non-user-file primary labels and prelude-only secondary labels for `AssertionFailed` errors in `to_diagnostic`.

## Test plan

- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test test_error_17` passes (error_175, error_176, error_177)
- [ ] `cargo test --lib` passes (1167 tests)
- [ ] Manual verification with the repro file shows actual string value and no prelude label

🤖 Generated with [Claude Code](https://claude.com/claude-code)