### PR TITLE
fix(parser): add CLOSE_SQUARE and BRACKET_CLOSE to legacy is_callable_terminal

### DIFF
--- a/src/syntax/kind.rs
+++ b/src/syntax/kind.rs
@@ -93,6 +93,8 @@ impl SyntaxKind {
     pub fn is_callable_terminal(&self) -> bool {
         *self == CLOSE_PAREN
             || *self == CLOSE_BRACE
+            || *self == CLOSE_SQUARE
+            || *self == BRACKET_CLOSE
             || *self == UNQUOTED_IDENTIFIER
             || *self == STRING_PATTERN_END
     }


### PR DESCRIPTION
## Summary

- `src/syntax/kind.rs` had the same `is_callable_terminal()` omission as `src/syntax/rowan/kind.rs` (fixed in #899)
- `CLOSE_SQUARE` and `BRACKET_CLOSE` were absent, meaning `expr][args]` and `⌈expr⌉[args]` could not be parsed as juxtaposed calls via the legacy code path
- Two-line addition to match the rowan fix

## Test plan
- [ ] `cargo clippy --all-targets -- -D warnings` passes (verified)
- [ ] No behaviour change expected in current code paths (legacy kind.rs used at different pipeline stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)