### PR TITLE
fix(build): sanitise eu.build metadata

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -197,8 +197,8 @@ jobs:
         run: cargo install --path . --target-dir /tmp/eu-install
       - name: prepare build files for new version
         run: |
-          export OSTYPE=$(uname)
-          export HOSTTYPE=$(uname -m)
+          export EU_TARGET_TRIPLE="x86_64-unknown-linux-gnu"
+          export EU_RUSTC_VERSION="$(rustc --version | awk '{print $2}')"
 
           eu build.eu -t build-meta > build-meta.yaml.new
           mv -f build-meta.yaml.new build-meta.yaml
@@ -273,8 +273,8 @@ jobs:
         run: cargo install --path . --target-dir /tmp/eu-install
       - name: Prepare build files for new version
         run: |
-          export OSTYPE=$(uname)
-          export HOSTTYPE=$(uname -m)
+          export EU_TARGET_TRIPLE="aarch64-apple-darwin"
+          export EU_RUSTC_VERSION="$(rustc --version | awk '{print $2}')"
 
           eu build.eu -t build-meta > build-meta.yaml.new
           mv -f build-meta.yaml.new build-meta.yaml
@@ -319,8 +319,8 @@ jobs:
         run: cargo install --path . --target-dir /tmp/eu-install
       - name: Prepare build files for new version
         run: |
-          export OSTYPE=$(uname)
-          export HOSTTYPE=$(uname -m)
+          export EU_TARGET_TRIPLE="aarch64-unknown-linux-gnu"
+          export EU_RUSTC_VERSION="$(rustc --version | awk '{print $2}')"
 
           eu build.eu -t build-meta > build-meta.yaml.new
           mv -f build-meta.yaml.new build-meta.yaml
@@ -364,8 +364,9 @@ jobs:
       - name: Prepare build files for new version
         shell: pwsh
         run: |
-          $env:OSTYPE = "Windows"
-          $env:HOSTTYPE = "x86_64"
+          $env:EU_TARGET_TRIPLE = "x86_64-pc-windows-msvc"
+          $rustcVersion = (rustc --version) -replace 'rustc (\S+).*', '$1'
+          $env:EU_RUSTC_VERSION = $rustcVersion
           eu build.eu -t build-meta > build-meta.yaml.new
           Move-Item -Force build-meta.yaml.new build-meta.yaml
           cargo run --package xtask -- prelude-compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to eucalypt are documented here.
 
-## [0.11.0] - Unreleased
+## [0.11.1] - Unreleased
+
+### Changed
+
+- **`eu.build` metadata sanitised** — the `github-env` block that captured all `GITHUB_*` environment variables from the CI runner (including filesystem paths, actor IDs, and workflow internals) has been replaced with a curated set of build metadata: version, commit, build number, URL, timestamp, target triple, Rust version, build profile, and prelude blob status
+
+## [0.11.0] - 2026-06-27
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "eucalypt"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 
 [package]
 name = "eucalypt"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 

--- a/build.eu
+++ b/build.eu
@@ -40,17 +40,20 @@ build: {
   ` "URL of build"
   url: workflow-url
 
-  ` "Architecture of build environment"
-  arch: env lookup-alts([:HOSTTYPE, :_system_arch], "unknown")
+  ` "Target triple (e.g. aarch64-apple-darwin)"
+  arch: env lookup-or(:EU_TARGET_TRIPLE, "unknown")
 
-  ` "Architecture of build environment"
-  os: env lookup-alts([:OSTYPE, :_system_name], "unknown")
+  ` "Rust compiler version"
+  rust: env lookup-or(:EU_RUSTC_VERSION, "unknown")
+
+  ` "Build profile (release or debug)"
+  profile: env lookup-or(:EU_BUILD_PROFILE, "release")
+
+  ` "Whether prelude blob is embedded"
+  prelude-blob: env lookup-or(:EU_PRELUDE_BLOB, "true")
 
   ` "Seconds since epoch at eu build time"
-  epoch-time: io.epoch-time
-
-  ` "GitHub environment variables"
-  github-env: env filter-items(by-key-match("^GITHUB.*")) block
+  time: io.epoch-time
 }
 
 ` {target: :version
@@ -63,7 +66,6 @@ new-version: "{version.major}.{version.minor}.{version.patch}+{build.number str.
 build-meta: {
   version: new-version
   commit: build.commit
-  url: build.url
   banner: "eu - Eucalypt v{version}"
   eu-build: build
 }


### PR DESCRIPTION
## Summary

- Replace the `github-env` block that captured ALL `GITHUB_*` env vars from the CI runner with a curated set of build metadata
- Bump version to 0.11.1
- CI workflow updated to set `EU_TARGET_TRIPLE` and `EU_RUSTC_VERSION`

## What changed in `build.eu`

**Removed:**
- `github-env: env filter-items(by-key-match("^GITHUB.*")) block` — captured runner paths, actor IDs, temp file paths, workflow internals

**Added:**
- `arch: env lookup-or(:EU_TARGET_TRIPLE, "unknown")` — target triple
- `rust: env lookup-or(:EU_RUSTC_VERSION, "unknown")` — Rust compiler version
- `profile` — build profile (release/debug)
- `prelude-blob` — whether blob prelude is embedded

**Before (0.11.0):**
```yaml
eu-build:
  github-env:
    GITHUB_WORKSPACE: /Users/runner/work/eucalypt/eucalypt
    GITHUB_ACTOR: gmorpheme
    GITHUB_EVENT_PATH: /Users/runner/work/_temp/...
    GITHUB_OUTPUT: /Users/runner/work/_temp/...
    ... (30+ fields)
```

**After (0.11.1):**
```yaml
eu-build:
  number: "NNNN"
  commit: abc123...
  url: https://github.com/curvelogic/eucalypt/runs/...
  arch: aarch64-apple-darwin
  rust: "1.87.0"
  profile: release
  prelude-blob: "true"
  time: 1782551032
```

## Test plan

- [x] `eu build.eu -t build-meta` produces clean output with no env leakage
- [x] Cargo.toml version bumped to 0.11.1
- [x] CHANGELOG.md updated
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)