### PR TITLE
spike(bytecode): BV0 dispatch-ceiling spike — NO-GO

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -14,7 +14,7 @@ use crate::{
     eval::{
         error::ExecutionError,
         machine::standard_machine,
-        stg::{self, make_standard_runtime, RenderType, StgSettings},
+        stg::{self, make_standard_runtime, runtime::Runtime as _, RenderType, StgSettings},
     },
     export,
 };
@@ -242,6 +242,12 @@ impl<'a> Executor<'a> {
         stats: &mut Statistics,
         format: String,
     ) -> Result<Option<u8>, ExecutionError> {
+        // BV0 spike: use bytecode dispatch when EU_BYTECODE=1
+        #[cfg(not(target_arch = "wasm32"))]
+        if std::env::var("EU_BYTECODE").as_deref() == Ok("1") {
+            let result = self.try_execute_bytecode(opt, stats, format);
+            return self.diagnose(result, opt.error_format());
+        }
         let result = self.try_execute(opt, stats, format);
         self.diagnose(result, opt.error_format())
     }
@@ -472,6 +478,190 @@ impl<'a> Executor<'a> {
                 result
             }
         }
+    }
+
+    /// Execute using bytecode dispatch (BV0 spike).
+    ///
+    /// Mirrors `try_execute` but encodes the STG to bytecode, patches
+    /// the machine's root and globals, and runs `bytecode_run` instead
+    /// of `machine.run()`.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn try_execute_bytecode(
+        &mut self,
+        opt: &EucalyptOptions,
+        stats: &mut Statistics,
+        format: String,
+    ) -> Result<Option<u8>, ExecutionError> {
+        let mut output: Box<dyn Write>;
+        if let Some(out) = &mut self.out {
+            output = Box::new(out);
+        } else if let Some(outfile) = opt.output() {
+            output = Box::new(std::fs::File::create(outfile)?);
+        } else {
+            output = Box::new(std::io::stdout());
+        }
+
+        let mut emitter = export::create_emitter(&format, output.as_mut())
+            .ok_or_else(|| ExecutionError::UnknownFormat(format.to_string()))?;
+
+        let mut rt = make_standard_runtime(&mut self.source_map);
+
+        if let Some(ref b) = self.prelude_blob {
+            let mut names = vec![String::new(); b.binding_entries.len()];
+            for (name, &slot) in &b.name_to_slot {
+                if slot < names.len() {
+                    names[slot] = name.clone();
+                }
+            }
+            rt.set_prelude_bindings(
+                b.nodes.clone(),
+                b.forms_pool.clone(),
+                b.binding_entries.clone(),
+                names,
+            );
+
+            let override_settings = stg::StgSettings {
+                generate_annotations: false,
+                suppress_updates: false,
+                suppress_inlining: true,
+                suppress_optimiser: false,
+                render_type: stg::RenderType::Headless,
+                prelude_globals: Some(b.name_to_slot.clone()),
+                ..Default::default()
+            };
+
+            if let Some(&args_slot) = b.name_to_slot.get("__args") {
+                let args_expr = crate::driver::io::create_args_pseudoblock(&self.args);
+                if let Ok(stg_syn) = stg::compile(&override_settings, args_expr, rt.as_ref()) {
+                    rt.set_prelude_slot_override(
+                        args_slot,
+                        stg::syntax::LambdaForm::thunk(stg_syn),
+                    );
+                }
+            }
+
+            if let Some(&io_slot) = b.name_to_slot.get("__io") {
+                let io_expr = crate::driver::io::create_io_pseudoblock(self.seed);
+                if let Ok(stg_syn) = stg::compile(&override_settings, io_expr, rt.as_ref()) {
+                    rt.set_prelude_slot_override(io_slot, stg::syntax::LambdaForm::thunk(stg_syn));
+                }
+            }
+        }
+
+        let mut stg_settings = StgSettings {
+            render_type: RenderType::Headless,
+            ..opt.stg_settings().clone()
+        };
+
+        if let Some(ref b) = self.prelude_blob {
+            stg_settings.prelude_globals = Some(b.name_to_slot.clone());
+        }
+
+        if !stg_settings.suppress_demand_analysis {
+            let t = Instant::now();
+            let (annotated, _signatures, named_signatures) =
+                crate::core::analyse_demand::analyse_demands(&self.evaluand);
+            self.evaluand = annotated;
+            stg_settings.user_demand_sigs = named_signatures;
+            stats.timings_mut().record("demand-analysis", t.elapsed());
+        }
+
+        {
+            let t = Instant::now();
+            self.evaluand = crate::core::reflatten::reflatten(&self.evaluand);
+            stats.timings_mut().record("reflatten", t.elapsed());
+        }
+
+        let syn = {
+            let t = Instant::now();
+            let syn = stg::compile(&stg_settings, self.evaluand.clone(), rt.as_ref())?;
+            stats.timings_mut().record("stg-compile", t.elapsed());
+            syn
+        };
+
+        // ── Bytecode encoding ────────────────────────────────────────
+        let globals = rt.globals();
+        let t_encode = Instant::now();
+        let (mut bc_program, root_off, global_forms) =
+            crate::eval::bytecode::encode::encode(&syn, &globals);
+        let encode_time = t_encode.elapsed();
+        stats.timings_mut().record("bc-encode", encode_time);
+        // Bytecode encoding stats are available in the statistics output
+
+        // ── Machine setup ────────────────────────────────────────────
+        emitter.stream_start();
+        let mut machine = standard_machine(&stg_settings, syn, emitter, rt.as_ref())?;
+
+        // Pre-convert constant pool.
+        // Use unsafe raw heap view to avoid borrow conflict with
+        // symbol_pool_mut.
+        {
+            use crate::eval::memory::mutator::MutatorHeapView;
+            let view = unsafe { MutatorHeapView::from_raw_heap(machine.heap() as *const _) };
+            bc_program.prepare_constants(view, machine.symbol_pool_mut());
+        }
+
+        // Patch root and globals for bytecode dispatch
+        crate::eval::bytecode::interp::patch_machine_for_bytecode(
+            &mut machine,
+            &bc_program,
+            root_off,
+            &global_forms,
+        )?;
+
+        // ── Run ──────────────────────────────────────────────────────
+        let t_exec = Instant::now();
+        let ret = crate::eval::bytecode::interp::bytecode_run(&mut machine, &bc_program);
+        stats.timings_mut().record("bc-eval", t_exec.elapsed());
+
+        // ── Render ───────────────────────────────────────────────────
+        // Use bytecode_run for all subsequent phases because closures
+        // created during bytecode evaluation contain bytecode stubs.
+        // bytecode_step automatically falls through to HeapSyn dispatch
+        // for non-bytecode closures (intrinsic wrappers, RENDER_DOC).
+        use crate::driver::io_run::BuildRenderDoc;
+        use crate::eval::memory::infotable::InfoTable as _;
+        let result = if ret.is_ok() {
+            if machine.io_yielded() {
+                // IO yield — not supported in BV0 spike
+                machine.take_emitter().stream_end();
+                Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "BV0 spike: IO yield not supported".to_string(),
+                ))
+            } else if machine.current_closure().arity() > 0 {
+                // IO function — not supported in BV0 spike
+                machine.take_emitter().stream_end();
+                Err(ExecutionError::Panic(
+                    Smid::default(),
+                    "BV0 spike: IO function not supported".to_string(),
+                ))
+            } else {
+                // Plain document — render via RENDER_DOC using bytecode_run
+                let value = machine.current_closure();
+                let render_c = machine.mutate(
+                    BuildRenderDoc {
+                        value,
+                        root_env: machine.root_env(),
+                    },
+                    (),
+                )?;
+                machine.resume_for_render(render_c);
+
+                let t_render = Instant::now();
+                let render_ret =
+                    crate::eval::bytecode::interp::bytecode_run(&mut machine, &bc_program);
+                stats.timings_mut().record("bc-render", t_render.elapsed());
+                machine.take_emitter().stream_end();
+                render_ret
+            }
+        } else {
+            machine.take_emitter().stream_end();
+            ret.map(|_| None)
+        };
+
+        collect_machine_stats(&machine, stats);
+        result
     }
 
     /// Print any errors as diagnoses to stderr

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -1026,9 +1026,9 @@ impl Mutator for BuildIoReturn {
 
 // ─── Mutator: build RENDER_DOC call for the final value ──────────────────────
 
-struct BuildRenderDoc {
-    value: SynClosure,
-    root_env: RefPtr<EnvFrame>,
+pub struct BuildRenderDoc {
+    pub value: SynClosure,
+    pub root_env: RefPtr<EnvFrame>,
 }
 
 impl Mutator for BuildRenderDoc {

--- a/src/eval/bytecode/encode.rs
+++ b/src/eval/bytecode/encode.rs
@@ -1,0 +1,386 @@
+//! Encode `StgSyn` trees into a flat bytecode stream.
+//!
+//! Uses post-order encoding: children are emitted first, then the
+//! parent references them by absolute `u32` offset.  This means leaf
+//! nodes appear at the lowest offsets and the root is emitted last.
+
+use std::rc::Rc;
+
+use crate::{
+    common::sourcemap::Smid,
+    eval::stg::syntax::{LambdaForm, Native as StgNative, Ref, StgSyn},
+};
+
+use super::{opcode, program::BytecodeProgram};
+
+/// Encoder state: accumulates bytes and constants.
+struct Encoder {
+    code: Vec<u8>,
+    constants: Vec<StgNative>,
+}
+
+impl Encoder {
+    fn new() -> Self {
+        Encoder {
+            code: Vec::with_capacity(4096),
+            constants: Vec::new(),
+        }
+    }
+
+    // ── Emit primitives ─────────────────────────────────────────────
+
+    fn emit_u8(&mut self, v: u8) {
+        self.code.push(v);
+    }
+
+    fn emit_u16(&mut self, v: u16) {
+        self.code.extend_from_slice(&v.to_le_bytes());
+    }
+
+    fn emit_u32(&mut self, v: u32) {
+        self.code.extend_from_slice(&v.to_le_bytes());
+    }
+
+    /// Add a native constant to the pool and return its index.
+    fn add_constant(&mut self, n: &StgNative) -> u32 {
+        // Dedup is not critical for the spike
+        let idx = self.constants.len() as u32;
+        self.constants.push(n.clone());
+        idx
+    }
+
+    /// Emit an inline ref (tag byte + value).
+    fn emit_ref(&mut self, r: &Ref) {
+        match r {
+            Ref::L(i) => {
+                self.emit_u8(opcode::REF_L);
+                self.emit_u16(*i as u16);
+            }
+            Ref::G(i) => {
+                self.emit_u8(opcode::REF_G);
+                self.emit_u16(*i as u16);
+            }
+            Ref::V(n) => {
+                self.emit_u8(opcode::REF_V);
+                let ci = self.add_constant(n);
+                self.emit_u32(ci);
+            }
+        }
+    }
+
+    // ── Node encoding (post-order) ──────────────────────────────────
+
+    /// Encode a `StgSyn` node, returning its start offset in the code buffer.
+    ///
+    /// Children are encoded first (post-order), so offsets are known
+    /// before the parent is emitted.
+    fn encode_node(&mut self, node: &Rc<StgSyn>) -> u32 {
+        match &**node {
+            StgSyn::Atom { evaluand } => {
+                let offset = self.code.len() as u32;
+                match evaluand {
+                    Ref::L(i) => {
+                        self.emit_u8(opcode::ATOM_L);
+                        self.emit_u16(*i as u16);
+                    }
+                    Ref::G(i) => {
+                        self.emit_u8(opcode::ATOM_G);
+                        self.emit_u16(*i as u16);
+                    }
+                    Ref::V(n) => {
+                        self.emit_u8(opcode::ATOM_V);
+                        let ci = self.add_constant(n);
+                        self.emit_u32(ci);
+                    }
+                }
+                offset
+            }
+
+            StgSyn::Case {
+                scrutinee,
+                branches,
+                fallback,
+            } => {
+                // Encode children first
+                let scr_off = self.encode_node(scrutinee);
+                let branch_data: Vec<(u8, u32)> = branches
+                    .iter()
+                    .map(|(tag, body)| (*tag, self.encode_node(body)))
+                    .collect();
+                let fb_off = fallback.as_ref().map(|fb| self.encode_node(fb));
+
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::CASE);
+                self.emit_u32(scr_off);
+                self.emit_u8(branch_data.len() as u8);
+                for (tag, off) in &branch_data {
+                    self.emit_u8(*tag);
+                    self.emit_u32(*off);
+                }
+                match fb_off {
+                    Some(off) => {
+                        self.emit_u8(1);
+                        self.emit_u32(off);
+                    }
+                    None => {
+                        self.emit_u8(0);
+                    }
+                }
+                offset
+            }
+
+            StgSyn::Cons { tag, args } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::CONS);
+                self.emit_u8(*tag);
+                self.emit_u8(args.len() as u8);
+                for r in args {
+                    self.emit_ref(r);
+                }
+                offset
+            }
+
+            StgSyn::App { callable, args } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::APP);
+                self.emit_ref(callable);
+                self.emit_u8(args.len() as u8);
+                for r in args {
+                    self.emit_ref(r);
+                }
+                offset
+            }
+
+            StgSyn::DirectApp {
+                smid,
+                callable,
+                args,
+            } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::DIRECT_APP);
+                let smid_val: u32 = (*smid).into();
+                self.emit_u32(smid_val);
+                self.emit_ref(callable);
+                self.emit_u8(args.len() as u8);
+                for r in args {
+                    self.emit_ref(r);
+                }
+                offset
+            }
+
+            StgSyn::Bif { intrinsic, args } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::BIF);
+                self.emit_u8(*intrinsic);
+                self.emit_u8(args.len() as u8);
+                for r in args {
+                    self.emit_ref(r);
+                }
+                offset
+            }
+
+            StgSyn::Let { bindings, body } => {
+                // Encode binding bodies and the let body first
+                let form_data: Vec<(u8, u8, u32, u32)> = bindings
+                    .iter()
+                    .map(|lf| {
+                        let body_off = self.encode_node(lf.body());
+                        let (kind, arity, smid) = classify_lambda_form(lf);
+                        let smid_val: u32 = smid.into();
+                        (kind, arity, smid_val, body_off)
+                    })
+                    .collect();
+                let body_off = self.encode_node(body);
+
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::LET);
+                self.emit_u16(form_data.len() as u16);
+                for (kind, arity, smid, boff) in &form_data {
+                    self.emit_u8(*kind);
+                    self.emit_u8(*arity);
+                    self.emit_u32(*smid);
+                    self.emit_u32(*boff);
+                }
+                self.emit_u32(body_off);
+                offset
+            }
+
+            StgSyn::LetRec { bindings, body } => {
+                let form_data: Vec<(u8, u8, u32, u32)> = bindings
+                    .iter()
+                    .map(|lf| {
+                        let body_off = self.encode_node(lf.body());
+                        let (kind, arity, smid) = classify_lambda_form(lf);
+                        let smid_val: u32 = smid.into();
+                        (kind, arity, smid_val, body_off)
+                    })
+                    .collect();
+                let body_off = self.encode_node(body);
+
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::LETREC);
+                self.emit_u16(form_data.len() as u16);
+                for (kind, arity, smid, boff) in &form_data {
+                    self.emit_u8(*kind);
+                    self.emit_u8(*arity);
+                    self.emit_u32(*smid);
+                    self.emit_u32(*boff);
+                }
+                self.emit_u32(body_off);
+                offset
+            }
+
+            StgSyn::Ann { smid, body } => {
+                let body_off = self.encode_node(body);
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::ANN);
+                let smid_val: u32 = (*smid).into();
+                self.emit_u32(smid_val);
+                self.emit_u32(body_off);
+                offset
+            }
+
+            StgSyn::Meta { meta, body } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::META);
+                self.emit_ref(meta);
+                self.emit_ref(body);
+                offset
+            }
+
+            StgSyn::DeMeta {
+                scrutinee,
+                handler,
+                or_else,
+            } => {
+                let scr_off = self.encode_node(scrutinee);
+                let handler_off = self.encode_node(handler);
+                let or_else_off = self.encode_node(or_else);
+
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::DEMETA);
+                self.emit_u32(scr_off);
+                self.emit_u32(handler_off);
+                self.emit_u32(or_else_off);
+                offset
+            }
+
+            StgSyn::Seq { scrutinee, body } => {
+                let scr_off = self.encode_node(scrutinee);
+                let body_off = self.encode_node(body);
+
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::SEQ);
+                self.emit_u32(scr_off);
+                self.emit_u32(body_off);
+                offset
+            }
+
+            StgSyn::LookupLit {
+                smid,
+                key,
+                obj,
+                default,
+            } => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::LOOKUP_LIT);
+                let smid_val: u32 = (*smid).into();
+                self.emit_u32(smid_val);
+                self.emit_ref(key);
+                self.emit_ref(obj);
+                self.emit_ref(default);
+                offset
+            }
+
+            StgSyn::BlackHole => {
+                let offset = self.code.len() as u32;
+                self.emit_u8(opcode::BLACKHOLE);
+                offset
+            }
+        }
+    }
+
+    fn into_program(self) -> BytecodeProgram {
+        BytecodeProgram {
+            code: self.code,
+            constants: self.constants,
+            heap_refs: Vec::new(), // populated later by prepare_constants()
+        }
+    }
+}
+
+/// Classify a `LambdaForm` for encoding.
+///
+/// Returns `(kind, arity, annotation)`.
+fn classify_lambda_form(lf: &LambdaForm) -> (u8, u8, Smid) {
+    if lf.update() {
+        (opcode::FORM_THUNK, 0, lf.annotation())
+    } else if lf.arity() == 0 {
+        (opcode::FORM_VALUE, 0, lf.annotation())
+    } else {
+        (opcode::FORM_LAMBDA, lf.arity(), lf.annotation())
+    }
+}
+
+/// Encoded global form: `(kind, arity, annotation, body_offset)`.
+pub type GlobalForm = (u8, u8, Smid, u32);
+
+/// Encode a user program's `StgSyn` root and its global lambda forms
+/// into a single `BytecodeProgram`.
+///
+/// Returns `(program, root_offset, global_offsets)` where
+/// `global_offsets[i]` is the bytecode offset for global `i`.
+/// Globals that are intrinsic wrappers (containing BIF nodes) are
+/// encoded normally — the interpreter handles BIF opcodes by setting
+/// `pending_bif`.
+pub fn encode(
+    root: &Rc<StgSyn>,
+    globals: &[LambdaForm],
+) -> (BytecodeProgram, u32, Vec<GlobalForm>) {
+    let mut enc = Encoder::new();
+
+    // Encode global lambda form bodies
+    let global_forms: Vec<GlobalForm> = globals
+        .iter()
+        .map(|lf| {
+            let body_off = enc.encode_node(lf.body());
+            let (kind, arity, smid) = classify_lambda_form(lf);
+            (kind, arity, smid, body_off)
+        })
+        .collect();
+
+    // Encode the root program
+    let root_off = enc.encode_node(root);
+
+    (enc.into_program(), root_off, global_forms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::stg::syntax::dsl;
+
+    #[test]
+    fn encode_atom_local() {
+        let syn = dsl::local(3);
+        let mut enc = Encoder::new();
+        let off = enc.encode_node(&syn);
+        assert_eq!(off, 0);
+        let prog = enc.into_program();
+        assert_eq!(prog.code[0], opcode::ATOM_L);
+        // u16 LE = 3
+        assert_eq!(prog.code[1], 3);
+        assert_eq!(prog.code[2], 0);
+    }
+
+    #[test]
+    fn encode_atom_global() {
+        let syn = dsl::global(42);
+        let mut enc = Encoder::new();
+        let off = enc.encode_node(&syn);
+        assert_eq!(off, 0);
+        let prog = enc.into_program();
+        assert_eq!(prog.code[0], opcode::ATOM_G);
+        assert_eq!(u16::from_le_bytes([prog.code[1], prog.code[2]]), 42);
+    }
+}

--- a/src/eval/bytecode/interp.rs
+++ b/src/eval/bytecode/interp.rs
@@ -1,0 +1,791 @@
+//! Bytecode interpreter: flat opcode dispatch replacing HeapSyn tree-walk.
+//!
+//! The interpreter reuses the existing continuation stack, environment
+//! frames, heap, and intrinsic machinery.  Only the dispatch path
+//! changes: instead of dereferencing a `RefPtr<HeapSyn>` and matching
+//! on an enum variant, we read a `u8` opcode from a contiguous
+//! `Vec<u8>` buffer and match on that.
+//!
+//! Closures that point to bytecode use `HeapSyn::Atom { V(Num(offset)) }`
+//! as their code pointer.  When the interpreter enters such a closure,
+//! it dispatches the opcode at `offset`.  Non-bytecode closures (e.g.
+//! those created by the runtime or by intrinsics that return HeapSyn
+//! closures) fall through to the existing HeapSyn dispatch.
+
+use serde_json::Number;
+
+use crate::{
+    common::sourcemap::Smid,
+    eval::{
+        emit::Emitter,
+        error::ExecutionError,
+        machine::{
+            cont::Continuation,
+            env::SynClosure,
+            env_builder::EnvBuilder,
+            intrinsic::StgIntrinsic,
+            metrics::{Metrics, ThreadOccupation},
+            vm::{interrupted, HeapNavigator, Machine, MachineBifContext, MachineState},
+        },
+        memory::{
+            alloc::ScopedAllocator,
+            array::Array,
+            infotable::{InfoTable, InfoTagged},
+            mutator::MutatorHeapView,
+            syntax::{HeapSyn, LambdaForm, Native, Ref, RefPtr, StgBuilder},
+        },
+        stg::tags::DataConstructor,
+    },
+};
+
+use super::{
+    opcode,
+    program::{read_u16, read_u32, read_u8, BytecodeProgram},
+};
+
+/// Bytecode stub sentinel base.  We use a large negative value
+/// (below i32::MIN) that cannot plausibly be a user-program number.
+/// Encoding: `sentinel = SENTINEL_BASE - offset`.
+/// Decoding: `offset = SENTINEL_BASE - sentinel`.
+const BYTECODE_SENTINEL_BASE: i64 = -0x4000_0000_0000;
+
+/// Detect a bytecode stub: `HeapSyn::Atom { V(Num(n)) }` where `n`
+/// is a very large negative integer (below the sentinel base).
+fn bytecode_offset(code: &HeapSyn) -> Option<usize> {
+    if let HeapSyn::Atom {
+        evaluand: Ref::V(Native::Num(n)),
+    } = code
+    {
+        n.as_i64().and_then(|i| {
+            if i <= BYTECODE_SENTINEL_BASE {
+                Some((BYTECODE_SENTINEL_BASE - i) as usize)
+            } else {
+                None
+            }
+        })
+    } else {
+        None
+    }
+}
+
+/// Allocate a `HeapSyn::Atom { V(Num(offset)) }` stub on the heap.
+///
+/// These tiny heap objects serve as code pointers for bytecode closures.
+/// They are never GC-scanned as code (the GC treats them as normal Atom
+/// nodes) and are never entered directly — the interpreter intercepts
+/// them before normal HeapSyn dispatch.
+fn alloc_bytecode_stub(
+    view: MutatorHeapView<'_>,
+    offset: u32,
+) -> Result<RefPtr<HeapSyn>, ExecutionError> {
+    let sentinel = BYTECODE_SENTINEL_BASE - (offset as i64);
+    let n = Number::from(sentinel);
+    Ok(view
+        .alloc(HeapSyn::Atom {
+            evaluand: Ref::V(Native::Num(n)),
+        })?
+        .as_ptr())
+}
+
+/// Read an inline ref from the bytecode stream.
+///
+/// Uses the pre-converted `heap_refs` for constant pool lookups.
+fn read_ref(code: &[u8], pc: &mut usize, program: &BytecodeProgram) -> Ref {
+    let tag = read_u8(code, pc);
+    match tag {
+        opcode::REF_L => Ref::L(read_u16(code, pc) as usize),
+        opcode::REF_G => Ref::G(read_u16(code, pc) as usize),
+        opcode::REF_V => {
+            let ci = read_u32(code, pc) as usize;
+            program.heap_refs[ci].clone()
+        }
+        _ => unreachable!("bad ref tag: {tag:#x}"),
+    }
+}
+
+/// Dispatch one bytecode instruction.
+///
+/// Called when the current closure's code is a bytecode stub.
+/// Reads the opcode at `pc` and executes it, modifying `state`
+/// (closure, stack, annotation, etc.) just as `handle_instruction`
+/// would.
+///
+/// # Safety
+///
+/// The caller must ensure that `pc` is a valid offset into
+/// `program.code`.
+fn dispatch(
+    state: &mut MachineState,
+    program: &BytecodeProgram,
+    pc: usize,
+    view: MutatorHeapView<'_>,
+    metrics: &mut Metrics,
+    _intrinsics: &[&dyn StgIntrinsic],
+) -> Result<(), ExecutionError> {
+    let code = &program.code;
+    let environment = state.closure.env();
+    let remaining_arity = state.closure.arity();
+
+    // Set annotation from the closure (same as HeapSyn path)
+    let closure_ann = state.closure.annotation();
+    if closure_ann.is_valid() {
+        state.annotation = closure_ann;
+    }
+
+    if remaining_arity > 0 {
+        return state.return_fun(view);
+    }
+
+    let mut pc = pc;
+    let op = read_u8(code, &mut pc);
+
+    match op {
+        opcode::ATOM_L => {
+            let i = read_u16(code, &mut pc) as usize;
+            let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+            state.closure = nav.get(i)?;
+            let is_thunk = state.closure.update();
+            if is_thunk {
+                let hole = view.alloc(HeapSyn::BlackHole)?;
+                let black_hole = SynClosure::new(hole.as_ptr(), environment);
+                let cont_env = view.scoped(environment);
+                cont_env.update(&view, i, black_hole)?;
+                state.push(
+                    view,
+                    Continuation::Update {
+                        environment,
+                        index: i,
+                    },
+                )?;
+            }
+        }
+
+        opcode::ATOM_G => {
+            let i = read_u16(code, &mut pc) as usize;
+            let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+            state.closure = nav.global(i)?;
+        }
+
+        opcode::ATOM_V => {
+            let ci = read_u32(code, &mut pc) as usize;
+            let heap_ref = &program.heap_refs[ci];
+            if let Ref::V(v) = heap_ref {
+                // Allocate a proper HeapSyn::Atom with the actual value
+                // so the closure code pointer holds the real value
+                // (not the bytecode stub offset).
+                let atom = view.alloc(HeapSyn::Atom {
+                    evaluand: heap_ref.clone(),
+                })?;
+                state.closure = SynClosure::new(atom.as_ptr(), environment);
+                state.return_native(view, v)?;
+            }
+        }
+
+        opcode::APP => {
+            let callable = read_ref(code, &mut pc, program);
+            let nargs = read_u8(code, &mut pc) as usize;
+            let mut refs = Vec::with_capacity(nargs);
+            for _ in 0..nargs {
+                refs.push(read_ref(code, &mut pc, program));
+            }
+            let array = view.create_arg_array(&refs, environment)?;
+            state.push(
+                view,
+                Continuation::ApplyTo {
+                    args: array,
+                    annotation: state.annotation,
+                },
+            )?;
+            // Handle thunk blackholing for local callable refs
+            if let Ref::L(i) = &callable {
+                let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+                let callee = nav.get(*i)?;
+                let is_thunk = callee.update();
+                if is_thunk {
+                    let hole = view.alloc(HeapSyn::BlackHole)?;
+                    let black_hole = SynClosure::new(hole.as_ptr(), environment);
+                    let cont_env = view.scoped(environment);
+                    cont_env.update(&view, *i, black_hole)?;
+                    state.push(
+                        view,
+                        Continuation::Update {
+                            environment,
+                            index: *i,
+                        },
+                    )?;
+                    state.closure = callee;
+                } else {
+                    let nav2 =
+                        HeapNavigator::new(view, environment, state.globals, state.annotation);
+                    state.closure = nav2.resolve_callable(&callable)?;
+                }
+            } else {
+                let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+                state.closure = nav.resolve_callable(&callable)?;
+            }
+        }
+
+        opcode::DIRECT_APP => {
+            let smid_val = read_u32(code, &mut pc);
+            let smid = Smid::from(smid_val);
+            state.annotation = smid;
+            let callable = read_ref(code, &mut pc, program);
+            let nargs = read_u8(code, &mut pc) as usize;
+            let mut refs = Vec::with_capacity(nargs);
+            for _ in 0..nargs {
+                refs.push(read_ref(code, &mut pc, program));
+            }
+            let array = view.create_arg_array(&refs, environment)?;
+            let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+            let closure = nav.resolve_callable(&callable)?;
+            if closure.arity() as usize == array.len() {
+                state.closure = view.saturate_with_array(&closure, array)?;
+            } else {
+                state.push(
+                    view,
+                    Continuation::ApplyTo {
+                        args: array,
+                        annotation: state.annotation,
+                    },
+                )?;
+                state.closure = closure;
+            }
+        }
+
+        opcode::BIF => {
+            let intrinsic_idx = read_u8(code, &mut pc);
+            let nargs = read_u8(code, &mut pc) as usize;
+            let mut refs = Vec::with_capacity(nargs);
+            for _ in 0..nargs {
+                refs.push(read_ref(code, &mut pc, program));
+            }
+            // Allocate a HeapSyn::Bif node on the heap so that
+            // Machine::step()'s pending_bif handler can read args from it.
+            let args_array = {
+                let mut a = Array::with_capacity(&view, nargs);
+                for r in &refs {
+                    a.push(&view, r.clone());
+                }
+                a
+            };
+            let bif_node = view.alloc(HeapSyn::Bif {
+                intrinsic: intrinsic_idx,
+                args: args_array,
+            })?;
+            // Reconstruct the closure with the BIF code pointer so that
+            // Machine::step()'s pending_bif handler can read the args
+            // from it.
+            state.closure = SynClosure::new(bif_node.as_ptr(), environment);
+            state.pending_bif = Some(intrinsic_idx);
+        }
+
+        opcode::CASE => {
+            let scr_off = read_u32(code, &mut pc);
+            let nbranches = read_u8(code, &mut pc) as usize;
+
+            // Build the branch table
+            let mut branches: Vec<(u8, u32)> = Vec::with_capacity(nbranches);
+            for _ in 0..nbranches {
+                let tag = read_u8(code, &mut pc);
+                let off = read_u32(code, &mut pc);
+                branches.push((tag, off));
+            }
+            let has_fallback = read_u8(code, &mut pc) != 0;
+            let fb_off = if has_fallback {
+                Some(read_u32(code, &mut pc))
+            } else {
+                None
+            };
+
+            // Build indexed branch table (as HeapSyn uses) with bytecode stubs
+            let min_tag = branches.iter().map(|(t, _)| *t).min().unwrap_or(0);
+            let max_tag = branches.iter().map(|(t, _)| *t).max().unwrap_or(0);
+            let table_size = if branches.is_empty() {
+                0
+            } else {
+                (max_tag - min_tag + 1) as usize
+            };
+
+            let mut branch_table: Array<Option<RefPtr<HeapSyn>>> =
+                Array::with_capacity(&view, table_size);
+            for _ in 0..table_size {
+                branch_table.push(&view, None);
+            }
+            for (tag, off) in &branches {
+                let stub = alloc_bytecode_stub(view, *off)?;
+                let index = (*tag - min_tag) as usize;
+                // SAFETY: index within range by construction
+                unsafe { branch_table.set_unchecked(index, Some(stub)) };
+            }
+
+            let fallback = match fb_off {
+                Some(off) => Some(alloc_bytecode_stub(view, off)?),
+                None => None,
+            };
+
+            state.push(
+                view,
+                Continuation::Branch {
+                    min_tag,
+                    branch_table,
+                    fallback,
+                    environment,
+                    annotation: state.annotation,
+                },
+            )?;
+
+            // Enter the scrutinee
+            let scr_stub = alloc_bytecode_stub(view, scr_off)?;
+            state.closure = SynClosure::new(scr_stub, environment);
+        }
+
+        opcode::CONS => {
+            let tag = read_u8(code, &mut pc);
+            let nargs = read_u8(code, &mut pc) as usize;
+            let mut refs = Vec::with_capacity(nargs);
+            for _ in 0..nargs {
+                refs.push(read_ref(code, &mut pc, program));
+            }
+            // Allocate a proper HeapSyn::Cons so the closure code
+            // reflects the actual data constructor (not the bytecode
+            // stub).  This is needed because return_data does not
+            // update the closure code when terminating.
+            let args_arr = Array::from_slice(&view, &refs);
+            let cons_node = view.alloc(HeapSyn::Cons {
+                tag,
+                args: args_arr,
+            })?;
+            state.closure = SynClosure::new(cons_node.as_ptr(), environment);
+            state.return_data(view, tag, &refs)?;
+        }
+
+        opcode::LET => {
+            let nbindings = read_u16(code, &mut pc) as usize;
+            metrics.alloc(nbindings);
+            let mut lambda_forms: Vec<LambdaForm> = Vec::with_capacity(nbindings);
+            for _ in 0..nbindings {
+                let kind = read_u8(code, &mut pc);
+                let arity = read_u8(code, &mut pc);
+                let smid_val = read_u32(code, &mut pc);
+                let body_off = read_u32(code, &mut pc);
+                let stub = alloc_bytecode_stub(view, body_off)?;
+                let smid = Smid::from(smid_val);
+                let lf = match kind {
+                    opcode::FORM_LAMBDA => InfoTagged::new(arity, stub, smid),
+                    opcode::FORM_THUNK => InfoTagged::thunk(stub),
+                    opcode::FORM_VALUE => InfoTagged::value(stub),
+                    _ => unreachable!("bad lambda form kind: {kind}"),
+                };
+                lambda_forms.push(lf);
+            }
+            let body_off = read_u32(code, &mut pc);
+
+            // Create env frame using existing from_let machinery
+            let binding_slice: Vec<LambdaForm> = lambda_forms;
+            let new_env = view.from_let(&binding_slice, environment, state.annotation)?;
+            let body_stub = alloc_bytecode_stub(view, body_off)?;
+            state.closure = SynClosure::new(body_stub, new_env);
+        }
+
+        opcode::LETREC => {
+            let nbindings = read_u16(code, &mut pc) as usize;
+            metrics.alloc(nbindings);
+            let mut lambda_forms: Vec<LambdaForm> = Vec::with_capacity(nbindings);
+            for _ in 0..nbindings {
+                let kind = read_u8(code, &mut pc);
+                let arity = read_u8(code, &mut pc);
+                let smid_val = read_u32(code, &mut pc);
+                let body_off = read_u32(code, &mut pc);
+                let stub = alloc_bytecode_stub(view, body_off)?;
+                let smid = Smid::from(smid_val);
+                let lf = match kind {
+                    opcode::FORM_LAMBDA => InfoTagged::new(arity, stub, smid),
+                    opcode::FORM_THUNK => InfoTagged::thunk(stub),
+                    opcode::FORM_VALUE => InfoTagged::value(stub),
+                    _ => unreachable!("bad lambda form kind: {kind}"),
+                };
+                lambda_forms.push(lf);
+            }
+            let body_off = read_u32(code, &mut pc);
+
+            let binding_slice: Vec<LambdaForm> = lambda_forms;
+            let new_env = view.from_letrec(&binding_slice, environment, state.annotation)?;
+            let body_stub = alloc_bytecode_stub(view, body_off)?;
+            state.closure = SynClosure::new(body_stub, new_env);
+        }
+
+        opcode::ANN => {
+            let smid_val = read_u32(code, &mut pc);
+            let body_off = read_u32(code, &mut pc);
+            state.annotation = Smid::from(smid_val);
+            let body_stub = alloc_bytecode_stub(view, body_off)?;
+            state.closure = SynClosure::new(body_stub, environment);
+        }
+
+        opcode::META => {
+            let meta = read_ref(code, &mut pc, program);
+            let body = read_ref(code, &mut pc, program);
+            state.return_meta(view, &meta, &body)?;
+        }
+
+        opcode::DEMETA => {
+            let scr_off = read_u32(code, &mut pc);
+            let handler_off = read_u32(code, &mut pc);
+            let or_else_off = read_u32(code, &mut pc);
+
+            let handler_stub = alloc_bytecode_stub(view, handler_off)?;
+            let or_else_stub = alloc_bytecode_stub(view, or_else_off)?;
+
+            state.push(
+                view,
+                Continuation::DeMeta {
+                    handler: handler_stub,
+                    or_else: or_else_stub,
+                    environment,
+                },
+            )?;
+            let scr_stub = alloc_bytecode_stub(view, scr_off)?;
+            state.closure = SynClosure::new(scr_stub, environment);
+        }
+
+        opcode::SEQ => {
+            let scr_off = read_u32(code, &mut pc);
+            let body_off = read_u32(code, &mut pc);
+
+            let body_stub = alloc_bytecode_stub(view, body_off)?;
+            state.push(
+                view,
+                Continuation::SeqBind {
+                    body: body_stub,
+                    environment,
+                    annotation: state.annotation,
+                },
+            )?;
+            let scr_stub = alloc_bytecode_stub(view, scr_off)?;
+            state.closure = SynClosure::new(scr_stub, environment);
+        }
+
+        opcode::LOOKUP_LIT => {
+            let smid_val = read_u32(code, &mut pc);
+            let smid = Smid::from(smid_val);
+            state.annotation = smid;
+            let key = read_ref(code, &mut pc, program);
+            let obj = read_ref(code, &mut pc, program);
+            let default = read_ref(code, &mut pc, program);
+
+            // Resolve the key to a SymbolId
+            let sym_id = match &key {
+                Ref::V(Native::Sym(id)) => *id,
+                _ => {
+                    return Err(ExecutionError::NotValue(
+                        state.annotation,
+                        "non-symbol key in LookupLit".to_string(),
+                    ))
+                }
+            };
+
+            // Resolve obj to a closure
+            let nav = HeapNavigator::new(view, environment, state.globals, state.annotation);
+            let obj_closure = match &obj {
+                Ref::L(i) => nav.get(*i)?,
+                Ref::G(i) => nav.global(*i)?,
+                Ref::V(_) => {
+                    return Err(ExecutionError::NotCallable(
+                        state.annotation,
+                        "native value".to_string(),
+                    ))
+                }
+            };
+
+            // Fast path: obj already a Block
+            let is_block = {
+                let obj_code = view.scoped(obj_closure.code());
+                matches!(&*obj_code, HeapSyn::Cons { tag, .. } if *tag == DataConstructor::Block.tag())
+            };
+            if is_block {
+                if let Some(value) =
+                    crate::eval::stg::block::lookup_lit_in_block(&nav, view, &obj_closure, sym_id)
+                {
+                    state.closure = value;
+                } else {
+                    state.closure = match &default {
+                        Ref::L(i) => nav.get(*i)?,
+                        Ref::G(i) => nav.global(*i)?,
+                        Ref::V(_) => {
+                            let atom = view.atom(default)?;
+                            SynClosure::new(atom.as_ptr(), environment)
+                        }
+                    };
+                }
+                return Ok(());
+            }
+
+            // Slow path: force the obj
+            let default_closure = match &default {
+                Ref::L(i) => nav.get(*i)?,
+                Ref::G(i) => nav.global(*i)?,
+                Ref::V(_) => {
+                    let atom = view.atom(default)?;
+                    SynClosure::new(atom.as_ptr(), environment)
+                }
+            };
+
+            state.push(
+                view,
+                Continuation::LookupLitForce {
+                    key: sym_id,
+                    smid,
+                    default_closure,
+                },
+            )?;
+
+            if let Ref::L(i) = &obj {
+                if obj_closure.update() {
+                    let hole = view.alloc(HeapSyn::BlackHole)?;
+                    let black_hole = SynClosure::new(hole.as_ptr(), environment);
+                    let cont_env = view.scoped(environment);
+                    cont_env.update(&view, *i, black_hole)?;
+                    state.push(
+                        view,
+                        Continuation::Update {
+                            environment,
+                            index: *i,
+                        },
+                    )?;
+                }
+            }
+
+            state.closure = obj_closure;
+        }
+
+        opcode::BLACKHOLE => {
+            return Err(ExecutionError::BlackHole(state.annotation));
+        }
+
+        _ => {
+            panic!("unimplemented bytecode opcode: {op:#x} at pc={}", pc - 1);
+        }
+    }
+
+    Ok(())
+}
+
+/// Patch the machine's root closure to use a bytecode stub.
+///
+/// `root_off` is the bytecode offset for the root program.
+///
+/// Globals are NOT patched — they stay as HeapSyn closures.  When
+/// bytecode dispatch encounters a global reference (ATOM_G), it
+/// retrieves the HeapSyn closure and the hybrid dispatcher falls
+/// through to HeapSyn dispatch.  This keeps intrinsic wrappers
+/// (RENDER_DOC, MERGE, LOOKUP, etc.) working correctly.
+///
+/// Must be called after `standard_machine()` and `prepare_constants()`.
+pub fn patch_machine_for_bytecode(
+    machine: &mut Machine<'_>,
+    _program: &BytecodeProgram,
+    root_off: u32,
+    _global_forms: &[super::encode::GlobalForm],
+) -> Result<(), ExecutionError> {
+    let view = MutatorHeapView::new(&machine.core.heap);
+
+    // Patch root closure only
+    let root_stub = alloc_bytecode_stub(view, root_off)?;
+    machine.state.closure = SynClosure::new(root_stub, machine.state.closure.env());
+
+    Ok(())
+}
+
+/// Run the machine using bytecode dispatch until termination.
+///
+/// This mirrors `Machine::run()` but checks each tick whether the
+/// current closure is a bytecode stub.  If so, dispatches via the
+/// bytecode interpreter; otherwise, falls through to the existing
+/// `handle_instruction` path.
+pub fn bytecode_run(
+    machine: &mut Machine<'_>,
+    program: &BytecodeProgram,
+) -> Result<Option<u8>, ExecutionError> {
+    // Register crash diagnostics
+    crate::eval::machine::crash::register_crash_diagnostics(&machine.core.crash_diagnostics);
+
+    machine.core.clock.switch(ThreadOccupation::Mutator);
+
+    let gc_check_freq: u32 = 500;
+    let mut gc_countdown: u32 = gc_check_freq;
+
+    while !machine.state.terminated {
+        gc_countdown -= 1;
+        if gc_countdown == 0 {
+            gc_countdown = gc_check_freq;
+
+            if interrupted() {
+                return Err(ExecutionError::Interrupted);
+            }
+
+            if machine.core.heap.policy_requires_collection() {
+                machine.collect_with_diagnostics();
+                machine.core.clock.switch(ThreadOccupation::Mutator);
+            }
+        }
+
+        bytecode_step(machine, program)?;
+    }
+
+    if machine.core.heap.policy_requires_collection() {
+        machine.collect_with_diagnostics();
+    }
+    machine.core.clock.stop();
+
+    Ok(machine.exit_code())
+}
+
+/// Execute one step using bytecode dispatch where possible.
+fn bytecode_step(
+    machine: &mut Machine<'_>,
+    program: &BytecodeProgram,
+) -> Result<(), ExecutionError> {
+    machine.core.metrics.tick();
+
+    let view = MutatorHeapView::new(&machine.core.heap);
+
+    // Check if current closure points to bytecode
+    let code: &HeapSyn = unsafe { &*machine.state.closure.code().as_ptr() };
+    if let Some(pc) = bytecode_offset(code) {
+        dispatch(
+            &mut machine.state,
+            program,
+            pc,
+            view,
+            &mut machine.core.metrics,
+            &machine.core.intrinsics,
+        )
+        .map_err(|e| {
+            let nav_view = MutatorHeapView::new(&machine.core.heap);
+            let nav = HeapNavigator::new(
+                nav_view,
+                machine.state.closure.env(),
+                machine.state.globals,
+                machine.state.annotation,
+            );
+            ExecutionError::Traced(
+                Box::new(e),
+                nav.env_trace(),
+                machine
+                    .state
+                    .stack_trace(&MutatorHeapView::new(&machine.core.heap)),
+            )
+        })?;
+    } else {
+        // HeapSyn dispatch (for intrinsic wrappers, data constructors, etc.)
+        let emitter: &mut dyn Emitter = if let Some(top) = machine.capture_emitters.last_mut() {
+            top as &mut dyn Emitter
+        } else {
+            machine.emitter.as_mut()
+        };
+        machine
+            .state
+            .handle_instruction(
+                view,
+                emitter,
+                &machine.core.intrinsics,
+                &mut machine.core.metrics,
+            )
+            .map_err(|e| {
+                let nav_view = MutatorHeapView::new(&machine.core.heap);
+                ExecutionError::Traced(
+                    Box::new(e),
+                    HeapNavigator::new(
+                        nav_view,
+                        machine.state.closure.env(),
+                        machine.state.globals,
+                        machine.state.annotation,
+                    )
+                    .env_trace(),
+                    machine
+                        .state
+                        .stack_trace(&MutatorHeapView::new(&machine.core.heap)),
+                )
+            })?;
+    }
+
+    // Handle pending BIF (same as Machine::step())
+    if let Some(intrinsic_idx) = machine.state.pending_bif.take() {
+        let bif = machine.core.intrinsics[intrinsic_idx as usize];
+        // Build view from raw ptr so that &mut core remains available for ctx.
+        let bif_view = unsafe { MutatorHeapView::from_raw_heap(&machine.core.heap as *const _) };
+        // Re-derive args from the closure (same as Machine::step()).
+        let args: &[Ref] = match unsafe { &*machine.state.closure.code().as_ptr() } {
+            HeapSyn::Bif { args, .. } => args.as_slice(),
+            _ => &[],
+        };
+        let bif_emitter: &mut dyn Emitter = if let Some(top) = machine.capture_emitters.last_mut() {
+            top as &mut dyn Emitter
+        } else {
+            machine.emitter.as_mut()
+        };
+        let mut ctx = MachineBifContext {
+            state: &mut machine.state,
+            core: &mut machine.core,
+        };
+        let bif_result = bif.execute(&mut ctx, bif_view, bif_emitter, args);
+        if bif_result.is_err() {
+            let ann_view = unsafe { MutatorHeapView::from_raw_heap(&ctx.core.heap as *const _) };
+            if let Ok(global_closure) = HeapNavigator::new(
+                ann_view,
+                ctx.state.closure.env(),
+                ctx.state.globals,
+                ctx.state.annotation,
+            )
+            .global(intrinsic_idx as usize)
+            {
+                let ann = global_closure.annotation();
+                if ann.is_valid() {
+                    ctx.state.annotation = ann;
+                }
+            }
+        }
+        // ctx borrows end here.
+        bif_result.map_err(|e| {
+            let view = MutatorHeapView::new(&machine.core.heap);
+            ExecutionError::Traced(
+                Box::new(e),
+                HeapNavigator::new(
+                    view,
+                    machine.state.closure.env(),
+                    machine.state.globals,
+                    machine.state.annotation,
+                )
+                .env_trace(),
+                machine
+                    .state
+                    .stack_trace(&MutatorHeapView::new(&machine.core.heap)),
+            )
+        })?;
+    }
+
+    // Handle capture lifecycle
+    if let Some(format) = machine.state.pending_capture_start.take() {
+        let mut capture = crate::eval::stg::render_to_string::OwnedCaptureEmitter::new(
+            &format,
+            machine.state.annotation,
+        )?;
+        capture.stream_start();
+        machine.capture_emitters.push(capture);
+    }
+
+    if machine.state.capture_end_pending {
+        machine.state.capture_end_pending = false;
+        let mut capture = machine.capture_emitters.pop().ok_or_else(|| {
+            ExecutionError::Panic(Smid::default(), "no active capture emitter".to_string())
+        })?;
+        capture.stream_end();
+        let result_str = capture.into_string(machine.state.annotation)?;
+        let view = MutatorHeapView::new(&machine.core.heap);
+        let str_ref = view.str_ref(result_str)?;
+        let atom = view.alloc(HeapSyn::Atom { evaluand: str_ref })?.as_ptr();
+        machine.state.closure = SynClosure::new(atom, machine.state.root_env);
+    }
+
+    Ok(())
+}

--- a/src/eval/bytecode/mod.rs
+++ b/src/eval/bytecode/mod.rs
@@ -1,0 +1,16 @@
+//! Bytecode encoding and dispatch spike (BV0).
+//!
+//! This module implements a flat bytecode interpreter alongside the
+//! existing `HeapSyn` tree-walk VM.  It encodes `StgSyn` into a
+//! contiguous `Vec<u8>` opcode stream and dispatches via `match` on
+//! `u8` opcodes — testing whether cache-friendly flat dispatch is
+//! significantly faster than pointer-chasing through heap-allocated
+//! `HeapSyn` nodes.
+//!
+//! All code in this module is experimental and does not modify the
+//! production `HeapSyn` VM.
+
+pub mod encode;
+pub mod interp;
+pub mod opcode;
+pub mod program;

--- a/src/eval/bytecode/opcode.rs
+++ b/src/eval/bytecode/opcode.rs
@@ -1,0 +1,35 @@
+//! Bytecode opcode definitions.
+//!
+//! Each opcode is a `u8` constant matching one `HeapSyn` variant.
+//! Refs are encoded inline with a tag byte + value.
+
+// ── Opcodes ─────────────────────────────────────────────────────────
+
+pub const ATOM_L: u8 = 0x01;
+pub const ATOM_G: u8 = 0x02;
+pub const ATOM_V: u8 = 0x03;
+pub const APP: u8 = 0x04;
+pub const DIRECT_APP: u8 = 0x05;
+pub const BIF: u8 = 0x06;
+pub const CASE: u8 = 0x07;
+pub const CONS: u8 = 0x08;
+pub const LET: u8 = 0x09;
+pub const LETREC: u8 = 0x0A;
+pub const ANN: u8 = 0x0B;
+pub const META: u8 = 0x0C;
+pub const DEMETA: u8 = 0x0D;
+pub const SEQ: u8 = 0x0E;
+pub const LOOKUP_LIT: u8 = 0x0F;
+pub const BLACKHOLE: u8 = 0x10;
+
+// ── Inline ref tag bytes ────────────────────────────────────────────
+
+pub const REF_L: u8 = 0x00;
+pub const REF_G: u8 = 0x01;
+pub const REF_V: u8 = 0x02;
+
+// ── Lambda form kind bytes ──────────────────────────────────────────
+
+pub const FORM_LAMBDA: u8 = 0x00;
+pub const FORM_THUNK: u8 = 0x01;
+pub const FORM_VALUE: u8 = 0x02;

--- a/src/eval/bytecode/program.rs
+++ b/src/eval/bytecode/program.rs
@@ -1,0 +1,86 @@
+//! Bytecode program structure: flat opcode buffer + constant pool.
+
+use crate::eval::{
+    memory::{
+        alloc::ScopedAllocator,
+        mutator::MutatorHeapView,
+        string::HeapString,
+        symbol::SymbolPool,
+        syntax::{Native, Ref},
+    },
+    stg::syntax::Native as StgNative,
+};
+
+/// A compiled bytecode program.
+///
+/// Code is a flat `Vec<u8>` of opcodes and inline operands.
+/// Constants holds native values referenced by `ATOM_V` operands.
+/// The `heap_refs` field is populated after machine initialisation to
+/// hold pre-converted `Ref` values (with interned symbols and
+/// heap-allocated strings).
+#[derive(Debug, Default)]
+pub struct BytecodeProgram {
+    /// Flat opcode stream.
+    pub code: Vec<u8>,
+    /// Constant pool: STG-level native values (strings, symbols, numbers).
+    pub constants: Vec<StgNative>,
+    /// Pre-converted heap-level refs, one per constant.
+    /// Populated by `prepare_constants()` after the machine heap and
+    /// symbol pool are available.
+    pub heap_refs: Vec<Ref>,
+}
+
+impl BytecodeProgram {
+    /// Pre-convert all constant pool entries from `StgNative` to
+    /// heap-level `Ref` values.
+    ///
+    /// Must be called after the machine's symbol pool is populated
+    /// (i.e., after `standard_machine()` has loaded globals).
+    pub fn prepare_constants(&mut self, view: MutatorHeapView<'_>, pool: &mut SymbolPool) {
+        self.heap_refs = self
+            .constants
+            .iter()
+            .map(|n| match n {
+                StgNative::Num(num) => Ref::V(Native::Num(num.clone())),
+                StgNative::Str(s) => {
+                    let ptr = view
+                        .alloc(HeapString::from_str(&view, s.as_str()))
+                        .expect("alloc heap str in bytecode constant pool")
+                        .as_ptr();
+                    Ref::V(Native::Str(ptr))
+                }
+                StgNative::Sym(s) => {
+                    let id = pool.intern(s.as_str());
+                    Ref::V(Native::Sym(id))
+                }
+                StgNative::Zdt(dt) => Ref::V(Native::Zdt(*dt)),
+            })
+            .collect();
+    }
+}
+
+// ── Read helpers ────────────────────────────────────────────────────
+
+/// Read a `u8` from `code` at `*pc` and advance `*pc`.
+#[inline(always)]
+pub fn read_u8(code: &[u8], pc: &mut usize) -> u8 {
+    let v = code[*pc];
+    *pc += 1;
+    v
+}
+
+/// Read a little-endian `u16` from `code` at `*pc` and advance `*pc`.
+#[inline(always)]
+pub fn read_u16(code: &[u8], pc: &mut usize) -> u16 {
+    let v = u16::from_le_bytes([code[*pc], code[*pc + 1]]);
+    *pc += 2;
+    v
+}
+
+/// Read a little-endian `u32` from `code` at `*pc` and advance `*pc`.
+#[inline(always)]
+pub fn read_u32(code: &[u8], pc: &mut usize) -> u32 {
+    let v = u32::from_le_bytes([code[*pc], code[*pc + 1], code[*pc + 2], code[*pc + 3]]);
+    *pc += 4;
+    v
+}

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -71,6 +71,21 @@ pub struct HeapNavigator<'scope> {
 }
 
 impl HeapNavigator<'_> {
+    /// Construct a navigator from explicit components.
+    pub(crate) fn new<'a>(
+        view: MutatorHeapView<'a>,
+        local_env: RefPtr<EnvFrame>,
+        global_env: RefPtr<EnvFrame>,
+        annotation: Smid,
+    ) -> HeapNavigator<'a> {
+        HeapNavigator {
+            locals: view.scoped(local_env),
+            globals: view.scoped(global_env),
+            view,
+            annotation,
+        }
+    }
+
     /// Resolve a ref (creating atom closure if it resolves to native)
     pub fn resolve(&self, r: &Ref) -> Result<SynClosure, ExecutionError> {
         match r {
@@ -204,7 +219,7 @@ impl HeapNavigator<'_> {
 /// Used by `env_from_data_args` to determine whether the new environment frame
 /// can share backing storage with the constructor's environment frame, preserving
 /// thunk memoisation across multiple traversals of the same structure.
-enum ArgPattern {
+pub(crate) enum ArgPattern {
     /// All args map to physical slots `0, 1, ..., n-1` (after composing with the
     /// constructor env's remap if any) and `n == backing_len` — identity physical
     /// mapping, shares full backing with no remap overhead.
@@ -230,7 +245,7 @@ enum ArgPattern {
 /// The `backing_len` parameter is the physical slot count of the constructor's top
 /// frame.  `logical_len` is its exposed (logical) slot count.  They differ when the
 /// constructor frame itself has a remap table.
-fn classify_args(
+pub(crate) fn classify_args(
     args: &[Ref],
     logical_len: usize,
     backing_len: usize,
@@ -274,27 +289,27 @@ fn classify_args(
 /// The state of the machine (stack / closure etc.)
 pub struct MachineState {
     /// Root (empty) environment
-    root_env: RefPtr<EnvFrame>,
+    pub(crate) root_env: RefPtr<EnvFrame>,
     /// Current closure
-    closure: SynClosure,
+    pub(crate) closure: SynClosure,
     /// Globals (primarily STG wrappers for intrinsics)
-    globals: RefPtr<EnvFrame>,
+    pub(crate) globals: RefPtr<EnvFrame>,
     /// Stack of continuations (stored inline, not on the eucalypt heap)
-    stack: Vec<Continuation>,
+    pub(crate) stack: Vec<Continuation>,
     /// Termination flag. Set when machine has terminated
-    terminated: bool,
+    pub(crate) terminated: bool,
     /// Yield flag. Set (alongside `terminated`) when the machine has
     /// evaluated an IO constructor to WHNF with no pending Branch or
     /// ApplyTo continuations.  The `io-run` driver loop checks this
     /// flag to distinguish a normal termination from an IO yield and
     /// inspects `closure` to read the IO constructor tag and fields.
-    yielded_io: bool,
+    pub(crate) yielded_io: bool,
     /// Annotation to paint on any environments we create
-    annotation: Smid,
+    pub(crate) annotation: Smid,
     /// Cache compiled regexes
-    rcache: LruCache<String, Regex>,
+    pub(crate) rcache: LruCache<String, Regex>,
     /// Interned symbol pool for fast symbol comparison
-    symbol_pool: SymbolPool,
+    pub(crate) symbol_pool: SymbolPool,
     /// Stash of closures kept alive across `machine.run()` calls.
     ///
     /// The io-run driver holds closures (e.g. `cont` and `world` from an
@@ -303,24 +318,24 @@ pub struct MachineState {
     /// continuation stack, so the GC would not mark them.  Pushing them
     /// into this stash ensures they are scanned as GC roots for the
     /// duration of the io-run loop.
-    stash: Vec<SynClosure>,
+    pub(crate) stash: Vec<SynClosure>,
     /// Suspended continuation stacks saved during `evaluate_to_whnf` calls.
     ///
     /// When `evaluate_to_whnf` is called with a non-empty continuation stack,
     /// the current stack is moved here (rather than dropped) so that the GC
     /// can trace its heap pointers during the sub-evaluation `run()`.  Each
     /// entry is popped and restored after the sub-evaluation completes.
-    suspended_stacks: Vec<Vec<Continuation>>,
+    pub(crate) suspended_stacks: Vec<Vec<Continuation>>,
     /// Set by `CaptureEnd` continuation to signal `Machine::step()` to
     /// pop the capture emitter and produce the result string.
-    capture_end_pending: bool,
+    pub(crate) capture_end_pending: bool,
     /// Captured string results from completed emitter captures.
-    capture_results: Vec<String>,
+    pub(crate) capture_results: Vec<String>,
     /// Format name for a pending capture start, set by `start_capture()`.
     /// `Machine::step()` reads this to push the actual emitter.
-    pending_capture_start: Option<String>,
+    pub(crate) pending_capture_start: Option<String>,
     /// Test mode flag — `__EXPECT` failures return false instead of panicking.
-    test_mode: bool,
+    pub(crate) test_mode: bool,
     /// Pending BIF intrinsic index, set by `handle_instruction` when it
     /// encounters a `HeapSyn::Bif` node.
     ///
@@ -330,7 +345,7 @@ pub struct MachineState {
     /// re-derives the argument slice directly from `self.state.closure` — no
     /// allocation or copy is needed because no GC can fire between
     /// `handle_instruction` returning and the BIF being dispatched.
-    pending_bif: Option<u8>,
+    pub(crate) pending_bif: Option<u8>,
 }
 
 impl Default for MachineState {
@@ -380,14 +395,18 @@ impl MachineState {
     }
 
     /// Push a new continuation onto the stack
-    fn push(&mut self, _view: MutatorHeapView, cont: Continuation) -> Result<(), ExecutionError> {
+    pub(crate) fn push(
+        &mut self,
+        _view: MutatorHeapView,
+        cont: Continuation,
+    ) -> Result<(), ExecutionError> {
         self.stack.push(cont);
         Ok(())
     }
 
     /// Handle an instruction
     #[inline]
-    fn handle_instruction<'guard>(
+    pub(crate) fn handle_instruction<'guard>(
         &mut self,
         view: MutatorHeapView<'guard>,
         _emitter: &mut dyn Emitter,
@@ -708,7 +727,7 @@ impl MachineState {
     }
 
     /// Update environment index to point to current closure
-    fn update(
+    pub(crate) fn update(
         &mut self,
         view: MutatorHeapView,
         environment: RefPtr<EnvFrame>,
@@ -720,7 +739,7 @@ impl MachineState {
 
     /// Return meta into a demeta destructuring or just strip metadata
     /// and continue
-    fn return_meta(
+    pub(crate) fn return_meta(
         &mut self,
         view: MutatorHeapView<'_>,
         meta: &Ref,
@@ -766,7 +785,7 @@ impl MachineState {
     /// The current closure already wraps the native in an Atom on the
     /// heap, so we reuse that closure when building the env frame for
     /// Branch/DeMeta fallbacks instead of allocating a fresh Atom.
-    fn return_native(
+    pub(crate) fn return_native(
         &mut self,
         view: MutatorHeapView<'_>,
         value: &Native,
@@ -873,7 +892,7 @@ impl MachineState {
     ///   (it chains into a deeper frame — sharing across frames is unsupported)
     /// - more than 4 args (remap table capacity)
     #[inline]
-    fn env_from_data_args(
+    pub(crate) fn env_from_data_args(
         &self,
         view: MutatorHeapView<'_>,
         args: &[Ref],
@@ -928,7 +947,7 @@ impl MachineState {
     /// (`Ref::V` or `Ref::G`), more than 4 args, or physical indices that reach
     /// beyond the constructor's top frame.  This is the original behaviour prior
     /// to the shared-env optimisation.
-    fn env_from_data_args_copy(
+    pub(crate) fn env_from_data_args_copy(
         &self,
         view: MutatorHeapView<'_>,
         args: &[Ref],
@@ -964,7 +983,7 @@ impl MachineState {
     ///
     /// Data is destructured for tag handlers but not for the default
     /// handler which is used for natives and unknown data constructors.
-    fn return_data(
+    pub(crate) fn return_data(
         &mut self,
         view: MutatorHeapView<'_>,
         tag: Tag,
@@ -1117,7 +1136,7 @@ impl MachineState {
     }
 
     /// Return function to either apply to args or default case branch
-    fn return_fun(&mut self, view: MutatorHeapView) -> Result<(), ExecutionError> {
+    pub(crate) fn return_fun(&mut self, view: MutatorHeapView) -> Result<(), ExecutionError> {
         if let Some(continuation) = self.stack.pop() {
             match continuation {
                 Continuation::ApplyTo { args, annotation } => {
@@ -1228,7 +1247,7 @@ impl MachineState {
     ///
     /// Used as a fallback when the immediate continuation has no
     /// annotation, to attribute errors to their enclosing call context.
-    fn nearest_stack_annotation(&self, view: MutatorHeapView) -> Smid {
+    pub(crate) fn nearest_stack_annotation(&self, view: MutatorHeapView) -> Smid {
         for cont in self.stack.iter().rev() {
             let smid = match cont {
                 Continuation::Branch { annotation, .. }
@@ -1443,18 +1462,18 @@ pub struct MachineSettings {
 /// `MachineBifContext`, enabling sound `evaluate_to_whnf` support.
 pub struct MachineCore<'a> {
     /// Main VM Memory — interior mutability throughout
-    heap: Heap,
+    pub(crate) heap: Heap,
     /// Intrinsics (actions with access into machine)
-    intrinsics: Vec<&'a dyn StgIntrinsic>,
+    pub(crate) intrinsics: Vec<&'a dyn StgIntrinsic>,
     /// Whether to trace every step to stderr
-    settings: MachineSettings,
+    pub(crate) settings: MachineSettings,
     /// Metrics
-    metrics: Metrics,
+    pub(crate) metrics: Metrics,
     /// Clock
-    clock: Clock,
+    pub(crate) clock: Clock,
     /// Crash diagnostics snapshot — updated periodically, read by signal handler.
     /// Boxed to guarantee a stable address regardless of Machine moves.
-    crash_diagnostics: Box<super::crash::CrashDiagnostics>,
+    pub(crate) crash_diagnostics: Box<super::crash::CrashDiagnostics>,
 }
 
 /// An STG machine variant using cactus environment
@@ -1465,22 +1484,22 @@ pub struct MachineCore<'a> {
 /// - stack
 pub struct Machine<'a> {
     /// Non-state fields (heap, intrinsics, settings, metrics, clock, diagnostics)
-    core: MachineCore<'a>,
+    pub(crate) core: MachineCore<'a>,
     /// The current state of the machine - operated on as mutable ref
-    state: MachineState,
+    pub(crate) state: MachineState,
     /// Emitter to send output and error events to.
     ///
     /// Kept as a direct field (not in `MachineCore`) so that `step()` can
     /// borrow it independently from `core`, allowing simultaneous
     /// `&mut core` (for `MachineBifContext`) and `&mut emitter`.
-    emitter: Box<dyn Emitter + 'a>,
+    pub(crate) emitter: Box<dyn Emitter + 'a>,
     /// Active capture emitters for nested `render-as` calls.
     ///
     /// **GC constraint**: This field is NOT scanned by the garbage collector.
     /// Emitters must hold only off-heap data (Rust-owned buffers, trait objects).
     /// If future changes require storing heap pointers here, move this field
     /// to `MachineState` so it participates in GC marking.
-    capture_emitters: Vec<crate::eval::stg::render_to_string::OwnedCaptureEmitter>,
+    pub(crate) capture_emitters: Vec<crate::eval::stg::render_to_string::OwnedCaptureEmitter>,
 }
 
 /// Evaluate `closure` to WHNF using `state` and `core`.
@@ -1731,6 +1750,12 @@ impl<'a> Machine<'a> {
     /// Read-only access to the symbol pool for resolving `SymbolId` to text.
     pub fn symbol_pool(&self) -> &SymbolPool {
         &self.state.symbol_pool
+    }
+
+    /// Mutable access to the symbol pool for bytecode constant
+    /// preparation (BV0 spike).
+    pub fn symbol_pool_mut(&mut self) -> &mut SymbolPool {
+        &mut self.state.symbol_pool
     }
 
     /// Intern a symbol string into the machine's symbol pool and return its ID.
@@ -1991,7 +2016,7 @@ impl<'a> Machine<'a> {
     }
 
     /// Run a GC collection and update crash diagnostics around it.
-    fn collect_with_diagnostics(&mut self) {
+    pub(crate) fn collect_with_diagnostics(&mut self) {
         let ticks = self.core.metrics.ticks();
 
         // Snapshot VM state before collection

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,3 +1,4 @@
+pub mod bytecode;
 pub mod emit;
 pub mod error;
 pub mod intrinsics;


### PR DESCRIPTION
## Summary

BV0 bytecode encoding + dispatch-ceiling spike for the BV programme gate.

- Adds `src/eval/bytecode/` with encoder, opcode set, flat bytecode program, and hybrid interpreter
- Encodes full `StgSyn` tree to post-order bytecode stream (~187KB for day11)
- Hybrid dispatch: bytecode closures dispatch via opcode; HeapSyn closures (intrinsics, runtime-created) fall through to existing VM
- Activated via `EU_BYTECODE=1` environment variable
- Output is byte-identical to HeapSyn path
- Passes `EU_GC_VERIFY=2 EU_GC_STRESS=1` validation

## Measurements

| Mode | Run 1 | Run 2 | Run 3 | Median |
|------|-------|-------|-------|--------|
| HeapSyn | 1.557s | 1.549s | 1.529s | **1.549s** |
| Bytecode | 1.787s | 1.780s | 1.763s | **1.780s** |

**Bytecode is 1.15× slower**, not faster. Gate: **NO-GO** (target was ≥2×).

## Root cause

Each bytecode dispatch allocates a `HeapSyn::Atom` stub on the heap to encode the bytecode offset as a closure code pointer. This adds allocation overhead that outweighs any benefit from flat opcode dispatch. The fundamental issue is that the existing continuation/closure machinery expects `RefPtr<HeapSyn>` code pointers, so bytecode offsets must be wrapped in heap objects.

A viable bytecode approach would need to either:
1. Change the closure representation to support raw bytecode offsets natively (large refactor)
2. Use a register-based or stack-based VM that avoids per-step closure allocation

## Test plan

- [x] All 1181 tests pass (`cargo test`)
- [x] Output identity verified (day11 part-1 produces identical `477`)
- [x] `EU_GC_VERIFY=2 EU_GC_STRESS=1` passes
- [x] Clippy clean, formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)