### PR TITLE
fix(parser): accept idiot-bracket expression as juxtaposed call target

### DIFF
--- a/src/syntax/rowan/kind.rs
+++ b/src/syntax/rowan/kind.rs
@@ -133,6 +133,7 @@ impl SyntaxKind {
         *self == CLOSE_PAREN
             || *self == CLOSE_BRACE
             || *self == CLOSE_SQUARE
+            || *self == BRACKET_CLOSE
             || *self == UNQUOTED_IDENTIFIER
             || *self == STRING_PATTERN_END
             || *self == C_STRING_PATTERN_END

--- a/tests/harness/172_idiot_bracket_juxtaposed_call.eu
+++ b/tests/harness/172_idiot_bracket_juxtaposed_call.eu
@@ -1,0 +1,30 @@
+#!/usr/bin/env eu
+# Regression test for idiot-bracket expressions as juxtaposed call targets.
+#
+# Prior to the fix, `⌈expr⌉[args]` was parsed as catenation of the bracket
+# expression with a plain list literal, rather than as a juxtaposed call
+# (the bracket expression calling a function with `[args]` as argument).
+# This happened because BRACKET_CLOSE was not included in `is_callable_terminal()`,
+# so the lexer emitted OPEN_SQUARE instead of OPEN_SQUARE_APPLY.
+
+# Define a custom bracket pair that extracts the single item from its list
+# and returns it — so ⌊f⌋ is equivalent to f.
+⌊xs⌋: xs head
+
+# Juxtaposed list call: ⌊map(_ * 2)⌋[1, 2, 3] should call map(_ * 2) with [1, 2, 3]
+list-call-ok: ⌊map(_ * 2)⌋[1, 2, 3] = [2, 4, 6]
+
+# Juxtaposed block call: ⌊lookup(:b)⌋{a: 1, b: 99} should look up :b in the block
+block-call-ok: ⌊lookup(:b)⌋{a: 1, b: 99} = 99
+
+# Nested: bracket expression as receiver in a further chain
+# ⌊map(_ + 10)⌋[5, 6] should give [15, 16], then filter(> 14) gives [15, 16]
+nested-ok: (⌊map(_ + 10)⌋[5, 6] filter(> 14)) = [15, 16]
+
+# The standard prelude ceiling/floor brackets are not affected:
+# ⌈n⌉[args] would be a runtime error (ceiling returns a number, not a
+# function), so we only test that the *parser* accepts the syntax by
+# checking the juxtaposed-call cases above.
+
+RESULT: [list-call-ok, block-call-ok, nested-ok] all-true?
+  then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2556,6 +2556,13 @@ pub fn test_171_strict_prelude_args() {
 }
 
 #[test]
+/// Idiot-bracket expressions accepted as juxtaposed call targets: ⌈expr⌉[args]
+/// and ⌈expr⌉{block} are parsed as calls, not catenation with a list literal.
+pub fn test_172_idiot_bracket_juxtaposed_call() {
+    run_test(&opts("172_idiot_bracket_juxtaposed_call.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }


### PR DESCRIPTION
## Summary

- `⌈expr⌉[args]` was parsed as a catenation of the bracket expression with a plain list literal, instead of as a juxtaposed call (i.e. calling the result of `⌈expr⌉` with `[args]` as argument)
- Root cause: `BRACKET_CLOSE` was missing from `is_callable_terminal()` in `src/syntax/rowan/kind.rs`; the lexer uses that predicate to decide whether a following `[` or `{` (with no whitespace) should be emitted as `OPEN_SQUARE_APPLY`/`OPEN_BRACE_APPLY` rather than a plain list/block literal
- Fix: add `BRACKET_CLOSE` to `is_callable_terminal()`, giving it the same treatment as `CLOSE_PAREN`, `CLOSE_BRACE`, and `CLOSE_SQUARE`

## Test plan

- [ ] `cargo test test_172_idiot_bracket_juxtaposed_call` passes (new regression test)
- [ ] `cargo test --test harness_test` — all 457 tests pass, no regressions
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)