### PR TITLE
docs(changelog): finalise 0.10.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to eucalypt are documented here.
 
-## [0.10.1] - Unreleased
+## [0.10.1] - 2026-06-25
+
+### Fixed
+
+- **Idiot-bracket expressions as juxtaposed call targets** — an idiot-bracket expression immediately followed by a call bracket now parses as a call rather than as catenation with a literal. `⌊map(_ * 2)⌋[1, 2, 3]` calls the bracket expression with `[1, 2, 3]`, and `⌊lookup(:b)⌋{a: 1, b: 99}` with the block. `CLOSE_SQUARE`/`BRACKET_CLOSE` are now callable terminals, so the lexer emits the apply-bracket token; the tree-sitter grammar is updated to match (#899, #901, #902)
 
 ## [0.10.0] - 2026-06-22
 


### PR DESCRIPTION
## Summary

Finalises the `[0.10.1]` changelog section for release. Version is already `0.10.1` (Cargo.toml + Cargo.lock); `build-meta.yaml` is regenerated by CI at release time, so the changelog is the only thing outstanding.

The only user-facing change since 0.10.0:

- **Idiot-bracket expressions as juxtaposed call targets** — `⌊map(_ * 2)⌋[1, 2, 3]` / `⌊lookup(:b)⌋{a: 1, b: 99}` now parse as calls rather than catenation with a literal (`CLOSE_SQUARE`/`BRACKET_CLOSE` are now callable terminals; tree-sitter updated to match). Covered by harness test `172_idiot_bracket_juxtaposed_call.eu` (#899, #901, #902).

Omitted (internal / not user-facing, consistent with the 0.10.0 release dropping its internal-only section):
- legacy LALRPOP-era parser removal (#902)
- docs: agent-reference / lens / AoC performance / roadmap (#894, #900, #903)
- `eu doc` prelude-index supplement hook (#900)

## Notes

On merge to master this becomes the release notes for the 0.10.1 build. Marked ready (not draft) since merging is the intended next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgpsmrY2nprcxfBGY5dF9x)_