### PR TITLE
docs: review and restructure CLAUDE.md for accuracy and effectiveness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Eucalypt is a Rust-based tool and language for generating, templating, rendering
 
 ## Writing Eucalypt Code
 
-**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.** Agents that skip this produce incorrect code and waste cycles — precedence, lambda syntax, and prelude contents in eucalypt are all unlike mainstream languages.
+**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.** Agents that skip this produce incorrect code and waste cycles — catenation's pipeline semantics, lambda syntax, and prelude contents in eucalypt are all unlike mainstream languages.
 
 ### Required Reading
 
@@ -30,8 +30,8 @@ For specific topics, also consult:
 
 ### Critical Rules (Most Common Agent Mistakes)
 
-1. **Catenation precedence is LOW (20)**: ALL infix operators bind tighter. `xs f(a) + 1` parses as `xs(f(a) + 1)` NOT `(xs f(a)) + 1`. Fix: use parentheses or split into named bindings.
-2. **Dot `.` binds tighter (90) than catenation (20)**: `list head.name` parses as `list (head.name)`. Fix: `(list head).name`. **Simple lookup** (`.name`) is key lookup restricted to block bindings. **Generalised lookup** (`.{ block }`, `.(expr)`, etc.) evaluates the RHS in the block's scope with access to outer scope.
+1. **Catenation precedence is LOW (20)**: ALL infix operators bind tighter, so they grab adjacent atoms before catenation does. `xs f(a) + 1` groups as `(f(a) + 1)(xs)` — the `+` binds `f(a)` and `1` into one unit first, and *that unit*, not `xs`, is what gets called; `xs` is its argument. NOT `(xs f(a)) + 1`. Fix: use parentheses or split into named bindings.
+2. **Dot `.` binds tighter (90) than catenation (20), and prefix `↑` (head) tighter still (95)**: `list head.name` groups as `head.name` first, and *that* — not `list` — is what's applied: `head.name(list)`, NOT `(list head).name`. Likewise `↑xs.name` = `(↑xs).name`, not `↑(xs.name)`. Fix: `(list head).name`. **Simple lookup** (`.name`) is key lookup restricted to block bindings. **Generalised lookup** (`.{ block }`, `.(expr)`, etc.) evaluates the RHS in the block's scope with access to outer scope.
 3. **NO lambda/arrow syntax**: `->` is the `const` operator, NOT lambda. Use sections `(+ 1)`, expression anaphora `(_ + 1)`, or named functions.
 4. **Each `_` creates a new param**: `_ + _` means `_0 + _1` (two params). Use `_0 * _0` to reference the same param twice.
 5. **Backtick is metadata, not comment**: `` ` "text" `` attaches to the NEXT declaration. Use `#` for comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,134 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Eucalypt is a Rust-based tool and language for generating, templating, rendering and processing structured data formats like YAML, JSON and TOML. The project is implemented in Rust using Cargo as the build system.
-
-## Build and Development Commands
-
-### Basic Development
-- `cargo build` - Build the project
-- `cargo test` - Run all tests (includes unit tests and harness tests)
-- `cargo run` - Run the eucalypt binary
-- `cargo install --path .` - Install local `eu` binary
-
-### Type Checking
-- `eu check file.eu` - Type-check a file (report warnings)
-- `eu check --strict file.eu` - Type-check with warnings as errors
-- `eu --type-check file.eu` - Type-check then evaluate (warnings to stderr)
-
-### Testing
-- `cargo test` - Run all tests including the comprehensive harness test suite
-- `cargo test test_harness_001` - Run a specific harness test (e.g., test 001)
-- `cargo test --test harness_test` - Run only the harness tests
-- `cargo bench` - Run benchmarks (located in `benches/`)
-
-### Build System
-- Parsing uses a hand-written, lossless Rowan-based parser (`src/syntax/rowan/`); there is no separate grammar file or parser generator
-- Build metadata is generated via `eu build.eu -t build-meta`
-
-## Architecture
-
-### Core Components
-
-**Core Pipeline (`src/core/`)**:
-- `syntax/` - Lexing, parsing, and AST representation
-- `desugar/` - AST transformation and desugaring
-- `cook/` - Operator precedence and fixity resolution
-- `verify/` - Binding and content verification
-- `simplify/` - Expression simplification and optimization
-- `transform/` - Various AST transformations including namespace lambda hoisting (`hoist.rs`)
-- `inline/` - Inlining and reduction passes
-- `typecheck/` - Gradual type system: type representation, parser, subtyping, bidirectional checker, polymorphic instantiation
-
-**Evaluation (`src/eval/`)**:
-- `machine/` - Virtual machine implementation with garbage collection
-- `memory/` - Memory management, heap, and GC
-- `stg/` - STG (Spineless Tagless G-machine) backend
-- `intrinsics.rs` - Built-in functions and primitives
-
-**I/O (`src/import/` and `src/export/`)**:
-- Import: CSV, EDN, TOML, XML, YAML, text
-- Export: EDN, HTML, JSON, markup, table, text, TOML, YAML
-
-**Driver (`src/driver/`)**:
-- `eval.rs` - Main evaluation pipeline
-- `tester.rs` - Test harness execution
-- `options.rs` - Command-line option handling
-
-### Test Architecture
-
-**Harness Tests (`tests/harness/`)**:
-- Comprehensive test suite with 50+ test files
-- Tests cover language features, edge cases, and error conditions
-- Test files use `.eu` extension for eucalypt source
-- Also includes YAML, TOML, CSV, XML, and EDN test files
-- Error tests in `tests/harness/errors/` directory
-- Benchmark tests in `tests/harness/bench/` directory
-
-**Test Execution**:
-- Tests are run via `tests/harness_test.rs`
-- Each test corresponds to a file in `tests/harness/`
-- Tests can be run individually or as a complete suite
-- Uses the `tester` module for test execution
-
-### Memory Management
-
-The project includes a sophisticated garbage collector:
-- Generational GC with multiple generations
-- Bump allocation for young generation
-- Mark-and-sweep for older generations
-- Custom memory layout for eucalypt values
-
-### Debug Environment Variables
-
-| Variable | Effect |
-|----------|--------|
-| `EU_GC_POISON=1` | Fill swept memory with `0xDE` poison pattern. Detects use-after-free by checking for poison in `mark()`. Also enables hole verification in the bump allocator. |
-| `EU_GC_VERIFY=1` | After each GC mark phase, re-traverse from roots and verify no reachable objects were missed. Panics if any unmarked-but-reachable objects are found. |
-| `EU_GC_VERIFY=2` | Full multi-checkpoint structural verification: header validity, pointer validity, line consistency (post-mark), forwarding pointer lifecycle (post-evacuate/update), and block list integrity (post-sweep). Level 2 implies level 1. |
-| `EU_STACK_DIAG=1` | Log continuation stack composition to stderr whenever a new max stack depth is reached. |
-| `EU_ERROR_TRACE_DUMP=1` | Dump full env trace and stack trace Smid details as diagnostic notes on every execution error. Useful for debugging which source locations are available at error time. |
-| `EU_IO_TRACE=1` | Trace all `io.shell` and `io.exec` commands to stderr before execution. Shows the command string and whether stdin is piped. |
-
-The crash signal handler (SIGSEGV/SIGBUS diagnostics) is always active and has no environment variable — it installs unconditionally in `main()`.
-
-### Dump Commands for Debugging
-
-Use `eu dump <phase>` to inspect intermediate representations at each pipeline stage. These are the **primary tool** for investigating compiler and core expression issues — do NOT add temporary debug prints.
-
-| Command | Shows |
-|---------|-------|
-| `eu dump ast <file>` | Parsed syntax tree |
-| `eu dump desugared <file>` | Core expression after desugaring |
-| `eu dump cooked <file>` | Core expression after operator precedence resolution |
-| `eu dump inlined <file>` | Core expression after namespace hoisting + inlining |
-| `eu dump pruned <file>` | Core expression after dead code elimination |
-| `eu dump stg <file>` | Compiled STG syntax |
-| `eu dump runtime <file>` | Runtime globals |
-
-Add `--debug-format` for the Rust Debug representation (shows full structure including de Bruijn indices), or `--embed` for eucalypt source representation.
-
-### Language Features
-
-- Functional programming with lazy evaluation
-- Built-in support for structured data (YAML, JSON, TOML)
-- Import system for external data files
-- Metadata system for attaching information to values
-- String interpolation and templating
-- Comprehensive numeric operations
-- Time and date handling
-
-## Development Notes
-
-- The project uses custom memory management - be careful when modifying anything in `src/eval/memory/`
-- Parser changes are made directly in `src/syntax/rowan/` (hand-written; no code-generation step)
-- Test files in `tests/harness/` serve as both tests and examples
-- The `lib/` directory contains eucalypt library code (prelude, markup, test utilities)
-- Build metadata is embedded in the binary via `build-meta.yaml` (generated by `eu build.eu -t build-meta`)
+Eucalypt is a Rust-based tool and language for generating, templating, rendering and processing structured data formats like YAML, JSON and TOML. It is a lazily-evaluated functional language with a gradual type system, built in Rust with Cargo.
 
 ## Writing Eucalypt Code
 
-**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.**
+**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.** Agents that skip this produce incorrect code and waste cycles — precedence, lambda syntax, and prelude contents in eucalypt are all unlike mainstream languages.
 
 ### Required Reading
 
@@ -170,6 +47,131 @@ For specific topics, also consult:
 15. **Use `deep-transform` for recursive rewrites**: return non-null to replace, null to recurse. Avoids nested `if(block?, ..., if(list?, ...))`.
 16. **Read `docs/eucalypt-style.md`** for idiomatic patterns: `when` over `if`, `bimap` for point-free, scope capture in blocks, sets for membership.
 
+## Build and Development Commands
+
+### Basic Development
+- `cargo build` - Build the project
+- `cargo test` - Run all tests (includes unit tests and harness tests)
+- `cargo run` - Run the eucalypt binary
+- `cargo install --path .` - Install local `eu` binary
+- `cargo xtask prelude-compile` - Regenerate `lib/prelude.blob` (the pre-compiled prelude) after changing prelude source; the build falls back to compiling from source when the blob is absent or stale
+- `eu doc <file>` - Extract documentation from eucalypt source (used to regenerate `docs/reference/prelude/`)
+
+### Type Checking
+
+Type checking runs **unconditionally** on every `eu` invocation (evaluate, dump, test) — it is not gated by a flag. Warnings go to stderr and never affect stdout or exit code unless `--strict` is used.
+
+- `eu check file.eu` - check-only: validate type annotations and run the checker without evaluating; reports warnings
+- `eu check --strict file.eu` - same, but promote warnings to errors and exit 1 (use for CI gates)
+- `eu file.eu --strict` / `eu run --strict file.eu` - evaluate, but abort before evaluation with exit 1 if there are type warnings
+- `eu file.eu --suppress-type-warnings` - evaluate normally, silencing warning output (the checker still runs)
+- `--type-check` is a **deprecated no-op** kept for backwards compatibility — type checking used to be opt-in via this flag; it always runs now
+
+### Testing
+- `cargo test` - Run all tests including the comprehensive harness test suite
+- `cargo test test_harness_001` - Run a specific harness test (e.g., test 001)
+- `cargo test --test harness_test` - Run only the harness tests
+- `cargo bench` - Run benchmarks (located in `benches/`)
+
+### Build System
+- Parsing uses a hand-written, lossless Rowan-based parser (`src/syntax/rowan/`); there is no separate grammar file or parser generator
+- Build metadata is generated via `eu build.eu -t build-meta` and embedded in the binary via `build-meta.yaml`
+
+## Architecture
+
+### Core Components
+
+**Parsing (`src/syntax/rowan/`)**: hand-written, lossless Rowan-based parser — no grammar file or generator.
+
+**Core Pipeline (`src/core/`)**:
+- `desugar/` - AST transformation and desugaring
+- `cook/` - Operator precedence and fixity resolution
+- `verify/` - Binding and content verification
+- `simplify/` - Expression simplification and optimisation
+- `transform/` - Various AST transformations including namespace lambda hoisting (`hoist.rs`)
+- `inline/` - Inlining and reduction passes
+- `typecheck/` - Gradual type system: type representation, parser, subtyping, bidirectional checker, polymorphic instantiation
+- `analyse/` - Demand analysis (strictness/usage), feeding codegen decisions
+
+**Evaluation (`src/eval/`)**:
+- `machine/` - Virtual machine implementation with garbage collection
+- `memory/` - Memory management, heap, and GC
+- `stg/` - STG (Spineless Tagless G-machine) backend
+- `intrinsics.rs` - Built-in functions and primitives
+
+**I/O (`src/import/` and `src/export/`)**:
+- Import: CSV, EDN, TOML, XML, YAML, text, JSONL, git refs, streaming sources
+- Export: EDN, HTML, JSON, markup, table, text, TOML, YAML
+
+**Driver (`src/driver/`)**:
+- `eval.rs` - Main evaluation pipeline
+- `options.rs` - Command-line option handling
+- `check.rs` - `eu check` driver; also caches the prelude's type-check result once per process
+- `tester.rs` - Test harness execution
+- `doc/` - `eu doc` reference-doc extraction
+- `lsp/` - Language Server Protocol server (stdio, via `lsp-server`)
+- `statistics.rs` - `-S`/`--statistics` timing and pipeline stats reporting
+
+### Test Architecture
+
+**Harness Tests (`tests/harness/`)**:
+- Large test suite covering language features, edge cases, and error conditions
+- Test files use `.eu` extension for eucalypt source, plus YAML, TOML, CSV, XML, and EDN fixtures
+- Error tests in `tests/harness/errors/` directory
+- Benchmark tests in `tests/harness/bench/` directory
+
+**Test Execution**:
+- Tests are run via `tests/harness_test.rs`, one test per file in `tests/harness/`, using the `tester` module
+
+### Memory Management
+
+The project includes a sophisticated garbage collector:
+- Generational GC with multiple generations
+- Bump allocation for young generation
+- Mark-and-sweep for older generations
+- Custom memory layout for eucalypt values
+
+### Debug Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `EU_GC_POISON=1` | Fill swept memory with `0xDE` poison pattern. Detects use-after-free by checking for poison in `mark()`. Also enables hole verification in the bump allocator. |
+| `EU_GC_VERIFY=1` | After each GC mark phase, re-traverse from roots and verify no reachable objects were missed. Panics if any unmarked-but-reachable objects are found. |
+| `EU_GC_VERIFY=2` | Full multi-checkpoint structural verification: header validity, pointer validity, line consistency (post-mark), forwarding pointer lifecycle (post-evacuate/update), and block list integrity (post-sweep). Level 2 implies level 1. |
+| `EU_STACK_DIAG=1` | Log continuation stack composition to stderr whenever a new max stack depth is reached. |
+| `EU_ERROR_TRACE_DUMP=1` | Dump full env trace and stack trace Smid details as diagnostic notes on every execution error. Useful for debugging which source locations are available at error time. |
+| `EU_IO_TRACE=1` | Trace all `io.shell` and `io.exec` commands to stderr before execution. Shows the command string and whether stdin is piped. |
+
+The crash signal handler (SIGSEGV/SIGBUS diagnostics) is always active and has no environment variable — it installs unconditionally in `main()`.
+
+`--suppress-demand-analysis` (an `eu run` flag) disables the demand analysis pass for debugging, leaving all demands at `Unknown`.
+
+### Dump Commands for Debugging
+
+Use `eu dump <phase>` to inspect intermediate representations at each pipeline stage. These are the **primary tool** for investigating compiler and core expression issues — do NOT add temporary debug prints.
+
+| Command | Shows |
+|---------|-------|
+| `eu dump ast <file>` | Parsed syntax tree |
+| `eu dump desugared <file>` | Core expression after desugaring |
+| `eu dump cooked <file>` | Core expression after operator precedence resolution |
+| `eu dump split <file>` | Core expression after SCC-based LetRec splitting |
+| `eu dump inlined <file>` | Core expression after namespace hoisting + inlining |
+| `eu dump pruned <file>` | Core expression after dead code elimination |
+| `eu dump demands <file>` | Core expression annotated with demand analysis results |
+| `eu dump reflatten <file>` | Core expression after re-flattening nested Let scopes |
+| `eu dump stg <file>` | Compiled STG syntax |
+| `eu dump runtime <file>` | Runtime globals |
+
+Add `--debug-format` for the Rust Debug representation (shows full structure including de Bruijn indices), or `--embed` for eucalypt source representation.
+
+## Development Notes
+
+- The project uses custom memory management - be careful when modifying anything in `src/eval/memory/`
+- Parser changes are made directly in `src/syntax/rowan/` (hand-written; no code-generation step)
+- Test files in `tests/harness/` serve as both tests and examples
+- The `lib/` directory contains eucalypt library code (prelude, markup, test utilities)
+
 ## Panics Are Critical
 
 - **Panics must NEVER be deferred.** If you encounter a panic (thread panicked, assertion failure, etc.), stop what you are doing, reproduce a minimal case, and investigate the root cause immediately.
@@ -184,57 +186,18 @@ For specific topics, also consult:
 - **Always wrap `eu` in `timeout`** to guard against divergent programs: `timeout 60 ./target/release/eu ...`
 - **Benchmark verification**: Agent-reported benchmark numbers MUST be independently verified before acceptance. Always do a clean build (`cargo clean && cargo build --release`) when verifying.
 
-## Code Quality Rules
+## Code Quality, Style, and Security
 
-- **ABSOLUTELY NEVER allow clippy warnings unless explicitly permitted by the user**
-- **ALL clippy issues must be fixed, not suppressed with `#[allow()]` attributes**
-- **Fix EVERY SINGLE clippy warning without exception**
-- Maintain strict code quality standards throughout the codebase
-- When asked to fix clippy issues, fix ALL of them systematically, not selectively
-
-## Language and Style
-
-- **Use UK English spelling**: optimisation (not optimization), utilisation (not utilization), colour (not color), etc.
-- **Comments and documentation**: Follow UK English conventions throughout
+- **Never allow clippy warnings**: fix every one (don't suppress with `#[allow(...)]`) unless the user explicitly permits it. Use `cargo clippy --all-targets -- -D warnings` — `--all-targets` matters, since `--lib` alone misses tests and benches that CI validates.
+- **Use UK English spelling** throughout code, comments, and documentation: optimisation, utilisation, colour, etc.
+- **Fix dependabot/security alerts immediately**, with the same urgency as a build failure or clippy warning — treat them as blocking a PR. Prefer replacing deprecated dependencies over suppressing warnings (e.g. `atty` → `std::io::IsTerminal`).
 
 ## Development Workflow
 
 ### Pre-Commit Checklist
-**ALWAYS run these commands before committing to avoid CI failures:**
-1. `rustup update stable` - Ensure latest stable Rust to match CI (run weekly)
-2. `cargo fmt --all` - Fix formatting issues for all targets
-3. `cargo clippy --all-targets -- -D warnings` - Fix ALL lint warnings (matches CI exactly)
-4. `cargo test --lib` - Verify tests pass (when appropriate)  
-5. **Check and fix dependabot security alerts** - Address vulnerabilities immediately
-6. `git commit` and `git push`
-
-**CRITICAL Rust Version Matching**: 
-- CI uses `dtolnay/rust-toolchain@stable` (latest stable Rust)
-- Local development MUST use the same Rust version as CI to avoid clippy discrepancies
-- Different Rust versions have different clippy rules - this causes the "local passes, CI fails" cycle
-- Run `rustup update stable` regularly to stay current with CI
-
-**CRITICAL Clippy Targeting**: Use `--all-targets` for clippy to match CI behaviour exactly. Local `--lib` checks miss test and bench targets that CI validates.
-
-### Security and Dependencies
-- **MANDATORY: Fix dependabot security alerts immediately** - treat them like clippy warnings
-- **NEVER ignore security vulnerabilities** - address them with the same urgency as build failures
-- Monitor GitHub security alerts and resolve them as part of standard development workflow
-- Use `cargo update` to update dependencies within semver constraints
-- Replace deprecated dependencies with modern alternatives (e.g., `atty` → `std::io::IsTerminal`)
-- Fix deprecation warnings to maintain compatibility with newer dependency versions
-- **Security alerts should block PRs** - just like clippy and rustfmt failures
-
-## Development Standards (Based on Common Mistakes)
-
-### Technical Analysis Standards  
-- **Read relevant documentation FIRST** - always check `docs/` directory before making assumptions about language syntax or behaviour (see "Writing Eucalypt Code" section above)
-- **Understand root causes, not just symptoms** - investigate HOW things work, not just WHETHER they work
-- **Respect architectural boundaries** - only modify components within the defined scope (e.g., don't modify STG compiler when implementing Rowan parser)
-- **Track your own changes** - don't assume existing working code is broken without verifying what you changed
-
-### Communication and Progress Standards
-- **Be precise about what "working" means** - distinguish between "not crashing" and "producing correct results"
-- **Avoid flip-flopping** - gather solid evidence before changing diagnosis or approach
-- **Don't repeat failed investigations** - if an approach isn't  yielding insights, step back and ask to try a different angle
-- **Follow the scope of assigned tasks** - complete what's asked without expanding scope unnecessarily
+**ALWAYS run these commands before committing, in order, to avoid CI failures:**
+1. `rustup update stable` - CI uses `dtolnay/rust-toolchain@stable` (latest stable), so a stale local toolchain causes clippy discrepancies ("local passes, CI fails"); run this weekly
+2. `cargo fmt --all`
+3. `cargo clippy --all-targets -- -D warnings`
+4. `cargo test` - run the full suite (not just `--lib`) when the change might affect harness tests
+5. `git commit` and `git push`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,24 +28,7 @@ For specific topics, also consult:
 - `docs/guide/functions-and-combinators.md` — function definition and partial application
 - `docs/reference/prelude/` — full prelude reference by category
 
-### Critical Rules (Most Common Agent Mistakes)
-
-1. **Catenation precedence is LOW (20)**: ALL infix operators bind tighter, so they grab adjacent atoms before catenation does. `xs f(a) + 1` groups as `(f(a) + 1)(xs)` — the `+` binds `f(a)` and `1` into one unit first, and *that unit*, not `xs`, is what gets called; `xs` is its argument. NOT `(xs f(a)) + 1`. Fix: use parentheses or split into named bindings.
-2. **Dot `.` binds tighter (90) than catenation (20), and prefix `↑` (head) tighter still (95)**: `list head.name` groups as `head.name` first, and *that* — not `list` — is what's applied: `head.name(list)`, NOT `(list head).name`. Likewise `↑xs.name` = `(↑xs).name`, not `↑(xs.name)`. Fix: `(list head).name`. **Simple lookup** (`.name`) is key lookup restricted to block bindings. **Generalised lookup** (`.{ block }`, `.(expr)`, etc.) evaluates the RHS in the block's scope with access to outer scope.
-3. **NO lambda/arrow syntax**: `->` is the `const` operator, NOT lambda. Use sections `(+ 1)`, expression anaphora `(_ + 1)`, or named functions.
-4. **Each `_` creates a new param**: `_ + _` means `_0 + _1` (two params). Use `_0 * _0` to reference the same param twice.
-5. **Backtick is metadata, not comment**: `` ` "text" `` attaches to the NEXT declaration. Use `#` for comments.
-6. **`/` is floor division**: Use `÷` for exact division.
-7. **Many "obvious" functions don't exist**: No `str.trim`, `flatten`, `even?`, `odd?`. Check agent-reference.md section 5.11. Note: `str.replace`, `str.contains?`, `str.starts-with?`, `str.ends-with?`, and `abs` **do** exist.
-8. **`has` takes a symbol, not a string**: `has(:key)` not `has("key")`.
-9. **`str.split-on` uses regex**: `"a.b" str.split-on(".")` matches any char. Use `"[.]"`.
-10. **No whitespace before `(`**: `f(x)` is a call, `f (x)` is catenation.
-11. **Multiple imports go in one block**: `{ import: ["a.eu", "b.eu"] }` — do NOT write separate `{ import: "a.eu" }` and `{ import: "b.eu" }` blocks. Only the first block is unit metadata; the second becomes a separate expression.
-12. **`keys` returns symbols**: do NOT `map(sym)` over `keys` output — they are already symbols.
-13. **`if` with `_` anaphora doesn't make a rule**: `if(_ symbol?, x, null)` doesn't create a function — `if` evaluates its condition. Use a named function.
-14. **Use interpolation, not `str.join-on`**: `"{pfx}{name}"` not `[pfx, name] str.join-on("")`. Interpolation auto-converts values.
-15. **Use `deep-transform` for recursive rewrites**: return non-null to replace, null to recurse. Avoids nested `if(block?, ..., if(list?, ...))`.
-16. **Read `docs/eucalypt-style.md`** for idiomatic patterns: `when` over `if`, `bimap` for point-free, scope capture in blocks, sets for membership.
+`agent-reference.md` §5 ("Common Pitfalls") and `syntax-gotchas.md` already cover the specific traps (catenation precedence, dot-vs-catenation, anaphora scoping, functions that don't exist, etc.) in more depth and nuance than a condensed list here could — read them rather than relying on a summary.
 
 ## Build and Development Commands
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -48,7 +48,6 @@
   - [Random Numbers](reference/prelude/random.md)
   - [Metadata](reference/prelude/metadata.md)
   - [IO](reference/prelude/io.md)
-  - [N-Dimensional Arrays](reference/prelude/arrays.md)
 - [CLI Reference](reference/cli.md)
 - [Import Formats](reference/import-formats.md)
 - [Export Formats](reference/export-formats.md)

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -35,14 +35,15 @@ The precedence hierarchy (highest to lowest):
 **Problem**: The lookup operator (`.`) has higher precedence (90) than
 catenation (precedence 20), which can lead to unexpected parsing.
 
-**Gotcha**: Writing `objects head.id` is parsed as `objects (head.id)`
-rather than `(objects head).id`.
+**Gotcha**: Writing `objects head.id` groups `head.id` into one unit
+first, and *that unit* — not `objects` — is what gets applied. It is
+parsed as `head.id(objects)`, rather than `(objects head).id`.
 
 **Example**:
 ```eu,notest
 # This doesn't work as expected:
 objects: range(0, 5) map({ id: _ })
-result: objects head.id  # Parsed as: objects (head.id)
+result: objects head.id  # Parsed as: head.id(objects)
 
 # Correct syntax requires parentheses:
 result: (objects head).id  # Explicitly groups the field access

--- a/docs/appendices/syntax-gotchas.md
+++ b/docs/appendices/syntax-gotchas.md
@@ -58,6 +58,10 @@ access fields from:
 - Use `(expression).field` instead of `expression target.field`
 - Be explicit about precedence when combining catenation with field access
 
+The `↑` (head) prefix operator (precedence 95) binds even tighter than
+`.` (90), so it has the same gotcha one level up: `↑xs.id` means
+`(↑xs).id`, not `↑(xs.id)`.
+
 ### Arithmetic After a Pipeline
 
 **Problem**: Infix operators like `+`, `-`, `*` have higher precedence

--- a/docs/eucalypt-style.md
+++ b/docs/eucalypt-style.md
@@ -56,9 +56,9 @@ Rules:
 
 Catenation (juxtaposition / pipeline application) has the **lowest** operator precedence (20). ALL infix operators bind tighter, including `∧` (35), `∨` (30), `=` (40), `+` (75), etc. This means infix operators steal adjacent atoms from catenation pipelines:
 
-- `xs f(a) + 1` parses as `xs(f(a) + 1)` — `+` grabs `f(a)` and `1`
+- `xs f(a) + 1` parses as `(f(a) + 1)(xs)` — `+` grabs `f(a)` and `1` into one unit, which is then applied to `xs` (not the reverse)
 - `(k > 0) ∧ xs non-nil?` parses as `((k > 0) ∧ xs) non-nil?` — `∧` grabs `xs`
-- `xs tail ++ [0]` parses as `xs(tail ++ [0])` — `++` grabs `tail` and `[0]`
+- `xs tail ++ [0]` parses as `(tail ++ [0])(xs)` — `++` grabs `tail` and `[0]` into one unit, which is then applied to `xs`
 
 Fix with parens around the catenation: `(k > 0) ∧ (xs non-nil?)`, `(xs tail) ++ [0]`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -185,7 +185,9 @@ result: base << extra
 ### How do I handle the lookup precedence gotcha?
 
 The `.` (lookup) operator has higher precedence than catenation, so
-`xs head.id` parses as `xs (head.id)`, not `(xs head).id`.
+`xs head.id` groups `head.id` into one unit first — and that unit,
+not `xs`, is what gets applied: it parses as `head.id(xs)`, not
+`(xs head).id`.
 
 Use explicit parentheses:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -187,7 +187,8 @@ result: base << extra
 The `.` (lookup) operator has higher precedence than catenation, so
 `xs head.id` groups `head.id` into one unit first — and that unit,
 not `xs`, is what gets applied: it parses as `head.id(xs)`, not
-`(xs head).id`.
+`(xs head).id`. The `↑` (head) prefix operator binds even tighter
+still: `↑xs.id` means `(↑xs).id`, not `↑(xs.id)`.
 
 Use explicit parentheses:
 

--- a/docs/guide/expressions-and-pipelines.md
+++ b/docs/guide/expressions-and-pipelines.md
@@ -154,9 +154,10 @@ host: localhost
 ```
 
 > **Warning:** The dot operator binds very tightly (precedence 90).
-> Writing `list head.name` is parsed as `list (head.name)`, not
-> `(list head).name`. Use explicit parentheses when combining lookup
-> with catenation: `(list head).name`.
+> Writing `list head.name` groups `head.name` into one unit first —
+> and that unit, not `list`, is what gets applied: it parses as
+> `head.name(list)`, not `(list head).name`. Use explicit parentheses
+> when combining lookup with catenation: `(list head).name`.
 >
 > The `↑` (up arrow) prefix operator, which is shorthand for `head`,
 > binds even tighter (precedence 95). So `↑xs.name` means

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,11 +4,6 @@
 > into a single file for use by AI agents and coding assistants.
 > Generated from the eucalypt documentation source.
 
-
----
-
-<!-- Source: docs/welcome/index.md -->
-
 # eucalypt
 
 **eucalypt** is a tool, and a little language, for generating and
@@ -431,7 +426,53 @@ See [CLI Reference](../reference/cli.md) for more complete documentation.
 
 ---
 
-<!-- Source: docs/welcome/quick-start.md -->
+# What is Eucalypt?
+
+**Eucalypt** is a tool, and a little language, for generating,
+templating, rendering and processing structured data formats like
+YAML, JSON and TOML.
+
+If you use text-based templating to process these formats or you pipe
+these formats through several different tools or build steps,
+eucalypt might be able to help you generate your output more cleanly
+and with fewer cognitive somersaults.
+
+## Key Features
+
+- A concise native syntax for defining data, functions, and operators
+- A simple embedding into YAML files for in-place manipulation (a la
+  templating)
+- Facilities for manipulating blocks (think JSON objects, YAML mappings)
+- String interpolation and regular expressions
+- An ergonomic command line interface with environment variable access
+- Metadata annotations and numerous extension points
+- A [prelude](../reference/prelude/index.md) of built-in functions acting
+  as a standard library
+
+## Supported Formats
+
+**Input:** YAML, JSON, JSON Lines, TOML, EDN, XML, CSV, plain text,
+and eucalypt's own `.eu` syntax.
+
+**Output:** YAML, JSON, TOML, EDN, or plain text.
+
+## When to Use Eucalypt
+
+Eucalypt is a good fit when you need to:
+
+- Transform data between structured formats (e.g. JSON to YAML)
+- Generate configuration files with shared logic
+- Query and filter structured data from the command line
+- Template YAML or JSON with embedded expressions
+- Build data processing pipelines
+
+## Learn More
+
+- [Quick Start](quick-start.md) -- install eucalypt and run your first program
+- [Lightning Tour](index.md#a-lightning-tour) -- a quick taste of the syntax
+- [The Eucalypt Guide](../guide/blocks-and-declarations.md) -- a progressive tutorial
+
+---
 
 # Quick Start
 
@@ -570,302 +611,481 @@ eu hello.eu -j
 
 ---
 
-<!-- Source: docs/guide/expressions-and-pipelines.md -->
+# Eucalypt by Example
 
-# Expressions and Pipelines
+This page presents a collection of worked examples showing how
+eucalypt solves real-world problems. Each example includes the
+problem, the eucalypt code, and the expected output.
 
-In this chapter you will learn:
+## 1. Format Conversion: JSON to YAML
 
-- The primitive value types in eucalypt
-- How function application works via catenation (pipelining)
-- How partial application and currying work
-- How to compose pipelines of transformations
-
-## Primitive Values
-
-Eucalypt has the following primitive types:
-
-| Type | Examples | Notes |
-|------|----------|-------|
-| Numbers | `42`, `-7`, `3.14` | Integers and floats |
-| Strings | `"hello"`, `"it's"` | Double-quoted only |
-| Symbols | `:name`, `:active` | Colon-prefixed identifiers |
-| Booleans | `true`, `false` | |
-| Null | `null` | Renders as YAML `~` or JSON `null` |
-
-## Lists
-
-Lists are comma-separated values in square brackets (unlike in blocks,
-commas are required):
-
-```eu
-numbers: [1, 2, 3, 4, 5]
-mixed: [1, "two", :three, true]
-nested: [[1, 2], [3, 4]]
-empty: []
-```
-
-## Calling Functions
-
-Functions can be called by placing arguments in parentheses directly
-after the function name (with no intervening space):
-
-```eu
-add(x, y): x + y
-result: add(3, 4)
-```
-
-```yaml
-result: 7
-```
-
-## Catenation: The Pipeline Style
-
-One distinctive feature of eucalypt is **catenation**: applying a
-function by writing the argument before the function name, separated
-by whitespace.
-
-```eu
-result: 5 inc
-```
-
-This is equivalent to `inc(5)` and produces `6`.
-
-Catenation lets you chain operations into readable pipelines:
+**Problem:** Convert a JSON configuration file to YAML.
 
 ```sh
-eu -e '[1, 2, 3, 4, 5] reverse head'
+echo '{"database": {"host": "db.example.com", "port": 5432}}' | eu
 ```
+
+**Output:**
 
 ```yaml
-5
+database:
+  host: db.example.com
+  port: 5432
 ```
 
-Each step in the pipeline passes its result to the next function. You
-can read it left to right: "take the list, reverse it, take the head."
+Eucalypt reads JSON natively and defaults to YAML output. No code
+needed.
 
-## Combining Catenation with Arguments
+## 2. Extracting Fields from API Data
 
-When a function takes multiple arguments, you can supply some in
-parentheses and the rest via catenation. The catenated value becomes
-the *last* argument:
-
-```eu
-result: [1, 2, 3] map(inc)
-```
-
-Here `map` takes two arguments: a function and a list. `inc` is
-provided in parentheses and `[1, 2, 3]` is provided by catenation.
-The result is `[2, 3, 4]`.
-
-This is the standard eucalypt pattern for data processing pipelines:
+**Problem:** Given a list of users in JSON, extract just their names.
 
 ```sh
-eu -e '[1, 2, 3, 4, 5] filter(> 3) map(* 10)'
-```
-
-```yaml
-- 40
-- 50
-```
-
-## Currying and Partial Application
-
-All functions in eucalypt are curried: if you provide fewer arguments
-than a function expects, you get back a partially applied function.
-
-```eu
-add(x, y): x + y
-add-five: add(5)
-result: add-five(3)
-```
-
-```yaml
-result: 8
-```
-
-Curried application also works with multi-argument calls:
-
-```eu
-f(x, y, z): x + y + z
-
-a: f(1, 2, 3)   # all at once
-b: f(1)(2)(3)    # one at a time
-c: f(1, 2)(3)    # mixed
-```
-
-All three produce `6`.
-
-## Lookup: The Dot Operator
-
-The dot operator (`.`) accesses a named property within a block:
-
-```eu
-person: { name: "Alice" age: 30 }
-name: person.name
-```
-
-```yaml
-person:
-  name: Alice
-  age: 30
-name: Alice
-```
-
-Lookups can be chained:
-
-```eu
-config: { db: { host: "localhost" port: 5432 } }
-host: config.db.host
-```
-
-```yaml
-config:
-  db:
-    host: localhost
-    port: 5432
-host: localhost
-```
-
-> **Warning:** The dot operator binds very tightly (precedence 90).
-> Writing `list head.name` is parsed as `list (head.name)`, not
-> `(list head).name`. Use explicit parentheses when combining lookup
-> with catenation: `(list head).name`.
->
-> The `↑` (up arrow) prefix operator, which is shorthand for `head`,
-> binds even tighter (precedence 95). So `↑xs.name` means
-> `(↑xs).name`.
-
-## "Juxtaposed" call syntax
-
-When a function is passed only a single list argument or a single
-block argument, it is possible to omit the outer parentheses for
-brevity:
-
-``` eu,notest
-result: f[1, 2, 3] ∧ g{a: 1 b: 2}
-```
-
-The "juxtaposition" refers to the resulting feature that directly
-placing a function together with any form of brackets (with no
-intervening whitespace) is now call syntax - whereas using an
-intervening space is a pipeline syntax.
-
-Juxtaposed call syntax: `f(x), f[x], f{x}`.
-
-Pipeline syntax: `x f`, `[x] f`, `{x} f`.
-
-## Generalised Lookup (or "block-dot" notation)
-
-Lookup can be generalised: any expression after the dot is evaluated
-in the context of the block to the left.
-
-```eu
-point: { x: 3 y: 4 }
-sum: point.(x + y)
-pair: point.[x, y]
-label: point."{x},{y}"
-```
-
-```yaml
-point:
-  x: 3
-  y: 4
-sum: 7
-pair:
-- 3
-- 4
-label: 3,4
-```
-
-This is particularly useful for creating temporary scopes:
-
-```eu
-result: { a: 10 b: 20 }.(a * b)
-```
-
-```yaml
-result: 200
-```
-
-_"Block-dot"_ syntax is particularly significant in monadic blocks
-(see [Monads and the monad() Utility](monads.md)).
-
-## Building Pipelines
-
-Combining catenation, partial application, and the standard prelude
-creates powerful data processing pipelines:
-
-```sh
-eu -e '["alice", "bob", "charlie"] map(str.to-upper) filter(str.matches?("^[AB]"))'
-```
-
-```yaml
-- ALICE
-- BOB
-```
-
-A more complete example:
-
-```eu
-people: [
-  { name: "Alice" age: 30 }
-  { name: "Bob" age: 25 }
-  { name: "Charlie" age: 35 }
+eu -e 'map(.name)' <<'JSON'
+[
+  {"name": "Alice", "role": "admin"},
+  {"name": "Bob", "role": "user"},
+  {"name": "Charlie", "role": "user"}
 ]
-
-over-thirty: people filter(.age > 30) map(.name)
+JSON
 ```
 
+**Output:**
+
 ```yaml
-people:
-- name: Alice
-  age: 30
-- name: Bob
-  age: 25
-- name: Charlie
-  age: 35
-over-thirty:
+- Alice
+- Bob
 - Charlie
 ```
 
-## The `then` Function
+The `_` is an expression anaphor -- `_.name` means "look up `name`
+in whatever the argument is".
 
-The `then` function provides a pipeline-friendly conditional:
+## 3. Filtering and Transforming Data
 
-```sh
-eu -e '5 > 3 then("yes", "no")'
-```
-
-```yaml
-yes
-```
-
-It is equivalent to `if` with the condition as the last argument,
-making it natural in pipelines:
+**Problem:** From a list of products, find those over a price
+threshold and format them.
 
 ```eu
-result: [1, 2, 3] count (> 2) then("many", "few")
+# products.eu
+products: [
+  { name: "Widget" price: 9.99 }
+  { name: "Gadget" price: 24.99 }
+  { name: "Gizmo" price: 49.99 }
+  { name: "Doohickey" price: 4.99 }
+]
+
+expensive: products
+  filter(.price > 20)
+  map(.name str.to-upper)
 ```
+
+```sh
+eu products.eu -e expensive
+```
+
+**Output:**
 
 ```yaml
-result: many
+- GADGET
+- GIZMO
 ```
 
-## Key Concepts
+## 4. Generating Configuration with Shared Defaults
 
-- **Catenation** applies a function by writing the argument before the
-  function name: `5 inc` means `inc(5)`
-- Pipelines are built by chaining catenation: `data f g h`
-- Functions are **curried**: partial application is automatic
-- The **dot operator** looks up properties: `block.key`
-- **Generalised lookup** evaluates expressions in a block's scope:
-  `block.(expr)`
-- Combine these techniques for concise data processing pipelines
+**Problem:** Generate environment-specific configs that share common
+defaults.
+
+```eu
+# config.eu
+base: {
+  app: "my-service"
+  port: 8080
+  log-level: "info"
+  db: { host: "localhost" port: 5432 }
+}
+
+production: base << {
+  log-level: "warn"
+  db: { host: "prod-db.internal" }
+}
+
+staging: base << {
+  db: { host: "staging-db.internal" }
+}
+```
+
+```sh
+eu config.eu -e production -j
+```
+
+**Output:**
+
+```json
+{
+  "app": "my-service",
+  "port": 8080,
+  "log-level": "warn",
+  "db": {
+    "host": "prod-db.internal",
+    "port": 5432
+  }
+}
+```
+
+The `<<` operator deep-merges blocks, so nested keys like `db.port`
+are preserved while `db.host` is overridden.
+
+## 5. CSV to JSON Conversion
+
+**Problem:** Read a CSV file and output as a JSON array.
+
+Given `people.csv`:
+```csv
+name,age,city
+Alice,30,London
+Bob,25,Manchester
+Charlie,35,Edinburgh
+```
+
+```sh
+eu rows=people.csv -j -e 'rows map(.name)'
+```
+
+**Output:**
+
+```json
+["Alice", "Bob", "Charlie"]
+```
+
+Or to transform the data:
+
+```sh
+eu rows=people.csv -j -e 'rows map{ name: •0.name age: •0.age num }'
+```
+
+This converts age from string to number (CSV values are always
+strings).
+
+## 6. Generating Availability Zone Names
+
+**Problem:** Generate AWS availability zone names from a list of zone
+letters.
+
+```sh
+eu -e '["a", "b", "c"] map("eu-west-2{}")'
+```
+
+**Output:**
+
+```yaml
+- eu-west-2a
+- eu-west-2b
+- eu-west-2c
+```
+
+The string `"eu-west-2{}"` is a function: `{}` is a string anaphor
+that takes one argument.
+
+## 7. Merging Multiple YAML Files
+
+**Problem:** Combine values from several YAML files into a single
+output.
+
+Given `defaults.yaml`:
+```yaml
+timeout: 30
+retries: 3
+```
+
+Given `overrides.yaml`:
+```yaml
+timeout: 60
+debug: true
+```
+
+```sh
+eu defaults.yaml overrides.yaml
+```
+
+**Output:**
+
+```yaml
+timeout: 60
+retries: 3
+debug: true
+```
+
+Later inputs override earlier ones. For a merged view with both
+available, use named inputs:
+
+```sh
+eu d=defaults.yaml o=overrides.yaml -e 'd << o'
+```
+
+## 8. Data Aggregation Pipeline
+
+**Problem:** Compute summary statistics from structured data.
+
+```eu
+# sales.eu
+sales: [
+  { region: "North" amount: 1200 },
+  { region: "South" amount: 800 },
+  { region: "North" amount: 600 },
+  { region: "South" amount: 1500 },
+  { region: "East" amount: 900 }
+]
+
+` :suppress
+amounts: sales map(.amount)
+n: sales count
+
+summary: {
+  total: amounts sum
+  count: n
+  average: (amounts sum) / n
+  max: amounts max-of
+  min: amounts min-of
+}
+```
+
+```sh
+eu sales.eu -e summary
+```
+
+**Output:**
+
+```yaml
+total: 5000
+count: 5
+average: 1000
+max: 1500
+min: 600
+```
+
+## 9. Querying Deeply Nested Configuration
+
+**Problem:** Find all port numbers in a complex configuration.
+
+```sh
+eu -e '{
+  web: { host: "0.0.0.0" port: 80 }
+  api: { host: "0.0.0.0" port: 8080 }
+  db: { host: "localhost" port: 5432 }
+  cache: { host: "localhost" port: 6379 }
+} deep-query("port")'
+```
+
+**Output:**
+
+```yaml
+- 80
+- 8080
+- 5432
+- 6379
+```
+
+`deep-query` recursively searches nested blocks. You can also use
+wildcards: `deep-query("*.port", data)` matches ports one level deep,
+while `deep-query("**.port", data)` matches at any depth.
+
+## 10. String Processing: Parsing Log Lines
+
+**Problem:** Extract timestamps and levels from log lines.
+
+```eu,notest
+# logs.eu
+lines: [
+  "2024-03-15 10:30:00 ERROR Connection timeout"
+  "2024-03-15 10:30:05 INFO Retry attempt 1"
+  "2024-03-15 10:30:10 ERROR Connection timeout"
+  "2024-03-15 10:30:15 INFO Connected"
+]
+
+` :suppress
+parse(line): line str.match-with("(\S+ \S+) (\w+) (.*)") tail
+
+parsed: lines map(parse) map({parts: •}.({
+  timestamp: parts first
+  level: parts second
+  message: parts nth(2)
+}))
+
+errors: parsed filter(.level = "ERROR")
+```
+
+```sh
+eu logs.eu -e errors
+```
+
+**Output:**
+
+```yaml
+- timestamp: '2024-03-15 10:30:00'
+  level: ERROR
+  message: Connection timeout
+- timestamp: '2024-03-15 10:30:10'
+  level: ERROR
+  message: Connection timeout
+```
+
+## 11. Templating CloudFormation Resources
+
+**Problem:** Generate YAML with custom tags for CloudFormation.
+
+```eu
+# cfn.eu
+resource(type, props): {
+  Type: type
+  Properties: props
+}
+
+resources: {
+  MyBucket: resource("AWS::S3::Bucket", {
+    BucketName: "my-bucket"
+  })
+  MyQueue: resource("AWS::SQS::Queue", {
+    QueueName: "my-queue"
+  })
+}
+```
+
+This example shows how a simple function can template
+repetitive structure.
+
+## 12. Working with Dates
+
+**Problem:** Filter events by date and format the output.
+
+```eu
+# events.eu
+events: [
+  { name: "Launch" date: t"2024-01-15" }
+  { name: "Review" date: t"2024-06-01" }
+  { name: "Release" date: t"2024-09-30" }
+]
+
+cutoff: t"2024-06-01"
+
+upcoming: events
+  filter(.date >= cutoff)
+  map(.name)
+```
+
+```sh
+eu events.eu -e upcoming
+```
+
+**Output:**
+
+```yaml
+- Review
+- Release
+```
+
+The `t"..."` syntax creates date-time literals that support
+comparison operators.
+
+## 13. Generating a Lookup Table
+
+**Problem:** Build a key-value mapping from two parallel lists.
+
+```sh
+eu -e '["Alice", 30, "London"] zip-kv[:name, :age, :city]'
+```
+
+**Output:**
+
+```yaml
+name: Alice
+age: 30
+city: London
+```
+
+`zip-kv` pairs up symbols as keys with values to produce a block.
+Note that `zip-kv[:name, :age, :city]` is shorthand for
+`zip-kv([:name, :age, :city])` — when a function takes a single list
+or block argument, the outer parentheses can be omitted.
+
+## 14. Parameterised Scripts
+
+**Problem:** Write a reusable script that accepts command-line
+arguments.
+
+```eu,notest
+# greet.eu
+name: io.args head-or("World")
+times: io.args tail head-or("1") num
+
+greetings: repeat("Hello, {name}!") take(times)
+```
+
+```sh
+eu greet.eu -e greetings -- Alice 3
+```
+
+**Output:**
+
+```yaml
+- Hello, Alice!
+- Hello, Alice!
+- Hello, Alice!
+```
+
+Arguments after `--` are available via `io.args` as a list of
+strings. Use `num` to convert to numbers.
+
+## 15. Set Operations: Finding Unique Values
+
+**Problem:** Find the unique tags across multiple items and compute
+overlaps.
+
+```eu
+items: [
+  { name: "A" tags: ["fast", "reliable", "cheap"] }
+  { name: "B" tags: ["fast", "expensive"] }
+  { name: "C" tags: ["reliable", "cheap", "slow"] }
+]
+
+` :suppress
+tag-sets: items map(.tags set.from-list)
+
+all-tags: tag-sets foldl(set.union, ∅) set.to-list
+common-tags: tag-sets foldl(set.intersect, tag-sets head) set.to-list
+
+result: {
+  all: all-tags
+  common: common-tags
+}
+```
+
+```sh
+eu tags.eu -e result
+```
+
+**Output:**
+
+```yaml
+all:
+- cheap
+- expensive
+- fast
+- reliable
+- slow
+common: []
+```
+
+## Next Steps
+
+- Work through [The Eucalypt Guide](../guide/blocks-and-declarations.md)
+  for a progressive tutorial
+- Browse the [Prelude Reference](../reference/prelude/index.md) for
+  the full standard library
+- See the [CLI Reference](../reference/cli.md) for all command-line
+  options
 
 ---
-
-<!-- Source: docs/guide/blocks-and-declarations.md -->
 
 # Blocks and Declarations
 
@@ -1075,7 +1295,8 @@ A bare string is shorthand for documentation metadata.
 
 Some metadata keys activate special behaviour:
 
-- `:suppress` -- hides the declaration from output
+- `:suppress` -- hides the declaration from output (still visible to importers)
+- `:internal` -- hides from output AND importers (unit-private)
 - `:target` -- marks the declaration as an export target
 - `:main` -- marks the default target
 - Any other bare symbol -- marks a named target
@@ -1171,7 +1392,1134 @@ inner:
 
 ---
 
-<!-- Source: docs/guide/functions-and-combinators.md -->
+# Expressions and Pipelines
+
+In this chapter you will learn:
+
+- The primitive value types in eucalypt
+- How function application works via catenation (pipelining)
+- How partial application and currying work
+- How to compose pipelines of transformations
+
+## Primitive Values
+
+Eucalypt has the following primitive types:
+
+| Type | Examples | Notes |
+|------|----------|-------|
+| Numbers | `42`, `-7`, `3.14` | Integers and floats |
+| Strings | `"hello"`, `"it's"` | Double-quoted only |
+| Symbols | `:name`, `:active` | Colon-prefixed identifiers |
+| Booleans | `true`, `false` | |
+| Null | `null` | Renders as YAML `~` or JSON `null` |
+
+## Lists
+
+Lists are comma-separated values in square brackets (unlike in blocks,
+commas are required):
+
+```eu
+numbers: [1, 2, 3, 4, 5]
+mixed: [1, "two", :three, true]
+nested: [[1, 2], [3, 4]]
+empty: []
+```
+
+## Calling Functions
+
+Functions can be called by placing arguments in parentheses directly
+after the function name (with no intervening space):
+
+```eu
+add(x, y): x + y
+result: add(3, 4)
+```
+
+```yaml
+result: 7
+```
+
+## Catenation: The Pipeline Style
+
+One distinctive feature of eucalypt is **catenation**: applying a
+function by writing the argument before the function name, separated
+by whitespace.
+
+```eu
+result: 5 inc
+```
+
+This is equivalent to `inc(5)` and produces `6`.
+
+Catenation lets you chain operations into readable pipelines:
+
+```sh
+eu -e '[1, 2, 3, 4, 5] reverse head'
+```
+
+```yaml
+5
+```
+
+Each step in the pipeline passes its result to the next function. You
+can read it left to right: "take the list, reverse it, take the head."
+
+## Combining Catenation with Arguments
+
+When a function takes multiple arguments, you can supply some in
+parentheses and the rest via catenation. The catenated value becomes
+the *last* argument:
+
+```eu
+result: [1, 2, 3] map(inc)
+```
+
+Here `map` takes two arguments: a function and a list. `inc` is
+provided in parentheses and `[1, 2, 3]` is provided by catenation.
+The result is `[2, 3, 4]`.
+
+This is the standard eucalypt pattern for data processing pipelines:
+
+```sh
+eu -e '[1, 2, 3, 4, 5] filter(> 3) map(* 10)'
+```
+
+```yaml
+- 40
+- 50
+```
+
+## Currying and Partial Application
+
+All functions in eucalypt are curried: if you provide fewer arguments
+than a function expects, you get back a partially applied function.
+
+```eu
+add(x, y): x + y
+add-five: add(5)
+result: add-five(3)
+```
+
+```yaml
+result: 8
+```
+
+Curried application also works with multi-argument calls:
+
+```eu
+f(x, y, z): x + y + z
+
+a: f(1, 2, 3)   # all at once
+b: f(1)(2)(3)    # one at a time
+c: f(1, 2)(3)    # mixed
+```
+
+All three produce `6`.
+
+## Lookup: The Dot Operator
+
+The dot operator (`.`) accesses a named property within a block:
+
+```eu
+person: { name: "Alice" age: 30 }
+name: person.name
+```
+
+```yaml
+person:
+  name: Alice
+  age: 30
+name: Alice
+```
+
+Lookups can be chained:
+
+```eu
+config: { db: { host: "localhost" port: 5432 } }
+host: config.db.host
+```
+
+```yaml
+config:
+  db:
+    host: localhost
+    port: 5432
+host: localhost
+```
+
+> **Warning:** The dot operator binds very tightly (precedence 90).
+> Writing `list head.name` groups `head.name` into one unit first —
+> and that unit, not `list`, is what gets applied: it parses as
+> `head.name(list)`, not `(list head).name`. Use explicit parentheses
+> when combining lookup with catenation: `(list head).name`.
+>
+> The `↑` (up arrow) prefix operator, which is shorthand for `head`,
+> binds even tighter (precedence 95). So `↑xs.name` means
+> `(↑xs).name`.
+
+## "Juxtaposed" call syntax
+
+When a function is passed only a single list argument or a single
+block argument, it is possible to omit the outer parentheses for
+brevity:
+
+``` eu,notest
+result: f[1, 2, 3] ∧ g{a: 1 b: 2}
+```
+
+The "juxtaposition" refers to the resulting feature that directly
+placing a function together with any form of brackets (with no
+intervening whitespace) is now call syntax - whereas using an
+intervening space is a pipeline syntax.
+
+Juxtaposed call syntax: `f(x), f[x], f{x}`.
+
+Pipeline syntax: `x f`, `[x] f`, `{x} f`.
+
+## Generalised Lookup (or "block-dot" notation)
+
+Lookup can be generalised: any expression after the dot is evaluated
+in the context of the block to the left.
+
+```eu
+point: { x: 3 y: 4 }
+sum: point.(x + y)
+pair: point.[x, y]
+label: point."{x},{y}"
+```
+
+```yaml
+point:
+  x: 3
+  y: 4
+sum: 7
+pair:
+- 3
+- 4
+label: 3,4
+```
+
+This is particularly useful for creating temporary scopes:
+
+```eu
+result: { a: 10 b: 20 }.(a * b)
+```
+
+```yaml
+result: 200
+```
+
+_"Block-dot"_ syntax is particularly significant in monadic blocks
+(see [Monads and the monad() Utility](monads.md)).
+
+## Building Pipelines
+
+Combining catenation, partial application, and the standard prelude
+creates powerful data processing pipelines:
+
+```sh
+eu -e '["alice", "bob", "charlie"] map(str.to-upper) filter(str.matches?("^[AB]"))'
+```
+
+```yaml
+- ALICE
+- BOB
+```
+
+A more complete example:
+
+```eu
+people: [
+  { name: "Alice" age: 30 }
+  { name: "Bob" age: 25 }
+  { name: "Charlie" age: 35 }
+]
+
+over-thirty: people filter(.age > 30) map(.name)
+```
+
+```yaml
+people:
+- name: Alice
+  age: 30
+- name: Bob
+  age: 25
+- name: Charlie
+  age: 35
+over-thirty:
+- Charlie
+```
+
+## The `then` Function
+
+The `then` function provides a pipeline-friendly conditional:
+
+```sh
+eu -e '5 > 3 then("yes", "no")'
+```
+
+```yaml
+yes
+```
+
+It is equivalent to `if` with the condition as the last argument,
+making it natural in pipelines:
+
+```eu
+result: [1, 2, 3] count (> 2) then("many", "few")
+```
+
+```yaml
+result: many
+```
+
+## Key Concepts
+
+- **Catenation** applies a function by writing the argument before the
+  function name: `5 inc` means `inc(5)`
+- Pipelines are built by chaining catenation: `data f g h`
+- Functions are **curried**: partial application is automatic
+- The **dot operator** looks up properties: `block.key`
+- **Generalised lookup** evaluates expressions in a block's scope:
+  `block.(expr)`
+- Combine these techniques for concise data processing pipelines
+
+---
+
+# Lists and Transformations
+
+In this chapter you will learn:
+
+- How to create and deconstruct lists
+- The core list operations: `map`, `filter`, `foldl`, `foldr`
+- Other useful list functions from the prelude
+- How to combine list operations into pipelines
+
+## Creating Lists
+
+Lists are written with square brackets and commas:
+
+```eu
+numbers: [1, 2, 3, 4, 5]
+strings: ["hello", "world"]
+empty: []
+nested: [[1, 2], [3, 4]]
+```
+
+## Basic List Operations
+
+### `head` and `tail`
+
+`head` returns the first element; `tail` returns everything after it:
+
+```sh
+eu -e '[10, 20, 30] head'
+```
+
+```yaml
+10
+```
+
+```sh
+eu -e '[10, 20, 30] tail'
+```
+
+```yaml
+- 20
+- 30
+```
+
+Use `head-or` to provide a default for empty lists:
+
+```sh
+eu -e '[] head-or(0)'
+```
+
+```yaml
+0
+```
+
+### `first` and `second`
+
+`first` is an alias for `head`. `second` returns the second element:
+
+```sh
+eu -e '[:a, :b, :c] second'
+```
+
+```yaml
+b
+```
+
+### `cons`
+
+`cons` prepends an element to a list:
+
+```sh
+eu -e 'cons(0, [1, 2, 3])'
+```
+
+```yaml
+- 0
+- 1
+- 2
+- 3
+```
+
+### `nil?`
+
+Test whether a list is empty:
+
+```sh
+eu -e '[] nil?'
+```
+
+```yaml
+true
+```
+
+### `count`
+
+Count the elements:
+
+```sh
+eu -e '[10, 20, 30] count'
+```
+
+```yaml
+3
+```
+
+## Transforming Lists
+
+### `map`
+
+Apply a function to every element:
+
+```sh
+eu -e '[1, 2, 3] map(inc)'
+```
+
+```yaml
+- 2
+- 3
+- 4
+```
+
+```sh
+eu -e '[1, 2, 3] map(* 10)'
+```
+
+```yaml
+- 10
+- 20
+- 30
+```
+
+### `filter`
+
+Keep only elements satisfying a predicate:
+
+```sh
+eu -e '[1, 2, 3, 4, 5, 6] filter(> 3)'
+```
+
+```yaml
+- 4
+- 5
+- 6
+```
+
+### `remove`
+
+The opposite of `filter` -- remove elements satisfying the predicate:
+
+```sh
+eu -e '[1, 2, 3, 4, 5] remove(> 3)'
+```
+
+```yaml
+- 1
+- 2
+- 3
+```
+
+## Folding
+
+Folds reduce a list to a single value by applying a binary function
+across all elements.
+
+### `foldl`
+
+Left fold: `foldl(op, init, list)` applies `op` from the left:
+
+```sh
+eu -e 'foldl(+, 0, [1, 2, 3, 4, 5])'
+```
+
+```yaml
+15
+```
+
+### `foldr`
+
+Right fold: `foldr(op, init, list)` applies `op` from the right:
+
+```sh
+eu -e 'foldr(++, [], [[1, 2], [3, 4], [5]])'
+```
+
+```yaml
+- 1
+- 2
+- 3
+- 4
+- 5
+```
+
+## Slicing
+
+### `take` and `drop`
+
+```sh
+eu -e '[1, 2, 3, 4, 5] take(3)'
+```
+
+```yaml
+- 1
+- 2
+- 3
+```
+
+```sh
+eu -e '[1, 2, 3, 4, 5] drop(3)'
+```
+
+```yaml
+- 4
+- 5
+```
+
+### `take-while` and `drop-while`
+
+```sh
+eu -e '[1, 2, 3, 4, 5] take-while(< 4)'
+```
+
+```yaml
+- 1
+- 2
+- 3
+```
+
+## Combining Lists
+
+### `append` and `++`
+
+```sh
+eu -e '[1, 2] ++ [3, 4]'
+```
+
+```yaml
+- 1
+- 2
+- 3
+- 4
+```
+
+### `concat`
+
+Flatten a list of lists:
+
+```sh
+eu -e 'concat([[1, 2], [3], [4, 5]])'
+```
+
+```yaml
+- 1
+- 2
+- 3
+- 4
+- 5
+```
+
+### `mapcat`
+
+Map then flatten (also known as `flatMap` or `concatMap`):
+
+```sh
+eu -e '["ab", "cd"] mapcat(str.letters)'
+```
+
+```yaml
+- a
+- b
+- c
+- d
+```
+
+## Checking Lists
+
+### `all-true?` and `any-true?`
+
+```sh
+eu -e '[true, true, false] all-true?'
+```
+
+```yaml
+false
+```
+
+```sh
+eu -e '[true, true, false] any-true?'
+```
+
+```yaml
+true
+```
+
+### `all` and `any`
+
+Test with a predicate:
+
+```sh
+eu -e '[2, 4, 6] all(> 0)'
+```
+
+```yaml
+true
+```
+
+```sh
+eu -e '[1, 2, 3] any(zero?)'
+```
+
+```yaml
+false
+```
+
+## Reordering
+
+### `reverse`
+
+```sh
+eu -e '[:a, :b, :c] reverse'
+```
+
+```yaml
+- c
+- b
+- a
+```
+
+### `zip-with`
+
+Combine two lists element by element:
+
+```sh
+eu -e 'zip-with(+, [1, 2, 3], [10, 20, 30])'
+```
+
+```yaml
+- 11
+- 22
+- 33
+```
+
+### `zip-with` and `pair` to create blocks
+
+```sh
+eu -e 'zip-with(pair, [:x, :y, :z], [1, 2, 3]) block'
+```
+
+```yaml
+x: 1
+y: 2
+z: 3
+```
+
+## Infinite Lists
+
+Eucalypt supports lazy evaluation, so you can work with infinite lists:
+
+```sh
+eu -e 'repeat(:x) take(4)'
+```
+
+```yaml
+- x
+- x
+- x
+- x
+```
+
+Use `take` to extract a finite portion.
+
+## Sorting
+
+### `qsort`
+
+Sort with a comparison function:
+
+```sh
+eu -e '[5, 3, 1, 4, 2] qsort(<)'
+```
+
+```yaml
+- 1
+- 2
+- 3
+- 4
+- 5
+```
+
+### `sort-nums`
+
+A convenience for sorting numbers in ascending order:
+
+```sh
+eu -e '[30, 10, 20] sort-nums'
+```
+
+```yaml
+- 10
+- 20
+- 30
+```
+
+## Putting It Together
+
+Here is a more complete example combining multiple list operations:
+
+```eu
+data: [
+  { name: "Alice" score: 85 }
+  { name: "Bob" score: 92 }
+  { name: "Charlie" score: 78 }
+  { name: "Diana" score: 95 }
+]
+
+top-scorers: data
+  filter(.score >= 90)
+  map(.name)
+```
+
+```yaml
+data:
+- name: Alice
+  score: 85
+- name: Bob
+  score: 92
+- name: Charlie
+  score: 78
+- name: Diana
+  score: 95
+top-scorers:
+- Bob
+- Diana
+```
+
+## Key Concepts
+
+- Lists are created with `[...]` and can be heterogeneous
+- `map`, `filter`, and `foldl`/`foldr` are the core transformation
+  functions
+- `take`, `drop`, `reverse`, `append` (`++`), and `concat` reshape
+  lists
+- `all`, `any`, `all-true?`, and `any-true?` test list conditions
+- Lazy evaluation allows working with infinite lists via `repeat`
+- `qsort` sorts with a custom comparator; `sort-nums` sorts numbers
+
+---
+
+# Strings and Text
+
+In this chapter you will learn:
+
+- The two string literal types (raw and c-strings)
+- How to embed expressions in strings using `{...}` syntax
+- How strings with anaphora become functions
+- Format specifiers for controlling output
+- The string functions available in the `str` namespace
+
+## String Literal Types
+
+Eucalypt has two kinds of string literal: **raw strings** and
+**c-strings**.
+
+### Raw Strings
+
+A plain double-quoted string is a raw string — backslashes are
+literal characters with no escape processing. This is convenient for
+regular expression usage.
+
+```eu
+greeting: "Hello, World!"
+path: "C:\Users\alice\docs"
+regex: "^\d+\.\d+"
+```
+
+The `r"..."` prefix is equivalent and can be used for clarity when
+the string contains backslashes:
+
+```eu
+path: r"C:\Users\alice\docs"
+regex: r"^\d+\.\d+"
+```
+
+Raw strings support interpolation with `{...}`. Use `{{` and `}}`
+for literal braces.
+
+### C-Strings (`c"..."`)
+
+If you require C-style escapes, you can use C-strings:
+
+| Escape | Meaning |
+|--------|---------|
+| `\n` | Newline |
+| `\t` | Tab |
+| `\r` | Carriage return |
+| `\\` | Literal backslash |
+| `\"` | Literal quote |
+| `\{`, `\}` | Literal braces |
+| `\xHH` | Hex byte |
+| `\uHHHH` | Unicode code point |
+| `\UHHHHHHHH` | Extended Unicode |
+
+```eu
+multiline: c"first line\nsecond line"
+```
+
+C-strings also support interpolation with `{...}`.
+
+## Basic Interpolation
+
+Embed any expression inside a string using curly braces:
+
+```eu
+name: "World"
+greeting: "Hello, {name}!"
+```
+
+```yaml
+name: World
+greeting: Hello, World!
+```
+
+Interpolation braces accept names and dotted lookups. To use a
+computed value, bind it to a name first:
+
+```eu
+x: 3
+y: 4
+sum: x + y
+result: "{x} + {y} = {sum}"
+```
+
+```yaml
+x: 3
+y: 4
+sum: 7
+result: 3 + 4 = 7
+```
+
+## Nested Lookups in Interpolation
+
+You can use dotted paths inside interpolation:
+
+```eu
+data: { foo: { bar: 99 } }
+label: "{data.foo.bar}"
+```
+
+```yaml
+data:
+  foo:
+    bar: 99
+label: '99'
+```
+
+> **Note:** Interpolation braces accept names and dotted lookups, but
+> not arbitrary eucalypt expressions. If you need a computed value,
+> bind it to a name first:
+>
+> ```eu
+> sum: x + y
+> result: "{sum}"
+> ```
+
+## Escaping Braces
+
+To include a literal brace in a string, double it:
+
+```eu
+example: "Use {{braces}} for interpolation"
+```
+
+```yaml
+example: Use {braces} for interpolation
+```
+
+This is also needed in regular expressions within interpolated
+strings:
+
+```eu
+pattern: "01234" str.match-with("\d{{4}}")
+```
+
+## Format Specifiers
+
+Add a format specifier after a colon inside the interpolation braces.
+These use printf-style format codes:
+
+```eu
+pi: 3.14159
+formatted: "{pi:%.2f}"
+padded: "{42:%06d}"
+```
+
+```yaml
+pi: 3.14159
+formatted: '3.14'
+padded: '000042'
+```
+
+## String Anaphora
+
+When a string contains `{}` (empty braces) or `{0}`, `{1}`, etc.,
+the string literal actually defines a function rather than a plain
+string value:
+
+```sh
+eu -e '["a", "b", "c"] map("item: {}")'
+```
+
+```yaml
+- 'item: a'
+- 'item: b'
+- 'item: c'
+```
+
+Numbered anaphora control argument order:
+
+```eu
+reverse-pair: "{1},{0}"
+result: reverse-pair(:a, :b)
+```
+
+```yaml
+result: b,a
+```
+
+You can mix named references and anaphora:
+
+```eu
+prefix: "Hello"
+greet: "{prefix} {}!"
+result: greet("World")
+```
+
+```yaml
+prefix: Hello
+result: Hello World!
+```
+
+## String Functions
+
+The `str` namespace contains functions for working with strings.
+
+### Conversion
+
+```sh
+eu -e '42 str.of'
+```
+
+```yaml
+'42'
+```
+
+### Case Conversion
+
+```sh
+eu -e '"hello" str.to-upper'
+```
+
+```yaml
+HELLO
+```
+
+```sh
+eu -e '"GOODBYE" str.to-lower'
+```
+
+```yaml
+goodbye
+```
+
+### Splitting and Joining
+
+Split a string on a pattern:
+
+```sh
+eu -e '"one-two-three" str.split-on("-")'
+```
+
+```yaml
+- one
+- two
+- three
+```
+
+Join a list of strings:
+
+```sh
+eu -e '["a", "b", "c"] str.join-on(", ")'
+```
+
+```yaml
+a, b, c
+```
+
+### Prefix and Suffix
+
+```sh
+eu -e '"world" str.prefix("hello ")'
+```
+
+```yaml
+hello world
+```
+
+```sh
+eu -e '"hello" str.suffix("!")'
+```
+
+```yaml
+hello!
+```
+
+### Characters and Letters
+
+```sh
+eu -e '"hello" str.letters'
+```
+
+```yaml
+- h
+- e
+- l
+- l
+- o
+```
+
+```sh
+eu -e '"hello" str.letters count'
+```
+
+```yaml
+5
+```
+
+## Regular Expressions
+
+### Testing a Match
+
+```sh
+eu -e '"hello" str.matches?("^h.*o$")'
+```
+
+```yaml
+true
+```
+
+### Extracting Matches
+
+`str.match-with` returns the full match and capture groups:
+
+```sh
+eu -e '"192.168.0.1" str.match-with("(\d+)[.](\d+)[.](\d+)[.](\d+)") tail'
+```
+
+```yaml
+- '192'
+- '168'
+- '0'
+- '1'
+```
+
+`str.matches-of` returns all occurrences of a pattern:
+
+```sh
+eu -e '"192.168.0.1" str.matches-of("\d+")'
+```
+
+```yaml
+- '192'
+- '168'
+- '0'
+- '1'
+```
+
+### Base64 and SHA-256
+
+```sh
+eu -e '"hello" str.base64-encode'
+```
+
+```yaml
+aGVsbG8=
+```
+
+```sh
+eu -e '"hello" str.sha256'
+```
+
+```yaml
+2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```
+
+## Practical Examples
+
+### Generating URLs
+
+```eu
+base: "https://api.example.com"
+endpoints: ["users", "posts", "comments"] map("{base}/{}")
+```
+
+```yaml
+base: https://api.example.com
+endpoints:
+- https://api.example.com/users
+- https://api.example.com/posts
+- https://api.example.com/comments
+```
+
+### Formatting a Table
+
+```eu
+rows: [
+  { name: "Alice" score: 85 }
+  { name: "Bob" score: 92 }
+]
+
+` :suppress
+format-row(r): "{r.name:%10s} | {r.score:%3d}"
+
+table: rows map(format-row)
+```
+
+## Key Concepts
+
+- Interpolation uses `{expression}` inside double-quoted strings
+- Empty braces `{}` and numbered braces `{0}`, `{1}` create string
+  functions (anaphora)
+- Format specifiers follow a colon: `{value:%06d}`
+- Escape literal braces by doubling them: `{{` and `}}`
+- The `str` namespace provides splitting, joining, case conversion,
+  matching, and more
+
+---
 
 # Functions and Combinators
 
@@ -1776,7 +3124,309 @@ directory:
 
 ---
 
-<!-- Source: docs/guide/anaphora.md -->
+# Operators
+
+In this chapter you will learn:
+
+- How to define custom nullary, binary, prefix, and postfix operators
+- How precedence and associativity work
+- How to control operator behaviour with metadata
+- The built-in operators provided by the prelude
+
+## Defining Binary Operators
+
+A binary operator is declared by writing the operand names and the
+operator symbol in parentheses:
+
+```eu
+(x <+> y): x + y + 1
+
+result: 3 <+> 4
+```
+
+```yaml
+result: 8
+```
+
+Operator names use symbolic characters: `+`, `-`, `*`, `/`, `<`, `>`,
+`|`, `&`, `!`, `@`, `#`, `~`, `^`, and any Unicode symbol or
+punctuation characters.
+
+## Nullary Operators
+
+A nullary operator takes no operands — it is a constant written as a
+symbol:
+
+```eu
+(∅): '__SET.EMPTY'
+result: ∅ set.to-list
+```
+
+```yaml
+result: []
+```
+
+The empty set `∅` is the only nullary operator in the standard prelude,
+but you can define your own:
+
+```eu,notest
+(★): 42
+answer: ★
+```
+
+## Prefix and Postfix Operators
+
+Prefix operators have the operator before the operand:
+
+```eu
+(¬ x): not(x)
+result: ¬ true
+```
+
+```yaml
+result: false
+```
+
+Postfix operators have the operator after the operand:
+
+```eu
+(x !!): x * x
+result: 5 !!
+```
+
+```yaml
+result: 25
+```
+
+## Precedence
+
+Without precedence rules, operator expressions would be ambiguous. In
+eucalypt, precedence determines which operators bind more tightly.
+
+The prelude defines the standard precedence levels:
+
+| Level | Name | Operators |
+|-------|------|-----------|
+| 95 | prefix | `↑` (head) |
+| 90 | lookup | `.` |
+| 88 | bool-unary | `!`, `¬` |
+| 85 | exp | `^`, `!!` (nth) |
+| 80 | prod | `*`, `/`, `÷`, `%` |
+| 75 | sum | `+`, `-` |
+| 60 | shift | (shift operators) |
+| 55 | bitwise | (bitwise operators) |
+| 50 | cmp | `<`, `>`, `<=`, `>=` |
+| 45 | append | `++`, `<<` |
+| 40 | eq | `=`, `!=` |
+| 35 | bool-prod | `&&`, `∧` |
+| 30 | bool-sum | `\|\|`, `∨` |
+| 20 | cat | (catenation) |
+| 10 | apply | `@` |
+| 5 | meta | `//`, `//=`, `//=>`, `//=?`, `//!` |
+
+Higher numbers bind more tightly:
+
+```sh
+eu -e '1 + 2 * 3'
+```
+
+```yaml
+7
+```
+
+Because `*` (precedence 80) binds tighter than `+` (precedence 75),
+this is parsed as `1 + (2 * 3)`, not `(1 + 2) * 3`.
+
+## Associativity
+
+When the same operator (or operators at the same precedence) appear
+in sequence, associativity determines the grouping.
+
+- **Left-associative**: `1 - 2 - 3` = `(1 - 2) - 3` = `-4`
+- **Right-associative**: `a -> b -> c` = `a -> (b -> c)`
+
+Most arithmetic and comparison operators are left-associative.
+
+## Setting Precedence and Associativity
+
+Use declaration metadata to control your operator's precedence and
+associativity:
+
+```eu
+` { associates: :left
+    precedence: :sum }
+(x +++ y): x + y
+
+` { associates: :right
+    precedence: :prod }
+(x *** y): x * y
+```
+
+Precedence can be specified as:
+- A named level: `:sum`, `:prod`, `:exp`, `:cmp`, `:eq`, `:bool-prod`,
+  `:bool-sum`, `:append`, `:map`, `:bool-unary`, `:cat`, `:apply`,
+  `:meta`, `:shift`, `:bitwise`
+- A numeric value: any integer (higher binds tighter)
+
+Associativity can be `:left`, `:right`, or omitted (defaults to
+`:left`).
+
+## The Assertion Operators
+
+Two special operators are provided for testing:
+
+### `//=` (assert equals)
+
+Asserts that the left side equals the right side at runtime, and
+returns the value if true. Panics if false:
+
+```eu
+result: 2 + 2 //= 4
+```
+
+### `//=>` (assert equals with metadata)
+
+Like `//=` but also attaches the assertion as metadata:
+
+```eu
+checked: 2 + 2 //=> 4
+```
+
+Both are useful for embedding tests and sanity checks in code.
+
+## The Metadata Operator `//`
+
+Attach metadata to any value:
+
+```eu
+tagged: 42 // { note: "the answer" }
+```
+
+The metadata can be retrieved with `meta`:
+
+```eu,notest
+note: meta(tagged).note
+```
+
+```yaml
+note: the answer
+```
+
+See [Advanced Topics](advanced-topics.md) for more on metadata.
+
+## The Deep Merge Operator `<<`
+
+Deep merge combines two blocks, recursively merging nested blocks:
+
+```eu
+base: { a: { x: 1 y: 2 } b: 3 }
+overlay: { a: { y: 9 z: 10 } }
+result: base << overlay
+```
+
+```yaml
+base:
+  a:
+    x: 1
+    y: 2
+  b: 3
+overlay:
+  a:
+    y: 9
+    z: 10
+result:
+  a:
+    x: 1
+    y: 9
+    z: 10
+  b: 3
+```
+
+## The Append Operator `++`
+
+Concatenate two lists:
+
+```sh
+eu -e '[1, 2] ++ [3, 4]'
+```
+
+```yaml
+- 1
+- 2
+- 3
+- 4
+```
+
+## Dot Sections
+
+The dot operator can be used as a section to create lookup functions:
+
+```sh
+eu -e '[{x: 1}, {x: 2}, {x: 3}] map(.x)'
+```
+
+```yaml
+- 1
+- 2
+- 3
+```
+
+## Idiot Brackets
+
+Eucalypt lets you define custom Unicode bracket pairs that wrap and
+transform an expression. These are called *idiot brackets* (inspired
+by *idiom brackets* from applicative functor notation, but they are a
+general bracket overloading mechanism).
+
+```eu
+⌈ xs ⌉: xs map(_ * 2)
+
+each-doubled: ⌈ 3 4 5 ⌉
+```
+
+```yaml
+each-doubled:
+  - 6
+  - 8
+  - 10
+```
+
+The declaration `⌈ xs ⌉: body` defines a function named `⌈⌉` that
+takes one argument. Using `⌈ a b c ⌉` in an expression collects the
+items into a list and calls the function with `[a, b, c]`.
+
+Any matching Unicode bracket pair can be used:
+
+| Open | Close | Name |
+|------|-------|------|
+| `⟦`  | `⟧`   | Mathematical white square brackets |
+| `⟨`  | `⟩`   | Mathematical angle brackets |
+| `⟪`  | `⟫`   | Mathematical double angle brackets |
+| `⌈`  | `⌉`   | Ceiling brackets |
+| `⌊`  | `⌋`   | Floor brackets |
+| `«`  | `»`   | French guillemets |
+
+(and several others — see the
+[syntax reference](../reference/syntax.md) for the full list.)
+
+Idiot brackets can also be given a monadic interpretation for
+sequencing — see [Monads and the monad() Utility](monads.md) for
+details on bracket pair definitions with `:monad` metadata.
+
+## Key Concepts
+
+- Operators are declared with symbolic names in parentheses:
+  `(x op y):`, `(op x):`, `(x op):`
+- **Precedence** controls binding strength; higher numbers bind
+  tighter
+- **Associativity** determines grouping for equal-precedence
+  operators
+- Use metadata to set `precedence` and `associates` on custom
+  operators
+- The prelude provides standard arithmetic, comparison, boolean, and
+  utility operators
+
+---
 
 # Anaphora (Implicit Parameters)
 
@@ -1936,7 +3586,7 @@ Imagine you wanted a two-parameter function which placed the
 parameters in a block with keys `x` and `y`:
 
 ```eu
-f(x, y): {x: x y: y }
+f(x, y): {a: x b: y }
 ```
 
 An attempt to define this using expression anaphora would fail. This
@@ -2007,7 +3657,2651 @@ enough that the various species of anaphora can handle them neatly.
 
 ---
 
-<!-- Source: docs/guide/monads.md -->
+# Block Manipulation
+
+In this chapter you will learn:
+
+- How to merge blocks with catenation and `merge`
+- How to inspect, transform, and restructure blocks
+- Key prelude functions for working with blocks
+- Patterns for building and modifying configuration data
+
+## Block Merge by Catenation
+
+When two blocks appear next to each other, the result is a shallow
+merge. Later values override earlier ones:
+
+```sh
+eu -e '{ a: 1 } { b: 2 }'
+```
+
+```yaml
+a: 1
+b: 2
+```
+
+```sh
+eu -e '{ a: 1 } { a: 2 }'
+```
+
+```yaml
+a: 2
+```
+
+This is the same as calling the `merge` function:
+
+```sh
+eu -e 'merge({ a: 1 }, { b: 2 })'
+```
+
+```yaml
+a: 1
+b: 2
+```
+
+## Deep Merge
+
+Use `deep-merge` or the `<<` operator for recursive merging of nested
+blocks:
+
+```eu
+base: { server: { host: "localhost" port: 8080 } }
+override: { server: { port: 9090 debug: true } }
+config: base << override
+```
+
+```yaml
+base:
+  server:
+    host: localhost
+    port: 8080
+override:
+  server:
+    port: 9090
+    debug: true
+config:
+  server:
+    host: localhost
+    port: 9090
+    debug: true
+```
+
+Note that `<<` merges nested blocks but replaces lists entirely.
+
+## Inspecting Blocks
+
+### `elements`
+
+Break a block into its list of key-value pairs:
+
+```sh
+eu -e '{ a: 1 b: 2 } elements'
+```
+
+```yaml
+- - a
+  - 1
+- - b
+  - 2
+```
+
+Each element is a two-element list: `[key, value]`.
+
+### `keys` and `values`
+
+```sh
+eu -e '{ a: 1 b: 2 c: 3 } keys'
+```
+
+```yaml
+- a
+- b
+- c
+```
+
+```sh
+eu -e '{ a: 1 b: 2 c: 3 } values'
+```
+
+```yaml
+- 1
+- 2
+- 3
+```
+
+### `has`
+
+Check whether a block contains a key:
+
+```sh
+eu -e '{ a: 1 b: 2 } has(:a)'
+```
+
+```yaml
+true
+```
+
+### `lookup` and `lookup-or`
+
+Look up a value by symbol key:
+
+```sh
+eu -e '{ a: 1 b: 2 } lookup(:b)'
+```
+
+```yaml
+2
+```
+
+With a default for missing keys:
+
+```sh
+eu -e '{ a: 1 } lookup-or(:z, 99)'
+```
+
+```yaml
+99
+```
+
+## Reconstructing Blocks
+
+### `block`
+
+Build a block from a list of key-value pairs:
+
+```sh
+eu -e '[[:a, 1], [:b, 2], [:c, 3]] block'
+```
+
+```yaml
+a: 1
+b: 2
+c: 3
+```
+
+### `zip-kv`
+
+Build a block from separate key and value lists:
+
+```sh
+eu -e 'zip-kv([:x, :y, :z], [1, 2, 3])'
+```
+
+```yaml
+x: 1
+y: 2
+z: 3
+```
+
+### `merge-all`
+
+Merge a list of blocks into one:
+
+```sh
+eu -e '[{a: 1}, {b: 2}, {c: 3}] merge-all'
+```
+
+```yaml
+a: 1
+b: 2
+c: 3
+```
+
+## Transforming Blocks
+
+### `map-values`
+
+Apply a function to every value, keeping keys:
+
+```sh
+eu -e '{ a: 1 b: 2 c: 3 } map-values(* 10)'
+```
+
+```yaml
+a: 10
+b: 20
+c: 30
+```
+
+### `map-keys`
+
+Transform the keys of a block:
+
+```sh
+eu -e '{ a: 1 b: 2 } map-keys(sym ∘ str.prefix("x-") ∘ str.of)'
+```
+
+```yaml
+x-a: 1
+x-b: 2
+```
+
+### `filter-values`
+
+Return the list of values that satisfy a predicate (note: this returns
+a **list**, not a block):
+
+```sh
+eu -e '{ a: 1 b: 20 c: 3 d: 40 } filter-values(> 10)'
+```
+
+```yaml
+- 20
+- 40
+```
+
+To keep matching entries as a block, use `filter-items` with
+`by-value`:
+
+```sh
+eu -e '{ a: 1 b: 20 c: 3 d: 40 } filter-items(by-value(> 10)) block'
+```
+
+```yaml
+b: 20
+d: 40
+```
+
+### `map-kv`
+
+Apply a function to each key-value pair. The function receives two
+separate arguments `(key, value)` (it uses `uncurry` internally),
+and returns a transformed result:
+
+```sh
+eu -e '{ a: 1 b: 2 } map-kv("{}: {}")'
+```
+
+```yaml
+- 'a: 1'
+- 'b: 2'
+```
+
+To produce a new block, combine with `block`:
+
+```sh
+eu -e '{ a: 1 b: 2 } map-kv(pair) block'
+```
+
+```yaml
+a: 1
+b: 2
+```
+
+## Modifying Individual Values
+
+### `alter-value`
+
+Replace the value at a specific key:
+
+```eu
+config: { host: "localhost" port: 8080 }
+updated: config alter-value(:port, 9090)
+```
+
+```yaml
+config:
+  host: localhost
+  port: 8080
+updated:
+  host: localhost
+  port: 9090
+```
+
+### `update-value`
+
+Apply a function to the value at a specific key:
+
+```eu
+counters: { hits: 10 errors: 3 }
+result: counters update-value(:hits, inc)
+```
+
+```yaml
+counters:
+  hits: 10
+  errors: 3
+result:
+  hits: 11
+  errors: 3
+```
+
+### `set-value`
+
+Set a value, creating the key if it does not exist:
+
+```sh
+eu -e '{} set-value(:x, 42)'
+```
+
+```yaml
+x: 42
+```
+
+### `alter` and `update` (nested)
+
+Modify values deep in nested blocks using a key path:
+
+```eu
+config: { server: { db: { port: 5432 } } }
+changed: config alter([:server, :db, :port], 3306)
+bumped: config update([:server, :db, :port], inc)
+```
+
+```yaml
+config:
+  server:
+    db:
+      port: 5432
+changed:
+  server:
+    db:
+      port: 3306
+bumped:
+  server:
+    db:
+      port: 5433
+```
+
+### `merge-at`
+
+Merge additional keys into a nested block:
+
+```eu
+config: { server: { db: { port: 5432 } } }
+extended: config merge-at([:server, :db], { host: "10.0.0.1" })
+```
+
+```yaml
+config:
+  server:
+    db:
+      port: 5432
+extended:
+  server:
+    db:
+      port: 5432
+      host: 10.0.0.1
+```
+
+## Patterns: Configuration Templating
+
+A common pattern is to define a base configuration and layer
+environment-specific overrides on top:
+
+```eu
+base: {
+  server: {
+    host: "0.0.0.0"
+    port: 8080
+    workers: 4
+  }
+  logging: {
+    level: "info"
+    format: "json"
+  }
+}
+
+production: base << {
+  server: { workers: 16 }
+  logging: { level: "warn" }
+}
+
+development: base << {
+  server: { host: "localhost" }
+  logging: { level: "debug" format: "text" }
+}
+```
+
+## Key Concepts
+
+- **Block catenation** merges two blocks; later keys override earlier
+  ones
+- **Deep merge** (`<<`) recursively merges nested blocks
+- `elements`, `keys`, `values` decompose blocks; `block` and
+  `zip-kv` reconstruct them
+- `map-values`, `map-keys`, `filter-values` transform blocks
+- `alter-value`, `update-value`, `set-value` modify individual
+  entries
+- `alter`, `update`, `merge-at` modify deeply nested values
+
+---
+
+# Navigating Nested Data
+
+In this chapter you will learn:
+
+- How to safely access keys that may not exist using `~`
+- How to check data shape with `match?`
+- How to use lenses and traversals for deep get/set operations
+- When to use each approach
+
+## The Problem
+
+Structured data from YAML, JSON, or TOML is often deeply nested,
+with optional fields that may or may not be present. Eucalypt
+provides several complementary tools for working with this data,
+from simple safe navigation to powerful lens-based transformations.
+
+## Safe Navigation with `~`
+
+The dot operator (`.`) looks up a key in a block but errors if
+the key is missing or the value is not a block. The `~` operator
+is the safe alternative: it returns `null` instead of erroring.
+
+```eu
+config: { server: { host: "localhost", port: 5432 } }
+
+# Dot lookup — errors if key missing
+host: config.server.host
+
+# Safe navigation — returns null if any step fails
+host2: config ~ :server ~ :host
+missing: config ~ :cache ~ :host
+```
+
+```yaml
+config:
+  server:
+    host: localhost
+    port: 5432
+host: localhost
+host2: localhost
+missing: ~
+```
+
+`~` takes a symbol on the right and returns the value at that key
+if the left-hand side is a block containing the key, or `null`
+otherwise. Crucially, `null ~ :anything` returns `null`, so chains
+propagate failure naturally.
+
+### Sections for Pipelines
+
+Because `~` is a regular operator (left-associative, precedence
+90), sections work:
+
+```eu
+people: [
+  { name: "Alice", email: "alice@example.com" }
+  { name: "Bob" }
+  { name: "Charlie", email: "charlie@example.com" }
+]
+
+emails: people map(~ :email)
+have-email: people filter(_ ~ :email ✓)
+```
+
+```yaml
+people:
+- name: Alice
+  email: alice@example.com
+- name: Bob
+- name: Charlie
+  email: charlie@example.com
+emails:
+- alice@example.com
+- ~
+- charlie@example.com
+have-email:
+- name: Alice
+  email: alice@example.com
+- name: Charlie
+  email: charlie@example.com
+```
+
+### Mixing `~` and `.`
+
+Both `~` and `.` have the same precedence (90). Use `.` for keys
+you know exist and `~` for keys that might not:
+
+```eu,notest
+# Known structure, optional leaf
+config.server.db ~ :ssl-cert
+
+# Entirely optional path
+config ~ :cache ~ :host
+```
+
+If `~` returns `null` and you then use `.` on it, you get an error
+— `.` is not safe. Use `~` for the entire uncertain portion of the
+path.
+
+## Structural Matching with `match?`
+
+`match?(pattern, target)` checks whether a value conforms to a structural
+pattern, returning `true` or `false`. With a single block or list
+argument, use juxtaposed call syntax: `match?{...}` or `match?[...]`.
+
+### Pattern Language
+
+Pattern values are interpreted by type:
+
+| Pattern value | Interpretation |
+|---------------|----------------|
+| Block | Sub-pattern: keys must exist, values matched recursively |
+| List | Positional sub-pattern: length must match, elements matched |
+| Function | Applied as predicate |
+| Literal | Exact equality check |
+
+```eu
+data: { host: "10.0.0.1", port: 8080, name: "api" }
+
+# Key existence (any? matches any value)
+has-host: data match?{host: any?}
+
+# Value predicates
+high-port: data match?{port: (> 1000)}
+
+# Type checking
+typed: data match?{host: string?, port: number?}
+
+# Exact literal
+specific: data match?{port: 8080}
+
+# Nested sub-patterns
+nested: {server: data} match?{server: {host: any?}}
+```
+
+```yaml
+data:
+  host: 10.0.0.1
+  port: 8080
+  name: api
+has-host: true
+high-port: true
+typed: true
+specific: true
+nested: true
+```
+
+### Open Matching
+
+Block patterns are *open*: extra keys in the target are ignored.
+`{host: any?}` matches any block that has a `:host` key, regardless
+of what other keys it contains.
+
+### List Patterns
+
+List patterns check length and match elements positionally:
+
+```eu
+pair: [1, "hello"] match?[number?, string?]
+wrong-len: [1, 2, 3] match?[any?, any?]
+```
+
+```yaml
+pair: true
+wrong-len: false
+```
+
+### Composing `match?` with `when` and `filter`
+
+`match?` is pattern-first, so `match?{pattern}` is a partially
+applied predicate — perfect for `filter` and `when`:
+
+```eu
+servers: [
+  { host: "10.0.0.1", port: 8080 }
+  { name: "cache" }
+  { host: "10.0.0.2", port: 5432 }
+]
+
+with-host: servers filter(match?{host: any?})
+```
+
+```yaml
+servers:
+- host: 10.0.0.1
+  port: 8080
+- name: cache
+- host: 10.0.0.2
+  port: 5432
+with-host:
+- host: 10.0.0.1
+  port: 8080
+- host: 10.0.0.2
+  port: 5432
+```
+
+Use `when` for conditional transformation — apply a function only
+when the data matches a pattern, otherwise pass through unchanged:
+
+```eu,notest
+data when(match?{host: any?, port: any?}, .("{host}:{port}"))
+```
+
+### Deep Structural Queries
+
+Combine `match?` with `deep-fold` to find matching nodes at any
+depth:
+
+```eu,notest
+# Find all blocks with both host and port keys
+find-endpoints(data): {
+  emit(s, v): if(v match?{host: any?, port: any?}, [v], [])
+  next(s, k): null
+}.(deep-fold(emit, next, null, data))
+```
+
+## Lenses and Traversals
+
+With `~` and `.` you can *read* nested data easily. But what if you
+need to *update* a value deep inside a structure and get the whole
+structure back? Dot-lookup gives you the value but loses the
+surrounding context. To change the title of the second item in a
+list nested three levels deep, you'd have to manually reconstruct
+every layer of the structure around the changed value.
+
+Lenses solve this. A lens is a reusable description of a position
+within a data structure. Once defined, the same lens can *get*
+the value at that position, *set* it to a new value, or *modify*
+it with a function — always returning the complete updated structure.
+
+```eu,notest
+{ import: "lens.eu" }
+```
+
+### Define Once, Use for Get and Set
+
+```eu,notest
+{ import: "lens.eu" }
+
+# Define a lens once — it describes WHERE to look, not WHAT to do
+db-host: ‹:server :db :host›
+
+config: { server: { db: { host: "localhost", port: 5432 }, cache: { host: "redis" } } }
+
+# Read with view
+current: config view(db-host)
+# => "localhost"
+
+# Update with over (returns the WHOLE config, not just the changed part)
+migrated: config over(db-host, -> "10.0.0.5")
+# => { server: { db: { host: "10.0.0.5", port: 5432 }, cache: { host: "redis" } } }
+```
+
+The key insight: `db-host` is defined once and describes the path
+`:server` → `:db` → `:host`. You can use it with `view` to read or
+`over` to modify. The surrounding structure (`:port`, `:cache`, etc.)
+is preserved automatically.
+
+### Lens Constructors
+
+`at(key)` focuses on a block key; `ix(n)` focuses on a list index.
+Compose with `∘` (read right to left) or use the `‹›` bracket
+shorthand:
+
+```eu,notest
+{ import: "lens.eu" }
+
+# These are equivalent:
+at(:server) ∘ at(:db) ∘ at(:host)
+‹:server :db :host›
+
+# Mix keys and indices:
+‹:items 0 :meta :title›    # items[0].meta.title
+```
+
+### Traversals
+
+Traversals extend lenses to focus on *multiple* positions. `each`
+targets all list elements; `filtered(pred)` targets only matching
+ones. Crucially, they compose with lenses — so you can target a
+specific field across every element:
+
+```eu,notest
+{ import: "lens.eu" }
+
+records: [{name: "a", score: 10}, {name: "b", score: 20}, {name: "c", score: 30}]
+
+# Define a traversal: the score of every record
+all-scores: each ∘ at(:score)
+
+# Collect all scores
+scores: records to-list-of(all-scores)
+# => [10, 20, 30]
+
+# Double all scores (returns the whole list with scores updated)
+boosted: records over(all-scores, * 2)
+# => [{name: "a", score: 20}, {name: "b", score: 40}, {name: "c", score: 60}]
+
+# Cap high scores only
+high-scores: filtered(_.score > 15) ∘ at(:score)
+capped: records over(high-scores, -> 15)
+# => [{name: "a", score: 10}, {name: "b", score: 15}, {name: "c", score: 15}]
+```
+
+Again, the traversal is defined once and reused. The surrounding
+structure (`:name` fields, list positions, non-matching elements)
+is preserved through every transformation.
+
+### Tip: `->` for Setting Values
+
+`over` takes a function to apply to the focused value. When you
+want to *replace* rather than *transform*, use the `->` const
+operator — `-> value` ignores its argument and returns `value`:
+
+```eu,notest
+# Set db host to a fixed value (-> discards the old value)
+config over(‹:server :db :host›, -> "10.0.0.5")
+
+# Clear all scores
+records over(each ∘ at(:score), -> 0)
+
+# Also useful with when — replace matching data entirely
+data when(match?{status: "draft"}, -> {status: "published"})
+```
+
+### Working with All Foci as a List
+
+Sometimes you want to operate on all the traversed values *as a
+group* rather than individually — sorting them, reversing them, or
+replacing them with a specific list. `parts-of(traversal)` turns a
+traversal into a lens that focuses on the list of all foci:
+
+```eu,notest
+# Sort all scores (the list [10, 20, 5] is sorted, then distributed back)
+records over(parts-of(each ∘ at(:score)), sort-nums)
+
+# Reverse the y values in a deep structure
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+data over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse)
+# => {x: [{y: 3}, {y: 2}, {y: 1}]}
+
+# Only reverse filtered positions — non-matching elements stay put
+[1, 4, 2, 5, 3] over(parts-of(filtered(> 2)), reverse)
+# => [1, 3, 2, 5, 4]
+```
+
+`view(parts-of(traversal), data)` gives the same result as
+`to-list-of(traversal, data)`. The difference is that `parts-of`
+also supports `over` — the transformed list is distributed back into
+the original positions.
+
+### Lens Consumers
+
+| Function | Description |
+|----------|-------------|
+| `view(lens, data)` | Extract the focused value (single-focus lenses only) |
+| `over(lens, fn, data)` | Apply `fn` at each focus, return whole structure |
+| `to-list-of(traversal, data)` | Collect all foci into a list |
+| `parts-of(traversal)` | Turn a traversal into a lens on the list of foci |
+
+### Lens and Traversal Constructors
+
+| Constructor | Description |
+|-------------|-------------|
+| `at(key)` | Focus on block value at symbol key |
+| `ix(n)` | Focus on list element at index n |
+| `item(pred)` | Focus on first list element matching predicate |
+| `element(pred)` | Focus on first `[key, value]` pair matching predicate |
+| `each` | Traverse all list elements |
+| `filtered(pred)` | Traverse list elements matching predicate |
+| `_value` | Focus on value of a `[key, value]` pair |
+| `_key` | Focus on key of a `[key, value]` pair |
+
+## Choosing the Right Tool
+
+| Task | Tool | Example |
+|------|------|---------|
+| Access an optional key | `~` | `data ~ :host` |
+| Chain through optional keys | `~` chain | `data ~ :server ~ :host` |
+| Check if data has a shape | `match?` | `data match?{host: any?}` |
+| Filter by shape | `match?` + `filter` | `items filter(match?{host: any?})` |
+| Conditional transform | `match?` + `when` | `data when(match?{host: any?}, f)` |
+| Find by key at any depth | `deep-find` | `data deep-find(:host)` |
+| Get a value deep in a known structure | `view` + lens | `data view(‹:server :host›)` |
+| Modify a value deep in a structure | `over` + lens | `data over(‹:server :port›, + 1)` |
+| Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.upper)` |
+| Collect values from all elements | `to-list-of` + `each` | `items to-list-of(each ∘ at(:name))` |
+| Sort/reverse/replace all foci | `parts-of` + traversal | `items over(parts-of(each ∘ at(:score)), sort-nums)` |
+
+**Rules of thumb:**
+
+- Use `~` for quick, safe extraction where you don't need to
+  modify the structure.
+- Use `match?` when you need to check shape before acting.
+- Use lenses when you need to *modify* values deep inside a
+  structure and get the whole structure back.
+- Use `deep-find` / `deep-fold` when you need to search at
+  arbitrary depth.
+
+---
+
+# Lenses
+
+In this chapter you will learn:
+
+- What a lens is and what problem it solves
+- How to read, update, and transform nested data with `view` and `over`
+- What a traversal is and how it generalises lenses to multiple foci
+- How to compose lenses and traversals with `∘` and the `‹›` shorthand
+- How to operate on all foci as a group with `parts-of`
+
+## The Problem: Updating Nested Data
+
+Reading a value deep inside a structure is easy with dot-lookup:
+
+```eu,notest
+config.server.db.host   # => "localhost"
+```
+
+But modifying it is painful. If you want to change just that one field
+and keep the rest of the structure intact, you must manually reconstruct
+every layer:
+
+```eu,notest
+config { server: config.server { db: config.server.db { host: "10.0.0.5" } } }
+```
+
+This is verbose, error-prone, and breaks whenever the structure changes.
+Lenses solve this.
+
+## Importing the Lens Library
+
+Lenses are not built into the prelude — they live in `lib/lens.eu`:
+
+```eu,notest
+{ import: "lens.eu" }
+```
+
+All functions described in this chapter come from that import.
+
+## What Is a Lens?
+
+A **lens** is a reusable description of a *position* inside a data structure.
+Once you have a lens, you can:
+
+- **Read** the value at that position with `view`
+- **Replace** it with a new value using `over` and the `->` const operator
+- **Transform** it with a function using `over`
+
+Crucially, `over` always returns the *complete* updated structure — you never
+lose the surrounding data.
+
+```eu,notest
+{ import: "lens.eu" }
+
+config: { server: { db: { host: "localhost", port: 5432 } } }
+
+# Read with view
+host: config view(‹:server :db :host›)
+# => "localhost"
+
+# Replace with over (note: -> discards the old value)
+migrated: config over(‹:server :db :host›, -> "10.0.0.5")
+# => { server: { db: { host: "10.0.0.5", port: 5432 } } }
+
+# Transform with over
+bumped: config over(‹:server :db :port›, + 1)
+# => { server: { db: { host: "localhost", port: 5433 } } }
+```
+
+The lens `‹:server :db :host›` is defined *once* and can be reused for any
+combination of reading and modifying. Everything else in `config` — the
+`:port`, other sibling keys — is preserved automatically.
+
+## Building Lenses
+
+### The `at` Constructor
+
+`at(key)` creates a lens that focuses on a block value at the given symbol key:
+
+```eu,notest
+{ import: "lens.eu" }
+
+data: { name: "Alice", score: 95 }
+
+data view(at(:name))            # => "Alice"
+data over(at(:score), + 5)      # => { name: "Alice", score: 100 }
+```
+
+### The `ix` Constructor
+
+`ix(n)` creates a lens that focuses on a list element at index `n` (zero-based):
+
+```eu,notest
+{ import: "lens.eu" }
+
+items: ["a", "b", "c"]
+
+items view(ix(1))               # => "b"
+items over(ix(0), str.to-upper) # => ["A", "b", "c"]
+```
+
+### The `item` Constructor
+
+`item(pred)` focuses on the *first* list element matching a predicate:
+
+```eu,notest
+{ import: "lens.eu" }
+
+records: [{id: 1, value: "a"}, {id: 2, value: "b"}]
+
+records view(item(_.id = 2))    # => {id: 2, value: "b"}
+records over(item(_.id = 1) ∘ at(:value), str.to-upper)
+# => [{id: 1, value: "A"}, {id: 2, value: "b"}]
+```
+
+## Composing Lenses
+
+Compose lenses with `∘` (right-to-left) to navigate deeper into a structure.
+A lens composed with another lens is still a lens:
+
+```eu,notest
+{ import: "lens.eu" }
+
+# Navigate to a nested field step by step
+at(:server) ∘ at(:db) ∘ at(:host)
+
+# Shorter: the ‹› bracket shorthand
+# Symbols become at(), numbers become ix()
+‹:server :db :host›
+‹:items 0 :meta :title›    # at(:items) ∘ ix(0) ∘ at(:meta) ∘ at(:title)
+```
+
+The `‹›` shorthand accepts:
+- **Symbols** — converted to `at(sym)`
+- **Numbers** — converted to `ix(n)`
+- **Lens values** — used directly (e.g. `item(pred)`, `element(pred)`)
+
+Mixed paths are fine:
+
+```eu,notest
+# Lens function inside a path
+‹element(by-key(_ = :b)) _value›
+# => element(by-key(_ = :b)) ∘ _value
+```
+
+## Traversals
+
+A **traversal** generalises a lens to focus on *multiple* positions.
+`over` applies a function at each focus; `to-list-of` collects all
+foci into a list.
+
+### The `each` Traversal
+
+`each` traverses all elements of a list:
+
+```eu,notest
+{ import: "lens.eu" }
+
+items: [1, 2, 3, 4, 5]
+
+items to-list-of(each)          # => [1, 2, 3, 4, 5]
+items over(each, * 2)           # => [2, 4, 6, 8, 10]
+```
+
+Compose `each` with `at` to reach a field inside every element:
+
+```eu,notest
+{ import: "lens.eu" }
+
+records: [{name: "alice", score: 10}, {name: "bob", score: 20}]
+
+# Collect all scores
+records to-list-of(each ∘ at(:score))     # => [10, 20]
+
+# Double all scores (whole list returned, :name untouched)
+records over(each ∘ at(:score), * 2)
+# => [{name: "alice", score: 20}, {name: "bob", score: 40}]
+```
+
+### The `filtered` Traversal
+
+`filtered(pred)` traverses only the list elements that satisfy the predicate.
+Non-matching elements are left untouched by `over`:
+
+```eu,notest
+{ import: "lens.eu" }
+
+[1, 2, 3, 4, 5] over(filtered(_ > 3), negate)
+# => [1, 2, 3, -4, -5]
+
+[1, 2, 3, 4, 5] to-list-of(filtered(_ > 3))
+# => [4, 5]
+```
+
+### Block Traversals
+
+For blocks, `each-element` traverses all `[key, value]` pairs, and
+`filtered-elements(pred)` traverses only those matching the predicate.
+Pair with `_value` (focus on index 1) or `_key` (focus on index 0):
+
+```eu,notest
+{ import: "lens.eu" }
+
+data: {a: 1, b: 2, c: 3}
+
+# Collect all values
+data to-list-of(each-element ∘ _value)         # => [1, 2, 3]
+
+# Double all values
+data over(each-element ∘ _value, * 10)          # => {a: 10, b: 20, c: 30}
+
+# Only values greater than 1
+data over(filtered-elements(by-value(_ > 1)) ∘ _value, negate)
+# => {a: 1, b: -2, c: -3}
+```
+
+## Composing Lenses and Traversals
+
+A lens composed with a traversal yields a traversal. This lets you
+navigate into a specific part of a structure and then traverse *within*
+that part:
+
+```eu,notest
+{ import: "lens.eu" }
+
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+
+# Lens into :x, then traverse each element, then lens into :y
+data to-list-of(at(:x) ∘ each ∘ at(:y))
+# => [1, 2, 3]
+
+data over(at(:x) ∘ each ∘ at(:y), * 10)
+# => {x: [{y: 10}, {y: 20}, {y: 30}]}
+```
+
+The same applies to `filtered`:
+
+```eu,notest
+{ import: "lens.eu" }
+
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+
+# Only y values greater than 1
+data to-list-of(at(:x) ∘ filtered(_.y > 1) ∘ at(:y))
+# => [2, 3]
+```
+
+## Operating on All Foci as a Group: `parts-of`
+
+Sometimes you want to treat all the traversal foci as a *single list*
+and apply a list-level operation — sorting, reversing, replacing with a
+given list. `parts-of(traversal)` turns a traversal into a lens that
+focuses on the list of all foci.
+
+```eu,notest
+{ import: "lens.eu" }
+
+# Sort all elements
+[3, 1, 4, 1, 5] over(parts-of(each), sort-nums)
+# => [1, 1, 3, 4, 5]
+
+# Reverse only the filtered elements; non-matching elements stay put
+[1, 4, 2, 5, 3] over(parts-of(filtered(> 2)), reverse)
+# => [1, 3, 2, 5, 4]
+
+# Collect: view on parts-of is the same as to-list-of
+[1, 2, 3] view(parts-of(each))    # => [1, 2, 3]
+
+# Replace all foci with a new list
+[1, 2, 3] over(parts-of(each), -> [10, 20, 30])   # => [10, 20, 30]
+```
+
+Works equally well on deep compositions:
+
+```eu,notest
+{ import: "lens.eu" }
+
+data: {x: [{y: 1}, {y: 2}, {y: 3}]}
+
+data over(parts-of(at(:x) ∘ each ∘ at(:y)), reverse)
+# => {x: [{y: 3}, {y: 2}, {y: 1}]}
+```
+
+## Quick Reference
+
+| Function | Description |
+|----------|-------------|
+| `view(lens, data)` | Read the focused value (lens only, not traversal) |
+| `over(optic, fn, data)` | Apply `fn` at each focus; return whole structure |
+| `to-list-of(optic, data)` | Collect all foci into a list |
+| `parts-of(traversal)` | Lens on the list of all foci |
+
+| Constructor | Type | Description |
+|-------------|------|-------------|
+| `at(key)` | Lens | Block value at symbol key |
+| `ix(n)` | Lens | List element at index `n` |
+| `item(p?)` | Lens | First list element matching predicate |
+| `element(p?)` | Lens | First block `[key, value]` pair matching predicate |
+| `_value` | Lens | Value (index 1) of a `[key, value]` pair |
+| `_key` | Lens | Key (index 0) of a `[key, value]` pair |
+| `each` | Traversal | All list elements |
+| `filtered(p?)` | Traversal | List elements matching predicate |
+| `each-element` | Traversal | All block `[key, value]` pairs |
+| `filtered-elements(p?)` | Traversal | Block pairs matching predicate |
+
+**Composition**: `∘` (right-to-left). `‹sym num ...›` shorthand converts
+symbols to `at()` and numbers to `ix()`.
+
+## Type Checker Integration
+
+The type checker understands `Lens(a, b)` and `Traversal(a, b)` as
+opaque types. Passing a traversal to `view` triggers a type warning —
+use `to-list-of` instead. Composing optics with incompatible inner and
+outer types also produces a warning.
+
+```eu,notest
+` { type: "Lens(a, b) → a → b" }
+view: ...
+
+# Type warning: each is Traversal([a], a), not Lens
+[1, 2, 3] view(each)       # warning: use to-list-of for traversals
+```
+
+See [Navigating Nested Data](navigating-nested-data.md) for a tutorial
+that combines lenses with `~` safe navigation and `match?` pattern
+matching, and the
+[Agent Reference Section 11](../reference/agent-reference.md#11-lens-library-liblenseu)
+for a terse all-in-one summary.
+
+---
+
+# Imports and Modules
+
+In this chapter you will learn:
+
+- How to import other eucalypt files and data files
+- How to scope imports to specific declarations
+- How to use named imports for namespacing
+- How git imports work for external dependencies
+
+## Basic Imports
+
+Import another eucalypt file using the `import` key in declaration
+metadata:
+
+```eu,notest
+{ import: "helpers.eu" }
+
+# Names from helpers.eu are now available
+result: helper-function(42)
+```
+
+When the metadata is at unit level (the first item in the file), the
+imported names are available throughout the entire file.
+
+## Scoped Imports
+
+Imports can be scoped to a specific declaration, limiting where the
+imported names are visible:
+
+```eu,notest
+` { import: "math.eu" }
+calculations: {
+  # Names from math.eu are available only within this block
+  result: advanced-calculation(10)
+}
+
+# math.eu names are NOT available here
+```
+
+## Named Imports
+
+Give an import a name to access its contents under a namespace:
+
+```eu,notest
+{ import: "cfg=config.eu" }
+
+host: cfg.host
+port: cfg.port
+```
+
+This is especially useful when importing data files that might contain
+names which clash with your own:
+
+```eu,notest
+{ import: "prod=production.yaml" }
+
+url: "https://{prod.host}:{prod.port}"
+```
+
+## Importing Multiple Files
+
+Supply a list to import several files at once:
+
+```eu,notest
+{ import: ["helpers.eu", "config.eu"] }
+
+result: helper(config-value)
+```
+
+Named and unnamed imports can be mixed:
+
+```eu,notest
+{ import: ["helpers.eu", "cfg=config.eu"] }
+
+result: helper(cfg.port)
+```
+
+## Importing Data Files
+
+Eucalypt can import files in any supported format. The format is
+inferred from the file extension:
+
+```eu,notest
+{ import: "data=records.yaml" }
+
+first-record: data head
+```
+
+You can override the format when the extension is misleading:
+
+```eu,notest
+{ import: "data=yaml@records.txt" }
+```
+
+### Formats That Return Lists
+
+Some formats (CSV, JSON Lines, text) produce lists rather than blocks.
+These **must** be given a name:
+
+```eu,notest
+{ import: "rows=transactions.csv" }
+
+total: rows map(.amount num) foldl(+, 0)
+```
+
+## Nested Imports
+
+Imports can be placed at any level of nesting:
+
+```eu,notest
+deep: {
+  nested: {
+    ` { import: "local-config.eu" }
+    config: {
+      value: local-setting
+    }
+  }
+}
+```
+
+## Import Resolution Order
+
+When an import path is a relative string (e.g. `"helpers.eu"` rather than an
+absolute path or a git import), eucalypt resolves it by searching in this order:
+
+1. **Source-relative directory** — the directory containing the file that
+   contains the `import` declaration.
+2. **Global lib path** — the directories supplied via `-L` flags and the current
+   working directory, searched in the order they were specified.
+
+If the file is found in the source-relative directory it is used immediately and
+the global lib path is not consulted.
+
+### Transitive resolution
+
+Resolution is always relative to the *importing* file, not to the entry-point
+file passed on the command line. This means:
+
+- `main.eu` imports `"lib/utils.eu"` → resolved as `<dir-of-main>/lib/utils.eu`
+- `lib/utils.eu` imports `"helpers/misc.eu"` → resolved as
+  `<dir-of-main>/lib/helpers/misc.eu` (relative to `utils.eu`, not to `main.eu`)
+- `lib/helpers/misc.eu` imports `"sub/detail.eu"` → resolved as
+  `<dir-of-main>/lib/helpers/sub/detail.eu`
+
+Each file sees its own directory as the base for relative imports, no matter how
+deep the chain goes.
+
+### Practical example
+
+Suppose your project is laid out as follows:
+
+```
+project/
+  main.eu
+  lib/
+    utils.eu
+    helpers/
+      misc.eu
+```
+
+`main.eu` can import `lib/utils.eu` using a path relative to itself:
+
+```eu,notest
+{ import: "lib/utils.eu" }
+
+result: util-function(42)
+```
+
+`lib/utils.eu` can import from `lib/helpers/misc.eu` using a path relative to
+*its own* location:
+
+```eu,notest
+{ import: "helpers/misc.eu" }
+
+util-function(x): misc-helper(x)
+```
+
+No `-L` flags or absolute paths are needed. If a file is not found
+source-relatively, eucalypt falls back to the global lib path, so existing
+projects that rely on `-L` continue to work without modification.
+
+## Git Imports
+
+Import eucalypt code directly from a git repository. This is useful
+for sharing libraries without manually managing local copies:
+
+```eu,notest
+{ import: { git: "https://github.com/user/eu-lib"
+            commit: "abc123def456"
+            import: "lib/helpers.eu" } }
+
+result: lib-function(42)
+```
+
+The `commit` field is mandatory and should be a full SHA. This ensures
+the import is repeatable and cacheable.
+
+Multiple git imports can be listed alongside simple imports:
+
+```eu,notest
+{ import: [
+  "local.eu",
+  { git: "https://github.com/user/lib"
+    commit: "abc123"
+    import: "helpers.eu" }
+] }
+```
+
+## Streaming Imports
+
+For large files, streaming imports read data lazily:
+
+```eu,notest
+{ import: "events=jsonl-stream@events.jsonl" }
+
+recent: events take(100)
+```
+
+Available streaming formats:
+
+| Format | Description |
+|--------|-------------|
+| `jsonl-stream` | JSON Lines (one object per line) |
+| `csv-stream` | CSV with headers |
+| `text-stream` | Plain text (one string per line) |
+
+## Combining Imports with the Command Line
+
+Imports in `.eu` files complement the command line input system. You
+can use both together:
+
+```sh
+eu data.yaml transform.eu
+```
+
+Here `data.yaml` is a command-line input and `transform.eu` can also
+have its own `{ import: ... }` declarations for helpers or
+configuration.
+
+See [The Command Line](command-line.md) for details on the input
+system.
+
+## Practical Example: Configuration Layering
+
+```eu,notest
+# base.eu
+defaults: {
+  host: "0.0.0.0"
+  port: 8080
+  workers: 4
+}
+```
+
+```eu,notest
+# deploy.eu
+{ import: "base.eu" }
+
+production: defaults << {
+  workers: 16
+  host: "prod.example.com"
+}
+
+staging: defaults << {
+  host: "staging.example.com"
+}
+```
+
+Running `eu deploy.eu` produces layered configuration with shared
+defaults.
+
+## Key Concepts
+
+- Use `{ import: "file.eu" }` in metadata to import files
+- **Named imports** (`"name=file"`) provide namespace isolation
+- Imports can be **scoped** to individual declarations
+- **Data files** (YAML, JSON, CSV, etc.) can be imported like code
+- **Relative paths** resolve against the importing file's directory first,
+  then the global lib path — no `-L` flags needed for co-located helpers
+- **Git imports** pull code directly from repositories at a specific
+  commit
+- **Streaming imports** (`jsonl-stream@`, `csv-stream@`,
+  `text-stream@`) handle large files lazily
+
+---
+
+# Working with Data
+
+In this chapter you will learn:
+
+- How to process JSON, YAML, TOML, CSV, and XML data
+- How to convert between formats on the command line
+- Patterns for querying and transforming structured data
+- How to combine multiple data sources
+
+## Format Conversion
+
+The simplest use of eucalypt is converting between data formats. By
+default, output is YAML:
+
+```sh
+# JSON to YAML
+eu data.json
+
+# YAML to JSON
+eu data.yaml -j
+
+# JSON to TOML
+eu data.json -x toml
+```
+
+## Processing JSON
+
+Pipe JSON from other tools into eucalypt:
+
+```sh
+curl -s https://api.example.com/users | eu -e 'map(.name)'
+```
+
+Or process a JSON file:
+
+```sh
+eu -e 'users filter(.active) map(.email)' data.json
+```
+
+## Processing YAML
+
+YAML files are read natively. All YAML features including anchors,
+aliases, and merge keys are supported:
+
+```yaml
+# config.yaml
+defaults: &defaults
+  timeout: 30
+  retries: 3
+
+production:
+  <<: *defaults
+  debug: false
+```
+
+```sh
+eu config.yaml -e 'production'
+```
+
+```yaml
+timeout: 30
+retries: 3
+debug: false
+```
+
+### YAML Timestamps
+
+YAML timestamps are automatically converted to date-time values:
+
+```yaml
+created: 2024-03-15
+updated: 2024-03-15T14:30:00Z
+```
+
+Quote the value to keep it as a string: `created: "2024-03-15"`.
+
+## Processing TOML
+
+```sh
+eu config.toml -e 'database.port'
+```
+
+```yaml
+5432
+```
+
+## Processing CSV
+
+CSV files are imported as a list of blocks, where each row becomes a
+block with column headers as keys:
+
+```sh
+eu -e 'rows filter(_.age num > 30)' rows=people.csv
+```
+
+CSV values are always strings. Use `num` to convert to numbers when
+needed.
+
+## Processing XML
+
+XML is imported as a nested list structure. Each element is
+represented as `[tag, attributes, ...children]`:
+
+```sh
+eu -e 'root' root=xml@data.xml
+```
+
+Use list functions to navigate the structure:
+
+```eu,notest
+{ import: "root=xml@data.xml" }
+
+# Get the tag name (first element)
+tag: root first
+
+# Get attributes (second element)
+attrs: root second
+
+# Get child elements (everything after the first two)
+children: root drop(2)
+```
+
+## Named Inputs
+
+Use named inputs to make data available under a specific name:
+
+```sh
+eu users=users.json roles=roles.json -e 'users map(.name)'
+```
+
+Named inputs are essential for list-based formats (CSV, JSON Lines,
+text):
+
+```sh
+eu lines=text@log.txt -e 'lines filter(str.matches?("ERROR")) count'
+```
+
+## Combining Multiple Sources
+
+A powerful pattern is combining data from multiple sources:
+
+```sh
+eu users.yaml roles.yaml merge.eu
+```
+
+Where `merge.eu` contains logic that uses names from both inputs:
+
+```eu,notest
+# merge.eu
+summary: {
+  user-count: users count
+  role-count: roles count
+}
+```
+
+## Using Evaluands
+
+The `-e` flag specifies an expression to evaluate against the loaded
+inputs:
+
+```sh
+# Select a nested value
+eu config.yaml -e 'database.host'
+
+# Transform and filter
+eu data.json -e 'items filter(.price > 100) map(.name)'
+
+# Aggregate
+eu data.json -e 'items map(.price) foldl(+, 0)'
+```
+
+## Collecting Inputs
+
+The `--collect-as` (`-c`) flag gathers multiple files into a list:
+
+```sh
+eu -c configs *.yaml -e 'configs map(.name)'
+```
+
+Add `--name-inputs` (`-N`) to get a block keyed by filename:
+
+```sh
+eu -c configs -N *.yaml
+```
+
+```yaml
+configs:
+  a.yaml:
+    name: alpha
+  b.yaml:
+    name: beta
+```
+
+## Output Formats
+
+Control the output format:
+
+| Flag | Format |
+|------|--------|
+| (default) | YAML |
+| `-j` | JSON |
+| `-x json` | JSON |
+| `-x toml` | TOML |
+| `-x edn` | EDN |
+| `-x text` | Plain text |
+
+The format can also be inferred from the output file:
+
+```sh
+eu data.yaml -o output.json
+```
+
+## Practical Example: Data Pipeline
+
+Suppose you have a CSV of sales data and want to generate a JSON
+summary:
+
+```sh
+eu sales=sales.csv -j -e '{
+  total: sales map(.amount num) foldl(+, 0)
+  count: sales count
+  regions: sales map(.region) unique
+}'
+```
+
+Or as a reusable eucalypt file:
+
+```eu,notest
+# report.eu
+{ import: "sales=sales.csv" }
+
+` :suppress
+amounts: sales map(.amount num)
+
+report: {
+  total: amounts foldl(+, 0)
+  count: sales count
+  average: report.total / report.count
+}
+```
+
+```sh
+eu report.eu -j -e report
+```
+
+## Key Concepts
+
+- Eucalypt reads JSON, YAML, TOML, CSV, XML, EDN, JSON Lines, and
+  plain text
+- Output defaults to YAML; use `-j` for JSON or `-x` for other
+  formats
+- **Named inputs** (`name=file`) give data a name for reference
+- The `-e` flag evaluates expressions against loaded data
+- `--collect-as` gathers multiple files into a list or block
+- CSV values are strings; use `num` to convert to numbers
+- Combine multiple sources with the command line input system or
+  imports
+
+---
+
+# The Command Line
+
+In this chapter you will learn:
+
+- The `eu` command structure and subcommands
+- How to specify inputs, outputs, and evaluands
+- How to use targets, arguments, and environment variables
+- How to use the formatter and other tools
+
+## Command Structure
+
+```sh
+eu [GLOBAL_OPTIONS] [SUBCOMMAND] [SUBCOMMAND_OPTIONS] [FILES...]
+```
+
+When no subcommand is given, `run` is assumed:
+
+```sh
+eu file.eu          # same as: eu run file.eu
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `run` | Evaluate and render (default) |
+| `test` | Run embedded tests |
+| `dump` | Dump intermediate representations |
+| `version` | Show version information |
+| `explain` | Show what would be executed |
+| `list-targets` | List export targets |
+| `fmt` | Format source files |
+| `lsp` | Start the Language Server Protocol server |
+
+## Inputs
+
+### File Inputs
+
+Specify one or more files to process:
+
+```sh
+eu data.yaml transform.eu
+```
+
+Inputs are merged left to right. Names from earlier inputs are
+available to later ones. The final input determines what is rendered.
+
+### stdin
+
+Use `-` to read from stdin, or simply pipe data when no files are
+specified:
+
+```sh
+curl -s https://api.example.com/data | eu -e 'items count'
+```
+
+### Format Override
+
+Override the assumed format with a `format@` prefix:
+
+```sh
+eu yaml@data.txt json@-
+```
+
+### Named Inputs
+
+Prefix with `name=` to make the input available under a name:
+
+```sh
+eu config=settings.yaml app.eu
+```
+
+In `app.eu`, the YAML content is available as `config`:
+
+```eu,notest
+port: config.port
+```
+
+### Collecting Inputs
+
+Gather multiple files into a named collection:
+
+```sh
+eu -c data *.json -e 'data map(.name)'
+```
+
+Add `-N` to key by filename:
+
+```sh
+eu -c data -N *.json
+```
+
+## Outputs
+
+### Format
+
+Output defaults to YAML. Common options:
+
+```sh
+eu file.eu            # YAML (default)
+eu file.eu -j         # JSON (shortcut)
+eu file.eu -x json    # JSON (explicit)
+eu file.eu -x toml    # TOML
+eu file.eu -x text    # Plain text
+```
+
+### Output File
+
+Write to a file (format inferred from extension):
+
+```sh
+eu data.eu -o output.json
+```
+
+## Evaluands
+
+The `-e` flag specifies an expression to evaluate:
+
+```sh
+eu -e '2 + 2'
+```
+
+```yaml
+4
+```
+
+When combined with file inputs, the evaluand has access to all loaded
+names:
+
+```sh
+eu data.yaml -e 'users filter(.active) count'
+```
+
+Multiple `-e` flags are allowed; the last one determines the output.
+
+### Quick Expressions
+
+Use `-e` for quick data exploration:
+
+```sh
+# Inspect a value
+eu config.yaml -e 'database'
+
+# Count items
+eu data.json -e 'items count'
+
+# Extract and transform
+eu data.json -e 'items map(.name) reverse'
+```
+
+## Targets
+
+Declarations annotated with `:target` metadata can be selected for
+rendering:
+
+```eu,notest
+# multi-output.eu
+` { target: :summary }
+summary: { count: items count }
+
+` { target: :detail }
+detail: items
+```
+
+List available targets:
+
+```sh
+eu list-targets multi-output.eu
+```
+
+Select a target:
+
+```sh
+eu -t summary multi-output.eu
+```
+
+A target named `main` is rendered by default. If no `:main` target
+exists, the entire unit is the target.
+
+## Passing Arguments
+
+Arguments after `--` are available via `io.args`:
+
+```sh
+eu -e 'io.args' -- hello world
+```
+
+```yaml
+- hello
+- world
+```
+
+Use in scripts:
+
+```eu
+# greet.eu
+name: io.args head-or("World")
+greeting: "Hello, {name}!"
+```
+
+```sh
+eu greet.eu -e greeting -- Alice
+```
+
+```yaml
+Hello, Alice!
+```
+
+Arguments are strings. Use `num` to convert:
+
+```eu
+numbers: io.args map(num)
+total: numbers foldl(+, 0)
+```
+
+## Environment Variables
+
+Access environment variables through `io.env`:
+
+```eu
+home: io.env lookup-or(:HOME, "/tmp")
+path: io.env lookup(:PATH)
+```
+
+## Random Seed
+
+By default, random numbers use system entropy. Use `--seed` for
+reproducible output:
+
+```sh
+eu --seed 42 template.eu
+```
+
+## The Formatter
+
+Format eucalypt source files:
+
+```sh
+eu fmt file.eu              # print formatted to stdout
+eu fmt --write file.eu      # format in place
+eu fmt --check file.eu      # check (exit 1 if unformatted)
+eu fmt --reformat file.eu   # full reformatting
+```
+
+Options:
+- `-w, --width <N>` -- line width (default: 80)
+- `--indent <N>` -- indent size (default: 2)
+
+## Debugging
+
+### Dumping Intermediate Representations
+
+```sh
+eu dump ast file.eu         # syntax tree
+eu dump desugared file.eu   # core expression
+eu dump stg file.eu         # compiled STG
+```
+
+### Explaining Execution
+
+```sh
+eu explain file.eu          # show what would be executed
+```
+
+### Statistics
+
+```sh
+eu -S file.eu               # print metrics to stderr
+```
+
+## Suppressing the Prelude
+
+The standard prelude is loaded automatically. Suppress it with `-Q`:
+
+```sh
+eu -Q file.eu
+```
+
+> **Warning:** Without the prelude, even `true`, `false`, `if`, and
+> basic operators are unavailable.
+
+## Version Assertions
+
+Ensure a minimum `eu` version in source files:
+
+```eu
+_ : eu.requires(">=0.3.0")
+```
+
+Check the current version:
+
+```sh
+eu version
+```
+
+## LSP Server
+
+Start a Language Server Protocol server for editor integration:
+
+```sh
+eu lsp
+```
+
+Provides syntax error diagnostics and formatting support.
+
+## Key Concepts
+
+- `eu` defaults to `run` when no subcommand is given
+- Inputs are merged left to right; the final input determines output
+- Named inputs (`name=file`) provide namespace isolation
+- `-e` evaluates an expression against loaded inputs
+- `-t` selects a named target for rendering
+- `--` passes arguments available via `io.args`
+- `eu fmt` formats source files; `eu test` runs tests; `eu lsp`
+  starts the language server
+
+---
+
+# YAML Embedding
+
+Eucalypt can be embedded in YAML files via the following tags:
+
+- `eu`
+- `eu::suppress`
+- `eu::fn`
+
+The YAML embedding is not as capable as the native Eucalypt syntax but
+it is rich enough to be used for many YAML templating use cases,
+particularly when combined with the ability to specify several inputs
+on the command line.
+
+## Evaluating eucalypt expressions
+
+As you would expect, YAML mappings correspond to Eucalypt blocks and
+bind names just as Eucalypt blocks do and YAML sequences correspond to
+Eucalypt lists.
+
+YAML allows a wide variety of forms of expressing these (block styles
+and flow styles), to the extent that JSON is valid YAML.
+
+Eucalypt expressions can be evaluated using the `!eu` tag and have
+access to all the names defined in the YAML unit and any others
+brought into scope by specifying inputs on the command line.
+
+```yaml
+values:
+  x: world
+  y: hello
+
+result: !eu "{values.y} {values.x}!"
+```
+
+...will render as:
+
+```yaml
+values:
+  x: world
+  y: hello
+
+result: Hello World!
+```
+
+## Suppressing rendering
+
+Items can be hidden using the `eu::suppress` tag. This is equivalent
+to `:suppress` metadata in the eucalypt syntax.
+
+```yaml
+values: !eu::suppress
+  x: world
+  y: hello
+
+result: !eu "{values.y} {values.x}!"
+```
+
+...will render as:
+
+```yaml
+result: Hello World!
+```
+
+## Defining functions
+
+Functions can be defined using `eu::fn` and supplying an argument
+list:
+
+```yaml
+values: !eu::suppress
+  x: world
+  y: hello
+  greet: !eu::fn (h, w) "{h} {w}!"
+
+result: !eu values.greet(values.y, values.x)
+```
+
+...will render as:
+
+```yaml
+result: Hello World!
+```
+
+## The escape hatch
+
+Larger chunks of eucalypt syntax can be embedded using YAML's support
+for larger chunks of text, combined with `!eu`. Using this workaround
+you can access capabilities of eucalypt that are not yet available in
+the YAML embedding. (Although operators cannot be made available in
+YAML blocks because of the way that operator names are bound - see
+[Operator Precedence Table](../reference/operators-and-identifiers.md).)
+
+```yaml
+block: !eu |
+  {
+    x: 99
+    (l ^^^ r): "{l} <_> {r}"
+    f(n): n ^^^ x
+  }
+
+result: block.f(99)
+```
+
+---
+
+# Testing with Eucalypt
+
+Eucalypt has a built-in test runner which can be used to run tests
+embedded in eucalypt files.
+
+Test mode is invoked by the `eu test` subcommand and:
+
+- analyses the file to build a test plan consisting of a list of test
+  targets and validations to run
+- executes the test plan and generates an *evidence* file
+- applies validations against the evidence to generate a results file
+- outputs results and generates an HTML report
+
+## Simple tests
+
+By default eucalypt searches for targets beginning with `test-` and
+runs each to render a `yaml` output. The result is parsed read back in
+and eucalypt checks for the presence of a `RESULT` key. If it finds it
+and the value is `PASS`, the test passes. Anything else is considered
+a fail.
+
+```eu
+my-add(x, y): x + y
+
+` { target: :test-add }
+test: {
+  RESULT: (2 + 2 = 4) then(:PASS, :FAIL)
+}
+```
+
+Several test targets can be embedded in one file. Each is run as a
+separate test.
+
+## Test files
+
+If your intention is not to embed tests in a eucalypt file but instead
+to write a test as a single file, then you can omit the test targets.
+Eucalypt will use a `main` target or run the entire file as usual and
+then validate the result (looking for a `RESULT` key, by default).
+
+## Other formats
+
+In test mode, eucalypt processes the test subject to generate output
+and then parses that back to validate the result. This is to provide
+for validation of the rendered text and the parsing machinery.
+
+By default YAML is generated and parsed back for each test target in
+the file but other formats can be selected in header metadata.
+
+```eu
+{
+  test-targets: [:yaml, :json]
+}
+
+` { target: :test-add }
+add: {
+  RESULT: (2 + 2 = 4) then(:PASS, :FAIL)
+}
+
+` { target: :test-sub }
+sub: {
+  RESULT: (2 - 2 = 0) then(:PASS, :FAIL)
+}
+```
+
+Running this file using `eu test` will result in four tests being run,
+two formats for each of the two targets.
+
+Using the default validator, for all formats for which eucalypt
+provides import and export capability, it shouldn't make any
+difference which format is used. However, custom validators provide
+the ability to check the precise text that is rendered.
+
+## Custom validators
+
+When a test runs, the execution generates an evidence block which has
+the following keys:
+
+- `exit` the exit code (0 on success) of the eucalypt execution
+- `stdout` text as a list of strings
+- `stderr` text as a list of strings
+- `result` (the stdout parsed back)
+- `stats` some statistics from the run
+
+---
+
+# Date, Time, and Random Numbers
+
+## Zoned Date-Time (ZDT) Values
+
+Eucalypt has native support for date-time values through the ZDT
+(Zoned Date-Time) type. ZDT values represent a point in time with
+timezone information.
+
+### ZDT Literals
+
+Use the `t"..."` prefix to write date-time literals directly in
+eucalypt source:
+
+```eu
+today: t"2024-03-15"
+meeting: t"2024-03-15T14:30:00Z"
+local: t"2024-03-15T14:30:00+01:00"
+```
+
+The `t"..."` syntax accepts ISO 8601 formats:
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Date only | `t"2024-03-15"` | Midnight UTC |
+| UTC | `t"2024-03-15T14:30:00Z"` | |
+| With offset | `t"2024-03-15T14:30:00+05:00"` | |
+| Fractional seconds | `t"2024-03-15T14:30:00.123Z"` | |
+
+### Parsing and Formatting
+
+The `cal` namespace provides functions for working with date-time
+values:
+
+```eu,notest
+# Parse from a string
+d: cal.parse("2024-03-15T14:30:00Z")
+
+# Format to a custom string
+label: t"2024-03-15" cal.format("%Y-%m-%d")  # "2024-03-15"
+```
+
+### Date-Time Arithmetic
+
+ZDT values support comparison operators:
+
+```eu
+before: t"2024-01-01" < t"2024-12-31"   # true
+same: t"2024-03-15" = t"2024-03-15"     # true
+```
+
+### Sorting Date-Times
+
+```eu
+dates: [t"2024-12-25", t"2024-01-01", t"2024-07-04"]
+sorted: dates sort-zdts  # [Jan 1, Jul 4, Dec 25]
+```
+
+### YAML Timestamps
+
+When importing YAML files, unquoted timestamp values are automatically
+converted to ZDT values:
+
+```yaml
+created: 2024-03-15
+updated: 2024-03-15T14:30:00Z
+```
+
+Quote the value to keep it as a string: `created: "2024-03-15"`.
+
+See [Import Formats](../reference/import-formats.md) for full details.
+
+### Current Time
+
+The `io.epoch-time` binding provides the current Unix epoch time in
+seconds:
+
+```eu
+now: io.epoch-time
+```
+
+## Random Numbers
+
+Eucalypt provides pseudo-random number generation via the `random`
+namespace, which is a state monad over a PRNG stream.
+
+### The random stream
+
+A random stream is provided at startup as `io.random`. Each run
+produces different values unless you supply a seed:
+
+```sh
+eu --seed 42 example.eu
+```
+
+### Single random values
+
+For a single random value, pass `io.random` as the stream:
+
+```eu,notest
+roll: random.int(6, io.random).value + 1
+colour: random.choice(["red", "green", "blue"], io.random).value
+```
+
+Each operation returns a `{value, rest}` block — extract `.value`
+to get the result.
+
+### Multiple random values
+
+When you need several random values, you must propagate the stream
+from each call to the next. Reusing `io.random` would give the same
+value each time:
+
+```eu,notest
+# WRONG — both use the same stream, so d1 = d2
+d1: random.int(6, io.random).value
+d2: random.int(6, io.random).value
+
+# RIGHT — thread the stream manually
+r1: random.int(6, io.random)
+r2: random.int(6, r1.rest)
+total: r1.value + r2.value + 2
+```
+
+This manual threading is error-prone. The `random` monad can ease the
+overhead somewhat — use a `{ :random ... }` monadic block or
+combinators like `sequence` and `map-m`:
+
+```eu,notest
+# Monadic block — stream threads automatically
+dice: { :random
+  d6: random.int(6)
+  d20: random.int(20)
+}.[d6, d20]
+
+result: dice(io.random).value  # e.g. [3, 14]
+
+# Or use sequence for a list of actions
+two-dice: random.sequence([random.int(6), random.int(6)], io.random).value
+```
+
+### Other operations
+
+```eu,notest
+shuffled: random.shuffle(["a", "b", "c", "d"], io.random).value
+picked: random.sample(3, range(1, 50), io.random).value
+```
+
+See the [Random Numbers reference](../reference/prelude/random.md) for
+the full API and the [Monads guide](monads.md) for details on the
+state monad pattern.
+
+---
+
+# IO and Shell Commands
+
+As of version 0.5.0 Eucalypt can execute IO by invoking shell
+commands, via the *IO monad*. 
+
+Eucalypt is not a scripting language, it is a small, lazy, dynamically
+typed, pure functional language for transformation and templating of
+semi-structured data formats and that remains its sweet spot. Do not
+get too ambitious.
+
+However, prior to the IO monad, arranging the sources of data in and
+out of the program was limited to what could be named or streamed in
+from the shell, and piped to pre-planned destinations. Allowing more
+direct control over IO within the process (while staying within the
+functional paradigm) allows much more flexibility.
+
+IO operations are sequenced strictly by the runtime and the monad
+idiom. 
+
+**All IO operations require the `--allow-io` / `-I` flag.**
+
+---
+
+## The IO monad
+
+This is not a monad tutorial. Suffice it to say than an IO action
+(which may have side effects) is represented by an object in Eucalypt.
+The monad and the runtime together, ensure that the action is run at the
+appropriate time and its output is safely incorporated into the
+computation without imperiling the referential transparency of non-IO
+code. 
+
+In initial versions of this functionality, the *only* IO capability
+available is running shell programs or binaries from eucalypt, and
+passing data in and out of them. Data passed into and out of the
+shelled program is not streamed incrementally, but buffered whole.
+This is not suitable for large data pipelines.
+
+The monad provides several ways to create IO actions, and
+string them together. When you run a eucalypt program, if the value of
+the named target (or `:main` target) is an IO action, that is run.
+
+Just embedding an IO action in a data structure is not sufficient to
+have it execute. It must either be the value of the top-level target
+of a program, or invoked in some way by that action.
+
+The key monad functions `bind` and `return` are defined in the `io`
+namespace, along with several traditional monad combinators. This
+supports the use of `{ :io ... }` monadic blocks to combine several
+monad actions into one. [Monads and the monad() Utility](monads.md) explains Eucalypt's monad
+machinery in a little more detail.
+
+A simple IO action that doesn't perform any IO at all but represents a
+constant value, can be created with `io.return`.  e.g.
+
+``` eu,notest
+greeting: io.return("hello")
+```
+
+To create more interesting IO actions, read on.
+
+## Running a shell command
+
+The simplest way to run a command is `io.shell`:
+
+```eu,notest
+result: "echo hello" io.shell
+```
+
+This creates an IO action which runs the specified command via `sh -c`
+and returns a block:
+
+```yaml
+stdout: "hello\n"
+stderr: ""
+exit-code: 0
+```
+
+To extract a specific field, either use generalised lookup syntax on
+an `:io` monad block...
+
+```eu,notest
+{ :io r: io.shell("echo hello") }.(r.stdout)
+```
+
+... or use `io.map` to apply a section within the IO monad chain.
+
+``` eu,notest
+"echo hello" io.shell io.map(.stdout)
+```
+
+---
+
+## The { :io ... } monadic block
+
+A block tagged `:io` desugars into nested `io.bind` calls. Each field
+is a bind step; the name becomes available in all subsequent steps.
+The `.()` expression after the closing brace is the return value.
+
+```eu,notest
+{ :io
+  r: io.shell("echo hello")
+  _: io.check(r)
+}.(r.stdout)
+```
+
+**Important:** unlike normal blocks, monadic blocks bind names
+sequentially — each step can only refer to names from earlier steps,
+not later ones. See [Monads and the monad() Utility](monads.md) for
+full details on monadic block syntax, forms, and the sequential
+binding constraint.
+
+---
+
+## Checking for errors
+
+`io.check` inspects a command result. If the exit code is non-zero,
+it fails the IO monad with the stderr message. Otherwise it returns
+the result unchanged:
+
+```eu,notest
+{ :io
+  r: io.shell("grep pattern file.txt")
+  _: io.check(r)
+}.(r.stdout)
+```
+
+If `grep` finds no matches (exit code 1), this produces an
+`io.fail` error with whatever was on stderr.
+
+---
+
+## Exec: running a binary directly
+
+`io.exec` runs a binary without going via the shell. The argument is a
+list where the first element is the command and the rest are
+arguments:
+
+```eu,notest
+{ :io
+  r: io.exec(["git", "rev-parse", "HEAD"])
+}.(r.stdout)
+```
+
+If the binary does not exist, `io.exec` returns a result block with
+exit-code 127 and the OS error in stderr, rather than failing outright.
+
+---
+
+## Options: stdin, timeout
+
+Both `io.shell-with` and `io.exec-with` accept an options block as
+the first argument. This is merged into the spec block, overriding
+defaults:
+
+```eu,notest
+"cat" io.shell-with{stdin: "hello world", timeout: 60} io.map(.stdout)
+```
+
+Available options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `stdin` | (none) | String to pipe to the command's standard input |
+| `timeout` | 30 | Maximum seconds before the command is killed |
+
+The pipeline style reads naturally: the command string flows into
+`shell-with` which receives the options.
+
+---
+
+## Combining IO actions
+
+### Sequencing with bind
+
+`io.bind` chains two actions. The continuation receives the result of
+the first action:
+
+```eu,notest
+io.bind(io.shell("echo hello"),
+  _(r): io.shell("echo got: {r.stdout}"))
+```
+
+The `{ :io ... }` block is almost always preferable to explicit
+`io.bind` calls.
+
+### Mapping over a result
+
+`io.map` applies a pure function to the result of an action without
+needing a new IO step. The function can, of course, be a composition
+of several functions:
+
+```eu,notest
+` :main
+result: "curl https://example.com/test.json" io.shell io.map((.stdout) ; parse-as(:json))
+```
+
+### Failing explicitly
+
+`io.fail` aborts the IO monad with an error message:
+
+```eu,notest
+{ :io
+  r: io.shell("some-command")
+  _: (r.exit-code = 0) then(io.return(r), io.fail("command failed: {r.stderr}"))
+}.(r.stdout)
+```
+
+This is what `io.check` does internally — it is a convenience wrapper
+around this pattern:
+
+``` eu,notest
+` :main
+greeting: "echo hello world" io.shell io.check io.map(.stdout)
+```
+
+---
+
+## Practical examples
+
+### Git commit hash
+
+```eu,notest
+` :main
+hash: "git rev-parse --short HEAD" io.shell io.check io.map(.stdout)
+```
+
+### Run a command and parse the output as JSON
+
+```eu,notest
+` :main
+data: "curl -s https://api.example.com/data" 
+  io.shell 
+  io.check 
+  io.map((.stdout) ; parse-as(:json))
+```
+
+### Pipe data through a command
+
+```eu,notest
+` :main
+text: { :io
+  r: "jq '.name'" io.shell-with({stdin: render-as(:json, data)})
+}.(r.stdout)
+```
+
+### Multiple commands in sequence
+
+```eu,notest
+` :main
+main: { :io
+  a: io.shell("date +%s")
+  b: io.shell("hostname")
+}.(
+  { timestamp: a.stdout 
+    host: b.stdout }
+)
+```
+
+or, equivalently:
+
+``` eu,notest
+io.sequence[io.shell("date +%s") io.map(.stdout),
+            io.shell("hostname") io.map(.stdout)] with-keys[:timestamp, :host]
+
+```
+
+---
+
+## Testing IO code
+
+Test targets that use IO should include `requires-io: true` in their
+target metadata. The test runner (`eu test`) skips these tests
+gracefully when `--allow-io` is not set:
+
+```eu,notest
+` { target: :test requires-io: true }
+test:
+  { :io r: io.exec(["echo", "hello"]) }.(
+    if(r.stdout str.matches?("hello.*"),
+      { RESULT: :PASS },
+      { RESULT: :FAIL }))
+```
+
+---
+
+## Reference
+
+For the full API table, see the
+[IO prelude reference](../reference/prelude/io.md).
+
+For the monadic programming model, `monad()` utility, and how to
+build your own monads, see
+[Monads and the monad() Utility](monads.md).
+
+---
 
 # Monads and the monad() Utility
 
@@ -2113,6 +6407,10 @@ metadata:
 
 result: ⟦ x: some-action  y: other-action(x) ⟧.(x + y)
 ```
+
+**Restrictions:** monad brackets cannot be empty (at least one
+declaration is required), and cannot contain block metadata — the monad
+tag goes on the outer block or in the bracket pair definition.
 
 See the [syntax reference](../reference/syntax.md) for full details on
 bracket pair definitions.
@@ -2494,6 +6792,23 @@ ok:     maybe.bind(safe-head([42]), inc) # => 43
 
 ---
 
+## Type checking in monadic blocks
+
+`eu check` understands monadic blocks. When a namespace has a known
+element type (e.g. `io` uses `IO(a)`, `for` uses `[a]`), the checker
+infers the types of bound variables automatically and warns if a binding
+RHS has the wrong type.
+
+```sh
+eu check file.eu          # reports type warnings in monadic blocks
+eu check file.eu --strict # treats type warnings as errors
+```
+
+See [Type Checking — Monadic block binding types](type-checking.md#monadic-block-binding-types)
+for examples and a full explanation.
+
+---
+
 ## Key concepts
 
 - `monad(m)` takes `{bind, return}` and returns a block with `bind`,
@@ -2515,95 +6830,1165 @@ ok:     maybe.bind(safe-head([42]), inc) # => 43
 
 ---
 
-<!-- Source: docs/guide/testing.md -->
+# The State Monad
 
-# Testing with Eucalypt
+Eucalypt provides an optional state monad library for threading
+block-valued state through a sequence of operations. Import it with:
 
-Eucalypt has a built-in test runner which can be used to run tests
-embedded in eucalypt files.
+```eu,notest
+{ import: "state.eu" }
+```
 
-Test mode is invoked by the `eu test` subcommand and:
+## The Problem
 
-- analyses the file to build a test plan consisting of a list of test
-  targets and validations to run
-- executes the test plan and generates an *evidence* file
-- applies validations against the evidence to generate a results file
-- outputs results and generates an HTML report
-
-## Simple tests
-
-By default eucalypt searches for targets beginning with `test-` and
-runs each to render a `yaml` output. The result is parsed read back in
-and eucalypt checks for the presence of a `RESULT` key. If it finds it
-and the value is `PASS`, the test passes. Anything else is considered
-a fail.
+Eucalypt blocks are immutable. To "update" a value deep in a
+structure, you must reconstruct the entire surrounding structure.
+When several updates depend on each other, manually threading the
+modified state through each step is verbose and error-prone — the
+same problem that `{ :random ... }` solves for PRNG streams.
 
 ```eu
-my-add(x, y): x + y
+s0: { count: 0, name: "init" }
+s1: s0 merge({count: 1})
+s2: s1 merge({name: "updated"})
+```
 
-` { target: :test-add }
-test: {
-  RESULT: (2 + 2 = 4) then(:PASS, :FAIL)
+```yaml
+s0:
+  count: 0
+  name: init
+s1:
+  count: 1
+  name: init
+s2:
+  count: 1
+  name: updated
+```
+
+The state monad automates this threading.
+
+## State Actions
+
+A *state action* is a function from a state block to a block with
+`value` and `state` fields — the same pattern as the random monad's
+`value`/`rest` blocks:
+
+```eu,notest
+# An action that reads the count and increments it
+count-and-inc(s): { value: s.count, state: s merge({count: s.count + 1}) }
+```
+
+The state monad provides primitives for building these actions
+without manually deconstructing and reconstructing blocks.
+
+## Monadic Blocks with `{ :state ... }`
+
+Tag a block with `:state` to get automatic bind threading — each
+declaration becomes a monadic step:
+
+```eu
+{ import: "state.eu" }
+
+action: { :state
+  n: state.query(_.count)
+  _: state.put(:count, n + 1)
+  _: state.put(:name, "step-2")
+}
+
+result: state.exec(action, {count: 0, name: "init"})
+```
+
+```yaml
+result:
+  count: 1
+  name: step-2
+```
+
+Each step sees the state left by the previous step:
+
+- `state.get` returns the whole state as the value — then `.count`
+  navigates it
+- `state.put(:count, n + 1)` sets a key in the state
+- The implicit return synthesises `{n: n}` from the non-underscore
+  bindings (or use `.(expr)` for an explicit return)
+
+Run the action by passing an initial state to `state.run`,
+`state.eval` (value only), or `state.exec` (final state only).
+
+## Primitives
+
+| Function | Description |
+|----------|-------------|
+| `state.get` | Action: return the whole state as the value |
+| `state.put(k, v)` | Action: set key `k` to value `v` |
+| `state.lift(f)` | Action: apply `f` to transform the state, return null |
+| `state.query(f)` | Action: apply `f` to read from the state, state unchanged |
+| `state.modify(k, f)` | Action: update key `k` by applying `f` to its value |
+
+### Running Actions
+
+| Function | Description |
+|----------|-------------|
+| `state.run(action, s)` | Run action from state `s`, return block with `value` and `state` fields |
+| `state.eval(action, s)` | Run action, return only the value |
+| `state.exec(action, s)` | Run action, return only the final state |
+
+## Using Existing Pipeline Functions
+
+The `lift` and `query` primitives let you reuse existing eucalypt
+functions as state actions:
+
+```eu
+{ import: "state.eu" }
+
+action: { :state
+  _: :count %! (+ 1)
+  n: state.query(_.count)
+}.(n)
+
+result: state.eval(action, {count: 0})
+```
+
+```yaml
+result: 1
+```
+
+With the lens library imported, you can also use `state.lift` with
+lens functions like `over(at(:key), f)` for deep updates. Since
+`state.eu` imports `lens.eu` internally, the lens functions are
+available without a separate import.
+
+## Lens Operators
+
+The `=!` and `%!` operators provide concise syntax for lens-based
+state updates. When the left operand is a symbol, it is
+automatically wrapped in `at()`:
+
+```eu
+{ import: "state.eu" }
+
+action: { :state
+  _: :count =! 0
+  _: :count %! (+ 1)
+  _: :count %! (+ 1)
+}
+
+result: state.exec(action, {count: 99}).count
+```
+
+```yaml
+result: 2
+```
+
+| Operator | Meaning | Equivalent to |
+|----------|---------|---------------|
+| `lens =! val` | Set at lens | `state.lift(over(lens, -> val))` |
+| `lens %! fn` | Modify at lens | `state.lift(over(lens, fn))` |
+
+## Comparison with the Random Monad
+
+The state monad follows the same pattern as `{ :random ... }`:
+
+| | Random | State |
+|---|---|---|
+| State type | PRNG stream | Block |
+| Import | Built-in (prelude) | `{ import: "state.eu" }` |
+| Block tag | `{ :random ... }` | `{ :state ... }` |
+| Run | `random.run(action, stream)` | `state.run(action, initial)` |
+| Read state | `random.float`, `random.int(n)` | `state.get`, `state.query(f)` |
+| Modify state | Automatic (stream advances) | `state.put`, `state.modify`, `=!`, `%!` |
+
+## Example: Accumulating Counts
+
+```eu
+{ import: "state.eu" }
+
+count-item(item): { :state
+  current: state.query(~ item)
+  _: state.put(item, current fnil(+ 1, 0))
+}
+
+count-items(s, item): state.exec(count-item(item), s)
+
+result: [:a, :b, :a, :c, :a, :b] foldl(count-items, {})
+```
+
+```yaml
+result:
+  a: 3
+  b: 2
+  c: 1
+```
+
+## How It Works
+
+Under the hood, `state-bind` and `state-ret` are:
+
+```eu,notest
+state-ret(v, s): { value: v, state: s }
+
+state-bind(action, f, s): {
+  r: action(s)
+  run: f(r.value)(r.state)
+  value: run.value
+  state: run.state
 }
 ```
 
-Several test targets can be embedded in one file. Each is run as a
-separate test.
-
-## Test files
-
-If your intention is not to embed tests in a eucalypt file but instead
-to write a test as a single file, then you can omit the test targets.
-Eucalypt will use a `main` target or run the entire file as usual and
-then validate the result (looking for a `RESULT` key, by default).
-
-## Other formats
-
-In test mode, eucalypt processes the test subject to generate output
-and then parses that back to validate the result. This is to provide
-for validation of the rendered text and the parsing machinery.
-
-By default YAML is generated and parsed back for each test target in
-the file but other formats can be selected in header metadata.
-
-```eu
-{
-  test-targets: [:yaml, :json]
-}
-
-` { target: :test-add }
-add: {
-  RESULT: (2 + 2 = 4) then(:PASS, :FAIL)
-}
-
-` { target: :test-sub }
-sub: {
-  RESULT: (2 - 2 = 0) then(:PASS, :FAIL)
-}
-```
-
-Running this file using `eu test` will result in four tests being run,
-two formats for each of the two targets.
-
-Using the default validator, for all formats for which eucalypt
-provides import and export capability, it shouldn't make any
-difference which format is used. However, custom validators provide
-the ability to check the precise text that is rendered.
-
-## Custom validators
-
-When a test runs, the execution generates an evidence block which has
-the following keys:
-
-- `exit` the exit code (0 on success) of the eucalypt execution
-- `stdout` text as a list of strings
-- `stderr` text as a list of strings
-- `result` (the stdout parsed back)
-- `stats` some statistics from the run
+The `state` namespace is registered with `monad: true` metadata, so
+the desugarer recognises `{ :state ... }` blocks and chains
+declarations through `state.bind` / `state.return` automatically.
 
 ---
 
-<!-- Source: docs/guide/advanced-topics.md -->
+# Type Checking
+
+Eucalypt includes an optional, advisory type checker. It never prevents
+your code from running — all existing code continues to work exactly as
+before. Think of it as a second pair of eyes that can catch common
+mistakes before they become confusing runtime errors.
+
+```sh
+eu check file.eu              # type-check, report warnings
+eu check file.eu --strict     # treat type warnings as errors
+eu --type-check file.eu       # check then evaluate
+```
+
+Type issues are reported as **warnings**, not errors. Your code runs
+regardless.
+
+---
+
+## What type checking catches
+
+The checker is most useful for catching a handful of mistakes that are
+easy to make and hard to debug:
+
+- **Passing an IO action where a plain value is expected.** `io.shell`
+  returns an `IO({..})`, not a block. Accessing `.stdout` on the action
+  itself is a common mistake the checker flags immediately.
+- **Accessing a missing or misspelled field on a block.** If you have
+  a block typed as `{name: string, age: number}`, accessing `.naem` is
+  a warning.
+- **Type mismatches in pipelines.** Piping a `string` into a function
+  expecting `number` produces a clear warning with a source location.
+- **Wrong lens composition.** `Lens(a, b)` composed with
+  `Lens(c, d)` requires `b = c`; the checker catches the mismatch.
+
+The checker works through inference — it does not require any
+annotations in your code. Annotated prelude functions (like `map`,
+`filter`, `str.of`, `io.shell`, `at`, `view`) propagate types through
+your pipelines automatically.
+
+## What type checking does not catch
+
+- **Runtime-dependent values.** If a function returns `any` (because
+  its type depends on a runtime value, like `lookup`), the checker
+  makes no assumptions about the result. This is correct — eucalypt
+  is gradual, not fully statically typed.
+- **Unannotated functions.** Code without `type:` annotations is
+  treated as `any -> any -> ... -> any`. The checker stays silent
+  rather than guessing.
+- **Dynamic block construction.** `block(kvs)` constructs a block
+  from a list of pairs at runtime; the checker cannot know its shape.
+
+---
+
+## Adding type annotations
+
+Annotations live in declaration metadata alongside doc strings:
+
+```eu,notest
+` { doc: "`double(x)` - double a number."
+    type: "number -> number" }
+double(x): x * 2
+```
+
+The `type:` value is a string containing a type expression. You can
+annotate as much or as little as you like. Unannotated declarations
+default to `any`.
+
+### Simple annotations
+
+```eu,notest
+` { type: "number -> number" }
+square(x): x * x
+
+` { type: "string -> string -> string" }
+greet(greeting, name): "{greeting}, {name}!"
+
+` { type: "[number] -> number" }
+total: fold(+, 0)
+```
+
+### Operators
+
+Operators use the same metadata syntax:
+
+```eu,notest
+` { doc: "`x |> f` - pipe x into f."
+    type: "a -> (a -> b) -> b"
+    associates: :left
+    precedence: 20 }
+(x |> f): f(x)
+```
+
+---
+
+## The type language
+
+### Primitives
+
+| Type       | Values                             |
+|------------|------------------------------------|
+| `number`   | integers and floats                |
+| `string`   | strings                            |
+| `symbol`   | symbolic atoms (`:key`, `:name`)   |
+| `bool`     | `true`, `false`                    |
+| `null`     | `null`                             |
+| `datetime` | zoned date-time values             |
+| `any`      | unknown — consistent with all types|
+
+### Literal types
+
+A **literal type** represents exactly one value. Literal types are
+subtypes of their corresponding primitive:
+
+| Type syntax     | Meaning                           | Subtype of |
+|-----------------|-----------------------------------|------------|
+| `"value"`       | the specific string `"value"`     | `string`   |
+| `:name`         | the specific symbol `:name`       | `symbol`   |
+
+Literal types are most useful in **discriminated unions** — type aliases
+where a tag field distinguishes variants:
+
+```eu,notest
+{ types: { Shape: c"{{type: \"circle\", radius: number, ..}} | {{type: \"rect\", w: number, h: number, ..}}" } }
+```
+
+Because writing complex union types inline is verbose, defining a `types:`
+alias is the recommended approach. (Note the `c"..."` **c-string** — see
+*Writing literal types in annotation strings* below.)
+
+**Subtyping rules**:
+- `"foo"` is consistent with `string` — a literal satisfies a string parameter
+- `"foo" | string` simplifies to `string` — the specific literal is absorbed
+- `:active` is consistent with `symbol` — same for symbols
+
+**Writing literal types in annotation strings**: a literal string type is
+written `"value"`, so its quotes need escaping inside the eucalypt
+annotation string — use **c-string escapes**: `c"\"value\""`. (A plain
+`"..."` string does not process `\"`.) Literal *symbol* types (`:name`)
+have no quotes, so need no escaping.
+
+Mind the precedence of `|` and `->`: as in most type languages `->` binds
+tighter, so a union in *argument* position needs brackets.
+`"circle" | "rect" -> bool` is the overload `"circle" | ("rect" -> bool)`
+(see *Unions* below); the one-argument reading is
+`("circle" | "rect") -> bool`.
+
+```eu,notest
+# Literal string union as an argument: c-string escapes, bracketed union.
+` { type: c"(\"circle\" | \"rect\") -> bool" }
+is-shape-name(s): s = "circle" or s = "rect"
+
+# Literal symbol union: no escaping needed, still bracketed.
+` { type: "(:ok | :err) -> bool" }
+ok?(status): status = :ok
+```
+
+Most often you name the union in a `types:` alias, which avoids the
+bracketing at the use site — the alias name is a single token:
+
+```eu,notest
+{ types: { Status: c"\"ok\" | \"err\"" } }
+
+` { type: "Status -> bool" }
+ok?(s): s = "ok"
+```
+
+### Lists
+
+`[T]` is a homogeneous list of `T`:
+
+```eu,notest
+` { type: "[number] -> [string]" }
+to-strings: map(str.of)
+
+` { type: "[a] -> a" }
+first: head
+```
+
+`NonEmpty([T])` is a non-empty list guaranteed to have at least one element.
+`head` and `tail` are safe on `NonEmpty([T])` without type warnings.
+
+#### List literal synthesis
+
+The checker assigns precise types to list literals:
+
+| Literal         | Synthesised type      | Notes                                  |
+|-----------------|-----------------------|----------------------------------------|
+| `[]`            | `List(Never)`         | Empty — `head` on this warns           |
+| `[42]`          | `Tuple([number])`     | 1–16 elements → Tuple with element types |
+| `[42, "hello"]` | `Tuple([number, string])` | Heterogeneous; `head` gives `number` |
+| `[e1..e17, ...]`| `NonEmpty([T])`       | >16 elements → non-empty homogeneous   |
+
+`cons(h, t)` and `h ‖ t` both return `NonEmpty([a])`.
+
+### Tuples
+
+Tuples use parentheses with commas:
+
+| Syntax    | Meaning          |
+|-----------|------------------|
+| `(A, B)`  | pair             |
+| `(A, B, C)` | triple         |
+| `(A,)`    | 1-tuple          |
+
+Tuples appear naturally in lens element types and in functions like
+`discriminate` that return pairs:
+
+```eu,notest
+` { type: "(a -> bool) -> [a] -> ([a], [a])" }
+discriminate: ...
+```
+
+`head` on a `Tuple([A, B, ...])` returns the precise first-element type `A`
+(not `A | B | ...`). `tail` returns `Tuple([B, ...])`:
+
+```eu,notest
+[42, "hello"] head       # type: number
+[42, "hello"] tail head  # type: string
+```
+
+The named pair accessors `first`/`key` (index 0) and `second`/`value` (index 1)
+are also precise on `Tuple` — the checker recognises their `head ∘ tail^n`
+composition as a **projection** and returns the exact element type:
+
+```eu,notest
+pair: ["alice", 42]
+pair key    # type: string  (index 0)
+pair value  # type: number  (index 1)
+second(pair) # type: number  (index 1)
+```
+
+Any user-defined function whose body is `xs tail head` (or `xs tail tail head`,
+etc.) acquires the same precise projection typing automatically.
+
+### Records
+
+Records describe the shape of blocks:
+
+| Syntax           | Meaning                                             |
+|------------------|-----------------------------------------------------|
+| `{k: T}`         | closed record — exactly the key `k` of type `T`    |
+| `{k: T, ..}`     | open record — at least `k: T`, may have more        |
+| `{k: T, ..r}`    | named row variable — `r` captures the extra fields  |
+| `{..r, ..s}`     | row concatenation — union of row `r` and row `s`    |
+| `block`          | any block (no known shape)                          |
+
+```eu,notest
+` { type: "{{name: string, age: number, ..}} -> string" }
+greet-person(p): "Hello, {p.name}!"
+```
+
+Open records are more commonly useful — most block-processing functions
+don't require a specific shape.
+
+#### `lookup` with a literal key
+
+When `lookup(:key, block)` is called with a **literal symbol** key, the checker
+resolves the field type precisely:
+
+```eu,notest
+` { type: "!{{name: string, age: number}}" }
+person: { name: "Alice", age: 30 }
+
+lookup(:name, person)   # type: string  (precise)
+lookup(:age, person)    # type: number  (precise)
+lookup(:naem, person)   # warning: unknown record key :naem (key typo in closed record)
+```
+
+- **Closed record + known key** → exact field type.
+- **Closed record + absent key** → `any` + a static warning (key typo caught before runtime).
+- **Open record + absent key** → `any`, no warning (the key may be present at runtime).
+- **`Dict(V)` + any literal key** → `V`.
+- **Non-literal key** → `any` (key value unknown at check time; may fail at runtime).
+
+### Dict
+
+`Dict(T)` represents a homogeneous block — a block where every value has
+the same type `T`. Use this when you know what the values are but not what
+the keys are:
+
+```eu,notest
+` { type: "Dict(number)" }
+scores: { alice: 95 bob: 87 carol: 92 }
+```
+
+Key prelude functions are annotated with `Dict` types:
+
+| Function     | Type                              |
+|--------------|-----------------------------------|
+| `map-values` | `(a -> b) -> Dict(a) -> Dict(b)`  |
+| `values`     | `Dict(a) -> [a]`                  |
+| `keys`       | `Dict(a) -> [symbol]`             |
+| `group-by`   | `(a -> any) -> [a] -> Dict([a])`  |
+
+A closed record is a subtype of the corresponding `Dict` type when all
+its field values share a common type. An open or annotated-Dict record is
+consistent with `Dict(T)` for gradual typing purposes.
+
+### Row polymorphism
+
+**Named row variables** allow functions that preserve the shape of records
+they do not inspect. The `merge` function is annotated:
+
+```eu,notest
+` { type: "{{..r}} -> {{..s}} -> {{..r, ..s}}" }
+merge: __MERGE
+```
+
+Here `r` and `s` are row variables that capture the fields from each
+input. The result contains both sets of fields. In a type annotation
+string, `{{` and `}}` are literal braces (eucalypt string escaping);
+the parser sees `{..r}` and `{..r, ..s}`.
+
+Row variables propagate through function applications: if a function
+with a named row in its type is applied to a concrete record, the
+checker unifies the known fields and binds the row variable to the
+remaining fields.
+
+#### Inference for unannotated block combinators (B9)
+
+When a lambda parameter is **used as a block** — projected (`.field`),
+merged (`merge`/`over`), or passed to a block-typed function — the
+checker allocates a fresh row variable for it automatically, even
+without an explicit `type:` annotation.
+
+```eu,notest
+# No annotation needed — f infers {..r} -> {..s} -> {..r, ..s}
+f(a, b): a merge(b)
+
+base: { x: 1 }
+ext: { y: "hello" }
+result: base f(ext)   # result : {x: number, y: string}
+```
+
+The checker uses a **use-driven** approach: only parameters that appear
+in a block position acquire row variables. Parameters used arithmetically
+(`x + y`) stay `any`, avoiding spurious warnings.
+
+### Functions
+
+Arrow `->` is right-associative. Multi-argument functions are curried:
+
+```eu,notest
+# a -> b -> c  means  a -> (b -> c)
+` { type: "a -> b -> a" }
+const(k, _): k
+```
+
+### Unions
+
+`|` expresses "either type". Useful for overloaded functions:
+
+```eu,notest
+` { type: "number -> number | string -> string" }
+to-upper-or-double: ...
+```
+
+Overloaded operators use union types:
+```
++   : number -> number -> number | [a] -> [a] -> [a] | array -> array -> array
+<   : number -> number -> bool | string -> string -> bool | symbol -> symbol -> bool
+```
+
+### Recursive types
+
+A **recursive alias** is an alias whose definition refers back to itself.
+The type checker resolves it to an equirecursive `μ`-type automatically —
+no special syntax is needed. Define recursive aliases with the `types:`
+metadata key:
+
+```eu,notest
+{ types: { Json: "number | string | bool | null | [Json] | Dict(Json)" } }
+
+` { type: "Json → string" }
+describe: str.from
+```
+
+`Json` unfolds to `number | string | bool | null | [Json] | Dict(Json)`,
+and any value whose type is a subtype of any variant passes without
+warning.  The type always *displays* as its alias name (`Json`) — never
+as the (infinite) unfolded form.
+
+**Unit metadata** (the bare block at the top of a file, no `` ` ``) is
+the natural place for type aliases shared across a whole file. Declaration
+metadata (with `` ` ``) can also carry a `types:` block to scope aliases
+to a single binding:
+
+```eu,notest
+` { types: { Tree: "{{value: number, children: [Tree]}}" } }
+root: { value: 1, children: [] }
+```
+
+**Mutual recursion** — aliases that reference each other are handled:
+the first alias expanded in an annotation becomes the outer `μ` binder.
+
+### Type variables
+
+Lowercase identifiers are type variables, universally quantified at
+the declaration level:
+
+```eu,notest
+` { type: "(a -> b) -> [a] -> [b]" }
+map: ...
+```
+
+At call sites, type variables are instantiated from the argument types.
+`map(str.of, [1, 2])` instantiates `a = number, b = string`, giving
+result type `[string]`.
+
+### Higher-kinded type variables
+
+Type variables can range over *type constructors* (types that take
+arguments), not just ordinary types.  A **kind** describes the arity
+of a type constructor:
+
+- `*` — an ordinary type (e.g. `number`, `[string]`)
+- `* -> *` — a unary type constructor (e.g. `List`, `IO`)
+- `* -> * -> *` — a binary type constructor (e.g. `Lens`, `Dict`)
+
+Declare a constructor variable with a kind annotation using `::`:
+
+```eu,notest
+` { type: "forall (m :: * -> *) a. m a -> m a" }
+hk-id: ...
+```
+
+Without a kind annotation, type variables default to kind `*` (ordinary
+types).  The `forall` keyword makes quantification explicit and allows
+kind annotations.  Implicit quantification (writing `a` directly in
+the type string) still works for kind-`*` variables.
+
+**Constructor application** uses juxtaposition:
+
+| Annotation          | Meaning                                   |
+|---------------------|-------------------------------------------|
+| `m a`               | Apply constructor variable `m` to type `a` |
+| `forall (m :: * -> *) a. m a -> m a` | Identity for any unary functor |
+| `forall a. a -> a`  | Polymorphic identity                       |
+
+The built-in constructors `List`, `IO`, `Dict`, `NonEmpty`, `Random`,
+and `State` all have kind `* -> *`.  `Lens` and `Traversal` have kind
+`* -> * -> *`.
+
+### Special types
+
+| Type             | Meaning                                               |
+|------------------|-------------------------------------------------------|
+| `any`            | gradual/dynamic — no errors involving `any`           |
+| `top`            | supertype of everything — nothing useful can be done with it |
+| `never`          | bottom type — unreachable code, empty collections     |
+| `ExecutionError` | the type of a raised runtime error (see Partial types below) |
+
+### Partial types
+
+Some functions can fail at runtime — for example `nth` raises an error
+when the index is out of range, and `parse-as` raises an error when the
+string is not valid in the given format.  These are called **partial
+functions**.
+
+Partial functions use the postfix `?` sugar in their type signatures:
+
+```
+nth      : number → [a] → a?         # may raise an error if index out of range
+parse-as : symbol → string → any?    # may raise an error if string is not valid
+lookup   : symbol → Dict(a) → a?     # may raise an error if key not found
+```
+
+`T?` is display sugar for `T | ExecutionError`.  The two forms are
+completely interchangeable in type annotations:
+
+```eu,notest
+` { type: "number → [a] → a?" }
+safe-nth(n, l): l nth(n)       # explicitly partial
+
+` { type: "number → [a] → a | ExecutionError" }
+also-safe-nth(n, l): l nth(n)  # identical — same type, different spelling
+```
+
+**Gradual self-limiting**: a partial result flowing into unannotated
+(`any`) code is **silent** — `ExecutionError <: any`.  A warning fires
+only when a partial result is used in a position that has been explicitly
+annotated as total:
+
+```eu,notest
+` { type: "number" }
+result: [1, 2, 3] nth(0)   # warning: expected number, found number?
+```
+
+Functions that A6 made total by input refinement (`head`/`tail` require
+`NonEmpty([a])`) are **not** partial — they keep their total types.
+`T?` documents the *residual* partiality that refinement cannot remove.
+
+---
+
+## IO actions
+
+`IO(T)` is a proper type constructor, not a block with metadata.
+IO actions have dedicated runtime representations — they are
+genuinely distinct from the values they produce.
+
+This is the type checker's most valuable capability: catching the
+common mistake of treating an IO action as its result:
+
+```eu,notest
+# WRONG: io.shell returns IO(block), not block
+result: io.shell("echo hello")
+name: result.stdout              # warning: IO(block) has no field .stdout
+
+# RIGHT: extract fields inside the monad
+name: io.shell("echo hello") io.map(_.stdout)  # IO(string) ✓
+```
+
+The prelude IO functions are typed:
+
+| Function         | Type                              |
+|------------------|-----------------------------------|
+| `io.shell(cmd)`  | `string -> IO(block)`             |
+| `io.return(a)`   | `a -> IO(a)`                      |
+| `io.bind(a, c)`  | `IO(a) -> (a -> IO(b)) -> IO(b)` |
+| `io.map(f, a)`   | `(a -> b) -> IO(a) -> IO(b)`     |
+| `io.fail(msg)`   | `string -> IO(a)`                 |
+
+`IO(T)` is opaque. The only way to work with the value inside is
+through `io.bind`, `io.map`, or the IO runner. This prevents IO
+values from leaking into pure data.
+
+---
+
+## Monadic block binding types
+
+When `eu check` encounters a monadic block, it uses the monad's element
+type to infer the types of bound variables. Each binding in a `{ :ns
+... }` block should be an action in that monad; the checker unwraps the
+monad layer and gives the bound name the result type.
+
+### The list monad: `{ :for ... }`
+
+The `for` namespace is the list monad. Binding a name draws elements
+from a list, so the bound variable gets the list's element type:
+
+```eu,notest
+{ :for x: [1, 2, 3] }.(x * 2)   # x : number  ✓
+{ :for s: ["a", "b"] }.(s)       # s : string  ✓
+```
+
+If you bind a non-list, `eu check` warns:
+
+```eu,notest
+{ :for x: 42 }.(x)   # warning: binding in :for block must be [a], got number
+```
+
+### The IO monad: `{ :io ... }`
+
+The `io` namespace is typed with `IO(a)`. Each binding must be an IO
+action; the bound variable gets the inner type:
+
+```eu,notest
+{ :io
+  r: io.shell("echo hello")   # r : block  (IO(block) unwrapped)
+  _: io.check(r)
+}.(r.stdout)                  # stdout lookup on block  ✓
+```
+
+The most common mistake the checker catches is binding a plain value
+instead of an IO action:
+
+```eu,notest
+{ :io
+  cmd: 42                     # warning: expected IO(a), got number
+}.(cmd)
+```
+
+### The state monad: `{ :random ... }` and `{ :state ... }`
+
+State monads wrap actions as functions of a state value. The checker
+validates that each binding is a valid monadic action for that namespace.
+Bound variables receive the result type (the `value` component):
+
+```eu,notest
+{ :random
+  d6:  random.int(6)     # d6  : number
+  d20: random.int(20)    # d20 : number
+}.[d6, d20]
+```
+
+### The identity monad: `{ :let ... }`
+
+`{ :let ... }` blocks use the identity monad — every binding is a plain
+value, so bound variables keep their inferred types directly:
+
+```eu,notest
+{ :let
+  x: 1 + 1               # x : number
+  s: str.of(x)           # s : string
+}.(x + 1)                # number + number  ✓
+```
+
+### User-defined monads: `monad()`
+
+`monad({ bind(m, f): ..., return(v): ... })` derives the standard
+monad combinators (`map`, `then`, `and-then`, `join`, `sequence`,
+`map-m`, `filter-m`) and annotates them with higher-kinded types using
+`forall (m :: * -> *)`.
+
+When `monad()` is called with a concrete `bind` and `return`, the type
+checker instantiates `m :: * → *` as a fresh higher-kinded variable and
+runs higher-order pattern unification: it unifies `m a` against the
+concrete first-argument type of `bind`.  For named constructors such as
+`List` (`[a]`) this decomposes via the first-order rule; for anonymous
+type constructors (e.g. `stream → {value: a, rest: stream}`) the
+Miller pattern fragment fires and binds `m` to a type-level lambda.
+No annotation is required — the binding is inferred entirely from the
+`bind` implementation.
+
+For example, a list monad:
+
+```eu,notest
+my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
+```
+
+The checker unifies `m a` against `[a]`, infers `m = List`, and gives
+`my-for.map` type `forall a b. (a → b) → [a] → [b]`.  Passing a
+non-function triggers a type warning:
+
+```eu,notest
+[1, 2, 3] my-for.map(true)   # warning: expected a → b, found bool
+```
+
+#### How combinator types are inferred
+
+Monad combinator types are inferred automatically via higher-order
+pattern unification — no `monad:` annotation is needed for type
+checking.  When `monad()` is called with a concrete `bind`
+implementation, the checker unifies the `bind` argument type against
+the polymorphic `m a → (a → m b) → m b` signature.  If `m` is applied
+to a variable (the Miller pattern fragment), the unifier constructs a
+type-level lambda: for example, a `bind` whose first argument has type
+`stream → {value: a, rest: stream}` causes the checker to infer
+`m = λa. stream → {value: a, rest: stream}` and propagate that
+instantiation through all nine derived combinators.
+
+Named constructors (`List`, `IO`) are handled by the existing
+first-order rule: `m a` against `[a]` decomposes as `m = List`.
+
+No annotation is required:
+
+```eu,notest
+my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
+```
+
+`my-for.bind` is inferred as `[a] → (a → [b]) → [b]`, `my-for.map`
+as `(a → b) → [a] → [b]`, and so on.
+
+#### `monad:` metadata for LSP hints
+
+The `monad:` metadata key is **not** used for type checking.  It is
+retained solely for A10 LSP element-type hints: when the language
+server displays inlay hints inside a monadic block, `monad:` tells it
+which element type to show next to each bound variable (e.g.
+`x: number` instead of `x: [number]`).
+
+```eu,notest
+` { monad: "[a]" }
+my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
+```
+
+Omitting `monad:` does not affect type checking; it only suppresses
+the LSP element-type inlay hints.
+
+### What the checker validates
+
+`eu check` reports a warning when:
+
+- A binding's RHS type is inconsistent with the monad's expected action
+  type (e.g. `number` in an `:io` block instead of `IO(a)`)
+- A bound variable is used in a way inconsistent with its unwrapped type
+  (e.g. calling `.stdout` on a `number`)
+
+The checker does **not** require annotations — it infers binding types
+from the monad's known type signature and the RHS expression type.
+
+When using an LSP-enabled editor, inlay hints display the inferred
+element type next to each bound variable name, e.g. `x: number` inside
+a `{ :for x: [...] }` block.
+
+---
+
+## Lens and traversal types
+
+The lens library is typed with two opaque type constructors:
+
+| Type              | Meaning                                      |
+|-------------------|----------------------------------------------|
+| `Lens(a, b)`      | focuses on a single `b` within an `a`        |
+| `Traversal(a, b)` | focuses on zero or more `b`s within an `a`   |
+
+`Lens(a, b)` is a subtype of `Traversal(a, b)`.
+
+```eu,notest
+` { type: "symbol -> Lens(block, any)" }
+at(key, k): ...
+
+` { type: "number -> Lens([a], a)" }
+ix(n, k): ...
+
+` { type: "Lens(a, b) -> a -> b" }
+view(lens, data): ...
+
+` { type: "Lens(a, b) | Traversal(a, b) -> (b -> b) -> a -> a" }
+over(lens, fn, data): ...
+```
+
+Composition of lenses via `∘` chains optic types:
+- `Lens(a, b) ∘ Lens(b, c)` → `Lens(a, c)`
+- `Lens(a, b) ∘ Traversal(b, c)` → `Traversal(a, c)`
+
+The checker catches broken compositions:
+
+```eu,notest
+# Works: a block → string → number (hypothetical)
+path: at(:name) ∘ at(:length)
+
+# Warning: Lens(block, any) ∘ ix(0) — ix expects [a], not any
+bad-path: at(:name) ∘ ix(0)
+```
+
+---
+
+## Type aliases
+
+For complex or repeated types, define aliases at the top of your file
+using unit metadata:
+
+```eu,notest
+{ import: "data.eu"
+  types: { Person: "{{name: string, age: number, email: string | null, ..}}"
+           Response: "{{status: number, body: string | null}}" } }
+
+` { type: "[Person] -> [string]" }
+names: map(_.name)
+
+` { type: "Response -> bool" }
+success?(r): r.status < 400
+```
+
+Alternatively, use `type-def:` on a declaration to name the type of
+a canonical value:
+
+```eu,notest
+` { type-def: "Point" }
+origin: { x: 0, y: 0 }
+# Defines: Point = {x: number, y: number, ..}
+# And: origin : Point
+
+` { type: "Point -> Point -> number" }
+distance(a, b): ((b.x - a.x)^2 + (b.y - a.y)^2) abs
+```
+
+Combine `type:` and `type-def:` to override inference:
+
+```eu,notest
+` { type-def: "Person"
+    type: "{{name: string, age: number, email: string | null, ..}}" }
+nobody: { name: "", age: 0, email: null }
+```
+
+---
+
+## A worked example
+
+Consider a small data processing pipeline with type annotations:
+
+```eu,notest
+{ types: { Record: "{{id: number, name: string, active: bool, ..}}" } }
+
+` { type: "[Record] -> [Record]" }
+active-records: filter(_.active)
+
+` { type: "[Record] -> block" }
+index-by-id: group-by(_.id)
+
+` { type: "Record -> string" }
+summary(r): "[{r.id}] {r.name}"
+```
+
+With these annotations in place, the checker can verify downstream
+code:
+
+```eu,notest
+# Warning: filter expects (a -> bool), but str.of has type any -> string
+bad: records filter(str.of)
+
+# Fine: map over active records, produce strings
+ok: records active-records map(summary)
+```
+
+---
+
+## Open vs. closed records
+
+An **open record** `{k: T, ..}` says "has at least this key", allowing
+additional fields. A **closed record** `{k: T}` says "has exactly this
+key".
+
+In practice, open records are more useful because eucalypt blocks
+typically have variable shapes:
+
+```eu,notest
+# Open: works with any block that has a .name field
+` { type: "{{name: string, ..}} -> string" }
+get-name(b): b.name
+
+# Closed: only works with blocks of exactly this shape
+` { type: "{{name: string}}" }
+exact-block: { name: "Alice" }
+```
+
+Width subtyping means `{x: number, y: number}` is a subtype of
+`{x: number, ..}` — a more specific block satisfies a less specific
+requirement.
+
+---
+
+## Namespace typing
+
+Functions within namespace blocks (`str`, `arr`, `set`, etc.) are
+annotated in the same way:
+
+```eu,notest
+str: {
+  ` { type: "any -> string" }
+  of: __STR
+
+  ` { type: "string -> number" }
+  len: __STR_LEN
+}
+```
+
+The checker synthesises the block's record type from its members, so
+`str.len` resolves to `string -> number` via standard record field
+lookup.
+
+---
+
+## Flow-sensitive narrowing
+
+After a recognised branch on a type predicate, the checker narrows the
+tested variable's type within each branch:
+
+```eu,notest
+# x : number | string | null
+# In the true branch, x is narrowed to `null`.
+# In the false branch, x is narrowed to `number | string` (null subtracted).
+` { type: "(number | string | null) -> string" }
+describe(x): if(x null?, "nothing", if(x string?, x, str(x)))
+```
+
+Recognised predicates: `number?`, `string?`, `symbol?`, `bool?`, `list?`,
+`block?`, `nil?`, `null?`, `not-nil?`.
+
+`nil?` narrows a `[T]` to `NonEmpty([T])` in the **false** branch (the
+list is non-empty), enabling `head` without a type warning:
+
+```eu,notest
+` { type: "[number] -> number" }
+safe-head(xs): if(xs nil?, 0, xs head)   # no warning — xs is NonEmpty([number]) in false branch
+```
+
+Recognised branchers: `if` (three-argument), `and`, `or`, `cond`.
+A user-defined brancher that aliases or wraps one of these inherits its
+narrowing — but only if the prelude's `if`/`and`/`or`/`cond` is used,
+not a local rebinding.
+
+## `cond` — multi-way conditional
+
+`cond` dispatches a list of `condition => result` clauses, returning the
+first result whose condition is true. A trailing bare expression is the
+default:
+
+```eu,notest
+classify(n): cond[n < 0 => "negative", n > 100 => "huge", "normal"]
+```
+
+The `=>` operator (precedence 15, right-associative) builds a clause pair.
+The Unicode alias `⇒` is equivalent. Both forms are recognised by the
+checker for flow-sensitive narrowing through each clause.
+
+---
+
+## Prelude type cache
+
+The checker builds the prelude's type information once per process and
+caches it.  Every subsequent file is checked in **standalone mode** —
+only the user file is loaded, and the cached prelude summary (binding
+types, type aliases, branch-shape classification) is seeded into the
+checker before it begins.
+
+This means:
+
+- The prelude is **fully checked** on the first call — every prelude
+  binding is a root in standalone mode, unlike the merged-then-pruned
+  path which only ever checks the subset reachable from the user file.
+- Each subsequent LSP re-check or `eu check` invocation **skips the
+  ~2 200-line prelude entirely**, giving a measurably faster response.
+- Results are identical to the merged check: prelude references resolve
+  to the same types, predicate narrowing fires on `number?`/`string?`/
+  etc., and user-defined brancher wrappers around prelude combinators
+  are recognised.
+
+The cache is keyed on the embedded prelude source and lives in process
+memory — it persists for the lifetime of the `eu` or LSP server process
+but is not written to disk.
+
+---
+
+## Summary
+
+| What                     | How                                              |
+|--------------------------|--------------------------------------------------|
+| Run the checker          | `eu check file.eu`                               |
+| Treat warnings as errors | `eu check file.eu --strict`                      |
+| Annotate a declaration   | `` ` { type: "number -> number" } ``             |
+| Any block                | `block`                                          |
+| Open record              | `{k: T, ..}`                                     |
+| Closed record            | `{k: T}`                                         |
+| Named row variable       | `{k: T, ..r}` (`{{k: T, ..r}}` in string)       |
+| Row concatenation        | `{..r, ..s}` (`{{..r, ..s}}` in string)          |
+| Homogeneous dict         | `Dict(T)`                                        |
+| IO action                | `IO(T)`                                          |
+| Lens                     | `Lens(a, b)`                                     |
+| Traversal                | `Traversal(a, b)`                                |
+| Literal string type      | `"value"` — c-string escapes: `c"\"value\""`     |
+| Literal symbol type      | `:name`                                           |
+| Type variable            | lowercase identifier: `a`, `b`, `s`              |
+| Explicit quantification  | `forall a. T` or `forall (m :: * -> *) a. T`    |
+| Constructor variable     | `m :: * -> *` in a `forall` binder               |
+| Constructor application  | `m a` (juxtaposition in type expressions)        |
+| Union type               | `A \| B`                              |
+| NonEmpty list            | `NonEmpty([a])`                       |
+| Empty list literal       | `[]` synthesises as `List(Never)`     |
+| Short list literal       | `[a, b]` synthesises as `Tuple([A, B])` (1–16 elements) |
+| `nil?` false-branch      | `[T]` narrowed to `NonEmpty([T])`     |
+| Type alias (unit meta)   | `{ types: { Name: "..." } }`          |
+| Type alias (declaration) | `` ` { type-def: "Name" } ``          |
+| Cond clause              | `condition => result`                 |
+| Multi-way conditional    | `cond[c1 => r1, c2 => r2, default]`   |
+
+---
 
 # Advanced Topics
 
@@ -2680,7 +8065,8 @@ helper(x): x + 1
 
 Key metadata properties:
 - `doc` -- documentation string
-- `export: :suppress` -- hide from output
+- `export: :suppress` -- hide from output (still visible to importers)
+- `export: :internal` -- hide from output AND importers (unit-private)
 - `target` -- mark as an export target
 - `import` -- import other files
 - `associates` / `precedence` -- operator fixity (see
@@ -3174,201 +8560,1926 @@ info: {
 
 ---
 
-<!-- Source: docs/guide/command-line.md -->
+# Language Syntax Reference
 
-# The Command Line
+Eucalypt has a native syntax which emphasises the mappings-and-lists
+nature of its underlying data model but adds enhancements for
+functions and expressions. Eucalypt is written in `.eu` files.
 
-In this chapter you will learn:
+While `eu` happily processes YAML inputs with embedded expressions,
+many features are not yet available in the YAML embedding and the
+embedded expressions are themselves in Eucalypt syntax, so it is
+necessary to have an overview of how the syntax works to do anything
+interesting with Eucalypt.
 
-- The `eu` command structure and subcommands
-- How to specify inputs, outputs, and evaluands
-- How to use targets, arguments, and environment variables
-- How to use the formatter and other tools
+A few aspects are unorthodox and experimental.
+
+## Overview
+
+Eucalypt syntax comes about by the overlapping of two sub-languages.
+
+- the *block DSL* is how you write blocks and their declarations
+- the *expression DSL* is how you write expressions
+
+They are entwined in a fairly typical way: block literals (from the
+*block DSL*) can be used in expressions (from the *expression DSL*)
+and expressions (from the *expression DSL*) appear in declarations
+(from the *block DSL*).
+
+Comments can be interspersed throughout. Eucalypt only has line level
+comments.
+
+```eu,notest
+foo: bar # Line comments start with '#' and run till the end of the line
+```
+
+> **Note:** If you feel you need a block comment, you can use an
+> actual block or a string property within a block and mark it with
+> annotation metadata `:suppress` to ensure it doesn't appear in
+> output.
+
+Eucalypt has two types of names:
+
+- normal names, which are largely alphanumeric (e.g. `f`, `blah`,
+  `some-thing!`, `ॵ`) and are used to name properties and functions
+- operator names, which are largely symbolic (e.g. `&&&`, `∧`, `-+-|`,
+  `⊚`) and are used to name operators
+
+See [Operator Precedence Table](operators-and-identifiers.md) for more.
+
+## The block DSL
+
+A **block** is surrounded by curly braces:
+
+```eu
+... { ... }
+```
+
+...and contains declarations...
+
+```eu,notest
+... {
+  a: 1
+  b: 2
+  c: 3
+}
+```
+
+...which may themselves have blocks as values...
+
+```eu,notest
+... {
+  foo: {
+    bar: {
+      baz: "hello world"
+    }
+  }
+}
+```
+
+The top-level block in a file (a **unit**) does not have braces:
+
+```eu
+a: 1
+b: 2
+c: 3
+```
+
+Blocks may also have a single expression, preceding its declarations
+which constitutes **block metadata**. This is optional.
+
+So the block pattern is braces (except for the unit level) containing,
+optionally metadata, then any number of declarations.
+
+```
+{ «metadata expression»?  [«declaration»]* }
+```
+
+Both the metadata expression and the declarations may contain blocks.
+This recursive application of the block pattern defines the major
+structure of any eucalypt code.
+
+So far all the declarations we have seen have been **property
+declarations** which contain a name and an expression, separated by a
+colon.
+
+Commas are entirely optional for delimiting declarations. Line endings
+are not significant. The following is a top-level block of three
+**property declarations**.
+
+```eu
+a: 1 b: 2 c: 3
+```
+
+There are other types of declarations. By specifying a parameter list,
+you get a **function declaration**:
+
+```eu
+# A function declaration
+f(x, y): x + y
+
+two: f(1, 1)
+```
+
+Function parameters can be **destructuring patterns** as well as
+simple names. A block pattern extracts named fields from a block
+argument; a list pattern extracts positional elements from a list
+argument:
+
+```eu
+# Block destructuring — shorthand binds field name as variable name
+sum-xy({x y}): x + y
+
+# Block destructuring — rename binds field under a new variable name
+product-ab({x: a  y: b}): a * b
+
+# Mixed shorthand and rename
+mixed({x  y: b}): x + b
+
+# Fixed-length list destructuring
+f-sum([a, b, c]): a + b + c
+f-first([a, b]): a
+
+# Head/tail list destructuring — colon separates fixed heads from tail
+get-head([x : xs]): x
+get-tail([x : xs]): xs
+drop-two([a, b : rest]): rest
+```
+
+Juxtaposed call syntax passes a block or list literal as a single
+argument without parentheses. No space between the function name and
+the opening bracket:
+
+```eu,notest
+# f{...} is sugar for f({...})
+sum-xy{x: 10 y: 20}
+
+# f[...] is sugar for f([...])
+add-pair[1, 2]
+```
+
+Combined with block destructuring, this gives named arguments:
+
+```eu
+greet({name greeting}): "{greeting}, {name}!"
+greet{name: "Alice" greeting: "Hello"}    # => "Hello, Alice!"
+```
+
+Juxtaposed syntax also works in definitions — the bracket or brace
+is written directly against the function name with no space. This is
+sugar for the parenthesised destructuring form:
+
+```eu
+# f[x, y]: ...  is sugar for  f([x, y]): ...
+add-pair[a, b]: a + b
+
+# f{x y}: ...   is sugar for  f({x y}): ...
+add-block{x y}: x + y
+
+# f[h : t]: ... is sugar for  f([h : t]): ...
+my-head[h : t]: h
+```
+
+Destructuring patterns can be mixed with normal parameters:
+
+```eu
+f(n, [a, b]): n * (a + b)
+```
+
+The `‖` operator (U+2016, DOUBLE VERTICAL LINE) prepends an element to
+a list. It is right-associative:
+
+```eu
+1 ‖ [2, 3]        # => [1, 2, 3]
+1 ‖ 2 ‖ [3]       # => [1, 2, 3]
+```
+
+See [Functions and Combinators](../guide/functions-and-combinators.md)
+for more detail on destructuring.
+
+...and using some brackets and suitable names, you can define
+operators too, either binary:
+
+```eu
+# A binary operator declaration
+(x ^|^ y): "{x} v {y}"
+```
+
+...or prefix or postfix unary operators:
+
+```eu
+# A prefix operator declaration
+(¬ x): not(x)
+
+# A postfix operator declaration
+(x ******): "maybe {x}"
+```
+
+Eucalypt should handle unicode gracefully and any unicode characters
+in the symbol or punctuation classes are fine for operators.
+
+In addition to named operators, you can define **idiot brackets** —
+custom Unicode bracket pairs that collect their content items into a
+list and pass it to a function. The name is inspired by *idiom
+brackets* from applicative functor notation, but they are a general
+bracket overloading mechanism.
+
+```eu
+# Ceiling brackets double each item
+⌈ xs ⌉: xs map(_ * 2)
+
+# Floor brackets sum the items
+⌊ xs ⌋: xs sum
+```
+
+Once declared, items inside the brackets are collected as a list:
+
+```eu,notest
+doubled: ⌈ 3 4 5 ⌉       # => [6, 8, 10]
+total:   ⌊ 10 20 30 ⌋    # => 60
+single:  ⌈ 7 ⌉            # => [14]
+```
+
+The declaration `⌈ xs ⌉: body` defines a function named `⌈⌉` (open
+then close bracket) that takes one argument — the list of items.
+Parenthesise sub-expressions to group them as a single item:
+`⌈ (1 + 2) (3 * 4) ⌉` passes `[3, 12]`.
+
+The parameter supports destructuring: `⌈ [f: args] ⌉: body` binds
+`f` to the first item and `args` to the rest.
+Using `⌈ expr ⌉` in an expression calls that function with `expr`.
+
+The following Unicode bracket pairs are built-in and can be used for
+idiot brackets without any registration:
+
+| Open | Close | Name |
+|------|-------|------|
+| `⟦`  | `⟧`   | Mathematical white square brackets |
+| `⟨`  | `⟩`   | Mathematical angle brackets |
+| `⟪`  | `⟫`   | Mathematical double angle brackets |
+| `⌈`  | `⌉`   | Ceiling brackets |
+| `⌊`  | `⌋`   | Floor brackets |
+| `⦃`  | `⦄`   | Mathematical white curly brackets |
+| `⦇`  | `⦈`   | Mathematical white tortoise shell brackets |
+| `⦉`  | `⦊`   | Mathematical flattened parentheses |
+| `«`  | `»`   | French guillemets |
+| `【` | `】`  | CJK lenticular brackets |
+| `〔` | `〕`  | CJK tortoise shell brackets |
+| `〖` | `〗`  | CJK white lenticular brackets |
+| `〘` | `〙`  | CJK white tortoise shell brackets |
+| `〚` | `〛`  | CJK white square brackets |
+
+### Monadic blocks
+
+Eucalypt supports monadic sequencing — analogous to Haskell `do`-notation —
+through two mechanisms: **bracket pair definitions** and **block metadata**.
+
+#### Bracket pair definitions
+
+A bracket pair gains a **monad spec** when declared with an empty block `{}`
+as its parameter and a body marked with `:monad` metadata, supplying `bind`
+and `return` function names:
+
+```eu,notest
+# Explicit bind/return functions
+⟦{}⟧: { :monad bind: my-bind  return: my-return }
+
+# Namespace reference — delegates to a block with bind and return members
+⟦{}⟧: { :monad namespace: my-monad }
+```
+
+A bracket pair declared with an empty block `{}` as its parameter (e.g.
+`⟦{}⟧: …`) is registered as **block-mode**.  When such a bracket pair is used,
+its content is parsed as a sequence of `name: monadic-action` declarations
+(a **bracket block**).  The closing bracket may be followed by `.return_expr`
+for an explicit return:
+
+```eu,notest
+result: ⟦ a: ma  b: mb ⟧.return_expr
+```
+
+The parser determines the parse mode from the bracket content itself using a
+**colon heuristic**: if the top-level content contains colons, the brackets are
+parsed as block-mode (declarations); if not, they are parsed as expression-mode
+(catenated items collected into a list).  Empty brackets are expression-mode.
+This means the same bracket pair can be used in either mode depending on the
+content.
+
+If no `.return_expr` follows, the block uses **implicit return**: the desugarer
+synthesises `return({ a: a, b: b })` automatically, collecting all bound names
+(except those starting with `_`) into a block.
+
+#### Block metadata forms
+
+Regular blocks can also be desugared monadically when the block carries monad
+metadata.  If followed by `.return_expr`, the expression is used as the return;
+otherwise, implicit return is used when the namespace is declared with
+`monad: true`.  Six forms are accepted:
+
+| Form | Syntax | Return |
+|------|--------|--------|
+| 1 | `{ :name decls }.expr` | Explicit |
+| 2 | `{ { monad: name } decls }.expr` | Explicit |
+| 3 | `{ { :monad namespace: name } decls }.expr` | Explicit |
+| 4 | `{ { :monad bind: f return: r } decls }.expr` | Explicit |
+| 1i | `{ :name decls }` (namespace has `monad: true`) | Implicit |
+| Bi | `⟦ decls ⟧` (bracket pair registered) | Implicit |
+
+For namespace forms, the named value must be a block in scope with `bind` and
+`return` member functions.  The desugarer emits `name.bind(…)` and
+`name.return(…)` lookup expressions.
+
+**Implicit return with `monad: true`:**  To allow `{ :name decls }` without
+`.expr`, declare `name` with `monad: true` metadata:
+
+```eu,notest
+` { monad: true }
+io: { ... }
+
+result: { :io r: io.shell("echo hello") }
+# result == { r: "hello\n" }  (all bound names collected into return block)
+```
+
+Bound names starting with `_` are excluded from the implicit return block,
+allowing intermediate computations to be suppressed.
+
+#### Desugaring
+
+All monadic block forms desugar to a right-to-left bind chain:
+
+```
+bind(ma, (a): bind(mb, (b): return(return_expr)))
+```
+
+All declarations are bind steps.  Each bound name is in scope for later actions
+and for the return expression.  With an explicit `.expr`, the return expression
+may be any single element: a name (`.r`), a parenthesised expression
+(`.(x + y)`), a list, or a block.  With implicit return, bound names
+(excluding `_`-prefixed ones) are collected into a return block automatically.
+
+**Example — identity monad (bracket pair, explicit return):**
+
+```eu
+id-bind(ma, f): f(ma)
+id-return(a): a
+
+⟦{}⟧: { :monad bind: id-bind  return: id-return }
+
+result: ⟦ x: 10  r: x + 5 ⟧.r     # => 15
+```
+
+**Example — identity monad (bracket pair, implicit return):**
+
+```eu
+id-bind(ma, f): f(ma)
+id-return(a): a
+
+⟦{}⟧: { :monad bind: id-bind  return: id-return }
+
+result: ⟦ a: 10  b: 20 ⟧    # => { a: 10, b: 20 }
+```
+
+**Example — maybe monad (namespace reference, explicit return):**
+
+```eu
+maybe: { bind(ma, f): if(ma = [], [], f(ma head))  return(a): [a] }
+
+just:    { :maybe x: [1]  y: [2] }.(x + y)   # => [3]
+nothing: { :maybe x: []   y: [2] }.(x + y)   # => []
+```
+
+**Example — namespace implicit return (`monad: true`):**
+
+```eu
+` { monad: true }
+maybe: { bind(ma, f): if(ma = [], [], f(ma head))  return(a): [a] }
+
+result: { :maybe x: [1]  y: [2] }   # => { x: 1, y: 2 }
+```
+
+**Example — maybe monad (bracket pair with namespace reference):**
+
+```eu
+maybe: { bind(ma, f): if(ma = [], [], f(ma head))  return(a): [a] }
+
+⌈{}⌉: { :monad namespace: maybe }
+
+just:    ⌈ x: [1]  y: [2] ⌉.(x + y)   # => [3]
+nothing: ⌈ x: []   y: [2] ⌉.(x + y)   # => []
+```
+
+To control the precedence and associativity of user defined operators,
+you need metadata annotations.
+
+**Declaration annotations** allow us to specify arbitrary metadata
+against declarations. These can be used for documentation and similar.
+
+To attach an annotation to a declaration, squeeze it between a leading
+backtick and the declaration itself:
+
+```eu
+` { doc: "This is a"}
+a: 1
+
+` { doc: "This is b"}
+b: 2
+```
+
+Some metadata activate special handling, such as the `associates` and
+`precedence` keys you can put on operator declarations:
+
+```eu
+` { doc: "`(f ∘ g)` - return composition of `f` and `g`"
+    associates: :right
+    precedence: 88 }
+(f ∘ g): compose(f,g)
+```
+
+Look out for other uses like `:target`, `:suppress`, `:main`.
+
+Finally, you can specify metadata at a unit level. If the first item
+in a unit is an expression, rather than a declaration, it is treated
+as metadata that is applied to the whole unit.
+
+```eu
+{ :doc "This is just an example unit" }
+a: 1 b: 2 c: 3
+```
+
+## The expression DSL
+
+Everything that can appear to the right of the colon in a declaration
+is an expression and defined by the expression DSL.
+
+### Primitives
+
+First there are primitives.
+
+...numbers...
+
+```eu
+123
+```
+
+```eu
+-123
+```
+
+```eu
+123.333
+```
+
+...double quoted strings...
+
+```eu
+"a string"
+```
+
+...**symbols**, prefixed by a colon...
+
+```eu
+:key
+```
+
+...which are currently very like strings, but used in circumstances
+where their internal structure is generally not significant (i.e. keys
+in a block's internal representation).
+
+Finally, booleans (`true` and `false`) are pre-defined constants. As
+is (`null`) which is a value which renders as YAML or JSON's version
+of null but is not used by Eucalypt itself.
+
+### Block literals
+
+Block literals (in braces, as defined in the *block DSL*) are
+expressions and can be the values of declarations or passed as
+function arguments or operands in any of the contexts below:
+
+```eu
+foo: { a: 1 b: 2 c: 3}
+```
+
+### List literals
+
+List literals are enclosed in square brackets and contain a comma
+separated sequence of expressions:
+
+```eu
+list: [1, 2, :a, "boo"]
+```
+
+### Names
+
+Then there are **names**, which refer to the surrounding context. They
+might refer to properties:
+
+```eu
+x: 22
+y: x
+```
+
+...or *functions*:
+
+```eu
+add-one(x): 1 + x
+three: add-one(2)
+```
+
+...or *operators*:
+
+```eu
+(x &&& y): [x, x, x, y]
+z: "da" &&& "dum"
+```
+
+### Calling functions
+
+Functions can be applied by suffixing an argument list in parens, with
+*no intervening whitespace*:
+
+```eu
+f(x, y): x + y
+result: f(2, 2) # no whitespace
+```
+
+In the special case of applying a single argument, *"catenation"* can
+be used:
+
+```eu
+add-one(x): 1 + x
+result: 2 add-one
+```
+
+...which allows succinct expressions of pipelines of operations.
+
+In addition, functions are curried so can be partially applied:
+
+```eu
+add(x, y): x + y
+increment: add(1)
+result: 2 increment
+```
+
+...and placeholder underscores (or *expression anaphora*) can be used
+to define simple functions without the song and dance of a function
+declaration:
+
+```eu,notest
+f: if(tuesday?, (_ * 32 / 12), (99 / _))
+result: f(3)
+```
+
+In fact, in many cases the underscores can be omitted, leading to a
+construct very similar to Haskell's *sections* only even brackets
+aren't necessary.
+
+> **Note:** Eucalypt uses its knowledge of the fixity and
+> associativity of each operator to find "gaps" and fills them with the
+> unwritten underscores. This is great for simple cases but worth
+> avoiding for complicated expressions.
+
+```eu
+increment: + 1
+result: 2 increment (126 /)
+```
+
+Both styles of function application together with partial application
+and sectioning can all be applied together:
+
+```eu,notest
+result: [1, 2, 3] map(+1) filter(odd?) //=> [3]
+```
+
+(`//=>` is an assertion operator which causes a panic if the left and
+right hand expressions aren't found to be equal at run time, but
+returns that value if they are.)
+
+> **Note:** There are no explicit lambda expressions in Eucalypt right
+> now. For simple cases, expression or string anaphora should do the
+> job. For more involved cases, you should use a named function
+> declaration. See [Anaphora](../guide/anaphora.md) for more.
+
+---
+
+# Operators and Identifiers
+
+Eucalypt distinguishes two different types of identifier, *normal*
+identifiers, like `x`, `y`, `α`, `א`, `ziggety-zaggety`, `zoom?`, and
+*operator identifiers* like `*`, `@`, `&&`, `∧`, `∘`, `⊙⊙⊙`, `<>` and
+so on.
+
+It is entirely a matter of the component characters which category an
+identifier falls into. Normal identifiers contain letters (including
+non-ASCII characters), numbers, "-", "?", "$". Operator identifiers
+contain the usual suspects and anything identified as an operator or
+symbol in unicode. Neither can contain ":" or "," or brackets which
+are special in eucalypt.
+
+Any sequence of characters at all can be treated as a normal
+identifier by surrounding them in single quotes. This is the only use
+of single quotes in eucalypt. This can be useful when you want to use
+file paths or other external identifiers as block keys for instance:
+
+```eu,notest
+home: {
+  '.bashrc': false
+  '.emacs.d': false
+  'notes.txt': true
+}
+
+z: home.'notes.txt'
+```
+
+## Normal identifiers
+
+Normal identifiers are brought into scope by declarations and can be
+referred to without qualification in their own block or in more
+nested blocks:
+
+```eu
+x: {
+  z: 99
+  foo: z //=> 99
+  bar: {
+    y: z //=> 99
+  }
+}
+```
+
+They can be accessed from within other blocks using the lookup
+operator:
+
+```eu
+x: {
+  z: 99
+}
+
+y: x.z //=> 99
+```
+
+They can be overridden using generalised lookup:
+
+```eu
+z: 99
+y: { z: 100 }."z is {z}" //=> "z is 100"
+```
+
+They can be shadowed:
+
+```eu
+z: 99
+y: { z: 100 r: z //=> 100 }
+```
+
+But beware trying to access the outer value:
+
+```eu,notest
+name: "foo"
+x: { name: name } //=> infinite recursion
+```
+
+Accessing shadowed values is not yet easily possible unless you can
+refer to an enclosing block and use a lookup.
+
+## Prefix operators
+
+Some operators are defined as prefix (unary) operators rather than
+infix (binary) operators. These bind tightly to the expression that
+follows.
+
+For example, the `↑` operator is a tight-binding prefix form of `head`:
+
+```eu
+xs: [1, 2, 3]
+first: ↑xs  //=> 1
+```
+
+Because it binds tightly (precedence 95), it works naturally in
+pipelines without parentheses:
+
+```eu
+xs: [[1, 2], [3, 4]]
+result: xs map(↑)  # map head over list of lists
+```
+
+Other prefix operators include `!` and `¬` for boolean negation, and
+`∸` for numeric negation.
+
+## Operator identifiers
+
+Operator identifiers are more limited than normal identifiers.
+
+They are brought into scope by operator declarations and available
+without qualification in their own block and more nested blocks:
+
+```eu
+( l -->> r): "{l} shoots arrow at {r}"
+
+x: {
+  y: 2 -->> 3 //=> "2 shoots arrow at 3"
+}
+```
+
+...and can be shadowed:
+
+```eu
+(l !!! r): l + r
+
+y: {
+  (l !!! r): l - r
+  z: 100 !!! 1 //=> 99
+}
+```
+
+But:
+
+- they cannot be accessed by lookup, so there is no way of forming a
+  qualified name to access an operator
+- they cannot be overridden by generalised lookup
+
+---
+
+# Prelude Reference
+
+The eucalypt **prelude** is a standard library of functions, operators, and constants that is automatically loaded before your code runs. You can suppress the prelude with `-Q` if needed, though this leaves a very bare environment (even `true`, `false`, and `if` are defined in the prelude).
+
+## Categories
+
+- [Lists](lists.md) -- list construction, transformation, folding, sorting (91 entries)
+- [Blocks](blocks.md) -- block construction, access, merging, transformation (66 entries)
+- [Strings](strings.md) -- string manipulation, regex, formatting (36 entries)
+- [Numbers and Arithmetic](numbers.md) -- numeric operations and predicates (30 entries)
+- [Booleans and Comparison](booleans.md) -- boolean logic and comparison operators (12 entries)
+- [Combinators](combinators.md) -- function composition, application, utilities (14 entries)
+- [Calendar](calendar.md) -- date and time functions (8 entries)
+- [Sets](sets.md) -- set operations (14 entries)
+- [Random Numbers](random.md) -- random number generation, monadic random: namespace (15 entries)
+- [Metadata](metadata.md) -- metadata and assertion functions (4 entries)
+- [IO](io.md) -- environment, time, argument access, and monad utility (80 entries)
+
+*370 documented entries in total.*
+
+## Standard Libraries
+
+These are not part of the prelude (they require an explicit import) but
+ship with eucalypt:
+
+- **[Lens Library](../../guide/lenses.md)** (`{ import: "lens.eu" }`) — composable
+  lenses and traversals for reading and updating nested data: `view`, `over`,
+  `to-list-of`, `parts-of`, `at`, `ix`, `item`, `element`, `each`, `filtered`,
+  `each-element`, `filtered-elements`, `_value`, `_key`, `‹›` path shorthand.
+
+---
+
+# Lists
+
+## Basic Operations
+
+| Function | Description |
+|----------|-------------|
+| `cons` | Construct new list by prepending item `h` to list `t` |
+| `snoc(x, l)` | Append element `x` to the end of list `l` |
+| `(l ‖ r)` | Prepend element `x` to list `xs`. Right-associative cons operator |
+| `head` | Return the head item of list `xs`, panic if empty |
+| `(↑ x)` | Return first element of list `xs`. Tight-binding prefix operator |
+| `nil?` | `true` if list `xs` is empty, `false` otherwise |
+| `non-nil?` | `true` if list `xs` is non-empty, `false` otherwise |
+| `null?` | `true` if `x` is null, `false` otherwise |
+| `(x ✓)` | `true` if `x` is not null, `false` otherwise. Postfix not-null check operator |
+| `coalesce(xs)` | Return the first non-null element from list `xs`, or null if all are null |
+| `head-or(d, xs)` | Return the head item of list `xs` or default `d` if empty |
+| `tail` | Return list `xs` without the head item. [] causes error |
+| `tail-or(d, xs)` | Return list `xs` without the head item or `d` for empty list |
+| `nil` | Identical to `[]`, the empty list |
+| `first` | Return first item of list `xs` - error if the list is empty |
+| `second(xs)` | Return second item of list - error if there is none |
+| `second-or(d, xs)` | Return second item of list - default `d` if there is none |
+
+## List Construction
+
+| Function | Description |
+|----------|-------------|
+| `repeat(i)` | Return infinite list of instances of item `i` |
+| `iterate(f, i)` | Return list of `i` with subsequent repeated applications of `f` to `i` |
+| `ints-from` | Return infinite list of integers from `n` upwards, alias `iota` for backwards compatibility |
+| `range(b, e)` | Return list of ints from `b` to `e` (not including `e`) |
+| `cycle(l)` | Create infinite list by cycling elements of list `l` |
+
+## Transformations
+
+| Function | Description |
+|----------|-------------|
+| `take(n, l)` | Return initial segment of integer `n` elements from list `l` |
+| `drop(n, l)` | Return result of dropping integer `n` elements from list `l` |
+| `take-while(p?, l)` | Initial elements of list `l` while `p?` is true |
+| `take-until(p?)` | Initial elements of list `l` while `p?` is false |
+| `drop-while(p?, l)` | Skip initial elements of list `l` while `p?` is true |
+| `drop-until(p?)` | Skip initial elements of list `l` while `p?` is false |
+| `map(f, l)` | Map function `f` over list `l` |
+| `map2(f, l1, l2)` | Map function `f` over lists `l1` and `l2`, until the shorter is exhausted |
+| `cross(f, xs, ys)` | Apply `f` to every combination of elements from `xs` and `ys` (cartesian product) |
+| `filter(p?, l)` | Return list of elements of list `l` that satisfy predicate `p?` |
+| `remove(p?, l)` | Return list of elements of list `l` that do not satisfy predicate `p?` |
+| `reverse(l)` | Reverse list `l` |
+
+## Combining Lists
+
+| Function | Description |
+|----------|-------------|
+| `zip-with` | Map function `f` over lists `l1` and `l2`, until the shorter is exhausted |
+| `zip` | List of pairs of elements  `l1` and `l2`, until the shorter is exhausted |
+| `append(l1, l2)` | Concatenate two lists `l1` and `l2` |
+| `prepend` | Concatenate two lists with `l1` after `l2` |
+| `concat(ls)` | Concatenate all lists in `ls` together |
+| `mapcat(f)` | Map items in l with `f` and concatenate the resulting lists |
+| `zip-apply(fs, vs)` | Apply fns in list `fs` to corresponding values in list `vs`, until shorter is exhausted |
+
+## Splitting Lists
+
+| Function | Description |
+|----------|-------------|
+| `split-at(n, l)` | Split list into two at `n`th item and return pair |
+| `split-after(p?, l)` | Split list where `p?` becomes false and return pair |
+| `split-when(p?, l)` | Split list where `p?` becomes true and return pair |
+| `window(n, step, l)` | List of lists of sliding windows over list `l` of size `n` and offset `step` |
+| `partition(n)` | List of lists of non-overlapping segments of list `l` of size `n` |
+| `discriminate(pred, xs)` | Return pair of `xs` for which `pred(_)` is true and `xs` for which `pred(_)` is false |
+
+## Folds and Scans
+
+| Function | Description |
+|----------|-------------|
+| `foldl(op, i, l)` | Left fold operator `op` over list `l` starting from value `i` |
+| `foldr(op, i, l)` | Right fold operator `op` over list `l` ending with value `i` |
+| `scanl(op, i, l)` | Left scan operator `op` over list `l` starting from value `i` |
+| `scanr(op, i, l)` | Right scan operator `op` over list `l` ending with value `i` |
+
+## Predicates
+
+| Function | Description |
+|----------|-------------|
+| `all-true?(l)` | True if and only if all items in list `l` are true |
+| `all(p?, l)` | True if and only if all items in list `l` satisfy predicate `p?` |
+| `any-true?(l)` | True if and only if any items in list `l` are true |
+| `any(p?, l)` | True if and only if any items in list `l` satisfy predicate `p?` |
+
+## Sorting
+
+| Function | Description |
+|----------|-------------|
+| `group-by(k, xs)` | Group xs by key function returning block of key to subgroups, maintains order |
+| `qsort(lt, xs)` | Sort `xs` using 'less-than' function `lt` |
+| `sort-nums` | Sort list of numbers ascending (Rust-level intrinsic) |
+| `sort-strs(xs)` | Sort list of strings or symbols ascending |
+| `sort-zdts(xs)` | Sort list of zoned date-times ascending |
+| `sort-by(key-fn, cmp, xs)` | Sort list `xs` by key extracted with `key-fn` using comparator `cmp` |
+| `sort-by-num(key-fn)` | Sort list `xs` ascending by numeric key extracted with `key-fn` |
+| `sort-by-str(key-fn)` | Sort list `xs` ascending by string key extracted with `key-fn` |
+| `sort-by-zdt(key-fn)` | Sort list `xs` ascending by zoned date-time key extracted with `key-fn` |
+
+### Sorting Examples
+
+```eu
+nums: [3, 1, 4, 1, 5] sort-nums          # [1, 1, 3, 4, 5]
+words: ["banana", "apple", "cherry"] sort-strs  # ["apple", "banana", "cherry"]
+
+people: [{name: "Zara" age: 30}, {name: "Alice" age: 25}]
+by-name: people sort-by-str(.name)       # sorted by name
+by-age: people sort-by-num(.age)         # sorted by age
+```
+
+## Other
+
+| Function | Description |
+|----------|-------------|
+| `nth(n, l)` | Return `n`th item of list if it exists, otherwise error |
+| `(l !! r)` | Return `n`th item of list `l` if it exists, otherwise error. For arrays, `n` must be a coordinate list (e.g. `[row, col]`) and !! delegates to `arr.get` |
+| `count(l)` | Return count of items in list `l` |
+| `last` | Return last element of list `l` |
+| `over-sliding-pairs(f, l)` | Apply binary fn `f` to each overlapping pair in `l` to form new list |
+| `differences` | Calculate difference between each overlapping pair in list of numbers `l` |
+
+## Other
+
+| Function | Description |
+|----------|-------------|
+| `rotate(n, l)` | Rotate list `l` left by `n` positions |
+| `transpose(rows)` | Transpose a matrix (list of lists) |
+| `update-nth(n, f, l)` | Apply `f` to element at index `n` in list `l`.
+Panics if `n` is out of range |
+| `update-first(p?, f, l)` | Apply `f` to the first element matching `p?` in list `l`.
+Returns `l` unchanged if no element matches |
+| `reduce(op, l)` | Left fold with no initial value; uses first element as seed. Panics on empty list |
+| `tails(l)` | Return list of successive tails of `l`: `[l, tail(l), tail(tail(l)), ...]` |
+| `iota(n)` | Return infinite list of integers from `n` upwards |
+| `ℕ` | The natural numbers: `[0, 1, 2, ...]` |
+| `butlast(l)` | Return all elements of list `l` except the last |
+| `unzip(pairs)` | List of pairs to pair of lists. Inverse of zip |
+| `interleave(a, b)` | Alternate elements from lists `a` and `b`. When one is exhausted, the remainder of the other is appended |
+| `window-all(n, step, l)` | Like window but includes the final short chunk even if smaller than `n` |
+| `partition-all(n)` | List of lists of non-overlapping segments of `l`, including any final short chunk |
+| `group-consecutive-by(f, xs)` | Group consecutive elements where `f` returns equal values into sublists |
+| `group-consecutive` | Group consecutive equal elements into sublists |
+| `uniq(xs)` | Remove consecutive duplicates from a list |
+| `nub-by(key, xs)` | Remove duplicates from `xs`, keeping the first occurrence of each distinct `key(x)` value. Unlike `uniq`, works on non-consecutive duplicates |
+| `split-on(pred, xs)` | Split list `xs` into sublists, breaking on
+elements that satisfy `pred`. Matching elements are discarded |
+| `running-max` | Running maximum over a number list.
+`[3, 1, 4, 1]` → `[3, 3, 4, 4]`. (Rust-level intrinsic) |
+| `running-min` | Running minimum over a number list.
+`[3, 1, 4, 1]` → `[3, 1, 1, 1]`. (Rust-level intrinsic) |
+| `running-sum` | Cumulative sum over a number list.
+`[3, 1, 4, 1]` → `[3, 4, 8, 9]`. (Rust-level intrinsic) |
+
+---
+
+# Blocks
+
+## Block Construction and Merging
+
+| Function | Description |
+|----------|-------------|
+| `sym` | Create symbol with name given by string `s` |
+| `merge` | Shallow merge block `b2` on top of `b1` |
+| `deep-merge` | Deep merge block `b2` on top of `b1`, merges nested blocks but not lists |
+| `block?` | True if and only if `v` is a block |
+| `list?` | True if and only if `v` is a list |
+| `number?` | True if and only if `v` is a number |
+| `string?` | True if and only if `v` is a string |
+| `symbol?` | True if and only if `v` is a symbol |
+| `bool?` | True if and only if `v` is a boolean |
+| `datetime?` | True if and only if `v` is a zoned datetime value |
+| `type-data?` | True if and only if v is a type-data literal produced by the s prefix |
+| `elements` | Expose list of elements of block `b` |
+| `block` | (re)construct block from list `kvs` of elements |
+| `has(s, b)` | True if and only if block `b` has key (symbol) `s` |
+| `lookup(s, b)` | Look up symbol `s` in block `b`, error if not found |
+| `lookup-in(b, s)` | Look up symbol `s` in block `b`, error if not found |
+| `lookup-or(s, d, b)` | Look up symbol `s` in block `b`, default `d` if not found |
+| `lookup-or-in(b, s, d)` | Look up symbol `s` in block `b`, default `d` if not found |
+| `(l ~ r)` | A ~ :k - safe key lookup. Returns value at key :k if a is a block containing :k, else null. Null-propagating for chained navigation |
+| `lookup-alts(syms, d, b)` | Look up symbols `syms` in turn in block `b` until a value is found, default `d` if none |
+| `lookup-across(s, d, bs)` | Look up symbol `s` in turn in each of blocks `bs` until a value is found, default `d` if none |
+| `lookup-path(ks, b)` | Look up value at key path `ks` in block `b` |
+
+## Block Utilities
+
+| Function | Description |
+|----------|-------------|
+| `merge-all(bs)` | Merge all blocks in list `bs` together, later overriding earlier |
+| `key` | Return key in a block element / pair |
+| `value` | Return value in a block element / pair |
+| `keys(b)` | Return keys of block `b` |
+| `values(b)` | Return values of block `b` |
+| `sort-keys(b)` | Return block `b` with keys sorted alphabetically |
+| `pair-key-lt(p1, p2)` |  |
+| `bimap(f, g, pr)` | Apply f to first item of pair and g to second, return pair |
+| `map-first(f, prs)` | Apply f to first elements of all pairs in list of pairs `prs` |
+| `map-second(f, prs)` | Apply f to second elements of all pairs in list of pairs `prs` |
+| `map-kv(f, b)` | Apply `f(k, v)` to each key / value pair in block `b`, returning list |
+| `map-elements(f, b)` | Apply `f([k, v])` to each element of block `b`, returning a new block. `f` receives and should return a `[key, value]` pair |
+| `map-as-block(f, syms)` | Map each symbol in `syms` and create block mapping `syms` to mapped values |
+| `pair(k, v)` | Form a block element from key (symbol) `k` and value `v` |
+| `kv-block(k, v)` | Create a single-entry block from key `k` and value `v` |
+| `zip-kv(ks, vs)` | Create a block by zipping together keys `ks` and values `vs` |
+| `with-keys` | Create block from list of values by assigning list of keys `ks` against them |
+| `map-values(f, b)` | Apply `f(v)` to each value in block `b` |
+| `map-keys(f, b)` | Apply `f(k)` to each key in block `b` |
+| `filter-items(f, b)` | Return items from block `b` which match item match function `f` |
+| `by-key(p?)` | Return item match function that checks predicate `p?` against the (symbol) key |
+| `by-key-name(p?)` | Return item match function that checks predicate `p?` against string representation of the key |
+| `by-key-match(re)` | Return item match function that checks string representation of the key matches regex `re` |
+| `by-value(p?)` | Return item match function that checks predicate `p?` against the item value |
+| `match-filter-values(re, b)` | Return list of values from block `b` with keys matching regex `re` |
+| `filter-values(p?, b)` | Return items from block `b` where values match predicate `p?` |
+| `select(ks, b)` | Return block containing only keys listed in `ks`. `b select([:a, :c])` returns a sub-block with just those keys |
+| `dissoc(ks, b)` | Return block with keys listed in `ks` removed. `b dissoc([:a, :c])` returns a sub-block without those keys |
+
+## Block Alteration
+
+| Function | Description |
+|----------|-------------|
+| `alter-value(k, v, b)` | Alter `b.k` to value `v` |
+| `update-value(k, f, b)` | Update `b.k` to `f(b.k)` |
+| `alter(ks, v, b)` | In nested block `b` alter value to value `v` at path-of-keys `ks` |
+| `update(ks, f, b)` | In nested block `b` apply `f` to value at path-of-keys `ks` |
+| `update-value-or(k, f, d, b)` | Set `b.k` to `f(v)` where v is current value, otherwise add with default value `d` |
+| `set-value(k, v)` | Set `b.k` to `v`, adding if absent |
+| `tongue(ks, v)` | Construct block with a single nested path-of-keys `ks` down to value `v` |
+| `merge-at(ks, v, b)` | Shallow merge block `v` into block value at path-of-keys `ks` |
+| `deep-merge-at(ks, v, b)` | Deep merge block `v` into block value at path-of-keys `ks` |
+
+## Deep Find and Query
+
+| Function | Description |
+|----------|-------------|
+| `deep-find(k, b)` | Return list of all values for key `k` (a symbol) at any depth in block `b`, depth-first |
+| `deep-find-first(k, d, b)` | Return first value for key `k` (a symbol) at any depth in block `b`, or default `d` |
+| `deep-find-paths(k, b)` | Return list of key paths to all occurrences of key `k` (a symbol) at any depth in block `b` |
+| `deep-query-fold(pattern, b)` | Core query engine returning `[path, value]` pairs matching the dot-separated `pattern` in block `b` |
+| `deep-query(pattern, b)` | Query block `b` using dot-separated pattern string. `*` matches one level, `**` matches any depth. Bare `foo` is sugar for `**.foo` |
+| `deep-query-first(pattern, d, b)` | Return first match for `pattern` in block `b`, or default `d` |
+| `deep-query-paths(pattern, b)` | Return list of key paths matching `pattern` in block `b` |
+
+### Deep Find
+
+Searches for a key at any nesting level:
+
+```eu
+config: {
+  server: { host: "localhost" port: 8080 }
+  db: { host: "db.local" port: 5432 }
+}
+
+hosts: config deep-find(:host)  # ["localhost", "db.local"]
+first-host: config deep-find-first(:host, "unknown")  # "localhost"
+```
+
+### Deep Query
+
+Queries using dot-separated patterns with wildcards:
+
+- Bare name `foo` is sugar for `**.foo` (find at any depth)
+- `*` matches one level
+- `**` matches any depth
+
+```eu
+data: {
+  us: { config: { host: "us.example.com" } }
+  eu: { config: { host: "eu.example.com" } }
+}
+
+# Find all hosts under any config
+hosts: data deep-query("config.host")  # ["us.example.com", "eu.example.com"]
+
+# Wildcard: any key at one level, then host
+hosts: data deep-query("*.config.host")
+```
+
+---
+
+# Strings
+
+## String Processing
+
+> String processing functions
+
+| Function | Description |
+|----------|-------------|
+| `str.of` | Convert `e` to string |
+| `str.split` | Split string `s` on separators matching regex `re` |
+| `str.split-on` | Split string `s` on separators matching regex `re` |
+| `str.join` | Join list of strings `l` by interposing string s |
+| `str.join-on` | Join list of strings `l` by interposing string s |
+| `str.match` | Match string `s` using regex `re`, return list of full match then capture groups |
+| `str.match-with` | Match string `s` using regex `re`, return list of full match then capture groups |
+| `str.extract(re)` | Use regex `re` (with single capture) to extract substring of s - or error |
+| `str.extract-or(re, d, s)` | Use regex `re` (with single capture) to extract substring of `s` - or default `d` |
+| `str.matches` | Return list of all matches in string `s` of regex `re` |
+| `str.matches-of` | Return list of all matches in string `s` of regex `re` |
+| `str.matches?(re, s)` | Return true if `re` matches full string `s` |
+| `str.suffix(b, a)` | Return string `b` suffixed onto `a` |
+| `str.prefix(b, a)` | Return string `b` prefixed onto `a` |
+| `str.letters` | Return individual letters of `s` as list of strings |
+| `str.len` | Return length of string in characters |
+| `str.fmt` | Format `x` using printf-style format `spec` |
+| `str.to-upper` | Convert string `s` to upper case |
+| `str.to-lower` | Convert string `s` to lower case |
+| `str.lt(a, b)` | True if string `a` is lexicographically less than `b` |
+| `str.gt(a, b)` | True if string `a` is lexicographically greater than `b` |
+| `str.lte(a, b)` | True if string `a` is lexicographically less than or equal to `b` |
+| `str.gte(a, b)` | True if string `a` is lexicographically greater than or equal to `b` |
+| `str.base64-encode` | Encode string `s` as base64 |
+| `str.base64-decode` | Decode base64 string `s` back to its original string |
+| `str.sha256` | Return the SHA-256 hash of string `s` as lowercase hex |
+| `str.replace(pattern, replacement, s)` | Replace all occurrences of regex `pattern` with `replacement` in string `s`. Pipeline: s str.replace(pat, rep) |
+| `str.contains?(pattern, s)` | True if string `s` contains a match for regex `pattern`. Pipeline: s str.contains?(pat) |
+| `str.trim` | Trim leading and trailing whitespace from string `s` |
+| `str.starts-with?(re, s)` | True if string `s` starts with a match for regex `re` |
+| `str.ends-with?(re, s)` | True if string `s` ends with a match for regex `re` |
+| `str.shell-escape(s)` | Wrap string in single quotes for safe shell use. Embedded single quotes are escaped |
+| `str.dq-escape(s)` | Escape string for use inside double quotes in shell commands. Escapes backslash, dollar, backtick, and double quote |
+
+## Character Constants
+
+> We don't support the usual string escapes so these make it
+a little more convenient to use interpolation instead..
+
+| Function | Description |
+|----------|-------------|
+| `ch.n` |  |
+| `ch.t` |  |
+| `ch.dq` |  |
+
+The `ch` namespace provides special characters:
+
+- `ch.n` -- Newline
+- `ch.t` -- Tab
+- `ch.dq` -- Double quote
+
+### Encoding and Hashing Examples
+
+```eu
+encoded: "hello" str.base64-encode    # "aGVsbG8="
+decoded: "aGVsbG8=" str.base64-decode # "hello"
+hash: "hello" str.sha256              # "2cf24dba5fb0a30e..."
+```
+
+---
+
+# Numbers and Arithmetic
+
+## Arithmetic Operators
+
+| Function | Description |
+|----------|-------------|
+| `(∸ x)` | Unary minus; negate |
+
+## Numeric Functions
+
+| Function | Description |
+|----------|-------------|
+| `inc` | Increment number `x` by 1 |
+| `dec` | Decrement number `x` by 1 |
+| `negate` | Negate number `n` |
+| `abs(n)` | Absolute value of number `n` |
+| `zero?` | Return true if and only if number `n` is 0 |
+| `pos?` | Return true if and only if number `n` is strictly positive |
+| `neg?` | Return true if and only if number `n` is strictly negative |
+| `num` | Parse number from string |
+| `floor` | Round number downwards to nearest integer |
+| `ceiling` | Round number upwards to nearest integer |
+| `⌈⌉` | Ceiling bracket notation, round `n` upwards to nearest integer |
+| `⌊⌋` | Floor bracket notation, round `n` downwards to nearest integer |
+| `pow(b, e)` | Raise `b` to the power `e` |
+| `div(a, b)` | Floor division; same as `a / b` |
+| `mod(a, b)` | Floor modulus; same as `a % b` |
+| `quot(a, b)` | Truncation division; rounds toward zero |
+| `rem(a, b)` | Truncation remainder; result has same sign as dividend |
+| `sum(l)` | Sum a list of numbers |
+| `product(l)` | Multiply a list of numbers |
+| `max(l, r)` | Return max of `l` and `r` by `>` |
+| `max-of(l)` | `max-of(l) - return max element in list of numbers `l` - error if empty` |
+| `max-of-by(f, l)` | Return the element of `l` that maximises `f`. Error if empty |
+| `max-map(f, l)` | Return maximum value of `f(x)` across elements of `l` |
+| `max-of-or(d, l)` | Return max element in list `l`, or default `d` if empty |
+| `min(l, r)` | Return min of `l` and `r` by `<` |
+| `min-of(l)` | `min-of(l) - return min element in list of numbers `l` - error if empty` |
+| `min-of-by(f, l)` | Return the element of `l` that minimises `f`. Error if empty |
+| `min-map(f, l)` | Return minimum value of `f(x)` across elements of `l` |
+| `min-of-or(d, l)` | Return min element in list `l`, or default `d` if empty |
+
+---
+
+# Booleans and Comparison
+
+## Essentials
+
+| Function | Description |
+|----------|-------------|
+| `null` | A null value. To export as `null` in JSON or ~ in YAML |
+| `true` | Constant logical true |
+| `false` | Constant logical false |
+| `if` | If `c` is `true`, return `t` else `f` |
+| `then(t, f, c)` | For pipeline if: `x? then(t, f)` |
+| `when(p?, f, x)` | When `x` satisfies `p?` apply `f` else pass through unchanged |
+
+## Error and Debug Support
+
+| Function | Description |
+|----------|-------------|
+| `panic` | Raise runtime error with message string `s` |
+
+## Boolean Logic
+
+| Function | Description |
+|----------|-------------|
+| `not` | Toggle boolean |
+| `(! x)` | Not x, toggle boolean |
+| `(¬ x)` | Not x, toggle boolean |
+| `and` | True if and only if `l` and `r` are true |
+| `or` | True if and only if `l` or `r` is true |
+
+---
+
+# Combinators
+
+## Combinators
+
+| Function | Description |
+|----------|-------------|
+| `identity(v)` | Identity function, return value `v` |
+| `const(k, _)` | Return single arg function that always returns `k` |
+| `(-> x)` | Const; return single arg function that always returns `k` |
+| `compose(f, g, x)` | Apply function `f` to `g(x)` |
+| `apply(f, xs)` | Apply function `f` to arguments in list `xs` |
+| `flip(f, x, y)` | Flip arguments of function `f`, flip(f)(x, y) == f(y, x) |
+| `complement(p?)` | Invert truth value of predicate function |
+| `curry(f, x, y)` | Turn f((x, y)) into f(x, y) |
+| `uncurry(f, l)` | Turn f(x, y) into f([x, y]). Semantically: (a → b → c) → (a, b) → c |
+| `cond` | Multi-way conditional: evaluate each `cond => result` clause in turn, returning the first matching result, or the last element as a default |
+| `(l => r)` | Build a cond clause: condition `c` paired with result `r`. Use inside `cond([...])` lists |
+| `(l ⇒ r)` | Unicode alias for `c => r` |
+| `juxt(f, g, x)` | Apply both `f` and `g` to `x`, returning pair (f(x), g(x)) |
+
+## Utilities
+
+| Function | Description |
+|----------|-------------|
+| `fnil(f, v, x)` | Return a function equivalent to f except it sees `x` instead of `null` when null is passed |
+
+---
+
+# Calendar
+
+## Date and Time Functions
+
+> Function for working with a human view of time.
+
+| Function | Description |
+|----------|-------------|
+| `cal.ifields` |  |
+| `cal.now` |  |
+| `cal.epoch` |  |
+| `cal.zdt` | Create zoned date time from datetime components and timezone string (e.g. '+0100') |
+| `cal.datetime(b)` | Convert block of time fields to zoned datetime (defaults: y=1, m=1, d=1, H=0, M=0, S=0, Z=UTC) |
+| `cal.parse` | Parse an ISO8601 formatted date string into a zoned date time |
+| `cal.format` | Format a zoned date time as ISO8601 |
+| `cal.fields` | Decompose a zoned date time into a block of its component fields (y,m,d,H,M,S,Z) |
+
+---
+
+# Sets
+
+## Set Operations
+
+| Function | Description |
+|----------|-------------|
+| `set.from-list(xs)` | Create a set from list `xs` of primitive values |
+| `set.to-list` | Return sorted list of elements in set `s` |
+| `set.add` | Add element `e` to set `s` |
+| `set.remove` | Remove element `e` from set `s` |
+| `set.contains?` | True if set `s` contains element `e` |
+| `set.size` | Return number of elements in set `s` |
+| `set.empty?(s)` | True if set `s` has no elements |
+| `set.union` | Return union of sets `a` and `b` |
+| `set.intersect` | Return intersection of sets `a` and `b` |
+| `set.diff` | Return elements in set `a` that are not in set `b` |
+| `set.sample(k, s, stream)` | Random monad action: pick `n` random elements from set `s`. Returns value/rest block |
+| `∅` | The empty set |
+| `(l ∈ r)` | True if element `v` is a member of set `s` |
+| `(l ∉ r)` | True if element `v` is not a member of set `s` |
+
+```eu
+s: set.from-list([1, 2, 3, 2, 1])
+# s contains {1, 2, 3} (duplicates removed)
+```
+
+## Set Algebra
+
+```eu
+a: set.from-list([1, 2, 3])
+b: set.from-list([2, 3, 4])
+u: set.union(a, b) set.to-list       # [1, 2, 3, 4]
+i: set.intersect(a, b) set.to-list   # [2, 3]
+d: set.diff(a, b) set.to-list        # [1]
+```
+
+---
+
+# Random Numbers
+
+Eucalypt provides pseudo-random number generation through the `io.random`
+stream and a set of prelude functions.
+
+## The Random Stream
+
+The `io.random` binding is an opaque PRNG stream, seeded from system
+entropy or the `--seed` command-line flag. Use `random.*` actions to
+draw values from it, or `random.as-list` to obtain a lazy cons-list of
+floats in `[0, 1)`.
+
+```eu
+first-random: random.float(io.random).value
+```
+
+Because `io.random` is seeded from the system clock by default, it
+produces different values on each run. Use `--seed` for reproducible
+results:
+
+```sh
+eu --seed 42 example.eu
+```
+
+## Random Number Generation
+
+| Function | Description |
+|----------|-------------|
+| `random-stream(seed)` |  |
+| `stream-advance(n, s)` |  |
+| `random-ret(v, stream)` |  |
+| `random-bind(m, f, stream)` |  |
+| `random.stream(seed)` | Create an opaque PRNG stream from integer seed |
+| `random.as-list(s)` | Convert an opaque random stream to a lazy cons-list of floats |
+| `random.float(s)` | State-monad action returning a random float in [0,1) |
+| `random.int(n, s)` | State-monad action returning a random integer in [0,n) |
+| `random.split(s)` | State-monad action that splits the stream into two independent streams. Returns a value/rest block where value and rest are each independent streams |
+| `random.choice(lst, stream)` | State-monad action returning a random element from list |
+| `random.shuffle(lst)` | State-monad action returning a shuffled copy of list |
+| `random.sample(n, lst, stream)` | State-monad action returning n elements sampled without replacement |
+| `random.run(action, stream)` | Run a random action on a stream; returns a value/rest block |
+| `random.eval(action, stream)` | Run a random action and return only the value |
+| `random.exec(action, stream)` | Run a random action and return only the remaining stream |
+
+## Usage Pattern
+
+The `random` namespace is a state monad. A random stream is provided
+at startup as `io.random`. Each operation takes a stream and returns
+a `{value, rest}` block:
+
+```eu,notest
+result: random.int(6, io.random)
+die-roll: result.value    # a number from 0 to 5
+```
+
+For multiple random values, propagate `.rest` into the next call — or
+use the random monad to handle threading automatically:
+
+```eu,notest
+# Monadic block — no manual threading
+dice: { :random
+  a: random.int(6)
+  b: random.int(6)
+}.[a + b + 2]
+
+result: dice(io.random).value
+```
+
+`random.sequence` and `random.map-m` also handle threading:
+
+```eu,notest
+two-dice: random.sequence([random.int(6), random.int(6)], io.random).value
+```
+
+## Shuffling and Sampling
+
+```eu,notest
+deck: range(1, 53)
+hand: random.shuffle(deck, io.random).value take(5)
+```
+
+```eu,notest
+colours: ["red", "green", "blue", "yellow", "purple"]
+two-colours: random.sample(2, colours, io.random).value
+```
+
+## Deterministic Seeds
+
+For reproducible output (useful in tests), use `--seed` on the
+command line or create a stream from a fixed seed:
+
+```sh
+eu --seed 42 my-template.eu
+```
+
+```eu,notest
+stream: random.stream(12345)
+x: random.int(100, stream)
+# x.value is always the same for seed 12345
+```
+
+---
+
+# Metadata
+
+Metadata is a powerful mechanism for attaching auxiliary information to
+any eucalypt expression. It is used for documentation, export control,
+import declarations, operator definitions, and testing assertions.
+
+## Attaching and Reading Metadata
+
+## Metadata Basics
+
+| Function | Description |
+|----------|-------------|
+| `with-meta` | Add metadata block `m` to expression `e` |
+| `meta` | Retrieve expression metadata for `e` |
+| `raw-meta` | Retrieve immediate metadata of e without recursing into inner layers |
+| `merge-meta(m, e)` | Merge block `m` into `e`'s metadata |
+
+## Documentation Metadata
+
+The backtick (`` ` ``) before a declaration attaches metadata. When the
+value is a string, it sets the `doc` key:
+
+```eu
+` "Add two numbers together"
+add(a, b): a + b
+```
+
+This is equivalent to:
+
+```eu
+` { doc: "Add two numbers together" }
+add(a, b): a + b
+```
+
+For richer metadata, use a block:
+
+```eu
+` { doc: "Infix addition operator"
+    precedence: :sum
+    associates: :left }
+(a + b): __ADD(a, b)
+```
+
+### Common Metadata Keys
+
+| Key | Purpose |
+|-----|---------|
+| `doc` | Documentation string |
+| `import` | Import specification |
+| `target` | Export target name |
+| `export` | Export control (`:suppress` to hide) |
+| `precedence` | Operator precedence level |
+| `associates` | Operator associativity (`:left`, `:right`) |
+| `parse-embed` | Embedded representation format |
+
+---
+
+# IO
+
+## Prelude Versioning
+
+| Function | Description |
+|----------|-------------|
+| `eu.prelude` | Metadata about this version of the standard prelude |
+| `eu.build` | Metadata about this version of the eucalypt executable |
+| `eu.requires` | Assert that the eucalypt version satisfies the given semver constraint (e.g. '>=0.2.0') |
+| `eu.os` | Operating system: linux, macos, windows, etc |
+| `eu.arch` | CPU architecture: x86_64, aarch64, etc |
+
+## IO Functions
+
+> IO related declarations. The io namespace is a monad: io.bind, io.return, io.sequence, io.map-m, io.filter-m, io.then, io.join are derived automatically.
+
+| Function | Description |
+|----------|-------------|
+| `io.env` | Read access to environment variables at time of launch |
+| `io.epoch-time` | Seconds since the Unix epoch at launch time |
+| `io.args` | Command-line arguments passed after -- separator |
+| `io.RANDOM_SEED` | Seed for random number generation (from --seed or system time) |
+| `io.random` | Opaque random stream seeded from system entropy or --seed flag. Use random.* actions or random.as-list to consume |
+| `io.shell(c)` | Run a shell command via sh -c. Returns a block with stdout, stderr, and exit-code fields |
+| `io.shell-with(opts, c)` | Run a shell command via sh -c with extra options merged in. Options may include stdin and timeout |
+| `io.exec` | Run a command directly without a shell. Returns a block with stdout, stderr, and exit-code fields |
+| `io.exec-with(opts)` | Run a command directly without a shell, with extra options merged in. Options may include stdin and timeout |
+| `io.check(result)` | Check a command result: if exit-code is non-zero, fail with the stderr message; otherwise return the result |
+| `io.checked` | Pipeline-friendly check: bind the preceding IO action through check |
+| `io.fail(msg)` | Fail the IO action with the given error message |
+
+## Other
+
+| Function | Description |
+|----------|-------------|
+| `monad(m)` | Derive standard monad combinators from a block m with bind and return fields. Returns a block with bind, return, map, then, and-then, join, sequence, map-m, and filter-m |
+| `deep-fold(emit, next-state, s, b)` | Depth-first fold over nested blocks and lists. `emit(state, block)` returns a list of results at each block node. `next-state(state, child-key)` updates state for recursion into a child. `s` is the initial state |
+| `deep-transform(rule, data)` | Recursively transform a nested structure. At each node, call `rule(node)`. If it returns non-null, use that as the replacement (stop recursing into that node). If it returns null, recurse into children (block values and list elements) |
+| `any?` | Predicate that matches any value. For use in match? patterns |
+| `match?(pat, target)` | Structural predicate. Returns true if `target` conforms to `pattern`. Pattern values are interpreted by type: blocks and lists recurse as sub-patterns, functions are applied as predicates, literals are exact equality checks. Open matching: extra keys in target are ignored |
+| `bit.and(l, r)` | Bitwise AND of integers `l` and `r` |
+| `bit.or(l, r)` | Bitwise OR of integers `l` and `r` |
+| `bit.xor(l, r)` | Bitwise XOR of integers `l` and `r` |
+| `bit.not(n)` | Bitwise NOT of integer `n` |
+| `bit.shl(n, k)` | Left shift `n` by `k` bits |
+| `bit.shr(n, k)` | Arithmetic right shift `n` by `k` bits |
+| `bit.popcount(n)` | Count set bits in integer `n` |
+| `bit.ctz(n)` | Count trailing zeros in integer `n` (position of lowest set bit). Returns 64 if n is 0 |
+| `bit.clz(n)` | Count leading zeros in integer `n` |
+| `render(value)` | Serialise value to a YAML string |
+| `render-as(fmt, value)` | Serialise value to a string in the named format. Pipeline-friendly: data render-as(:json). Supported formats: :yaml, :json, :toml, :text, :edn, :html, :eu |
+| `parse-as(fmt, str)` | Parse a string of structured data in the named format and return eucalypt data. The inverse of render-as. Supported formats: :json, :yaml, :toml, :csv, :xml, :edn, :jsonl. Content is parsed as inert data; embedded eucalypt expressions (e.g. YAML !eu tags) are never evaluated |
+| `assert(p?, s, v)` | If `v p?` is true then return `v` otherwise error with message `s` |
+| `__dbg-render(v)` | Print value `v` to stderr and return `v` unchanged. opts keys: label (string) |
+| `dbg(opts, v)` |  |
+| `__dbg-val(v)` | Debug-trace value or function. On a value, prints it to stderr and returns it. On a function, returns a wrapped version that traces each output |
+| `__dbg-after(f, x)` |  |
+| `(▶ x)` |  |
+| `alter?(k?, v!, k, v)` | If `k` satisfies `k?` then `v!` else `v` |
+| `update?(k?, f, k, v)` | If `k` satisfies `k?` then `v!` else `v` |
+| `vec.of` | Convert list `xs` of primitive values to a vec for O(1) indexed access |
+| `vec.len` | Return the number of elements in vec `v` |
+| `vec.nth` | Return the element at index `n` (0-based) in vec `v` |
+| `vec.slice` | Return a new vec with elements in the range `[from, to)` of `v` |
+| `vec.sample(n, v, stream)` | Random monad action: pick `n` random elements from vec `v` without replacement |
+| `vec.shuffle(v, stream)` | Random monad action: return vec `v` in random order |
+| `vec.to-list` | Convert vec `v` back to a cons-list |
+| `arr.zeros` | Create an array of zeros with the given shape list |
+| `arr.fill` | Create an array filled with `val` with the given shape list |
+| `arr.from-flat` | Create an array from a flat list of numbers with the given shape |
+| `arr.get` | Get element at coordinate list `coords` in array `a`. Pipeline: `a arr.get(coords)` |
+| `arr.set` | Return new array with element at `coords` set to `val`. Pipeline: `a arr.set(coords, val)` |
+| `arr.shape` | Return shape of array `a` as a list of integers |
+| `arr.rank` | Return number of dimensions of array `a` |
+| `arr.length` | Return total number of elements in array `a` |
+| `arr.to-list` | Return flat list of elements in row-major order |
+| `arr.array?` | True if `x` is an array |
+| `arr.transpose` | Reverse all axes of array `a` |
+| `arr.reshape` | Reshape array `a` to new shape (total elements must match). Pipeline: `a arr.reshape(shape)` |
+| `arr.slice(axis, idx, a)` | Take a slice along `axis` at `idx`, reducing rank by 1. Pipeline: `a arr.slice(axis, idx)` |
+| `arr.add` | Element-wise addition; `b` may be a scalar |
+| `arr.sub` | Element-wise subtraction; `b` may be a scalar |
+| `arr.mul` | Element-wise multiplication; `b` may be a scalar |
+| `arr.div` | Element-wise division; `b` may be a scalar |
+| `arr.indices` | Return list of coordinate lists for all elements in row-major order |
+| `arr.map(f, a)` | Apply `f` to each element, return new array of same shape |
+| `arr.map-indexed(f, a)` | Apply `f(coords, val)` to each element, return new array of same shape |
+| `arr.fold(f, init, a)` | Left-fold `f` over all elements of `a` in row-major order |
+| `arr.neighbours(coords, offsets, a)` | Return list of values at valid neighbouring coordinates. Pipeline: `a arr.neighbours(coords, offsets)`. `offsets` is a list of offset lists (one per neighbour direction). Out-of-bounds neighbours are omitted |
+| `arr.unit-arrays(shape)` | List of arrays with a single 1 at each coordinate position |
+| `is-array?(x)` | True if `x` is an n-dimensional array |
+| `graph.union-find(n, edges)` | Connected components via union-find.
+  Given `n` nodes and `edges` as `[[i,j],...]`, return list of n component labels |
+| `graph.topo-sort(n, edges)` | Topological ordering via Kahn's algorithm.
+  Given `n` nodes and directed `edges` as `[[from,to],...]`, return node ordering.
+  Partial result if cycle exists (check count(result) = n) |
+| `graph.kruskal-edges(n, edges)` | Kruskal-order merge history.
+  Process `edges` in order via union-find. Return flat list of
+  `[edge-index, remaining-components, ...]` for each edge that merges
+  two distinct components |
+| `let` | Identity monad for sequential let-bindings. Use :let blocks for sequential evaluation without the self-reference gotcha |
+| `for` | List monad for list comprehensions. Each binding draws from a list; subsequent bindings can depend on earlier ones. Use [x] filter(pred?) for guards |
+| `as-spec(t)` | Convert type-data to a match?-compatible pattern.
+         Primitive types become predicates, records become block patterns,
+         lists become list predicates, unions become disjunctive predicates,
+         partials accept null or the inner type |
+| `parse-args(defaults, args)` | Parse command-line argument list against a defaults block. Each key in `defaults` defines an option with its default value. Field metadata configures parsing: `short` (symbol for short flag), `doc` (description), `flag` (true for boolean toggle). Returns the `defaults` block updated with parsed values, plus an `args` key containing positional arguments as a list. Unknown options cause a runtime error. Use `--help` for auto-generated help text |
+
+---
+
+# CLI Reference
+
+Eucalypt is available as a command line tool, `eu`, which reads inputs
+and writes outputs.
+
+Everything it does in between is purely functional and there is no
+mutable state.
+
+It is intended to be simple to use in unix pipelines.
+
+```sh
+eu --version # shows the current eu version
+eu --help # lists command line options
+```
+
+### Global Options
+
+- `--source-prelude` - Force the source-prelude pipeline even when a pre-compiled
+  prelude blob is available. Use this when you need to trace through prelude source
+  during debugging, or when the cached blob is suspected to be stale.
 
 ## Command Structure
+
+The `eu` command uses a subcommand structure for clarity and extensibility:
 
 ```sh
 eu [GLOBAL_OPTIONS] [SUBCOMMAND] [SUBCOMMAND_OPTIONS] [FILES...]
 ```
 
-When no subcommand is given, `run` is assumed:
-
-```sh
-eu file.eu          # same as: eu run file.eu
-```
-
 ### Subcommands
 
-| Command | Description |
-|---------|-------------|
-| `run` | Evaluate and render (default) |
-| `test` | Run embedded tests |
-| `dump` | Dump intermediate representations |
-| `version` | Show version information |
-| `explain` | Show what would be executed |
-| `list-targets` | List export targets |
-| `fmt` | Format source files |
-| `lsp` | Start the Language Server Protocol server |
+- `run` (default) - Evaluate eucalypt code
+- `test` - Run tests
+- `check` - Type-check eucalypt source files
+- `doc` - Extract documentation from eucalypt source files
+- `dump` - Dump intermediate representations
+- `version` - Show version information
+- `explain` - Explain what would be executed
+- `list-targets` - List targets defined in the source
+- `fmt` - Format eucalypt source files
+- `lsp` - Start the Language Server Protocol server
+
+When no subcommand is specified, `run` is used by default, so these are equivalent:
+
+```sh
+eu file.eu
+eu run file.eu
+```
 
 ## Inputs
 
-### File Inputs
+### Files / *stdin*
 
-Specify one or more files to process:
+`eu` can read several inputs, specified by command line arguments.
 
-```sh
-eu data.yaml transform.eu
-```
+Inputs specify text data from:
 
-Inputs are merged left to right. Names from earlier inputs are
-available to later ones. The final input determines what is rendered.
+ - files
+ - stdin
+ - internal resources (ignored for now)
+ - git repository files (via `{ git: … }` import blocks — see [Import Formats](import-formats.md#git-imports))
 
-### stdin
+...of which the first two are the common case. In the simplest case,
+file inputs are specified by file name, stdin is specified by `-`.
 
-Use `-` to read from stdin, or simply pipe data when no files are
-specified:
-
-```sh
-curl -s https://api.example.com/data | eu -e 'items count'
-```
-
-### Format Override
-
-Override the assumed format with a `format@` prefix:
+So
 
 ```sh
-eu yaml@data.txt json@-
+eu a.yaml - b.eu
 ```
 
-### Named Inputs
+...will read input from `a.yaml`, stdin and `b.eu`.
+Each will be read into **eucalypt**'s core representation and merged
+before output is rendered.
 
-Prefix with `name=` to make the input available under a name:
+### Input format
+
+Inputs must be one of the formats that **eucalypt** supports, which
+at present, are:
+
+ - yaml
+ - json
+ - jsonl (JSON Lines)
+ - toml
+ - edn
+ - xml
+ - csv
+ - text
+
+Of these yaml, json, toml, edn and xml return blocks; jsonl, csv and
+text return lists. Inputs that return lists frequently need to be named (see
+below) to allow them to be used.
+
+Usually the format is inferred from file extension but it can be
+overridden on an input by input basis using a `format@` prefix.
+
+For instance:
 
 ```sh
-eu config=settings.yaml app.eu
+eu yaml@a.txt json@- yaml@b.txt
 ```
 
-In `app.eu`, the YAML content is available as `config`:
+...will read YAML from `a.txt`, JSON from stdin and YAML from `b.txt`.
+
+### Named inputs
+
+Finally inputs can be *named* using a `name=` prefix. This alters the
+way that data is merged by making the contents of an input available
+in a block or list with the specified name, instead of at the top
+level.
+
+Suppose we have two inputs:
+
+```yaml
+foo: bar
+```
+
+```eu
+x: 42
+```
+
+then
+
+```sh
+eu a.yaml b.eu
+```
+
+would generate:
+
+```yaml
+foo: bar
+x: 42
+```
+
+but
+
+```sh
+eu data=a.yaml b.eu
+```
+
+would generate:
+
+```yaml
+data:
+  foo: bar
+
+x: 42
+```
+
+This can be useful for various reasons, particularly when:
+
+- the form of the input's content is not known in advance
+- the input's content is a list rather than a block
+
+### Full input syntax
+
+The full input syntax is therefore:
+
+```
+[name=][format@][URL/file]
+```
+
+This applies at the command line and also when specifying
+[imports](import-formats.md) in `.eu` files.
+
+### *stdin* defaulting
+
+When no inputs are specified and `eu` is being used in a pipeline, it
+will accept input from *stdin* by default, making it easy to pipe JSON
+or YAML from other tools into eu.
+
+For example, this takes JSON from the `aws` CLI and formats it as YAML
+to stdout.
+
+```sh
+aws s3-api list-buckets | eu
+```
+
+### How inputs are merged
+
+When several inputs are listed, names from earlier inputs become
+available to later inputs, but the content that will be rendered is
+that of the final input.
+
+So for instance:
+
+a.eu
+```eu
+x: 4
+y: 8
+```
+
+b.eu
 
 ```eu,notest
-port: config.port
+z: x + y
 ```
-
-### Collecting Inputs
-
-Gather multiple files into a named collection:
 
 ```sh
-eu -c data *.json -e 'data map(.name)'
+eu a.eu b.eu
 ```
 
-Add `-N` to key by filename:
+will output
+
+```yaml
+z: 12
+```
+
+The common use cases are:
+- a final input containing logic to inspect or process data
+  provided by previous inputs
+- a final input which uses functions defined in earlier inputs to
+  process data provided in previous inputs
+
+If you want to render contents of earlier inputs, you need a named
+input to provide a name for that content which you can then use.
+
+For instance:
 
 ```sh
-eu -c data -N *.json
+eu r=a.eu b.eu -e r
 ```
+
+will render:
+
+```yaml
+x: 4
+y: 8
+```
+
+#### `--collect-as` and `--name-inputs`
+
+Occasionally it is useful to aggregate data from an arbitrary number
+of sources files, typically specified by shell wildcards. To refer to
+this data we need to introduce a name for the collection of data.
+
+This is what the command line switch `--collect-as` / `-c` is for.
+
+```sh
+eu --collect-as inputs *.eu
+```
+
+...will render:
+
+```yaml
+inputs:
+  - x: 4
+    y: 8
+  - z: 12
+```
+
+It is common to use `-e` to select an item to render:
+
+```sh
+eu -c inputs *.eu -e 'inputs head'
+```
+
+...renders:
+
+```yaml
+x: 4
+y: 8
+```
+
+If you are likely to need to refer to inputs by name, you can add
+`--name-inputs` / `-N` to pass inputs as a block instead of a list:
+
+```sh
+eu --collect-as inputs --name-inputs *.eu
+```
+
+...renders:
+
+```yaml
+inputs:
+  a.eu:
+    x: 4
+    y: 8
+  b.eu:
+    z: 12
+```
+
+This makes it easier to invoke specific functions from named inputs
+although you will need single-quote name syntax to use the generated
+names which contain `.`s.
 
 ## Outputs
 
-### Format
+`eu` produces a single output stream per invocation.
 
-Output defaults to YAML. Common options:
+### Output format
 
-```sh
-eu file.eu            # YAML (default)
-eu file.eu -j         # JSON (shortcut)
-eu file.eu -x json    # JSON (explicit)
-eu file.eu -x toml    # TOML
-eu file.eu -x text    # Plain text
-```
-
-### Output File
-
-Write to a file (format inferred from extension):
+Output is rendered as YAML by default. Other formats can be specified
+using the `-x` command line option:
 
 ```sh
-eu data.eu -o output.json
+eu -x json # for JSON
+eu -x text # for plain text
 ```
+
+JSON is such a common case that there is a shortcut: `-j`.
+
+### Output targets
+
+By default, **eucalypt** renders all the content of the final input to
+output.
+
+There are various ways to override this. First, `:target` metadata can
+be specified in the final input to identify different parts for
+potential export.
+
+To list the **targets** found in the specified inputs, use the
+`list-targets` subcommand.
+
+```sh
+eu list-targets file.eu
+```
+
+...and a particular target can be selected for render using `-t`.
+
+```sh
+eu -t my-target
+```
+
+If there is a **target** called "main" it will be used by default
+unless another target is specified.
 
 ## Evaluands
 
-The `-e` flag specifies an expression to evaluate:
+In addition to inputs, an *evaluand* can be specified at the command
+line. This is a **eucalypt** expression which has access to all names
+defined in the inputs and replaces the input body or targets as the
+data to export.
 
-```sh
-eu -e '2 + 2'
+It can be used to select content or derive values from data in the
+inputs:
+
+```console
+$ aws s3api list-buckets | eu -e 'Buckets map(lookup(:CreationDate)) head'
+2016-12-25T14:22:30.000Z
 ```
 
-```yaml
-4
+...or just to test out short expressions or command line features:
+
+```console
+$ eu -e '{a: 1 b: 2 * 2}' -j
+{"a": 1, "b": 4}
 ```
 
-When combined with file inputs, the evaluand has access to all loaded
-names:
+## Passing Arguments to Programs
 
-```sh
-eu data.yaml -e 'users filter(.active) count'
+You can pass command-line arguments to your eucalypt program using the
+`--` separator. Arguments after `--` are available via `io.args`:
+
+```console
+$ eu -e 'io.args' -- foo bar baz
+---
+- foo
+- bar
+- baz
 ```
 
-Multiple `-e` flags are allowed; the last one determines the output.
-
-### Quick Expressions
-
-Use `-e` for quick data exploration:
-
-```sh
-# Inspect a value
-eu config.yaml -e 'database'
-
-# Count items
-eu data.json -e 'items count'
-
-# Extract and transform
-eu data.json -e 'items map(.name) reverse'
-```
-
-## Targets
-
-Declarations annotated with `:target` metadata can be selected for
-rendering:
-
-```eu,notest
-# multi-output.eu
-` { target: :summary }
-summary: { count: items count }
-
-` { target: :detail }
-detail: items
-```
-
-List available targets:
-
-```sh
-eu list-targets multi-output.eu
-```
-
-Select a target:
-
-```sh
-eu -t summary multi-output.eu
-```
-
-A target named `main` is rendered by default. If no `:main` target
-exists, the entire unit is the target.
-
-## Passing Arguments
-
-Arguments after `--` are available via `io.args`:
-
-```sh
-eu -e 'io.args' -- hello world
-```
-
-```yaml
-- hello
-- world
-```
-
-Use in scripts:
+This is useful for writing eucalypt scripts that accept parameters:
 
 ```eu
 # greet.eu
@@ -3376,224 +10487,659 @@ name: io.args head-or("World")
 greeting: "Hello, {name}!"
 ```
 
-```sh
-eu greet.eu -e greeting -- Alice
-```
-
-```yaml
+```console
+$ eu greet.eu -e greeting -- Alice
+---
 Hello, Alice!
 ```
 
-Arguments are strings. Use `num` to convert:
+Arguments are passed as strings. Use `num` to convert numeric arguments:
 
 ```eu
-numbers: io.args map(num)
-total: numbers foldl(+, 0)
+# sum.eu
+total: io.args map(num) foldl((+), 0)
 ```
 
-## Environment Variables
+```console
+$ eu sum.eu -e total -- 1 2 3 4 5
+---
+15
+```
 
-Access environment variables through `io.env`:
+When no arguments are passed, `io.args` is an empty list:
 
-```eu
-home: io.env lookup-or(:HOME, "/tmp")
-path: io.env lookup(:PATH)
+```console
+$ eu -e 'io.args nil?'
+---
+true
 ```
 
 ## Random Seed
 
-By default, random numbers use system entropy. Use `--seed` for
-reproducible output:
+By default, random numbers are seeded from system entropy and produce
+different results on each run. Use `--seed` for reproducible output:
 
 ```sh
 eu --seed 42 template.eu
 ```
 
-## The Formatter
+This sets `io.RANDOM_SEED` and seeds the `io.random` stream. See
+[Random Numbers](prelude/random.md) for the full random API.
 
-Format eucalypt source files:
+## IO Monad Operations
+
+By default, eucalypt is a pure functional language with no side effects. To
+enable IO monad operations — specifically shell command execution — you must
+pass the `--allow-io` / `-I` flag:
 
 ```sh
-eu fmt file.eu              # print formatted to stdout
-eu fmt --write file.eu      # format in place
-eu fmt --check file.eu      # check (exit 1 if unformatted)
-eu fmt --reformat file.eu   # full reformatting
+eu -I script.eu
+eu --allow-io script.eu
 ```
 
-Options:
-- `-w, --width <N>` -- line width (default: 80)
-- `--indent <N>` -- indent size (default: 2)
+Without this flag, any program that attempts to execute an IO action will fail
+with an error:
+
+```
+IO operations require the --allow-io (-I) flag
+```
+
+### Why this flag exists
+
+The flag is a deliberate security measure. Eucalypt files are often used as
+configuration or data templates, and it would be unsafe for arbitrary `.eu`
+files loaded from the filesystem or network to execute shell commands without
+explicit consent. The `--allow-io` flag is your explicit acknowledgement that
+the program you are running may perform shell execution.
+
+### Usage with IO targets
+
+IO programmes typically use the `:io` monadic block syntax and are run with a
+named target:
+
+```sh
+eu -I --target main script.eu
+eu -I -t main script.eu
+```
+
+See the IO monad design documentation for full details of the IO API.
+
+## Statistics and Diagnostics
+
+### Performance Statistics
+
+Use `-S` / `--statistics` to print execution metrics to stderr when the run
+completes. This includes heap usage, GC cycle counts, and evaluation time:
+
+```sh
+eu -S file.eu
+```
+
+To capture statistics as machine-readable JSON:
+
+```sh
+eu --statistics-file stats.json file.eu
+```
+
+The statistics file is written regardless of whether evaluation succeeds.
+
+### Heap Limit
+
+By default, `eu` allows the managed heap to grow up to 32 GiB. To cap it at
+a lower value (e.g., for CI or resource-constrained environments):
+
+```sh
+eu --heap-limit-mib 1024 file.eu    # limit to 1 GiB
+eu --heap-limit-mib 0    file.eu    # unbounded
+```
+
+### Error Output Format
+
+By default, errors are formatted for human reading. For programmatic use:
+
+```sh
+eu --error-format json file.eu      # structured JSON errors
+eu --error-format human file.eu     # default human-readable (explicit)
+```
+
+### Type Checking
+
+Run the type checker before evaluation with `--type-check`. Type warnings
+are reported to stderr but do not abort evaluation unless `--strict` is also
+passed:
+
+```sh
+eu --type-check file.eu             # warn on type issues, then evaluate
+eu --type-check --strict file.eu    # abort on first type warning
+```
+
+For checking without evaluating, use the `check` subcommand (see below).
+
+### Debugging: Dead Code Elimination
+
+Disable the dead code elimination pass to inspect the full compiled expression:
+
+```sh
+eu --no-dce file.eu
+```
+
+This is primarily useful when investigating the output of `eu dump` passes.
+
+## Suppressing prelude
+
+A standard *prelude* containing many functions and operators is
+automatically prepended to the input list.
+
+This can be suppressed using `-Q` if it is not required or if you
+would like to provide an alternative.
+
+> **Warning:** Many very basic facilities -- like the definition of
+> `true` and `false` and `if` -- are provided by the prelude so
+> suppressing it leaves a very bare environment.
 
 ## Debugging
 
-### Dumping Intermediate Representations
+`eu` has a variety of command line switches for dumping out internal
+representations or tracing execution. The `dump` subcommand provides
+access to intermediate representations:
 
 ```sh
-eu dump ast file.eu         # syntax tree
-eu dump desugared file.eu   # core expression
-eu dump stg file.eu         # compiled STG
+eu dump ast file.eu          # Parse and dump syntax tree
+eu dump desugared file.eu    # Dump core expression
+eu dump stg file.eu          # Dump compiled STG syntax
+eu list-targets file.eu      # List available targets
 ```
 
-### Explaining Execution
+Use `eu --help` and `eu <subcommand> --help` for complete option lists.
+
+## Formatting Source Files
+
+The `fmt` subcommand formats eucalypt source files for consistent style:
 
 ```sh
-eu explain file.eu          # show what would be executed
+eu fmt file.eu              # Print formatted output to stdout
+eu fmt --write file.eu      # Format in place
+eu fmt --check file.eu      # Check formatting (exit 1 if not formatted)
+eu fmt *.eu --write         # Format multiple files in place
 ```
 
-### Statistics
+### Options
+
+- `-w, --width <WIDTH>` - Line width for formatting (default: 80)
+- `--write` - Modify files in place
+- `--check` - Check if files are formatted (exit 1 if not)
+- `--reformat` - Full reformatting mode (instead of conservative)
+- `--indent <INDENT>` - Indent size in spaces (default: 2)
+
+The formatter has two modes:
+
+- **Conservative mode** (default) - Preserves original formatting choices
+  where possible, only reformatting where necessary
+- **Reformat mode** (`--reformat`) - Full reformatting that applies
+  consistent style throughout
+
+## Type Checking
+
+The `check` subcommand runs the type checker without evaluating:
 
 ```sh
-eu -S file.eu               # print metrics to stderr
+eu check file.eu             # report type annotation warnings
+eu check --strict file.eu    # treat warnings as errors (exit 1 if any)
 ```
 
-## Suppressing the Prelude
+Type annotations in eucalypt are gradual — the checker only reports issues
+where annotations are present and their constraints are violated. Use `check`
+in CI to enforce annotation coverage across a codebase.
 
-The standard prelude is loaded automatically. Suppress it with `-Q`:
+See the [type checking guide](../guide/type-checking.md) for full syntax and
+examples.
+
+## Documentation Extraction
+
+The `doc` subcommand extracts documentation from backtick docstrings in
+eucalypt source:
 
 ```sh
-eu -Q file.eu
+eu doc file.eu                    # Markdown output to stdout
+eu doc --format json file.eu      # JSON Schema output
+eu doc --prelude                  # Document the embedded prelude
+eu doc --check file.eu            # Report documentation coverage (exit 1 if < 100%)
+eu doc --output-dir out/ file.eu  # Write categorised Markdown files to a directory
 ```
 
-> **Warning:** Without the prelude, even `true`, `false`, `if`, and
-> basic operators are unavailable.
+### Options
 
-## Version Assertions
+- `--format <md|json>` - Output format: `md` (Markdown, default) or `json` (JSON Schema)
+- `--prelude` - Generate documentation for the built-in prelude
+- `--check` - Report documentation coverage rather than generating docs
+- `--output-dir <DIR>` - Write categorised multi-file Markdown output to a directory
+  (implies `--prelude`)
 
-Ensure a minimum `eu` version in source files:
+## Language Server Protocol
 
-```eu
-_ : eu.requires(">=0.3.0")
-```
-
-Check the current version:
-
-```sh
-eu version
-```
-
-## LSP Server
-
-Start a Language Server Protocol server for editor integration:
+The `lsp` subcommand starts an LSP server for use with editors that
+support the Language Server Protocol (e.g., VS Code, Neovim):
 
 ```sh
 eu lsp
 ```
 
-Provides syntax error diagnostics and formatting support.
+The LSP server provides:
 
-## Key Concepts
+- Syntax error diagnostics
+- Formatting support (via `textDocument/formatting`)
 
-- `eu` defaults to `run` when no subcommand is given
-- Inputs are merged left to right; the final input determines output
-- Named inputs (`name=file`) provide namespace isolation
-- `-e` evaluates an expression against loaded inputs
-- `-t` selects a named target for rendering
-- `--` passes arguments available via `io.args`
-- `eu fmt` formats source files; `eu test` runs tests; `eu lsp`
-  starts the language server
+Configure your editor to use `eu lsp` as the language server command
+for `.eu` files. A VS Code extension is available in the `editors/vscode/`
+directory of the repository.
 
----
+## Version Assertions
 
-<!-- Source: docs/guide/lsp.md -->
+The `eu.requires` function allows eucalypt source files to assert a
+minimum version of the eucalypt executable:
 
-# Language Server Protocol (LSP) Support
+```eu
+{ import: [] }  # unit-level metadata not required for eu.requires
 
-Eucalypt includes a built-in LSP server for editor integration.
-Start it with `eu lsp`.
-
-## Editor Setup
-
-### Emacs (eglot)
-
-Add to your eucalypt-mode configuration:
-
-```elisp
-(add-to-list 'eglot-server-programs '(eucalypt-mode "eu" "lsp"))
+# Assert that eu version satisfies semver constraint
+_ : eu.requires(">=0.3.0")
 ```
 
-### VS Code
+If the running version of `eu` does not satisfy the constraint, an
+error is raised immediately. This is useful for library code that
+depends on features introduced in a particular version.
 
-Install the eucalypt VS Code extension, which configures the
-language server automatically.
+The `eu` namespace also provides build metadata:
 
-## Features
+```eu
+version: eu.build.version    # e.g., "0.3.0"
+```
 
-### Diagnostics
+## Backward Compatibility
 
-- Parse errors appear as you type
-- Type warnings from `eu check` appear after a short debounce
-  (300ms after the last keystroke)
-- Pipeline errors (e.g. invalid monad spec) surface as warnings
-  with source locations
+All existing command patterns continue to work unchanged:
 
-### Hover
-
-- Declaration names show documentation and type annotations
-- Prelude functions show their type signatures
-- Monad tags (`:for`, `:io`) show monad description and binding
-  type
-- Bracket pair delimiters show pair name, mode, and documentation
-
-### Completion
-
-- Names from the current file, prelude, and imported files
-- Monad tag completion after `{ :`
-- Dotted access completion (e.g. `str.` offers string functions)
-
-### Go-to-definition
-
-- Jump to declaration in the current file
-- Jump into imported files
-- Jump to prelude source (via temp file)
-- Jump to bracket pair definitions from bracket delimiters
-
-### Inlay Hints
-
-- Monadic block binding types (e.g. `x: number` for
-  `{ :for x: [1,2,3] }`)
-- Operator fixity on operator declarations
-- Parameter names at multi-argument call sites
-
-### Code Actions
-
-- **Wrap as namespace** — wrap a single declaration's value into
-  a block, or wrap multiple selected declarations into a new
-  namespace with reference prefixing
-- **Promote metadata** — expand shortcut form to block
-  (e.g. `` ` "doc" `` → `` ` { doc: "doc" } ``)
-- **Demote metadata** — collapse single-field block to shortcut
-- **Add metadata field** — add type, doc, target, export, monad,
-  format, or type-def metadata
-- **Let-block toggle** — convert between `{ x: 1 }` and
-  `{ :let x: 1 }`
-- **Qualify name** — suggest `str.split` for unresolved `split`
-
-### Other
-
-- Document symbols (outline)
-- Folding ranges
-- Semantic tokens (syntax highlighting)
-- Document highlight (matching bracket pairs)
-- Find references
-- Rename symbol
-- Selection range
-- Formatting
-
-## Architecture
-
-The LSP server uses a two-tier architecture:
-
-1. **AST-level** (immediate): parse errors, completion, hover,
-   semantic tokens — works on every keystroke, even on broken
-   input
-2. **Pipeline-level** (debounced): type checking, import
-   resolution, monadic binding types — runs the full
-   desugarer/type checker pipeline after 300ms of no changes,
-   with green node comparison to skip unchanged documents
+```sh
+eu file.eu                   # Still works (uses run subcommand)
+eu -e "expression"           # Still works (uses run subcommand)
+eu -j file.eu                # Still works (JSON output)
+eu -S -Q file.eu             # Still works (statistics, no prelude)
+```
 
 ---
 
-<!-- Source: docs/reference/agent-reference.md -->
+# Import Formats
+
+Eucalypt supports importing content from other units in a variety of
+ways.
+
+Imported names can be scoped to specific declarations, they may be
+made accessible under a specific namespace, and they may be imported
+from disk or direct from git repositories.
+
+## Import scopes
+
+Imports are specified in declaration metadata and make the names in
+the imported unit available within the declaration that is annotated.
+
+```eu,notest
+{ import: "config.eu" }
+data: {
+  # names from config are available here
+  x: config-value
+}
+```
+
+As described in [Syntax Reference](syntax.md), declaration metadata can
+be applied at a unit level simply by including a metadata block as the
+very first thing in a eucalypt file:
+
+```eu,notest
+{ import: "config.eu" }
+
+# names from config are available here
+
+x: config-value
+```
+
+## Import syntax
+
+Imports are specified using the key `import` in a declaration metadata
+block. The value may be a single import specification:
+
+```eu,notest
+{ import: "dep-a.eu"}
+```
+
+or a list of import specifications:
+
+```eu,notest
+{ import: ["dep-a.eu", "dep-b.eu"]}
+```
+
+The import specification itself can be either a *simple import* or a
+*git import*.
+
+### Simple imports
+
+Simple imports are specified in exactly the same way as *inputs* are
+specified at the command line (see [CLI Reference](cli.md)).
+
+So you can override the format of the imported file when the file
+extension is misleading:
+
+```eu,notest
+{ import: "yaml@dep.txt" }
+```
+
+...and provide a name under which the imported names will be
+available:
+
+```eu,notest
+{ import: "cfg=config.eu" }
+
+# names in config.eu are available by lookup in cfg:
+
+x: cfg.x
+```
+
+In cases where the import format delivers a list rather than a block
+("text", "csv", "jsonl", ...) a name is mandatory:
+
+```eu,notest
+{ import: "txns=transactions.csv" }
+```
+
+Simple imports support exactly the same inputs as the command line,
+with the proviso that the stdin input ("-") will not be consumable if
+it has already been specified in the command line or another unit.
+
+### Git imports
+
+Git imports allow you to import eucalypt direct from a git repository
+at a specified commit, combining the convenience of not having to
+explicitly manage a git working copy and a library path with the
+repeatability of a git SHA. A git import is specified as a block with
+the keys "git", "commit" and "import", all of which are mandatory:
+
+```eu,notest
+{ import: { git: "https://github.com/gmorpheme/eu.aws"
+            commit: "0140232cf882a922bdd67b520ed56f0cddbd0637"
+            import: "aws/cloudformation.eu" } }
+```
+
+The `git` URL may be any format that the git command line expects.
+
+`commit` is required and should be a SHA. It is intended to ensure the
+import is repeatable and cacheable.
+
+`import` identifies the file within the repository to import.
+
+Just as with simple imports, several git imports may be listed:
+
+```eu
+{ import: [{ git: ... }, { git: ... }]}
+```
+
+...and simple imports and git imports may be freely mixed.
+
+## YAML import features
+
+When importing YAML files, eucalypt supports several YAML features that
+help reduce repetition and express data more naturally.
+
+### Anchors and aliases
+
+YAML anchors (`&name`) and aliases (`*name`) allow you to define a value
+once and reference it multiple times. When eucalypt imports a YAML file
+with anchors and aliases, the aliased values are resolved to copies of
+the anchored expression.
+
+```yaml
+# config.yaml
+defaults: &defaults
+  timeout: 30
+  retries: 3
+
+development:
+  <<: *defaults
+  debug: true
+
+production:
+  <<: *defaults
+  debug: false
+```
+
+Anchors can be applied to any YAML value: scalars, lists, or mappings.
+
+```yaml
+# Anchor on a scalar
+name: &author "Alice"
+books:
+  - title: "First Book"
+    author: *author
+  - title: "Second Book"
+    author: *author
+
+# Anchor on a list
+colours: &primary [red, green, blue]
+palette:
+  primary: *primary
+  secondary: [yellow, cyan, magenta]
+
+# Anchor on a mapping (block)
+base: &base
+  x: 1
+  y: 2
+ref: *base  # ref now has { x: 1, y: 2 }
+```
+
+Nested anchors are supported -- an anchored structure can itself contain
+anchored values:
+
+```yaml
+outer: &outer
+  inner: &inner 42
+ref_outer: *outer   # { inner: 42 }
+ref_inner: *inner   # 42
+```
+
+If you reference an undefined alias, eucalypt reports an error:
+
+```yaml
+# This will fail: *undefined is not defined
+value: *undefined
+```
+
+### Merge keys
+
+The YAML merge key (`<<`) allows you to merge entries from one or more
+mappings into another. This is useful for creating configuration
+variations that share a common base.
+
+**Single merge:**
+
+```yaml
+base: &base
+  host: localhost
+  port: 8080
+
+server:
+  <<: *base
+  name: main
+# server = { host: localhost, port: 8080, name: main }
+```
+
+**Multiple merge:**
+
+When merging multiple mappings, later ones override earlier ones:
+
+```yaml
+defaults: &defaults
+  timeout: 30
+  retries: 3
+
+overrides: &overrides
+  timeout: 60
+
+config:
+  <<: [*defaults, *overrides]
+  name: myapp
+# config = { timeout: 60, retries: 3, name: myapp }
+```
+
+**Explicit keys override merged values:**
+
+Keys defined explicitly in the mapping (before or after the merge)
+always take precedence over merged values:
+
+```yaml
+base: &base
+  x: 1
+  y: 2
+
+derived:
+  <<: *base
+  y: 99
+# derived = { x: 1, y: 99 }
+```
+
+**Inline merge:**
+
+You can also merge an inline mapping directly:
+
+```yaml
+config:
+  <<: { timeout: 30, retries: 3 }
+  name: myapp
+```
+
+The merge key value must be a mapping (or list of mappings). Attempting
+to merge a non-mapping value (e.g., `<<: 42`) results in an error.
+
+### Timestamps
+
+Eucalypt automatically converts YAML timestamps to ZDT (zoned date-time)
+expressions. Plain scalar values matching timestamp patterns are parsed
+and converted; quoted strings are left as strings.
+
+**Supported formats:**
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Date only | `2023-01-15` | Midnight UTC |
+| ISO 8601 UTC | `2023-01-15T10:30:00Z` | |
+| ISO 8601 offset | `2023-01-15T10:30:00+05:00` | |
+| Space separator | `2023-01-15 10:30:00` | Treated as UTC |
+| Fractional seconds | `2023-01-15T10:30:00.123456Z` | |
+
+**Examples:**
+
+```yaml
+# These are converted to ZDT expressions:
+created: 2023-01-15
+updated: 2023-01-15T10:30:00Z
+scheduled: 2023-06-01 09:00:00
+
+# This remains a string (quoted):
+date_string: "2023-01-15T10:30:00Z"
+```
+
+**Invalid timestamps fall back to strings:**
+
+If a value looks like a timestamp but has invalid date components
+(e.g., month 13 or day 45), it remains a string:
+
+```yaml
+invalid: 2023-13-45  # Remains string "2023-13-45"
+```
+
+**To keep timestamps as strings:**
+
+If you need to preserve a timestamp-like value as a string rather than
+converting it to a ZDT, quote it:
+
+```yaml
+# As ZDT:
+actual_date: 2023-01-15
+
+# As string:
+date_label: "2023-01-15"
+```
+
+## Streaming imports
+
+For large files, eucalypt supports streaming import formats that read
+data lazily without loading the entire file into memory. Streaming
+formats produce a lazy list of records.
+
+| Format | Description |
+|--------|-------------|
+| `jsonl-stream` | JSON Lines (one JSON object per line) |
+| `csv-stream` | CSV with headers (each row becomes a block) |
+| `text-stream` | Plain text (each line becomes a string) |
+
+Streaming formats are specified using the `format@path` syntax:
+
+```sh
+# Stream a JSONL file
+eu -e 'data take(10)' data=jsonl-stream@events.jsonl
+
+# Stream a large CSV
+eu -e 'data filter(.age > 30) count' data=csv-stream@people.csv
+
+# Stream lines of text
+eu -e 'data filter(str.matches?("ERROR"))' log=text-stream@app.log
+```
+
+Streaming imports can also be used via the import syntax in eucalypt
+source files:
+
+```eu,notest
+{ import: "events=jsonl-stream@events.jsonl" }
+
+recent: events take(100)
+```
+
+> **Note:** Streaming imports require a name binding (e.g., `data=`) because
+> they produce a list, not a block.
+
+> **Note:** `text-stream` supports reading from stdin using `-` as the path:
+> `eu -e 'data count' data=text-stream@-`
+
+---
+
+# Export Formats
+
+*Detailed export format documentation is under construction.*
+
+Eucalypt can export to the following formats:
+
+| Format | Flag | Notes |
+|--------|------|-------|
+| YAML | (default) | Default output format |
+| JSON | `-j` or `-x json` | Compact JSON output |
+| TOML | `-x toml` | TOML output |
+| EDN | `-x edn` | EDN output |
+| Text | `-x text` | Plain text output |
+| Eucalypt | `-x eu` | Eucalypt-syntax output; preserves symbols as `:name` |
+
+The output format can also be inferred from the output file extension
+when using `-o`:
+
+```sh
+eu input.eu -o output.json  # infers JSON format
+eu input.eu -o output.toml  # infers TOML format
+```
+
+---
+
+# Error Messages Guide
+
+*This reference is under construction. It will provide a guide to
+understanding eucalypt error messages with examples and solutions.*
+
+---
 
 # Agent Reference
 
@@ -3662,6 +11208,82 @@ interpolation.
 
 **Top-level unit**: the file itself is an implicit block without braces.
 
+### 1.3.1 Idiot Brackets
+
+Idiot brackets are user-definable Unicode bracket pairs. Inside the
+brackets, whitespace-separated items are collected into a list and
+passed as the single argument to the function named by the bracket
+pair's declaration.
+
+```eu,notest
+# Declare a bracket pair function (xs receives the item list)
+⟦ xs ⟧: xs map(_ * 2)
+
+# Usage — items are collected as a list
+⟦ 3 4 5 ⟧   # => [6, 8, 10]
+```
+
+Any matching Unicode bracket pair can be declared. The prelude defines
+two bracket pairs for rounding:
+
+```eu,notest
+⌈ x ⌉: x ceiling   # prelude: ceiling bracket
+⌊ x ⌋: x floor     # prelude: floor bracket
+
+⌈3.2⌉    # => 4
+⌊3.8⌋    # => 3
+⌈-1.5⌉   # => -1
+⌊-1.5⌋   # => -2
+```
+
+**Bracket parameter pattern**: the declaration's parameter is always
+the *list* of collected items. Use destructuring when the bracket
+expects a fixed structure:
+
+```eu,notest
+# Idiom bracket: first item is a function, rest are argument lists
+⌈ [f: lists] ⌉: foldl(zapp, repeat(f), lists)
+```
+
+**Juxtaposed call syntax after a bracket expression**: a bracket
+expression can be followed immediately by `[args]` or `{block}` to
+juxtapose-call the result. This is valid syntax (a parser fix ensures
+it works):
+
+```eu,notest
+# ⌈expr⌉[args]  — evaluate the bracket, then call with list argument
+⌈ g ⌉[xs]
+
+# ⌈expr⌉{block}  — evaluate the bracket, then call with block argument
+⌈ h ⌉{x: 1}
+```
+
+**Monadic brackets**: when a bracket pair is declared with `:monad`
+metadata, it acts as monadic do-notation. Items inside the brackets
+are bind steps (`name: action`); the return expression follows the
+closing bracket as `.name` or `.(expr)`:
+
+```eu,notest
+# List monad declared with ⌈⌉
+⌈{}⌉: { :monad bind(m, f): m mapcat(f)  return(v): [v] }
+
+# Usage: cartesian product
+⌈ x: [1, 2]  y: [10, 20] ⌉.(x + y)   # => [11, 21, 12, 22]
+```
+
+Monadic brackets **cannot be empty** — at least one bind step is
+required (an empty monadic block is a desugaring error).
+
+**Path bracket shorthand** (`‹›`): `lib/lens.eu` defines `‹›` as a
+bracket that converts a sequence of symbols and numbers into a
+composed lens path:
+
+```eu,notest
+{ import: "lens.eu" }
+‹:server :db :host›   # same as at(:server) ∘ at(:db) ∘ at(:host)
+‹:items 0 :title›     # at(:items) ∘ ix(0) ∘ at(:title)
+```
+
 ### 1.4 Comments
 
 ```eu,notest
@@ -3699,7 +11321,29 @@ report: { total: 42 }
 # Mark as main (default) target
 ` :main
 main: { result: 42 }
+
+# Mark as unit-internal (invisible to importers and output)
+` :internal
+helper(x): x + 1
+
+# Structured form of internal visibility
+` { export: :internal }
+another-helper(x): x * 2
 ```
+
+**Declaration visibility (`export:`)**: controls whether a declaration
+appears in rendered output and is visible to importers:
+
+| Value | Rendered | Visible to importers | Shorthand |
+|-------|----------|---------------------|-----------|
+| `:normal` (default) | yes | yes | — |
+| `:suppress` | **no** | yes | `` ` :suppress `` |
+| `:internal` | **no** | **no** | `` ` :internal `` |
+
+`:internal` makes a binding completely private to its unit — it stays
+accessible to sibling declarations within the same file but is invisible
+to any importing unit and absent from rendered output. Two units with
+same-named internal helpers do not conflict.
 
 **Unit-level metadata**: if the first item in a file is an expression
 (not a declaration), it becomes metadata for the entire unit:
@@ -3708,6 +11352,81 @@ main: { result: 42 }
 { import: "helpers.eu" }
 result: helper(42)
 ```
+
+Unit metadata keys:
+
+| Key | Value | Effect |
+|-----|-------|--------|
+| `import` | string or list | Import files/resources |
+| `requires` | semver string | Fail at load time if version doesn't match |
+| `prelude` | string path | Use an alternative prelude |
+| `doc` | string | Unit documentation |
+
+```eu,notest
+# Version pinning — checked at load time, before evaluation
+{ requires: ">=0.8"
+  import: "helpers.eu" }
+result: helper(42)
+
+# Alternative prelude
+{ prelude: "my-prelude.eu" }
+x: custom-fn(1)
+```
+
+**Trace metadata**: annotate declarations to trace entry arguments
+and/or exit values to stderr during evaluation:
+
+```eu,notest
+# Lazy entry trace — shows <thunk> for unevaluated args
+` :trace
+f(x, y): some-pipeline x y
+# stderr: → f(x: <thunk>, y: <thunk>)
+
+# Strict entry trace — forces args to WHNF before printing
+` { trace: :strict }
+f(x, y): some-pipeline x y
+# stderr: → f(x: 42, y: [1, 2, 3])
+
+# Entry + exit trace (lazy)
+` { trace: :exit }
+f(x, y): some-pipeline x y
+# stderr: → f(x: <thunk>, y: <thunk>)
+# stderr: ← f: <thunk>
+
+# Entry + exit trace (strict) — forces both args and result
+` { trace: :strict-exit }
+f(x, y): some-pipeline x y
+# stderr: → f(x: 42, y: [1, 2, 3])
+# stderr: ← f: 3
+```
+
+Trace output goes to stderr and does not affect the program's result.
+Lazy mode (`:trace`, `:exit`) never forces evaluation — it peeks at
+values that have already been evaluated. Strict mode (`:strict`,
+`:strict-exit`) forces arguments/results to WHNF, which changes
+evaluation order.
+
+**Deprecation metadata**: mark declarations as deprecated to generate
+compile-time warnings:
+
+```eu,notest
+# Bare deprecation
+` :deprecated
+old-fn(x): x + 1
+
+# With message
+` { deprecated: "use new-fn instead" }
+old-fn(x): x + 1
+
+# With replacement pointer (enables LSP quick-fix)
+` { deprecated: "use new-fn instead"
+    replaced-by: "new-fn" }
+old-fn(x): x + 1
+```
+
+Referencing a deprecated declaration emits a warning on stderr.
+Under `eu check --strict`, deprecation warnings become errors.
+Deprecated declarations still work — deprecation is advisory.
 
 **Type annotations** (optional, advisory): add `type:` alongside `doc:`
 to annotate declarations for the type checker (`eu check`):
@@ -3723,17 +11442,36 @@ map: __MAP
 ```
 
 **Type aliases**: define reusable type names in unit metadata or via
-`type-def:` on a declaration:
+`type-def:` / `result-def:` on a declaration:
 
 ```eu,notest
 # Named aliases in unit metadata
 { types: { Point: "{x: number, y: number}"
            Person: "{name: string, age: number, email: string | null, ..}" } }
 
-# Alias derived from a canonical instance
+# Alias using binding name (shorthand — `:type-def` or `type-def: true`)
+` :type-def
+origin: { x: 0, y: 0 }
+# Registers alias `origin` = the binding's type
+
+# Alias with an explicit name
 ` { type-def: "Point" }
 origin: { x: 0, y: 0 }
+# Registers alias `Point` = the binding's type
+
+# Return-type alias for a constructor function
+` { result-def: "Count"
+    type: "string → number" }
+char-count(s): str.length(s)
+# Registers alias `Count` = the function's return type (number)
+# Equivalent shorthand: `:result-def` uses the binding name as alias name
 ```
+
+`type-def: true` (or the bare `` ` :type-def `` shorthand) uses the binding's
+own name as the alias name; `type-def: "Name"` uses an explicit name.
+`result-def` is identical in shape but registers an alias for the function's
+*return type* rather than the full function type. `result-def` on a
+non-function binding emits a warning and is skipped.
 
 **Common type forms in annotations**:
 
@@ -3742,17 +11480,80 @@ origin: { x: 0, y: 0 }
 | `number`, `string`, `symbol`, `bool`, `null`, `datetime` | primitives |
 | `any`              | gradual/unknown — no type errors       |
 | `[T]`              | list of T                              |
+| `NonEmpty([T])`    | non-empty list of T                    |
 | `(A, B)`           | tuple                                  |
-| `{k: T, ..}`       | open record (at least k: T)            |
-| `{k: T, ..r}`      | named row variable (extra fields in r) |
-| `{k: T}`           | closed record                          |
-| `block`            | any block                              |
+| `{{k: T, ..}}`     | open record (at least k: T)            |
+| `{{k: T, ..r}}`    | named row variable (extra fields in r) |
+| `{{..r, ..s}}`     | row concatenation (union of r and s)   |
+| `{{k: T}}`         | closed record                          |
+| `block`            | any block (no known shape)             |
+| `Dict(T)`          | homogeneous block — all values type T  |
+| `"value"`          | literal string — subtype of `string`; c-string escapes for the quotes: `c"\"value\""` |
+| `:name`            | literal symbol — subtype of `symbol`   |
 | `A -> B`           | function                               |
 | `A \| B`           | union                                  |
-| `a`, `b`           | type variable                          |
+| `T?`               | partial — sugar for `T \| ExecutionError` |
+| `ExecutionError`   | the type of a raised runtime error     |
+| `a`, `b`           | type variable (kind `*`)               |
+| `m a`              | constructor application (`m` of kind `* -> *` applied to `a`) |
+| `forall a. T`      | explicit quantification over kind-`*` variable |
+| `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
 | `IO(T)`            | IO action producing T                  |
 | `Lens(a, b)`       | lens                                   |
 | `Traversal(a, b)`  | traversal                              |
+
+**User-defined monads**: `monad({ bind(m,f): ..., return(v): ... })`
+derives the standard combinators (`map`, `then`, `and-then`, `join`,
+`sequence`, `map-m`, `filter-m`) and annotates them with
+`forall (m :: * -> *)` types.  The type checker understands them
+polymorphically, so passing the wrong type triggers a warning:
+
+```eu,notest
+my-for: monad({bind(m, f): m mapcat(f), return(v): [v]})
+[1, 2, 3] my-for.map(true)   # warning: expected a → b, found bool
+```
+
+**Important**: record braces (`{`) in type strings trigger eucalypt
+string interpolation. Always escape with `{{` and `}}`:
+`"{{name: string, ..}} -> string"` not `"{name: string, ..} -> string"`.
+Types without braces (`"number -> number"`, `"IO(T)"`) need no escaping.
+Literal string types (`"value"`) escape their quotes with c-string escapes:
+`c"\"value\""`. Mind `|`/`->` precedence — bracket a union in argument
+position: `c"(\"a\" | \"b\") -> bool"`.
+
+**Partial functions**: functions that may raise a runtime error use the
+`T?` postfix sugar — equivalent to `T | ExecutionError`.  Several
+prelude functions are partial by nature:
+
+```
+nth      : number → [a] → a?         # out-of-range index
+parse-as : symbol → string → any?    # invalid input format
+lookup   : symbol → Dict(a) → a?     # key not found
+```
+
+A partial result flowing into `any` (unannotated code) is **silent** —
+a warning fires only when the receiving position is explicitly annotated
+as total:
+
+```eu,notest
+` { type: "number" }
+result: [1, 2, 3] nth(0)   # warning: expected number, found number?
+```
+
+**Flow-sensitive narrowing**: when a type-predicate test (`number?`,
+`string?`, `bool?`, `null?`, `list?`, `block?`, `symbol?`) on an
+annotated variable is used as the condition of `if`, `and`, `or`,
+`cond`, or a structural wrapper (e.g. `then(t,f,c): if(c,t,f)`), the
+checker narrows the variable's type in each branch.  Non-structural
+wrappers (e.g. `my-if(c,t,_f): t`) are not recognised as branchers
+and do not trigger narrowing.
+
+**LSP alias navigation**: alias names written inside `type:` strings
+support go-to-definition, hover (shows the alias name and resolved type), and
+rename.  This works for plain, unescaped type strings only — escaped or
+interpolated strings (`"{{...}}"`) degrade gracefully with no crash.  Rename
+updates plain-string references; any interpolated references that still mention
+the old name will produce an "unknown alias" type warning after the rename.
 
 See [Type Checking](../guide/type-checking.md) for the full guide.
 
@@ -3792,8 +11593,9 @@ config.db.host
 ```
 
 **Warning:** `.` binds very tightly (precedence 90). `list head.name`
-parses as `list (head.name)`, not `(list head).name`. Use parentheses:
-`(list head).name`.
+groups `head.name` into one unit first, and *that unit* — not `list`
+— is what gets applied: it parses as `head.name(list)`, not
+`(list head).name`. Use parentheses: `(list head).name`.
 
 ### 1.8 Anaphora (Implicit Parameters)
 
@@ -3910,7 +11712,8 @@ From highest (tightest) to lowest binding:
 | 35 | bool-prod | left | `&&`, `∧` | Logical AND |
 | 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
 | 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
-| 10 | apply | right | `@` | Function application |
+| 15 | clause | left | `=>`, `⇒` | Cond clause builder (`condition => result`) |
+| 10 | apply | left | `@` | Function application |
 | 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
 
 **Named precedence levels** for use in operator metadata: `:lookup`,
@@ -3984,17 +11787,25 @@ foldr(++, [], [[1,2],[3,4]])  # [1, 2, 3, 4]
 [10, 20, 30] head            # 10
 ```
 
+The type checker warns if `xs` could be empty (`List(T)` or `List(Never)`).
+Use `nil?` narrowing or annotate as `NonEmpty([T])` to suppress.  On a
+`Tuple([A, B, ...])` literal, `head` synthesises the precise type `A`.
+
 #### `tail(xs)` — all but first (panics if empty)
 
 ```
 [10, 20, 30] tail            # [20, 30]
 ```
 
+On a `Tuple([A, B, C])`, `tail` synthesises `Tuple([B, C])`.
+
 #### `cons(h, t)` — prepend element to list
 
 ```
 cons(0, [1, 2, 3])           # [0, 1, 2, 3]
 ```
+
+`cons` and `‖` return `NonEmpty([a])` — the result is guaranteed non-empty.
 
 #### `reverse(l)` — reverse a list
 
@@ -4114,6 +11925,23 @@ Patterns: bare `foo` = `**.foo`; `*` = one level; `**` = any depth.
 { a: { x: 1 } b: { x: 2 } } deep-query("*.x") # [1, 2]
 ```
 
+#### `select(ks, b)` — sub-block with only listed keys
+
+```
+{ a: 1 b: 2 c: 3 } select([:a, :c])   # { a: 1 c: 3 }
+{ a: 1 b: 2 } select([])               # {}
+{ a: 1 b: 2 } select([:z])             # {}
+```
+
+#### `dissoc(ks, b)` — sub-block with listed keys removed
+
+```
+{ a: 1 b: 2 c: 3 } dissoc([:a, :c])   # { b: 2 }
+{ a: 1 b: 2 } dissoc([])               # { a: 1 b: 2 }
+{ a: 1 b: 2 } dissoc([:z])             # { a: 1 b: 2 }
+{ a: 1 } dissoc([:a])                  # {}
+```
+
 ### 3.3 String Functions (str namespace)
 
 #### `str.split-on(re, s)` — split string on regex
@@ -4154,6 +11982,17 @@ See also: `identity(v)`, `const(k, _)`, `compose(f, g, x)`,
 `flip(f, x, y)`, `complement(p?)`, `curry(f, x, y)`,
 `uncurry(f, l)`, `cond(l, d)`.
 
+`cond` takes a list of clauses built with `=>` / `⇒` (precedence 15)
+and a default value.  Each clause is `condition => result`; the first
+true clause wins:
+
+```eu,notest
+classify(n): cond[n < 0 => "negative", n > 100 => "huge", "normal"]
+```
+
+Flow-sensitive narrowing applies inside each `cond` clause when the
+condition is a type-predicate test on an annotated variable.
+
 ### 3.5 Type Predicates
 
 ```eu,notest
@@ -4166,7 +12005,32 @@ true bool?          # true
 42 string?          # false
 ```
 
-All predicates take one argument and return a boolean.
+All predicates take one argument and return a boolean. `datetime?(v)` is also available for zoned-datetime values.
+
+### 3.5a Type Specs — `as-spec`
+
+Convert a type annotation (an `s"…"` type-data value) to a `match?`-compatible pattern:
+
+```eu,notest
+schema: s"{ name: string, age: number }" as-spec
+
+{name: "Alice", age: 30}     match?(schema)  # true
+{name: "Alice", age: "old"}  match?(schema)  # false
+```
+
+**Mapping:**
+
+| Type form | Pattern produced |
+|---|---|
+| `Number`, `String`, `Symbol`, `Bool`, `Null`, `DateTime`, `Any` | Corresponding predicate (`number?`, `string?`, …) |
+| `{ k: T }` record | Block pattern `{k: T-spec, …}` (open matching, extra keys ignored) |
+| `[T]` list | Predicate: `list? ∧ all(T-spec)` |
+| `A \| B` union | Predicate: true if value matches any branch |
+| `T?` partial/nullable | Predicate: `null?` or `T-spec` |
+| `(T1, T2, …)` tuple | List pattern `[T1-spec, T2-spec, …]` (exact length) |
+| `A → B` function | Predicate: `__SATURATED not` (checks it is a function) |
+| `forall …` | Erase quantifier, spec the body |
+| Type variables | `any?` (unconstrained at runtime) |
 
 ### 3.6 Command-line Argument Parsing
 
@@ -4194,7 +12058,7 @@ Returns defaults block with parsed values overridden, plus `args` key for positi
 
 **Supported forms:** `--key value`, `--key=value`, `--flag`, `-x`, `-xy` (combined shorts), positionals, `--help`.
 
-See `docs/reference/prelude/args.md` for full documentation.
+See `docs/reference/prelude/io.md` for full documentation.
 
 ---
 
@@ -4386,18 +12250,25 @@ define a partial: `sum: foldl(+, 0)` then `[1,2,3] sum`.
 `.` has precedence 90 vs catenation at 20. So:
 
 ```eu,notest
-list head.name    # WRONG: parses as list (head.name)
+list head.name    # WRONG: parses as head.name(list)
 (list head).name  # RIGHT: get head, then lookup .name
 ```
 
 The `↑` prefix operator (precedence 95) binds even tighter: `↑xs.name`
 = `(↑xs).name`.
 
-### 5.3 No Whitespace Before Parentheses in Calls
+### 5.3 No Whitespace in Call Syntax
+
+Whether `(`, `[`, or `{` immediately follows the callee (no space) is
+what distinguishes a call from catenation:
 
 ```eu,notest
 f(x)    # function call
 f (x)   # catenation: applies f to (x) as pipeline
+f[1,2]  # juxtaposed call with list argument
+f [1,2] # catenation: applies f to [1,2] as pipeline
+f{a: 1} # juxtaposed call with block argument
+f {a: 1}# catenation: applies f to {a: 1} as pipeline
 ```
 
 ### 5.4 map vs mapcat
@@ -4491,18 +12362,22 @@ generalised lookup.
 
 The following are commonly assumed but are **not** in the prelude:
 
-- `str.replace` — does not exist
-- `str.trim` — does not exist
-- `str.starts-with?` — does not exist
-- `str.ends-with?` — does not exist
-- `str.contains?` — does not exist
 - `flatten` — use `concat` (flattens one level)
 - `unique` — does not exist in prelude
-- `abs` — does not exist (use `if(x < 0, negate(x), x)`)
 - `even?` / `odd?` — do not exist (use `x % 2 = 0`)
 - `round` / `ceil` — use `floor` and `ceiling` (or bracket notation `⌊n⌋` and `⌈n⌉`)
-- `select` / `dissoc` — do not exist (use `filter-items` with
-  `by-key`)
+- `select(ks, b)` — **exists**: `{ a: 1, b: 2, c: 3 } select([:a, :c])` → `{ a: 1, c: 3 }`
+- `dissoc(ks, b)` — **exists**: `{ a: 1, b: 2 } dissoc([:a])` → `{ b: 2 }`
+
+These **do exist** and are commonly available:
+
+- `str.trim(s)` — trims leading/trailing whitespace
+- `str.replace(pattern, replacement, s)` — replaces all regex matches
+- `str.contains?(pattern, s)` — true if `s` contains a match for regex `pattern`
+- `str.starts-with?(re, s)` — true if `s` starts with regex match
+- `str.ends-with?(re, s)` — true if `s` ends with regex match
+- `abs(n)` — absolute value
+- `str.to-upper(s)` / `str.to-lower(s)` — case conversion (not `str.upper` / `str.lower`)
 
 ### 5.12 str.split-on Uses Regex, Not Literal Strings
 
@@ -4559,6 +12434,162 @@ rebuilds the block. Combine with `bimap` for point-free transforms:
 ```eu,notest
 blk map-elements(bimap(rename-key, transform-value))
 ```
+
+### 5.17 `{x: x}` Is Always Self-Reference
+
+Every declaration inside a block literal sees *itself* — including its
+own right-hand side. `{x: x}` does **not** copy an outer `x` into the
+block; it creates a self-referential binding that refers to itself.
+This most often bites function parameters:
+
+```eu,notest
+# WRONG — cmd refers to itself (infinite loop), not the parameter
+shell-spec(cmd): { :io-shell cmd: cmd, timeout: 30 }
+
+# CORRECT — use a different name so the parameter isn't shadowed
+shell-spec(c): { :io-shell cmd: c, timeout: 30 }
+```
+
+To transform a value and keep its name use a `:let` block (see 5.18)
+or pick a different local name.
+
+### 5.18 Sequential Bindings: Use `:let` Blocks
+
+Eucalypt has no `let … in` syntax. For sequential, non-self-referential
+bindings, use a `:let` block:
+
+```eu,notest
+# WRONG — 'in' is unresolved; 'let' is just a prelude value
+result: let x: 1 in x + 2
+
+# CORRECT — :let block; y can safely reference x
+result: { :let x: 1  y: x + 2 }.y
+```
+
+`:let` RHS expressions see the *outer* scope (including prior `:let`
+bindings), not themselves. This is the one place where `{name: name}`
+is not self-reference — the RHS is evaluated before the new binding
+takes effect:
+
+```eu,notest
+# Transform xs and keep its name — RHS xs is the function parameter
+normalise(xs): { :let xs: xs map(clean) }.xs
+```
+
+### 5.19 Backtick and Braces in Doc Strings
+
+The backtick (`` ` ``) inside a string is **not** an escape — it is
+parsed as a metadata marker. Using `` ` `` inside a doc string causes
+a parse error:
+
+```eu,notest
+# WRONG — backtick inside string triggers metadata parsing
+` "Run via `sh -c`"
+my-fn(x): x
+
+# CORRECT — use plain prose, no backticks inside the string
+` "Run via sh -c"
+my-fn(x): x
+```
+
+Similarly, `{` inside a doc string starts string interpolation. A
+literal `{` example (e.g. `"e.g. {stdin: s}"`) will try to look up
+`stdin` as a variable and likely fail:
+
+```eu,notest
+# WRONG — {stdin: s} triggers interpolation; s becomes a free variable
+` "Provide options e.g. {stdin: s}"
+run(opts): opts
+
+# CORRECT — describe with plain prose
+` "Provide options e.g. a block with stdin field"
+run(opts): opts
+```
+
+### 5.20 `:suppress` Leaks Through References
+
+`` ` :suppress `` hides a binding from rendered output, but the flag
+travels with the **value**. If you reference a suppressed value, the
+field it lands in is also silently suppressed:
+
+```eu,notest
+# WRONG — log4j is suppressed, so @id silently disappears
+` :suppress
+log4j: "pkg:maven/log4j-core@2.17.1"
+
+entry: { '@id': log4j }   # renders as {} — @id is gone
+
+# CORRECT — suppress the container, reference members directly
+` :suppress
+purls: { log4j: "pkg:maven/log4j-core@2.17.1" }
+
+entry: { '@id': purls.log4j }   # @id is present and correct
+```
+
+Only suppress a binding you do not reference elsewhere. To hide values
+you *do* reference, group them in a suppressed block and look up members
+from it.
+
+### 5.21 Cons Pattern Only Valid in Function Parameters
+
+The `[h : t]` destructuring pattern is only valid in a **function
+parameter position**. A colon inside a list expression is a parse
+error:
+
+```eu,notest
+# VALID — cons pattern in function parameter
+first([h : t]): h
+
+# INVALID — colon is not a list separator in expressions
+bad: [1 : rest]   # parse error
+```
+
+In expressions, use the `‖` cons operator or `cons` prelude function:
+
+```eu,notest
+built: 1 ‖ [2, 3]        # => [1, 2, 3]
+also: cons(1, [2, 3])     # => [1, 2, 3]
+```
+
+### 5.22 Prefer `when` Over `if` for Conditional Transforms
+
+`when(pred?, f, x)` applies `f` when the predicate is satisfied and
+passes `x` through unchanged. It is cleaner than `if(pred?(x), f(x),
+x)` because it avoids repeating `x`:
+
+```eu,notest
+# Prefer — no repetition
+x when(number?, + 1)
+
+# Avoid — x appears three times
+if(x number?, x + 1, x)
+```
+
+### 5.23 Anaphor Scoping: Parentheses Are Opaque
+
+Parentheses create a new anaphor scope. Anaphors inside parens form a
+lambda at the paren level, not at the enclosing expression:
+
+```eu,notest
+(_0 + _1) / 2   # WRONG: (_0 + _1) is its own 2-arg lambda;
+                #  / 2 then tries to divide a function by 2
+
+# Correct: use a named helper
+avg2(a, b): (a + b) / 2
+```
+
+**Subsumption**: if the enclosing expression already has a direct
+anaphor, inner paren groups become *transparent* — their anaphors join
+the outer scope:
+
+```eu,notest
+# _0✓ makes the outer expression anaphoric, so _0 inside count(_0)
+# is subsumed — both refer to the same parameter
+_0✓ && count(_0) >= 4    # λ(a). a != null && count(a) >= 4
+```
+
+Without the outer `_0✓`, the `_0` inside `count(_0)` would form a
+separate lambda at the ArgTuple level.
 
 ---
 
@@ -4678,9 +12709,2298 @@ Output format: `▶ <repr>` or `▶ label: <repr>`.
 `▶` is intentionally prominent — the Unicode triangle is hard to overlook
 in a code review.
 
+## 10. Version Requirements
+
+**Declare a minimum eucalypt version at the top of any `.eu` file that depends
+on features introduced in a specific release.**
+
+```eu
+_ : eu.requires(">=0.8")
+```
+
+`eu.requires` takes a semver constraint string.  It returns `null` on success
+and raises `VersionRequirementFailed` on failure.  Because `eu.requires`
+returns `null` it must be assigned to `_` (a discard binding) — a bare
+expression at the top level cannot reference `eu` directly.
+
+### Constraint syntax
+
+Uses [semver constraint syntax](https://docs.rs/semver/latest/semver/#requirements):
+
+| Constraint | Meaning |
+|------------|---------|
+| `">=0.8"` | Version 0.8.0 or later |
+| `"^0.8"` | Compatible with 0.8 (i.e. 0.8.x) |
+| `">=0.8, <1.0"` | 0.8.x up to but not including 1.0 |
+
+### Convention
+
+- Every shipped library file (`lib/lens.eu`, `lib/state.eu`, `lib/markup.eu`)
+  uses `_ : eu.requires(">=0.8")` near the top.
+- Place the declaration after any unit-level metadata block or file-level doc
+  string, before the first binding definition.
+- Build metadata (`+N`) is ignored by the version check — `">=0.8"` matches
+  `0.8.0+1685`.
+
 ---
 
-<!-- Source: docs/appendices/syntax-gotchas.md -->
+## 11. Lens Library (`lib/lens.eu`)
+
+The lens library provides composable, bidirectional accessors for
+nested data. Import it with:
+
+```eu,notest
+{ import: "lens.eu" }
+```
+
+### What a Lens Is
+
+A **lens** is a reusable description of a *position* within a data
+structure. Once defined, the same lens can read the value at that
+position (`view`), replace it (`over` with `->const`), or transform
+it with a function (`over`) — always returning the complete, updated
+structure.
+
+A **traversal** extends this to *multiple* positions: `over` applies a
+function at each focus and rebuilds the whole structure; `to-list-of`
+collects all foci into a list.
+
+### Core Operations
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `view(lens, data)` | `Lens(a, b) → a → b` | Read the focused value |
+| `over(optic, fn, data)` | `(Lens(a,b) \| Traversal(a,b)) → (b→b) → a → a` | Transform at each focus |
+| `to-list-of(optic, data)` | `(Lens(a,b) \| Traversal(a,b)) → a → [b]` | Collect all foci into a list |
+| `parts-of(traversal)` | `Traversal(a,b) → Lens(a,[b])` | Turn a traversal into a lens on the list of all foci |
+
+**Setting a value**: use `over` with the `->` const operator to
+replace rather than transform:
+
+```eu,notest
+data over(lens, -> "new-value")   # -> discards the old value
+```
+
+### Lens and Traversal Constructors
+
+| Constructor | Type | Description |
+|-------------|------|-------------|
+| `at(key)` | `symbol → Lens({..}, a)` | Focus on block value at symbol key |
+| `ix(n)` | `number → Lens([a], a)` | Focus on list element at index n |
+| `item(pred)` | `(a→bool) → Lens([a], a)` | Focus on first list element matching predicate |
+| `element(pred)` | `((sym,any)→bool) → Lens({..},[sym,any])` | Focus on first `[key,value]` pair matching predicate |
+| `_value` | `Lens([a], a)` | Focus on value (index 1) of a `[key,value]` pair |
+| `_key` | `Lens([a], a)` | Focus on key (index 0) of a `[key,value]` pair |
+| `each` | `Traversal([a], a)` | Traverse all list elements |
+| `filtered(pred)` | `(a→bool) → Traversal([a], a)` | Traverse only matching list elements |
+| `each-element` | `Traversal({..}, [sym,any])` | Traverse all block kv pairs |
+| `filtered-elements(pred)` | `((sym,any)→bool) → Traversal({..}, [sym,any])` | Traverse matching block kv pairs |
+
+### Composition
+
+Compose with `∘` (right-to-left) to focus deeper. A lens composed
+with a traversal yields a traversal:
+
+```eu,notest
+# Equivalent compositions
+at(:server) ∘ at(:db) ∘ at(:host)
+‹:server :db :host›       # shorthand bracket form
+
+# Mix key and index navigation
+‹:items 0 :meta :title›   # at(:items) ∘ ix(0) ∘ at(:meta) ∘ at(:title)
+```
+
+The `‹›` bracket shorthand converts symbols to `at` lenses and
+numbers to `ix` lenses, then composes them with `∘`. Lens function
+values may also appear in the path: `‹element(by-key(_ = :b)) _value›`.
+
+### Examples
+
+```eu,notest
+{ import: "lens.eu" }
+
+config: { server: { db: { host: "localhost", port: 5432 } } }
+
+# Read with view
+host: config view(‹:server :db :host›)
+# => "localhost"
+
+# Update with over — whole config returned, rest unchanged
+updated: config over(‹:server :db :host›, -> "10.0.0.5")
+# => { server: { db: { host: "10.0.0.5", port: 5432 } } }
+
+# Apply a function to a nested value
+bumped: config over(‹:server :db :port›, + 1)
+# => { server: { db: { host: "localhost", port: 5433 } } }
+```
+
+Traversal example — transform a field across every list element:
+
+```eu,notest
+{ import: "lens.eu" }
+
+records: [{name: "a", score: 10}, {name: "b", score: 20}]
+
+# Collect all scores
+records to-list-of(each ∘ at(:score))   # => [10, 20]
+
+# Double all scores
+records over(each ∘ at(:score), * 2)
+# => [{name: "a", score: 20}, {name: "b", score: 40}]
+
+# Sort all scores as a group (parts-of)
+[3, 1, 4, 1, 5] over(parts-of(each), sort-nums)   # => [1, 1, 3, 4, 5]
+```
+
+### Type Checker Integration
+
+The type checker understands `Lens(a, b)` and `Traversal(a, b)` as
+opaque types. Using `view` on a traversal (instead of `to-list-of`)
+triggers a type warning. Composing incompatible optics (e.g.
+`Lens(a, b) ∘ Lens(c, d)` where `b ≠ c`) also produces a warning.
+
+See [Navigating Nested Data](../guide/navigating-nested-data.md) for
+a complete tutorial including `~` safe navigation and `match?`.
+
+---
+
+# Design Philosophy
+
+**eucalypt**, the language, is unorthodox in many respects -- probably
+more than you might realise on first acquaintance.
+
+People tend to have deep-seated and inflexible opinions about
+programming languages and language design and will quite possibly find
+something in here that they have a kneejerk reaction against.
+
+However, the design is not unprincipled and, while it is experimental
+in some respects, I believe it's internally consistent. Several
+aspects of the design and the aesthetic are driven by the primary use
+case, templating and generating YAML. Maybe by exploring some of the
+inspiration and philosophy behind the language itself, I can pre-empt
+some of the knee jerks.
+
+## Accept crypticality for minimal intrusion
+
+**eucalypt** is first and foremost a *tool*, rather than a language. It is
+intended to replace generation and transformation processes on
+semi-structured data formats. Many or most uses of **eucalypt** the
+language should just be simple one-liner tags in YAML files, or maybe
+eucalypt files that are predominantly data rather than manipulation.
+
+The **eucalypt** language is the depth behind these one-liners that
+allows **eucalypt** to accommodate increasingly ambitious use cases
+without breaking the paradigm and reaching for a general purpose
+imperative scripting language or the lowest common denominator of
+text-based templating languages.
+
+The pre-eminence of one-liners and small annotations and "logic
+mark-up", means that **eucalypt** often favours concise and cryptic over
+wordy and transparent. This is a controversial approach.
+
+- **eucalypt** logic should "get out of the way" of the data. Templating
+  is attractive precisely because the generating source looks very
+  like the result. Template tags are often short (with "cryptic"
+  delimiters -- `{{}}`, `<%= %>`, `[| ]`...) because these are "marking
+  up" the data which is the main event. At the same time, the tags are
+  often "noisy" or visually disruptive to ensure they cannot be
+  ignored. **eucalypt** via operator and bracket definitions, picks and
+  chooses from a similar palette of expressive effects to try and be a
+  sympathetic cohabitee with its accompanying data.
+
+- There are many cases where it makes sense to resist offering an
+  incomplete understanding in favour of demanding full understanding.
+  For example, it is spurious to say that `bind(x, f)` gives more
+  understanding of what is going on than `x >>= f` -- unless you
+  understand the monad abstraction and the role of bind in it, you
+  gain nothing useful from the ideas that the word `bind` connotes
+  when you are trying to understand program text.
+
+- **eucalypt** just plain ignores the notion that program text should
+  be readable *as English text*. This (well motivated) idea has made a
+  resurgence in recent years through the back door of internal DSLs
+  and "fluent" Java interfaces. There is much merit in languages
+  supple enough to allow the APIs to approach the natural means of
+  expression of the problem domain. However, problem domains
+  frequently have their own technical jargon and notation which suit
+  their purpose better than natural language so it cuts both ways.
+  Program text should be approachable by its target audience but that
+  does not mean it should make no demands of its target audience.
+
+These stances lead directly to several slightly esoteric aspects of
+**eucalypt** that may be obnoxious to some:
+
+- **eucalypt** tends to be operator-heavy. Operators are concise (if
+  cryptic) and the full range of unicode is available to call upon.
+  Using operators keeps custom logic visually out of the way of the
+  data whilst also signposting it to attract closer attention.
+
+- **eucalypt** lets you define your own operators and specify their
+  precedence and associativity (which are applied at a relatively late
+  stage in the evaluation pipeline -- *operator soup* persists through
+  the initial parse). There are no ternary operators.
+
+- For absolute minimal intrusion, merely the act of placing elements
+  next to each other ("catenation"), `x f`, is meaningful in
+  **eucalypt**. By default this is pipeline-order function
+  application, but blocks can be applied as functions to make common
+  transformations, like block merge, very succinct.
+
+- For even more power, **eucalypt** has some recent experimental
+  features... You can alter the meaning of concatenation via *idiot
+  brackets* [^1]. (`«x y»: ...`), the ability to define handling of
+  arbitrary unicode bracket pairs. This is inspired by the *idiom
+  brackets* that can be used to express applicative styles in
+  functional programming [^2], but they can be used much more
+  generally, you could use them to define ternary operators for
+  instance.
+
+- You can also customise block handling by reinterpreting it as a
+  monadic pattern similar to Haskell's `do` notation. Such block
+  handling can be assigned to unicode bracket pairs. This is very
+  experimental but can be used to tidy up random number patterns for
+  instance which are currently awkward in the purely functional
+  context of **eucalypt**.
+
+## Cohabitation of code and data
+
+Just like templates, **eucalypt** source (or **eucalypt**-tagged YAML)
+should be almost entirely data.
+
+The idea behind **eucalypt** is to adopt the basic maps-and-arrays
+organisation philosophy of these data formats but make the data
+*active* -- allowing lambdas to live in and amongst it and operate on
+it and allowing the data to express dispositions towards its
+environment by addition of metadata that controls import, export, and
+execution preferences.
+
+**eucalypt** therefore collapses the separation of code and data to some
+degree. You can run `eu` against a mixture of YAML, JSON and eucalypt
+files and all the data and logic appears there together in the same
+namespace hierarchy. The namespace hierarchy just *is* the data.
+
+However, code and data aren't unified in the sense of Lisp for
+instance. **eucalypt** is not homoiconic. The relationship is more like
+cohabitation; code lives in amongst the data it operates on but is
+stripped out before export.
+
+Nevertheless **eucalypt** is heavily inspired by Lisp and aims for a
+similar fluidity through:
+
+- lazy evaluation (going some way towards matching uses of Lisp macros
+  which control evaluation order -- in eucalypt, `if` is just a
+  function)
+- economical syntax to facilitate (future) manipulation of code as
+  data
+
+## Simplicity
+
+- **eucalypt** values simplicity in the sense of fewer moving parts (and
+  therefore, hopefully, fewer things to go wrong). It values ease of
+  use in the sense of offering a rich and powerful toolkit. You may
+  not think it achieves either.
+
+- **eucalypt** values familiarity mostly in the "shallower" parts of
+  the language where it only requires a couple of mental leaps for the
+  average programmer in these areas -- the (ab)use of catenation being
+  the key one.
+
+- However, **eucalypt** isn't ashamed of its dusty corners. Dusty
+  corners are areas where novices and experts alike can get trapped
+  and lose time but they're also rich seams for experimentation,
+  innovation and discovery. If you have to venture too far off-piste
+  to find what you need, we'll find a way to bring it onto the nursery
+  slopes but we won't close off the mountain.
+
+
+---
+
+#### Footnotes
+
+[^1]: Inspired by *idiom brackets*. If I didn't call them that,
+    someone else would.
+
+[^2]: Applicative Programming with Effects, Conor McBride and Ross
+    Paterson. (2008)
+    http://www.staff.city.ac.uk/~ross/papers/Applicative.html
+
+---
+
+# Lazy Evaluation
+
+*This chapter is under construction.*
+
+Eucalypt uses lazy evaluation, meaning expressions are only evaluated
+when their values are needed. This has important consequences:
+
+- `if` is just a function (both branches are not evaluated)
+- Infinite lists are possible (e.g. `repeat(1)`, `ints-from(0)`)
+- Unused computations have no cost
+
+---
+
+# Eucalypt Architecture
+
+This document provides a comprehensive overview of Eucalypt's design and implementation architecture.
+
+## Overview
+
+Eucalypt is a functional programming language and tool for generating, templating, rendering, and processing structured data formats like YAML, JSON, and TOML. Written in Rust (~44,000 lines), it features a classic multi-phase compiler design with an STG (Spineless Tagless G-machine) runtime for lazy evaluation.
+
+## System Architecture
+
+### High-Level Pipeline
+
+```
+Source Code (*.eu files)
+        │
+        ▼
+┌───────────────────────┐
+│    Parsing Phase      │  src/syntax/
+│  Lexer → Parser → AST │
+└───────────────────────┘
+        │
+        ▼
+┌───────────────────────┐
+│     Core Phase        │  src/core/
+│  Desugar → Cook →     │
+│  Transform → Verify   │
+└───────────────────────┘
+        │
+        ▼
+┌───────────────────────┐
+│   Evaluation Phase    │  src/eval/
+│  STG Compile → VM →   │
+│  Memory Management    │
+└───────────────────────┘
+        │
+        ▼
+┌───────────────────────┐
+│    Export Phase       │  src/export/
+│  JSON/YAML/TOML/etc   │
+└───────────────────────┘
+```
+
+### Module Structure
+
+```
+eucalypt/
+├── src/
+│   ├── bin/eu.rs           # CLI entry point
+│   ├── lib.rs              # Library root
+│   ├── common/             # Shared utilities
+│   ├── syntax/             # Parsing and AST
+│   │   └── rowan/          # Rowan-based incremental parser
+│   ├── core/               # Core expression representation
+│   │   ├── desugar/        # AST to core transformation
+│   │   ├── cook/           # Operator fixity resolution
+│   │   ├── transform/      # Expression transformations
+│   │   ├── simplify/       # Optimisation passes
+│   │   ├── inline/         # Inlining passes
+│   │   ├── verify/         # Validation
+│   │   └── analyse/        # Program analysis
+│   ├── eval/               # Evaluation engine
+│   │   ├── stg/            # STG syntax and compiler
+│   │   ├── machine/        # Virtual machine
+│   │   └── memory/         # Heap and garbage collection
+│   ├── driver/             # CLI orchestration
+│   ├── export/             # Output format generation
+│   └── import/             # Input format parsing
+├── lib/                    # Standard library (eucalypt source)
+│   ├── prelude.eu          # Core prelude
+│   ├── test.eu             # Test framework
+│   └── markup.eu           # Markup utilities
+└── docs/                   # Documentation
+```
+
+## Parsing Pipeline
+
+The parsing pipeline transforms source text into a structured AST using Rowan, an incremental parsing library that preserves full source fidelity including whitespace and comments.
+
+### Lexer
+
+*Implementation*: `src/syntax/rowan/lex.rs`, `src/syntax/rowan/string_lex.rs`
+
+The lexer (`Lexer<C>`) tokenises source text into a stream of `SyntaxKind` tokens:
+
+```rust
+pub struct Lexer<C: Iterator<Item = char>> {
+    chars: Peekable<C>,           // Character stream with lookahead
+    location: ByteIndex,           // Source position tracking
+    last_token: Option<SyntaxKind>, // Context for disambiguation
+    whitespace_since_last_token: bool,
+    token_buffer: VecDeque<(SyntaxKind, Span)>,
+}
+```
+
+**Key features:**
+- Unicode-aware identifier and operator recognition
+- Context-sensitive tokenisation (distinguishes `OPEN_PAREN` from `OPEN_PAREN_APPLY`)
+- String pattern lexing with interpolation support (`"Hello {name}"`)
+- Preserves trivia (whitespace, comments) for full-fidelity AST
+
+**Token categories:**
+- Delimiters: `{ } ( ) [ ] : , \``
+- Identifiers: `foo`, `'quoted name'`, `+`, `&&`
+- Literals: Numbers, strings, symbols (`:keyword`)
+- Annotations: Whitespace, comments (`#`)
+
+### Parser
+
+*Implementation*: `src/syntax/rowan/parse.rs`
+
+The parser uses an event-driven recursive descent approach:
+
+```rust
+pub struct Parser<'text> {
+    tokens: Vec<(SyntaxKind, &'text str)>,
+    next_token: usize,
+    sink_stack: Vec<Box<dyn EventSink>>,
+    errors: Vec<ParseError>,
+}
+```
+
+**Parse events:**
+```rust
+enum ParseEvent {
+    StartNode(SyntaxKind),  // Begin syntax node
+    Finish,                  // Complete node
+    Token(SyntaxKind),      // Include token
+}
+```
+
+**Key parsing methods:**
+- `parse_unit()` - Top-level file (no braces required)
+- `parse_expression()` / `parse_soup()` - Expression sequences
+- `parse_block_expression()` - `{ ... }` blocks with declarations
+- `parse_string_pattern()` - Interpolated strings
+
+The parser maintains systematic error recovery for LSP support:
+- **Expression-level recovery**: missing `}`, `]`, or `)` delimiters trigger
+  `recover_to()` which advances to the next enclosing boundary, wrapping
+  consumed tokens in `ERROR_STOWAWAYS`.
+- **Declaration-level recovery**: headless declarations (e.g. a trailing
+  backtick with no following `name: value`) still produce a `DECLARATION`
+  node with an empty head. `Declaration::validate()` detects this and emits
+  a `MalformedDeclarationHead` error; the `ERROR` `SyntaxKind` is defined
+  for future use but is not yet emitted by the parser.
+- All parser panics in `validate.rs` are converted to proper errors.
+
+### AST
+
+*Implementation*: `src/syntax/rowan/ast.rs`
+
+The AST uses a two-layer design:
+1. **SyntaxNode** (Rowan) - Rich, source-preserving tree
+2. **AST Nodes** - Typed wrappers via macros
+
+```rust
+macro_rules! ast_node {
+    ($ast:ident, $kind:ident) => {
+        pub struct $ast(SyntaxNode);
+        impl AstNode for $ast { ... }
+    }
+}
+```
+
+**Key AST types:**
+
+| Type | Purpose |
+|------|---------|
+| `Unit` | Top-level file structure |
+| `Block` | Enclosed `{ ... }` block |
+| `Declaration` | Property/function declaration |
+| `DeclHead` | Declaration name (before `:`) |
+| `DeclBody` | Declaration value (after `:`) |
+| `Soup` | Unordered expression sequence |
+| `List` | List expression `[a, b, c]` |
+| `Name` | Identifier reference |
+| `Literal` | Literal value |
+| `StringPattern` | Interpolated string |
+
+## Core Expression Representation
+
+The core representation is an intermediate language that facilitates powerful transformations while maintaining source information for error reporting.
+
+### Expression Type
+
+*Implementation*: `src/core/expr.rs`
+
+The `Expr<T>` enum (where `T: BoundTerm<String>`) represents all expression forms:
+
+```rust
+pub enum Expr<T> {
+    // Variables
+    Var(Smid, Var<String>),           // Free or bound variable
+
+    // Primitives
+    Literal(Smid, Primitive),          // Number, string, symbol, bool, null
+
+    // Binding forms
+    Let(Smid, LetScope<T>, LetType),   // Recursive let binding
+    Lam(Smid, bool, LamScope<T>),      // Lambda abstraction
+
+    // Application
+    App(Smid, T, Vec<T>),              // Function application
+
+    // Data structures
+    List(Smid, Vec<T>),                // List literal
+    Block(Smid, BlockMap<T>),          // Object/record literal
+
+    // Operators (pre-cooking)
+    Operator(Smid, Fixity, Precedence, T),
+    Soup(Smid, Vec<T>),                // Unresolved operator soup
+
+    // Anaphora (implicit parameters)
+    BlockAnaphor(Smid, ...),
+    ExprAnaphor(Smid, ...),
+
+    // Access
+    Lookup(Smid, T, String, Option<T>), // Property access
+
+    // Metadata
+    Meta(Smid, T, T),                   // Expression with metadata
+
+    // Intrinsics
+    Intrinsic(Smid, String),           // Built-in function reference
+
+    // Error nodes
+    ErrUnresolved, ErrRedeclaration, ...
+}
+```
+
+**Primitive types:**
+```rust
+pub enum Primitive {
+    Str(String),
+    Sym(String),
+    Num(Number),
+    Bool(bool),
+    Null,
+}
+```
+
+**Standard wrapper**: `RcExpr` provides reference-counted immutable expressions with substitution and transformation methods.
+
+### Transformation Pipeline
+
+The core pipeline transforms expressions through several phases:
+
+```
+AST → Desugar → Cook → Simplify → Inline → Verify → STG
+```
+
+#### Desugaring
+
+*Implementation*: `src/core/desugar/`
+
+Transforms parsed AST into core expressions:
+- Converts block declarations into recursive let bindings
+- Extracts targets and documentation metadata
+- Handles imports and cross-file references
+- Processes both native AST and embedded data (JSON/YAML)
+
+#### Cooking
+
+*Implementation*: `src/core/cook/`
+
+Resolves operator precedence and anaphora:
+1. **Fixity distribution** - Propagate operator precedence info
+2. **Anaphor filling** - Infer missing implicit parameters (`(+ 10)` → `(_ + 10)`)
+3. **Shunting yard** - Apply precedence climbing to linearise operator soup
+4. **Anaphor processing** - Wrap lambda abstractions around anaphoric expressions
+
+Example transformation:
+```
+(+ 10)        →  (λ _ . (_ + 10))
+a + b * c     →  (+ a (* b c))      // with standard precedence
+```
+
+#### Simplification and Inlining
+
+*Implementation*: `src/core/simplify/`, `src/core/inline/`
+
+- **Compression** - Remove eliminated bindings
+- **Pruning** - Dead code elimination
+- **Inlining** - Inline marked expressions
+
+#### Verification
+
+*Implementation*: `src/core/verify/`
+
+Validates transformed expressions before STG compilation:
+- Binding verification
+- Content validation
+
+## STG Compilation and Evaluation Model
+
+Eucalypt uses a Spineless Tagless G-machine (STG) as its evaluation model, providing lazy evaluation with memoisation.
+
+### STG Syntax
+
+*Implementation*: `src/eval/stg/syntax.rs`
+
+The STG syntax represents executable code:
+
+```rust
+pub enum StgSyn {
+    Atom { evaluand: Ref },              // Value or reference
+    Case { scrutinee, branches, fallback }, // Pattern matching (evaluation point)
+    Cons { tag: Tag, args: Vec<Ref> },   // Data constructor
+    App { callable: Ref, args: Vec<Ref> }, // Function application
+    Bif { intrinsic: u8, args: Vec<Ref> }, // Built-in intrinsic
+    Let { bindings: Vec<LambdaForm>, body }, // Non-recursive let
+    LetRec { bindings: Vec<LambdaForm>, body }, // Recursive let
+    Ann { smid: Smid, body },            // Source annotation
+    Meta { meta: Ref, body: Ref },       // Metadata wrapper
+    DeMeta { scrutinee, handler, or_else }, // Metadata destructure
+    BlackHole,                            // Uninitialized marker
+}
+```
+
+**Reference types:**
+```rust
+pub enum Reference<T> {
+    L(usize),  // Local environment index
+    G(usize),  // Global environment index
+    V(T),      // Direct value (Native)
+}
+```
+
+**Lambda forms** control laziness:
+- `Lambda` - Function with explicit arity
+- `Thunk` - Lazy expression (evaluated and updated in-place)
+- `Value` - Already in WHNF (no update needed)
+
+### STG Compiler
+
+*Implementation*: `src/eval/stg/compiler.rs`
+
+The compiler transforms core expressions to STG syntax:
+
+```rust
+impl Compiler {
+    fn compile_body(&mut self, expr: &RcExpr) -> ProtoSyntax;
+    fn compile_binding(&mut self, expr: &RcExpr) -> ProtoBinding;
+    fn compile_lambda(&mut self, expr: &RcExpr) -> ProtoSyntax;
+    fn compile_application(&mut self, f: &RcExpr, args: &[RcExpr]) -> ProtoSyntax;
+}
+```
+
+**Key decisions:**
+- **Thunk creation**: Expressions not in WHNF and used more than once become thunks
+- **WHNF detection**: Constructors, native values, and metadata wrappers are WHNF
+- **Deferred compilation**: `ProtoSyntax` allows deferring binding construction until environment size is known
+
+### Virtual Machine
+
+*Implementation*: `src/eval/machine/vm.rs`
+
+The STG machine is a state machine executing closures:
+
+```rust
+pub struct MachineState {
+    root_env: SynEnvPtr,           // Empty root environment
+    closure: SynClosure,           // Current (code, environment) pair
+    globals: SynEnvPtr,            // Global bindings
+    stack: Vec<Continuation>,      // Continuation stack
+    terminated: bool,
+    annotation: Smid,              // Current source location
+}
+```
+
+**Execution loop:**
+```rust
+fn run(&mut self) {
+    while !self.terminated {
+        if self.gc_check_needed() {
+            self.collect_garbage();
+        }
+        self.step();
+    }
+}
+```
+
+**Instruction dispatch** (`handle_instruction`):
+
+| Code Form | Action |
+|-----------|--------|
+| `Atom` | Resolve reference; push Update continuation if thunk |
+| `Case` | Push Branch continuation, evaluate scrutinee |
+| `Cons` | Return data constructor |
+| `App` | Push ApplyTo continuation, evaluate callable |
+| `Bif` | Execute intrinsic directly |
+| `Let` | Allocate environment frame, continue in body |
+| `LetRec` | Allocate frame with backfilled recursive references |
+
+### Continuations
+
+*Implementation*: `src/eval/machine/cont.rs`
+
+Four continuation types manage control flow:
+
+1. **Branch** - Pattern matching branches for CASE
+2. **Update** - Deferred thunk update (memoisation)
+3. **ApplyTo** - Pending arguments for function application
+4. **DeMeta** - Metadata destructuring handler
+
+### Lazy Evaluation
+
+Laziness is achieved through thunks and updates:
+
+1. **Thunk creation** (compile time): Non-WHNF expressions become `LambdaForm::Thunk`
+2. **Thunk evaluation** (runtime): When a thunk is entered, push Update continuation
+3. **Memoisation**: After evaluation, update the environment slot with the result
+
+```rust
+// When entering a local reference
+if closure.update() {
+    stack.push(Continuation::Update { environment, index });
+}
+
+// After evaluation completes
+Continuation::Update { environment, index } => {
+    self.update(environment, index);  // Replace thunk with result
+}
+```
+
+## Memory Management and Garbage Collection
+
+Eucalypt uses an Immix-inspired memory layout with mark-and-sweep collection.
+
+### Memory Layout
+
+*Implementation*: `src/eval/memory/heap.rs`, `src/eval/memory/bump.rs`
+
+```
+Block (32KB)
+├── Line 0 (128B) ┐
+├── Line 1 (128B) │ 256 lines per block
+├── ...           │
+└── Line 255      ┘
+```
+
+**Size classes:**
+- **Small** (< 128 bytes) - Single line
+- **Medium** (128B - 32KB) - Multiple lines within block
+- **Large** (> 32KB) - Dedicated Large Object Block
+
+**Heap state:**
+```rust
+pub struct HeapState {
+    head: Option<BumpBlock>,           // Active small allocation
+    overflow: Option<BumpBlock>,       // Active medium allocation
+    recycled: VecDeque<BumpBlock>,     // Blocks with reusable holes
+    rest: VecDeque<BumpBlock>,         // Used blocks pending collection
+    lobs: Vec<LargeObjectBlock>,       // Large objects
+}
+```
+
+### Object Headers
+
+*Implementation*: `src/eval/memory/header.rs`
+
+Every object has a 16-byte header:
+```rust
+pub struct AllocHeader {
+    bits: HeaderBits,                  // Mark bit + forwarded flag
+    alloc_length: u32,                 // Object size
+    forwarded_to: Option<NonNull<()>>, // For potential evacuation
+}
+```
+
+### Garbage Collection
+
+*Implementation*: `src/eval/memory/collect.rs`
+
+**Mark phase:**
+1. Reset line maps across all blocks
+2. Breadth-first root scanning from machine state
+3. Transitive closure following object references
+4. Mark lines containing live objects
+
+**Sweep phase:**
+1. Scan line maps in each block
+2. Identify holes (2+ consecutive free lines)
+3. Move recyclable blocks to recycled list
+
+**Collection triggering:**
+- When `--heap-limit-mib` is set and limit exceeded
+- Check performed every 500 VM execution steps
+- Emergency collection on allocation failure
+
+See `gc-implementation.md` for detailed analysis.
+
+## The Prelude and Standard Library
+
+### Intrinsic Functions
+
+*Implementation*: `src/eval/intrinsics.rs`, `src/eval/stg/`
+
+Built-in functions are implemented in Rust and indexed by position:
+
+**Categories:**
+- **Control flow**: `__IF`, `__PANIC`, `__TRUE`, `__FALSE`, `__NULL`
+- **Lists**: `__CONS`, `__HEAD`, `__TAIL`, `__NIL`, `__REVERSE`
+- **Blocks**: `__MERGE`, `__DEEPMERGE`, `__ELEMENTS`, `__BLOCK`, `__LOOKUP`
+- **Arithmetic**: `__ADD`, `__SUB`, `__MUL`, `__DIV`, `__MOD`, comparisons
+- **Strings**: `__STR`, `__SPLIT`, `__JOIN`, `__MATCH`, `__FMT`
+- **Metadata**: `__META`, `__WITHMETA`
+- **Time**: `__ZDT`, `__ZDT.PARSE`, `__ZDT.FORMAT`
+- **I/O**: `__io.ENV`, `__io.EPOCHTIME`
+- **Emission**: `__RENDER`, `__EMIT*` family
+
+Each intrinsic implements the `StgIntrinsic` trait with direct access to machine state.
+
+### Prelude
+
+*Implementation*: `lib/prelude.eu`
+
+The prelude (~29KB) is written entirely in eucalypt, wrapping intrinsics with ergonomic functions:
+
+**List functions:**
+- `take`, `drop`, `nth` (`!!`), `fold`/`foldr`, `map`, `filter`
+- `append` (`++`), `concat`, `reverse`, `zip`, `group-by`, `qsort`
+
+**Block functions:**
+- `merge-all`, `keys`, `values`, `map-kv`, `map-keys`, `map-values`
+- `lookup-path`, `alter-value`, `update-value`
+
+**Combinators:**
+- `identity`, `const`, `compose` (`∘`, `;`), `flip`, `curry`, `uncurry`
+
+**String functions:**
+- `str.split`, `str.join`, `str.match`, `str.fmt`, `str.letters`
+
+**Loading:**
+- Prelude is embedded in the binary at compile time
+- Loaded by default unless `--no-prelude` / `-Q` flag is used
+
+## Driver and CLI Architecture
+
+### Entry Point
+
+*Implementation*: `src/bin/eu.rs`, `src/driver/options.rs`
+
+The CLI uses `clap v4` with derive macros:
+
+```rust
+#[derive(Parser)]
+struct EucalyptCli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+    files: Vec<String>,
+    // Global options...
+}
+
+enum Commands {
+    Run(RunArgs),
+    Test(TestArgs),
+    Dump(DumpArgs),
+    Fmt(FmtArgs),
+    Explain(ExplainArgs),
+    ListTargets(ListTargetsArgs),
+    Version,
+}
+```
+
+### Modes of Operation
+
+**Run (default):**
+```bash
+eu file.eu                    # Implicit run
+eu -e "expression" file.eu    # With evaluand
+eu -x json file.eu            # JSON output
+eu -t target file.eu          # Select target
+```
+
+**Test:**
+```bash
+eu test tests/              # Run all tests in directory
+eu test -t specific file.eu  # Run specific test target
+```
+
+**Format:**
+```bash
+eu fmt file.eu              # Print formatted to stdout
+eu fmt --write file.eu      # Modify in place
+eu fmt --check file.eu      # Check formatting (exit 1 if needs format)
+```
+
+**Dump:**
+```bash
+eu dump ast file.eu          # Dump AST
+eu dump desugared file.eu    # Dump after desugaring
+eu dump stg file.eu          # Dump STG syntax
+eu dump runtime              # Dump intrinsic definitions
+```
+
+### Output Formats
+
+*Implementation*: `src/export/`
+
+Emitters for each format implement the `Emitter` trait:
+- **YAML** (`yaml.rs`) - Uses `yaml_rust`, supports tags from metadata
+- **JSON** (`json.rs`) - Uses `serde_json`
+- **TOML** (`toml.rs`) - Structured output
+- **Text** (`text.rs`) - Plain text
+- **EDN** (`edn.rs`) - Clojure-like format
+- **HTML** (`html.rs`) - Markup with serialisation
+
+### Input Handling
+
+Inputs are merged in order:
+1. **Prologue**: Prelude, config files, build metadata, IO block
+2. **Explicit**: Files and options (`-c`/`--collect-as`)
+3. **Epilogue**: CLI evaluand (`-e`)
+
+Names from earlier inputs are available to later inputs.
+
+## Key Design Decisions and Trade-offs
+
+### Why STG?
+
+The STG machine provides a well-defined reference point for lazy functional language implementation:
+- Clear semantics for lazy evaluation with memoisation
+- Established compilation strategies
+- Potential for future optimisations
+
+*Trade-off*: More complex than direct interpretation but provides a solid foundation.
+
+### Why Rowan for Parsing?
+
+Rowan provides:
+- Incremental parsing for IDE support
+- Full source fidelity (preserves whitespace and comments)
+- Error recovery for partial parsing
+
+*Trade-off*: More complex API than traditional parser generators.
+
+### Core as Intermediate Language
+
+The core representation enables powerful transformations:
+- User-definable operator precedence resolved by syntax transformation
+- Block semantics (binding vs structuring) separated cleanly
+- Source information preserved through `Smid` for error reporting
+
+*Trade-off*: Additional compilation phase, but enables experimentation.
+
+### Block Duality
+
+Eucalypt blocks serve two roles:
+1. **Name binding** - Like `let` expressions
+2. **Data structuring** - Like objects/records
+
+The core phase separates these into distinct `Let` and `Block` expressions.
+
+*Trade-off*: Elegant surface syntax at cost of semantic complexity.
+
+### Immix-Inspired GC
+
+The memory layout provides:
+- Efficient bump allocation
+- Cache-friendly organisation
+- Effective hole reuse
+
+*Current limitation*: No evacuation/compaction (mark-sweep only).
+
+See `gc-implementation.md` for detailed analysis.
+
+### Embedded Prelude
+
+The prelude is:
+- Written in eucalypt itself
+- Compiled into the binary
+- Loaded unless explicitly disabled
+
+*Benefit*: Dogfooding, consistent semantics
+*Trade-off*: Slower startup if prelude is large
+
+## Performance Characteristics
+
+### Compilation
+- Parsing: O(n) with incremental support
+- Desugaring: O(n) pass over AST
+- Cooking: O(n log n) for operator precedence resolution
+- STG compilation: O(n) with binding analysis
+
+### Execution
+- Bump allocation: O(1) for most objects
+- Thunk updates: O(1) memoisation
+- GC: O(live objects) for marking, O(total blocks) for sweeping
+
+### Memory
+- 16-byte header overhead per object
+- Block-level allocation granularity
+- Large objects get dedicated blocks
+
+## Code Organisation Summary
+
+| Directory | Purpose | Key Files |
+|-----------|---------|-----------|
+| `src/syntax/rowan/` | Incremental parsing | `lex.rs`, `parse.rs`, `ast.rs` |
+| `src/core/` | Expression representation | `expr.rs` |
+| `src/core/desugar/` | AST to core | `desugarer.rs` |
+| `src/core/cook/` | Operator resolution | `shunt.rs`, `fixity.rs` |
+| `src/eval/stg/` | STG syntax and compiler | `syntax.rs`, `compiler.rs` |
+| `src/eval/machine/` | Virtual machine | `vm.rs`, `cont.rs`, `env.rs` |
+| `src/eval/memory/` | Heap and GC | `heap.rs`, `collect.rs` |
+| `src/driver/` | CLI orchestration | `options.rs`, `eval.rs` |
+| `src/export/` | Output formats | `yaml.rs`, `json.rs` |
+| `lib/` | Standard library | `prelude.eu` |
+
+## Further Reading
+
+- `implementation.md` - Brief implementation overview
+- `gc-implementation.md` - Detailed GC documentation
+- `command-line.md` - CLI usage guide
+- `syntax.md` - Language syntax reference
+- `operators-and-identifiers.md` - Operator definitions
+- `anaphora-and-lambdas.md` - Implicit parameter handling
+
+---
+
+# Eucalypt Style Guide
+
+Eucalypt is very flexible and allows you to write extremely ugly code.
+
+Here is some general style guidance for writing eucalypt idiomatically.
+
+## List access
+
+- **`head`/`tail`** for list decomposition (variable-length, processing elements sequentially)
+- **`first`/`second`/`!! n`** for positional access into fixed-size tuples or records
+
+Don't mix idioms on the same context. If you use `second(xs)`, use `first(xs)` not `head(xs)`. If you use `!! 2`, use `!! 0` and `!! 1` not `first` and `second`.
+
+## Conditionals
+
+- Prefer simple (unnested) conditionals.
+- Use `<bool> then(a, b)` over `if(cond, a, b)` for simple
+  conditionals.
+- If nesting is unavoidable, use `if`, nested `then`s are confusing.
+- Never mix `if()` and `then()` in the same expression — it looks like they go together and is confusing. 
+- Prefer restructuring to eliminate conditionals altogether: use `nil?` guards, `max`, `min`, default values (`min-of-or`, `max-of-or`), etc.
+- **`then(false, x)` and `then(true, x)` are antipatterns.** Refactor to
+  disjunctions and conjunctions: `cond ∧ x`, `cond ∨ x`, etc.
+  Use block bindings or parentheses to keep `∧`/`∨` separated from
+  catenation pipelines:
+  ```
+  { ok: xs non-nil?
+    result: xs map(f) sum
+  }.(ok ∧ result > 0)
+  ```
+
+### Multi-way conditionals: `cond`
+
+Use `cond` for three or more branches instead of nesting `if`. The `=>`
+operator (precedence 15, left-associative; Unicode alias `⇒`) builds a
+clause pair. The last list element is the default:
+
+```eu,notest
+# Prefer: cond for multi-way dispatch
+classify(n): cond[n < 0 => "negative", n > 100 => "huge", "normal"]
+
+# Avoid: nested if
+classify(n): if(n < 0, "negative", if(n > 100, "huge", "normal"))
+```
+
+Rules:
+- Use `cond` when there are **three or more branches**.
+- Use `if` or `then` for a single two-way test.
+- Use `when` for a **conditional transform** (pass-through if condition is false).
+- `cond` integrates with the type checker's flow-sensitive narrowing: each
+  clause condition narrows the variable's type within that branch.
+- The `⇒` Unicode alias is accepted everywhere `=>` is (input via `>>` in
+  the eucalypt input method).
+
+## Catenation precedence
+
+Catenation (juxtaposition / pipeline application) has the **lowest** operator precedence (20). ALL infix operators bind tighter, including `∧` (35), `∨` (30), `=` (40), `+` (75), etc. This means infix operators steal adjacent atoms from catenation pipelines:
+
+- `xs f(a) + 1` parses as `(f(a) + 1)(xs)` — `+` grabs `f(a)` and `1` into one unit, which is then applied to `xs` (not the reverse)
+- `(k > 0) ∧ xs non-nil?` parses as `((k > 0) ∧ xs) non-nil?` — `∧` grabs `xs`
+- `xs tail ++ [0]` parses as `(tail ++ [0])(xs)` — `++` grabs `tail` and `[0]` into one unit, which is then applied to `xs`
+
+Fix with parens around the catenation: `(k > 0) ∧ (xs non-nil?)`, `(xs tail) ++ [0]`.
+
+## Pipelines
+
+- The clearest function definition is a straight pipeline. Structure programs to maximise them.
+- Prefer pipeline (catenation) style: `xs head` not `head(xs)`, `xs map(f) filter(g)` not `filter(g, map(f, xs))`.
+- Use `;` (compose) for point-free function definitions and embedding
+  in pipelines: `abs ; (+ 1)`. 
+- `∘` is also acceptable, particularly in mathematical of strongly FP contexts
+- Partial application for pipeline steps: `map(area(p))`, `filter(v-spans(y))`.
+
+## Parameter order
+
+Choose parameter order to support partial application and pipeline style:
+
+- Put the "data" or "collection" parameter **last** so that partially applied functions slot into pipelines: `g remove-node("dac") count-paths("svr")` reads as a pipeline of transformations.
+- Put "configuration" or "small" parameters **first** so they can be fixed early: `map(lookup-count(table))`, `foldl(dp-step(g), {}, order)`.
+- If a function will be used as a `foldl` accumulator, match the `(acc, elem)` signature: `dfs-topo(g, state, node)` allows `foldl(dfs-topo(g), init, nodes)`.
+
+When in doubt, ask: "how will this function most commonly be called?" and put the varying argument last.
+
+## Naming
+
+- Predicates end with `?`: `vertical?`, `nil?`, `at-y`.
+- Use descriptive names: `make-edges` not `mk-edges`.
+
+## Recursion
+
+- Prefer folds, scans, or specific prelude algorithms over explicit recursion where possible.
+
+## Documentation
+
+- Use backtick string metadata (`` ` "..." ``) for documenting declarations. Backtick metadata attaches to the next declaration, so only use it when the comment is specific to that declaration.
+- Use `#` comments for inline explanatory notes within blocks (e.g. section separators, notes that apply to a group of bindings rather than one declaration) and for disabling code.
+- Doc metadata should be markdown: use backquotes for `param` and `function` names.
+
+## Sections and anaphora
+
+- Prefer sections without superfluous brackets: `iterate(+ 2, 0)` not `iterate((+ 2), 0)`, `map(* 2)` not `map((* 2))`.
+- Prefer sections over anaphora when a section suffices: `map(* 2)` not `map(_ * 2)`.
+- Use anaphora when the expression genuinely needs more than a simple section:  `map(_ * _ + 1)`.
+
+## String building
+
+- Use **string interpolation** for combining a fixed number of values: `"{pfx}{name}"` not `[pfx, name] str.join-on("")`.
+- Interpolation auto-converts values — symbols, numbers, etc. No `str.of` needed: `"{:foo}"` gives `"foo"`.
+- `str.join-on` is for joining a *list* of variable length, not for concatenating two known values.
+- String anaphora (`•`) works inside interpolation: `names map("{•}-suffixed")`.
+
+## Call syntax
+
+- Use **juxtaposed call syntax** with list/block arguments: `f[x, y]` not `f([x, y])`, `g{a: 1}` not `g({a: 1})`.
+- More generally, avoid superfluous parentheses around arguments that are already delimited: lists `[...]`, blocks `{...}`, and strings `"..."` do not need wrapping parens.
+
+## Blocks
+
+- Use blocks for local bindings: `{ x: ... y: ... }.(x + y)`, but limit to one block, do not stack this construct
+- Keep block "results"" in `.(...)` concise, preferably simple pipelines or expressions, or even just `{...}.result`
+- **Dynamic generalised lookup**: a function can return a block whose names are then used as a namespace for subsequent pipelines, e.g. `prepare(data).( edges take(k) ... )`. Use very sparingly — it can defeat static analysis. Never nest or stack dynamic lookups.
+- **Monadic blocks in lookup chains**: a monadic block after `.` gets implicit return and sees the LHS bindings. Use parens if you need an explicit return expression in lookup position: `ctx.(({ :let ... }.(expr)))`.
+- **Capture scope with local bindings**: when helpers share parameters, move them inside a block so they capture from scope rather than threading parameters explicitly:
+  ```eu,notest
+  # Before: f threaded through every helper
+  helper(f, x): f(x) + 1
+  go(f, xs): xs map(helper(f))
+
+  # After: f captured from enclosing block
+  go(f, xs): {
+    helper(x): f(x) + 1
+  }.(xs map(helper))
+  ```
+- **Reuse a name with `:let`**: an ordinary block binding sees *itself* on its
+  right-hand side, so `{ xs: xs map(f) }` is self-reference — `xs` is the new
+  binding, not an outer `xs` — which errors with "binding refers to itself" (or
+  loops when the shadowed name is in function position, e.g. `{ f: f(x) }`). To
+  transform a value and keep its name, use a sequential **`:let`** block, whose
+  RHS sees the *outer* scope and prior bindings, not itself:
+  ```eu,notest
+  normalise(xs): { :let xs: xs map(clean) }.xs   # RHS xs is the parameter
+  ```
+  Otherwise just pick a different local name: `{ cleaned: xs map(clean) }.cleaned`.
+
+- **Defaulting values from an options block**: to fill in specific
+  missing keys in a block from a defaults/options block, use
+  `select` + merge rather than repeated `lookup-or` calls:
+  ```eu,notest
+  # Good: select the keys you want defaulted, merge under the input
+  defaults select[:host, :port] config
+
+  # Avoid: verbose and repetitive
+  { host: config lookup-or(:host, defaults.host)
+    port: config lookup-or(:port, defaults.port)
+    db: config.db }
+  ```
+  The pattern is `defaults select[<keys-to-default>] input` — `select`
+  restricts the defaults block to the keys you want, then merge
+  applies them underneath the input (so input values win).
+
+## Prefer `when` over `if` for conditional transforms
+
+- `when(pred?, f, x)` applies `f` when `pred?` matches, otherwise passes `x` through unchanged. Cleaner than `if(pred?(x), f(x), x)` which repeats `x`.
+  ```eu,notest
+  # Before: x repeated in both branches
+  if(x number?, x + 1, x)
+
+  # After
+  x when(number?, + 1)
+  ```
+
+## Prefer point-free composition
+
+- Use `bimap`, `compose` (`;`), and partial application to eliminate intermediate named functions:
+  ```eu,notest
+  # Before: named function to combine two transforms on a pair
+  transform[k, v]: [rename(k), process(v)]
+  blk map-elements(transform)
+
+  # After: bimap composes the two directly
+  blk map-elements(bimap(rename, process))
+  ```
+
+## Avoid nested `if` for type dispatch
+
+- Nested `if(block?, ..., if(list?, ..., if(symbol?, ...)))` chains are hard to read. Prefer:
+  - **`deep-transform`** for recursive structural rewriting — it handles the block/list/atom dispatch internally
+  - **`when`** for single conditional transforms
+  - **Named predicates** for readability
+
+## Sets for membership
+
+- Use sets (`set.from-list`) for repeated membership testing, not `any(= x)` over a list. Faster and reads better with `∈`:
+  ```eu,notest
+  # Before
+  allowed: [:a, :b, :c]
+  allowed any(= v)
+
+  # After
+  allowed: set.from-list[:a, :b, :c]
+  v ∈ allowed            # as expression
+  v when(∈ allowed, f)   # section as predicate
+  ```
+
+---
+
+# Frequently Asked Questions
+
+## Getting Started
+
+### How do I install eucalypt?
+
+On macOS, use Homebrew:
+
+```sh
+brew install curvelogic/homebrew-tap/eucalypt
+```
+
+On Linux or macOS without Homebrew, use the install script:
+
+```sh
+curl -sSf https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+```
+
+You can also download a binary from the
+[GitHub releases](https://github.com/curvelogic/eucalypt/releases)
+page, or build from source with `cargo install --path .`.
+
+Verify installation with:
+
+```sh
+eu version
+```
+
+### How do I convert between data formats?
+
+Pass a file in one format and specify the output format with `-x` or
+`-j`:
+
+```sh
+# YAML to JSON
+eu data.yaml -j
+
+# JSON to YAML (default output)
+eu data.json
+
+# YAML to TOML
+eu data.yaml -x toml
+```
+
+### What data formats does eucalypt support?
+
+**Input formats**: YAML, JSON, JSON Lines (jsonl), TOML, EDN, XML,
+CSV, plain text, and eucalypt's own `.eu` syntax.
+
+**Output formats**: YAML (default), JSON, TOML, EDN, and plain text.
+
+**Streaming input formats** (for large files): `jsonl-stream`,
+`csv-stream`, `text-stream`.
+
+### How do I use eucalypt in a pipeline?
+
+`eu` reads from stdin by default when used in a pipe and writes to
+stdout:
+
+```sh
+# Filter JSON from an API
+curl -s https://api.example.com/data | eu -e 'items filter(.active)'
+
+# Transform and re-export
+cat data.yaml | eu transform.eu -j > output.json
+```
+
+Use `-e` to specify an expression to evaluate against the input data.
+
+### How do I pass arguments to a eucalypt program?
+
+Use `--` to separate `eu` flags from program arguments:
+
+```sh
+eu program.eu -- arg1 arg2 arg3
+```
+
+Inside your program, access them via `io.args`:
+
+```eu
+name: io.args head-or("World")
+greeting: "Hello, {name}!"
+```
+
+## Language
+
+### How do functions work in eucalypt?
+
+Define functions with a parameter list after the name:
+
+```eu
+double(x): x * 2
+result: double(21) //=> 42
+```
+
+Functions are curried -- applying fewer arguments than expected returns
+a partially applied function:
+
+```eu
+add(x, y): x + y
+increment: add(1)
+result: increment(9) //=> 10
+```
+
+### What is catenation?
+
+Catenation is eucalypt's pipeline syntax. Writing `x f` applies `f` to
+`x` as a single argument:
+
+```eu
+add-one(x): x + 1
+result: 5 add-one //=> 6
+```
+
+Chain multiple transforms by writing them in sequence:
+
+```eu
+double(x): x * 2
+add-one(x): x + 1
+result: 5 double add-one //=> 11
+```
+
+This reads left to right: start with 5, double it (10), add one (11).
+
+### What are anaphora and when should I use them?
+
+Anaphora are implicit parameters that let you define simple functions
+without naming them. There are three kinds:
+
+**Expression anaphora** (`_`, `_0`, `_1`): turn an expression into a
+function.
+
+```eu
+squares: [1, 2, 3] map(_0 * _0) //=> [1, 4, 9]
+```
+
+**String anaphora** (`{}`, `{0}`, `{1}`): turn a string template into
+a function.
+
+```eu
+labels: [1, 2, 3] map("item-{}") //=> ["item-1", "item-2", "item-3"]
+```
+
+**Block anaphora** (`•`, `•0`, `•1`): turn a block into a function.
+
+Use anaphora for simple, readable cases. For anything more complex,
+prefer a named function. See [Anaphora](guide/anaphora.md) for details.
+
+### Why is there no lambda syntax?
+
+Eucalypt deliberately omits lambda expressions. Instead, use:
+
+1. **Named functions** for anything non-trivial
+2. **Anaphora** (`_`, `{}`) for simple one-liners
+3. **Sections** (`(+ 1)`, `(* 2)`) for operator-based functions
+4. **Partial application** (`add(1)`) for curried functions
+
+```eu
+# All equivalent ways to add one:
+add-one(x): x + 1
+result1: [1, 2, 3] map(add-one) //=> [2, 3, 4]
+result2: [1, 2, 3] map(_ + 1) //=> [2, 3, 4]
+result3: [1, 2, 3] map(+ 1) //=> [2, 3, 4]
+```
+
+### How does block merging work?
+
+When you write one block after another (catenation), they merge:
+
+```eu
+base: { a: 1 b: 2 }
+overlay: { b: 3 c: 4 }
+merged: base overlay //=> { a: 1 b: 3 c: 4 }
+```
+
+The second block's values override the first. This is a **shallow**
+merge. For recursive deep merge, use the `<<` operator:
+
+```eu
+base: { x: { a: 1 b: 2 } }
+extra: { x: { c: 3 } }
+result: base << extra
+```
+
+### How do I handle the lookup precedence gotcha?
+
+The `.` (lookup) operator has higher precedence than catenation, so
+`xs head.id` groups `head.id` into one unit first — and that unit,
+not `xs`, is what gets applied: it parses as `head.id(xs)`, not
+`(xs head).id`. The `↑` (head) prefix operator binds even tighter
+still: `↑xs.id` means `(↑xs).id`, not `↑(xs.id)`.
+
+Use explicit parentheses:
+
+```eu
+data: [{ id: 1 }, { id: 2 }]
+first-id: (data head).id //=> 1
+```
+
+See [Syntax Gotchas](appendices/syntax-gotchas.md) for more.
+
+## Data Processing
+
+### How do I filter and transform lists?
+
+Use `map` to transform and `filter` to select:
+
+```eu
+numbers: [1, 2, 3, 4, 5, 6]
+small: numbers filter(< 4) //=> [1, 2, 3]
+doubled: numbers map(* 2) //=> [2, 4, 6, 8, 10, 12]
+```
+
+Combine them in a pipeline:
+
+```eu
+result: [1, 2, 3, 4, 5, 6] filter(> 3) map(* 10) //=> [40, 50, 60]
+```
+
+### How do I look up values in nested blocks?
+
+Use chained `.` lookups for known paths:
+
+```eu
+config: { db: { host: "localhost" port: 5432 } }
+host: config.db.host //=> "localhost"
+```
+
+For dynamic key lookup, use `lookup` with a symbol:
+
+```eu
+data: { name: "Alice" age: 30 }
+field: data lookup(:name) //=> "Alice"
+```
+
+Use `lookup-or` to provide a default:
+
+```eu
+data: { name: "Alice" }
+age: data lookup-or(:age, 0) //=> 0
+```
+
+### How do I search deeply nested data?
+
+Use `deep-find` for recursive key search:
+
+```eu,notest
+# Finds all values for key "id" at any depth
+ids: data deep-find("id")
+```
+
+Use `lookup-path` for a known sequence of keys:
+
+```eu
+data: { a: { b: { c: 42 } } }
+result: data lookup-path([:a, :b, :c]) //=> 42
+```
+
+### How do I sort data?
+
+Sort lists with `sort-nums` or `sort-strs`:
+
+```eu
+names: ["Charlie", "Alice", "Bob"]
+sorted: names sort-strs //=> ["Alice", "Bob", "Charlie"]
+```
+
+```eu
+nums: [5, 1, 3, 2, 4]
+sorted: nums sort-nums //=> [1, 2, 3, 4, 5]
+```
+
+For sorting by a key, use `sort-by-str` or `sort-by-num`:
+
+```eu
+people: [{ name: "Zoe" age: 25 }, { name: "Amy" age: 30 }]
+by-name: people sort-by-str(.name)
+youngest: (by-name head).name //=> "Amy"
+```
+
+### How do I work with dates?
+
+Use `t"..."` literals for date-time values:
+
+```eu
+meeting: t"2024-03-15T14:30:00Z"
+date-only: t"2024-03-15"
+before: t"2024-01-01" < t"2024-12-31" //=> true
+```
+
+See [Date, Time, and Random Numbers](guide/date-time-random.md) for
+parsing, formatting, and arithmetic.
+
+## Advanced
+
+### How do I attach metadata to declarations?
+
+Use the backtick (`` ` ``) prefix:
+
+```eu
+` "Compute the square of a number"
+square(x): x * x
+
+result: square(5) //=> 25
+```
+
+Metadata can be a string (documentation) or a block with structured
+data:
+
+```eu,notest
+` { doc: "Custom operator" associates: :left precedence: 75 }
+(l <+> r): l + r
+```
+
+### How do imports work?
+
+Imports are specified in declaration metadata using the `import` key:
+
+```eu,notest
+{ import: "helpers.eu" }
+
+result: helper-function(42)
+```
+
+For named imports (scoped access):
+
+```eu,notest
+{ import: "cfg=config.eu" }
+
+host: cfg.host
+```
+
+See [Import Formats](reference/import-formats.md) for the full syntax
+including git imports.
+
+### How do I write tests?
+
+Use the `//=>` assertion operator to check values inline:
+
+```eu
+double(x): x * 2
+result: double(21) //=> 42
+```
+
+If the assertion fails, eucalypt panics with a non-zero exit code.
+Other assertion operators:
+
+```eu
+x: 5
+check1: (x > 3) //!
+check2: x //=? (> 0)
+```
+
+### How do I generate random values?
+
+Use `io.random` for a stream of random floats, or pass `--seed` for
+reproducible output:
+
+```eu,notest
+die: random.int(6, io.random).value + 1
+```
+
+```sh
+eu --seed 42 game.eu
+```
+
+See [Random Numbers](reference/prelude/random.md) for the full API.
+
+### What are sets and how do I use them?
+
+The `set` namespace provides set operations. Convert lists to sets
+with `set.from-list`:
+
+```eu
+sa: set.from-list([1, 2, 3, 4])
+sb: set.from-list([3, 4, 5, 6])
+common: sa set.intersect(sb) set.to-list //=> [3, 4]
+combined: sa set.union(sb) set.to-list sort-nums //=> [1, 2, 3, 4, 5, 6]
+diff: sa set.diff(sb) set.to-list sort-nums //=> [1, 2]
+```
+
+---
+
+# Syntax Cheat Sheet
+
+A dense single-page reference covering all syntax forms, operators,
+common patterns, and key prelude functions.
+
+## Primitives
+
+| Type | Syntax | Examples |
+|------|--------|----------|
+| Integer | digits | `42`, `-7`, `0` |
+| Float | digits with `.` | `3.14`, `-0.5` |
+| String | double quotes | `"hello"`, `"line\nbreak"` |
+| Symbol | colon prefix | `:key`, `:name` |
+| Boolean | literals | `true`, `false` |
+| Null | literal | `null` |
+| ZDT | `t"..."` prefix | `t"2024-03-15"`, `t"2024-03-15T14:30:00Z"` |
+
+## Blocks
+
+```eu,notest
+# Property declaration
+name: expression
+
+# Function declaration
+f(x, y): expression
+
+# Operator declaration (binary)
+(l ++ r): expression
+
+# Operator declaration (prefix / postfix)
+(! x): expression
+(x ******): expression
+
+# Block literal
+{ a: 1 b: 2 c: 3 }
+
+# Commas are optional
+{ a: 1, b: 2, c: 3 }
+
+# Nested blocks
+{ outer: { inner: "value" } }
+```
+
+**Top-level unit**: the file itself is an implicit block (no braces needed).
+
+## Lists
+
+```eu,notest
+# List literal
+[1, 2, 3]
+
+# Empty list
+[]
+
+# Mixed types
+[1, "two", :three, true]
+```
+
+## String Interpolation
+
+```eu,notest
+# Insert expressions with {braces}
+"Hello, {name}!"
+
+# String anaphora (defines a function)
+"#{}"           # one-parameter function
+"{0} and {1}"   # two-parameter function
+```
+
+## Comments
+
+```eu,notest
+# Line comment (to end of line)
+x: 42 # inline comment
+```
+
+## Declarations
+
+| Form | Syntax | Notes |
+|------|--------|-------|
+| Property | `name: expr` | Defines a named value |
+| Function | `f(x, y): expr` | Named function with parameters |
+| Block pattern | `f({x y}): expr` | Destructures block argument fields |
+| Block rename | `f({x: a  y: b}): expr` | Destructures with renamed bindings |
+| List pattern | `f([a, b, c]): expr` | Destructures fixed-length list |
+| Cons pattern | `f([h : t]): expr` | Destructures head and tail of list |
+| Binary operator | `(l op r): expr` | Infix operator |
+| Prefix operator | `(op x): expr` | Unary prefix |
+| Postfix operator | `(x op): expr` | Unary postfix |
+| Idiot bracket | `⟦ xs ⟧: expr` | Custom Unicode bracket pair |
+
+## Declaration Visibility
+
+```eu,notest
+# Suppress from output (still visible to importers)
+` :suppress
+secret: 42
+
+# Internal — invisible to importers AND output (unit-private)
+` :internal
+private-data: "unit only"
+
+# Structured form
+` { export: :internal }
+also-private: "hidden"
+```
+
+## Idiot Brackets
+
+Idiot brackets allow custom Unicode bracket pairs that collect their
+content items into a list and pass it to a function.
+
+```eu,notest
+# Declare a bracket pair function (xs receives a list)
+⟦ xs ⟧: xs map(_ * 2)
+
+# Items are collected as a list: ⟦ a b c ⟧ = ⟦⟧([a, b, c])
+result: ⟦ 3 4 5 ⟧  # [6, 8, 10]
+```
+
+Any matching Unicode bracket pair works, e.g. `⟦⟧`, `⟨⟩`, `⟪⟫`, `⌈⌉`, `⌊⌋`, `‹›`, `⦃⦄`, `⦇⦈`, `⦉⦊`, `«»`,
+`【】`, `〔〕`, `〖〗`, `〘〙`, `〚〛`.
+
+The prelude defines `⌈⌉` and `⌊⌋` for ceiling and floor:
+
+```eu,notest
+⌈3.2⌉    # 4
+⌊3.8⌋    # 3
+⌈-1.5⌉   # -1
+⌊-1.5⌋   # -2
+```
+
+## Monadic Blocks
+
+Monadic sequencing (like `do`-notation) is supported via bracket pairs or block
+metadata.  A bracket block or annotated block followed by `.expr` desugars to a
+bind chain.
+
+```eu,notest
+# Bracket pair definition — explicit functions
+⟦{}⟧: { :monad bind: my-bind  return: my-return }
+
+# Bracket pair definition — namespace reference
+⟦{}⟧: { :monad namespace: my-monad }
+
+# ⟦ a: ma  b: mb ⟧.return_expr
+# desugars to: bind(ma, (a): bind(mb, (b): return(return_expr)))
+result: ⟦ a: ma  b: mb ⟧.(a + b)
+```
+
+All declarations are bind steps whose names are in scope for later declarations
+and the return expression.  The return expression follows the closing bracket (or
+block) as `.name`, `.(expr)`, or `.[list]`.
+
+**Restrictions:** monad brackets **cannot be empty** (at least one
+declaration required) and **cannot contain block metadata**.
+
+**Built-in monadic namespaces:**
+
+| Tag | Monad | Action type | Element type |
+|-----|-------|-------------|--------------|
+| `:io` | IO effects | `IO(a)` | `a` |
+| `:random` | Random state | `stream → {value: a, rest: stream}` | `a` |
+| `:state` | Block state (import `state.eu`) | `state → {value: a, state: state}` | `a` |
+| `:let` | Identity (sequential bindings) | any | same |
+| `:for` | List (comprehensions) | `[a]` | `a` |
+
+```eu,notest
+# List comprehension: cartesian product with filter
+{ :for x: [1, 2, 3], _: [x] filter(> 1) }.(x * 10)
+# => [20, 30]
+```
+
+## Metadata Annotations
+
+```eu,notest
+# Declaration metadata (backtick prefix)
+` "Documentation string"
+name: value
+
+# Structured metadata
+` { doc: "description" associates: :left precedence: 50 }
+(l op r): expr
+
+# Unit-level metadata (first expression in file)
+{ :doc "Unit description" }
+a: 1
+```
+
+**Special metadata keys**: `:target`, `:suppress`, `:internal`, `:main`,
+`associates`, `precedence`, `import`, `:deprecated`.
+
+**Declaration visibility (`export:`)**: `:normal` (default, rendered and
+importable), `:suppress` (hidden from output, still importable),
+`:internal` (hidden from output AND importers — unit-private).
+
+## Deprecation
+
+Mark a declaration as deprecated to emit a warning whenever it is used:
+
+```eu,notest
+# Bare deprecation (simplest form)
+` :deprecated
+old-fn(x): x
+
+# With a message
+` { deprecated: "use new-fn instead" }
+old-fn(x): x
+
+# With message and replacement hint
+` { deprecated: "use new-fn instead"
+    replaced-by: "new-fn" }
+old-fn(x): x
+```
+
+Deprecation warnings appear on stderr during evaluation and in LSP diagnostics.
+Under `eu check --strict`, deprecation warnings become errors.
+
+## Function Application
+
+```eu,notest
+# Parenthesised application (no whitespace before paren)
+f(x, y)
+
+# Catenation (pipeline style, single argument)
+x f              # equivalent to f(x)
+x f g h          # equivalent to h(g(f(x)))
+
+# Partial application (curried)
+add(1)           # returns a function adding 1
+
+# Sections (operator with gaps)
+(+ 1)            # function: add 1
+(* 2)            # function: multiply by 2
+(/)              # function: floor divide (two params)
+(÷)              # function: precise divide (two params)
+```
+
+## Lookup and Generalised Lookup
+
+```eu,notest
+# Simple lookup
+block.key
+
+# Generalised lookup (evaluate RHS in block's scope)
+{ a: 3 b: 4 }.(a + b)        # 7
+{ a: 3 b: 4 }.[a, b]         # [3, 4]
+{ a: 3 b: 4 }."{a} and {b}"  # "3 and 4"
+```
+
+## Anaphora (Implicit Parameters)
+
+| Type | Numbered | Unnumbered | Scope |
+|------|----------|------------|-------|
+| Expression | `_0`, `_1`, `_2` | `_` (each use = new param) | Expression |
+| Block | `•0`, `•1`, `•2` | `•` (each use = new param) | Block |
+| String | `{0}`, `{1}`, `{2}` | `{}` (each use = new param) | String |
+
+```eu,notest
+# Expression anaphora
+map(_0 * _0)        # square each element
+map(_ + 1)          # increment (each _ is a new param)
+
+# Block anaphora (bullet = Option-8 on Mac)
+{ x: •0 y: •1 }    # two-parameter block function
+
+# String anaphora
+map("item: {}")     # format each element
+```
+
+## Operator Precedence Table
+
+From highest to lowest binding:
+
+| Prec | Name | Assoc | Operators | Description |
+|------|------|-------|-----------|-------------|
+| 95 | -- | prefix | `↑` | Tight prefix (head) |
+| 90 | lookup | left | `.` | Field access / lookup |
+| 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
+| 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
+| 88 | -- | right/left | `∘`, `;` | Composition (right-to-left, left-to-right) |
+| 85 | exp | right | `^` | Power |
+| 85 | exp | right | `!!` | Indexing (`xs !! 0`, arrays use list: `a !! [r,c]`) |
+| 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
+| 75 | sum | left | `+`, `-` | Addition, subtraction |
+| 55 | -- | right | `‖` | List cons (prepend element) |
+| 50 | cmp | left | `<`, `>`, `<=`, `>=` | Comparison |
+| 45 | append | right | `++`, `<<` | List append, deep merge |
+| 42 | map | left | `<$>` | Functor map |
+| 40 | eq | left | `=`, `!=` | Equality |
+| 35 | bool-prod | left | `&&`, `∧` | Logical AND |
+| 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
+| 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
+| 15 | clause | right | `=>`, `⇒` | Cond clause builder (`condition => result`) |
+| 10 | apply | right | `@` | Function application |
+| 5 | meta | right | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata / assertions |
+
+**User-defined operators** default to left-associative, precedence 50.
+Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
+
+**Named precedence levels** for use in metadata: `lookup`, `call`,
+`bool-unary`, `exp`, `prod`, `sum`, `shift`, `bitwise`, `cmp`,
+`append`, `map`, `eq`, `bool-prod`, `bool-sum`, `cat`, `apply`, `meta`.
+
+## Block Merge
+
+```eu,notest
+# Catenation of blocks performs a shallow merge
+{ a: 1 } { b: 2 }       # { a: 1 b: 2 }
+{ a: 1 } { a: 2 }       # { a: 2 }
+
+# Deep merge operator
+{ a: { x: 1 } } << { a: { y: 2 } }  # { a: { x: 1 y: 2 } }
+```
+
+## Imports
+
+```eu,notest
+# Unit-level import
+{ import: "lib.eu" }
+
+# Named import
+{ import: "cfg=config.eu" }
+
+# Multiple imports
+{ import: ["dep-a.eu", "dep-b.eu"] }
+
+# Format override
+{ import: "yaml@data.txt" }
+
+# Git import
+{ import: { git: "https://..." commit: "sha..." import: "file.eu" } }
+```
+
+## Key Prelude Functions
+
+### Lists
+
+| Function | Description |
+|----------|-------------|
+| `head` | First element |
+| `tail` | All but first |
+| `cons(x, xs)` | Prepend element |
+| `map(f)` | Transform each element |
+| `filter(p?)` | Keep elements matching predicate |
+| `foldl(f, init)` | Left fold |
+| `foldr(f, init)` | Right fold |
+| `sort-by(f)` | Sort by key function |
+| `take(n)` | First n elements |
+| `drop(n)` | Remove first n |
+| `zip` | Pair elements from two lists |
+| `zip-with(f)` | Combine elements with function |
+| `concat` | Flatten nested lists one level (use `concat`, not `flatten` — does not exist) |
+| `reverse` | Reverse a list |
+| `count` | Number of elements |
+| `range(a, b)` | Integers from a to b-1 |
+| `nil?` | Is the list empty? |
+| `any(p?)` | Does any element match? |
+| `all(p?)` | Do all elements match? |
+| `nub-by(f)` | Deduplicate by key function (no `unique` in prelude) |
+
+### Blocks
+
+| Function | Description |
+|----------|-------------|
+| `lookup(key)` | Look up a key (symbol) |
+| `lookup-or(key, default)` | Look up with default |
+| `has(key)` | Does block contain key? |
+| `keys` | List of keys (as symbols) |
+| `values` | List of values |
+| `elements` | List of `{key, value}` pairs |
+| `map-keys(f)` | Transform keys |
+| `map-values(f)` | Transform values |
+| `filter-items(p?)` | Keep entries matching predicate (use with `by-key`, `by-value`) |
+| `merge(b)` | Shallow merge |
+| `deep-merge(b)` | Deep recursive merge |
+| `sort-keys` | Sort by key name |
+
+### Strings (`str` namespace)
+
+| Function | Description |
+|----------|-------------|
+| `str.len(s)` | String length |
+| `str.to-upper(s)` | Upper case |
+| `str.to-lower(s)` | Lower case |
+| `str.starts-with?(re, s)` | Starts with regex match? |
+| `str.ends-with?(re, s)` | Ends with regex match? |
+| `str.contains?(re, s)` | Contains regex match? |
+| `str.matches?(re, s)` | Matches full regex? |
+| `str.split-on(re, s)` | Split by regex (pipeline-friendly) |
+| `str.join-on(sep, l)` | Join list with separator (pipeline-friendly) |
+| `str.replace(re, rep, s)` | Replace all regex matches |
+| `str.prefix(b, a)` | Prepend `b` onto `a` |
+| `str.suffix(b, a)` | Append `b` onto `a` |
+
+**All str regex functions treat the pattern argument as a regular expression.**
+`str.split-on` and `str.contains?` are pipeline-friendly (data is last arg).
+Note: `str.trim` does **not** exist — strip leading/trailing manually with `str.replace`.
+
+### Serialisation and Parsing
+
+| Function | Description |
+|----------|-------------|
+| `render(value)` | Serialise to YAML string |
+| `render-as(fmt, value)` | Serialise to string in named format |
+| `parse-as(fmt, str)` | Parse string as structured data (inverse of `render-as`) |
+
+Formats for `render-as`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.
+Formats for `parse-as`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jsonl`.
+
+`parse-as` is safe for untrusted input — YAML `!eu` tags are never evaluated.
+
+### Combinators
+
+| Function | Description |
+|----------|-------------|
+| `identity` | Returns its argument unchanged |
+| `const(k)` | Always returns k |
+| `compose(f, g)` or `f ∘ g` | Compose functions |
+| `flip(f)` | Swap argument order |
+| `complement(p?)` | Negate a predicate |
+| `curry(f)` | Curry a function taking a pair |
+| `uncurry(f)` | Uncurry to take a pair |
+
+### Numbers
+
+| Function | Description |
+|----------|-------------|
+| `num` | Parse string to number |
+| `abs` | Absolute value |
+| `negate` | Negate number |
+| `inc` / `dec` | Increment / decrement |
+| `max(a, b)` / `min(a, b)` | Maximum / minimum |
+| `zero?` / `pos?` / `neg?` | Sign predicates |
+| `floor` / `ceiling` / `⌊n⌋` / `⌈n⌉` | Rounding (no `round`) |
+| `even?` / `odd?` | Do **not** exist — use `x % 2 = 0` / `x % 2 = 1` |
+
+### Lenses (`lens.eu`)
+
+Import with `{ import: "lens.eu" }`. A **lens** focuses on a single position
+in a structure; a **traversal** focuses on multiple positions.
+
+**Core operations:**
+
+| Operation | Description |
+|-----------|-------------|
+| `view(lens, data)` | Read the focused value |
+| `over(optic, fn, data)` | Apply `fn` at each focus; return whole structure |
+| `to-list-of(optic, data)` | Collect all foci into a list |
+| `parts-of(traversal)` | Turn traversal into a lens on the list of all foci |
+
+Set a value with `over` and the `->` const operator: `data over(lens, -> newval)`.
+
+**Constructors:**
+
+| Constructor | Description |
+|-------------|-------------|
+| `at(key)` | Block value at symbol key |
+| `ix(n)` | List element at index `n` |
+| `item(p?)` | First list element matching predicate |
+| `element(p?)` | First block `[key, value]` pair matching predicate |
+| `_value` | Value (index 1) of a `[key, value]` pair |
+| `_key` | Key (index 0) of a `[key, value]` pair |
+| `each` | All list elements (traversal) |
+| `filtered(p?)` | Matching list elements (traversal) |
+| `each-element` | All block kv pairs (traversal) |
+| `filtered-elements(p?)` | Matching block kv pairs (traversal) |
+
+**Composition:** `∘` composes right-to-left; `‹›` is bracket shorthand.
+
+```eu,notest
+{ import: "lens.eu" }
+
+config: { server: { db: { host: "localhost", port: 5432 } } }
+
+# Bracket shorthand — symbols become at(), numbers become ix()
+config view(‹:server :db :host›)              # "localhost"
+config over(‹:server :db :port›, + 1)         # whole config with port 5433
+
+# Traversal — operate across all list elements
+records: [{name: "a", score: 10}, {name: "b", score: 20}]
+records to-list-of(each ∘ at(:score))         # [10, 20]
+records over(each ∘ at(:score), * 2)          # scores doubled
+[3, 1, 2] over(parts-of(each), sort-nums)     # [1, 2, 3]
+```
+
+### Arrays (`arr` namespace)
+
+| Function | Description |
+|----------|-------------|
+| `arr.zeros(shape)` | Create array of zeros; `shape` is a list of integers |
+| `arr.fill(shape, val)` | Create array filled with `val` |
+| `arr.from-flat(shape, vals)` | Create array from flat list of numbers |
+| `a arr.get(coords)` | Element at coordinate list `coords` |
+| `a arr.set(coords, val)` | New array with element at `coords` set to `val` |
+| `arr.shape(a)` | Shape as list of integers |
+| `arr.rank(a)` | Number of dimensions |
+| `arr.length(a)` | Total number of elements |
+| `arr.to-list(a)` | Flat list of elements in row-major order |
+| `arr.array?(x)` / `is-array?(x)` | Is `x` an array? |
+| `arr.transpose(a)` | Reverse all axes |
+| `a arr.reshape(shape)` | Reshape (total elements must match) |
+| `a arr.slice(axis, idx)` | Slice along `axis` at `idx` (reduces rank by 1) |
+| `arr.add(a, b)` / `arr.sub` / `arr.mul` / `arr.div` | Element-wise arithmetic; `b` may be scalar |
+| `a !! coords` | Index operator; for arrays, `coords` is a list e.g. `[row, col]` |
+| `arr.indices(a)` | List of coordinate lists for every element (row-major) |
+| `arr.map(f, a)` | Apply `f` to each element; same shape |
+| `arr.map-indexed(f, a)` | Apply `f(coords, val)` to each element; same shape |
+| `arr.fold(f, init, a)` | Left-fold over all elements in row-major order |
+| `a arr.neighbours(coords, offsets)` | Values at valid in-bounds neighbours given offset vectors |
+
+The standard `+`, `-`, `*`, `/` operators are polymorphic and apply element-wise when
+either operand is an array. Scalar broadcasting is supported.
+
+### IO
+
+| Binding / Function | Description |
+|--------------------|-------------|
+| `io.env` | Block of environment variables |
+| `io.epoch-time` | Unix timestamp at launch |
+| `io.args` | Command-line arguments (after `--`) |
+| `io.random` | Infinite lazy stream of random floats |
+| `io.RANDOM_SEED` | Current random seed |
+| `io.return(a)` | Wrap a pure value in the IO monad |
+| `io.bind(action, cont)` | Sequence two IO actions |
+| `io.shell(cmd)` | Run `cmd` via `sh -c`; returns `{stdout, stderr, exit-code}` |
+| `io.shell-with(opts, cmd)` | Run `cmd` with extra options (e.g. `{stdin: s, timeout: 60}`). Pipeline: `"cmd" shell-with(opts)` |
+| `io.exec([cmd : args])` | Run `cmd` directly (no shell); argument is a list `[cmd, arg1, arg2, ...]` |
+| `io.exec-with(opts, [cmd : args])` | Run `cmd` directly with extra options. Pipeline: `["git", "log"] exec-with(opts)` |
+| `io.check(result)` | Fail with stderr if `exit-code` is non-zero; otherwise return result |
+| `io.map(f, action)` | Apply pure function to result of IO action (fmap) |
+
+## Test / Assertion Operators
+
+**Test expectations** (panic in normal mode, return `false` in test mode):
+
+| Operator | Description |
+|----------|-------------|
+| `e //= v` | Expect `e` equals `v`, return `true`/`false` |
+| `e //=? f` | Expect `f(e)` is `true`, return `true`/`false` |
+| `e //!` | Expect `e` is `true`, return `true`/`false` |
+
+**Assertions** (return `e`, panic on failure in normal mode):
+
+| Operator | Description |
+|----------|-------------|
+| `e //=> v` | Assert `e` equals `v`, return `e` |
+| `e //=?> f` | Assert `f(e)` is `true`, return `e` |
+
+## Command Line Quick Reference
+
+```sh
+eu file.eu                  # Evaluate file, output YAML
+eu -j file.eu               # Output JSON
+eu -x text file.eu          # Output plain text
+eu -e 'expression'          # Evaluate expression
+eu a.yaml b.eu              # Merge inputs
+eu -t target file.eu        # Render specific target
+eu list-targets file.eu     # List targets
+eu --seed 42 file.eu        # Deterministic random
+eu -Q file.eu               # Suppress prelude
+eu fmt file.eu              # Format source
+eu dump stg file.eu         # Dump STG syntax
+eu -- arg1 arg2             # Pass arguments (io.args)
+eu check file.eu            # Type-check, report warnings
+eu check --strict file.eu   # Treat type warnings as errors
+eu --type-check file.eu     # Check then evaluate
+eu doc file.eu              # Extract documentation (Markdown)
+eu doc --format json file.eu # Extract as JSON Schema
+eu doc --check file.eu      # Report documentation coverage
+```
+
+## Type Checking
+
+Type annotations live in declaration metadata alongside doc strings.
+All annotations are optional — unannotated code is treated as `any`.
+
+### Annotation syntax
+
+```eu,notest
+` { doc: "`double(x)` - double a number."
+    type: "number -> number" }
+double(x): x * 2
+
+# Operator
+` { doc: "..."
+    type: "a -> (a -> b) -> b"
+    associates: :left
+    precedence: 20 }
+(x |> f): f(x)
+```
+
+### Type aliases
+
+```eu,notest
+# In unit metadata
+{ types: { Person: "{name: string, age: number, ..}" } }
+
+# Via type-def: on a canonical instance
+` { type-def: "Point" }
+origin: { x: 0, y: 0 }
+```
+
+### Type forms
+
+| Syntax             | Meaning                                |
+|--------------------|----------------------------------------|
+| `number`           | number                                 |
+| `string`           | string                                 |
+| `symbol`           | symbol                                 |
+| `bool`             | boolean                                |
+| `null`             | null                                   |
+| `datetime`         | zoned date-time                        |
+| `any`              | gradual/unknown — no type errors       |
+| `[T]`              | homogeneous list of T                  |
+| `NonEmpty([T])`    | non-empty list of T                    |
+| `(A, B)`           | 2-tuple; `(A, B, C)` for triple        |
+| `(A,)`             | 1-tuple                                |
+| `{k: T}`           | closed record                          |
+| `{k: T, ..}`       | open record (at least k: T)            |
+| `{k: T, ..r}`      | named row variable (in string: `{{k: T, ..r}}`) |
+| `{..r, ..s}`       | row concatenation (in string: `{{..r, ..s}}`)   |
+| `block`            | any block (no known shape)             |
+| `Dict(T)`          | homogeneous block — all values type T  |
+| `Name` (capitalised) | type alias — defined via `types: { Name: "..." }` |
+| `"value"`          | literal string type (subtype of `string`); c-string escapes for the quotes: `c"\"value\""` |
+| `:name`            | literal symbol type (subtype of `symbol`)      |
+| `T?`               | partial — sugar for `T \| ExecutionError`; marks functions that may raise an error |
+| `ExecutionError`   | the type of a raised runtime error     |
+| `A -> B`           | function                               |
+| `A \| B`           | union                                  |
+| `a`, `b`, `s`      | type variable, kind `*` (lowercase)    |
+| `m a`              | constructor application (`m :: * -> *` applied to `a`) |
+| `forall a. T`      | explicit quantification (kind-`*`)     |
+| `forall (m :: * -> *) a. T` | explicit quantification with kind annotation |
+| `IO(T)`            | IO action producing T                  |
+| `Lens(a, b)`       | lens focusing on b within a            |
+| `Traversal(a, b)`  | traversal over b's within a            |
+| `set`              | ordered set of primitives              |
+| `vec`              | flat vector of primitives              |
+| `array`            | n-dimensional number array             |
+
+### User-defined monads
+
+`monad({ bind(m,f): ..., return(v): ... })` derives the standard
+combinators (`map`, `then`, `and-then`, `join`, `sequence`, `map-m`,
+`filter-m`) annotated with `forall (m :: * -> *)` types.  The type
+checker understands them polymorphically — passing a non-function to
+`my-monad.map` triggers a warning.
+
+---
 
 # Syntax Gotchas
 
@@ -4710,6 +15030,7 @@ The precedence hierarchy (highest to lowest):
 | 35         | bool-prod    | `∧` (and)                    |
 | 30         | bool-sum     | `∨` (or)                     |
 | 20         | cat          | catenation (juxtaposition)   |
+| 15         | clause       | `=>`, `⇒` (cond clause)      |
 | 10         | apply        |                              |
 | 5          | meta         | `` ` `` (metadata)           |
 
@@ -4718,14 +15039,15 @@ The precedence hierarchy (highest to lowest):
 **Problem**: The lookup operator (`.`) has higher precedence (90) than
 catenation (precedence 20), which can lead to unexpected parsing.
 
-**Gotcha**: Writing `objects head.id` is parsed as `objects (head.id)`
-rather than `(objects head).id`.
+**Gotcha**: Writing `objects head.id` groups `head.id` into one unit
+first, and *that unit* — not `objects` — is what gets applied. It is
+parsed as `head.id(objects)`, rather than `(objects head).id`.
 
 **Example**:
 ```eu,notest
 # This doesn't work as expected:
 objects: range(0, 5) map({ id: _ })
-result: objects head.id  # Parsed as: objects (head.id)
+result: objects head.id  # Parsed as: head.id(objects)
 
 # Correct syntax requires parentheses:
 result: (objects head).id  # Explicitly groups the field access
@@ -4739,6 +15061,10 @@ result: (objects head).id  # Explicitly groups the field access
 access fields from:
 - Use `(expression).field` instead of `expression target.field`
 - Be explicit about precedence when combining catenation with field access
+
+The `↑` (head) prefix operator (precedence 95) binds even tighter than
+`.` (90), so it has the same gotcha one level up: `↑xs.id` means
+`(↑xs).id`, not `↑(xs.id)`.
 
 ### Arithmetic After a Pipeline
 
@@ -5112,6 +15438,19 @@ reference `x` without the self-reference gotcha that affects ordinary block
 bindings (`{ x: expr  y: x + 1 }` would make `x` and `y` mutually
 self-referential).
 
+A `:let` binding may even **reuse a name from the enclosing scope** — the one
+case where `name: name …` is not self-reference — because its right-hand side
+is evaluated in the outer scope, before the new binding takes effect:
+
+```eu
+normalise(xs): { :let xs: xs map(_ + 1) }.xs
+shifted: normalise([1, 2, 3])   # => [2, 3, 4]
+```
+
+This is the idiom to reach for when an ordinary `{ name: name … }` would
+self-reference — common when a renderer maps over a parameter it would rather
+keep calling by its own name.
+
 **Why this matters**: Before `let` was defined as a prelude name, attempts to
 write `let x: 1 in x + 2` gave a diagnostic error "eucalypt has no 'let'
 expression". That specific hint is no longer raised; the error now falls through
@@ -5141,550 +15480,255 @@ The wrong pattern causes a compiler error because only the first
 block is unit metadata — the second becomes an anonymous block
 declaration catenated into the metadata expression.
 
-## Future Improvements
+## Type Annotation String Escaping
 
-These gotchas highlight areas where the language could benefit from:
+### Record Braces in Type Strings Require `{{` Escaping
 
-1. **Better Error Messages**: More specific error messages when
-   precedence issues occur
-2. **Linting Rules**: Static analysis to catch common precedence
-   mistakes
-3. **IDE Support**: Syntax highlighting and warnings for ambiguous
-   expressions
-4. **Documentation**: Better examples showing correct precedence usage
+Type annotation values (`type:`, `types:`) are ordinary eucalypt strings.
+`{` inside a eucalypt string starts string interpolation — it does
+**not** produce a literal `{` for the type parser.
+
+Any record type written in a type annotation string must escape braces
+with `{{` and `}}`:
+
+```eu,notest
+# WRONG — {..r} triggers string interpolation
+` { type: "{..r} -> {..r}" }
+pass-through(x): x
+
+# RIGHT — use {{ and }} for literal braces
+` { type: "{{..r}} -> {{..r}}" }
+pass-through(x): x
+
+# WRONG — {name: string} triggers interpolation
+` { type: "{name: string, age: number, ..} -> string" }
+greet(p): "Hello, {p.name}!"
+
+# RIGHT
+` { type: "{{name: string, age: number, ..}} -> string" }
+greet(p): "Hello, {p.name}!"
+```
+
+The same applies to `types:` unit metadata values:
+
+```eu,notest
+# RIGHT — escape braces in types: values too
+{ types: { Person: "{{name: string, age: number}}" } }
+```
+
+**When escaping is NOT needed**: type strings that contain no `{` at all
+never need escaping. Simple function types and built-in type constructors
+are fine as-is:
+
+```eu,notest
+` { type: "number -> number" }           # fine — no braces
+` { type: "[a] -> a" }                   # fine
+` { type: "IO(block)" }                  # fine — parens, not braces
+` { type: "Lens(a, b) -> a -> b" }       # fine
+` { type-def: "Point" }                  # fine — just a name, no braces
+```
+
+### Literal Types in Annotations
+
+Two things to remember when a `type:` annotation contains literal types:
+
+- **Literal string types need c-string escapes for the quotes** —
+  `c"\"block\" | \"log\""`. A plain `"..."` string does not process `\"`.
+  (Literal *symbol* types like `:block` have no quotes, so a plain string
+  is fine.)
+- **Mind `|`/`->` precedence** — `->` binds tighter, so a disjunction in
+  argument position needs brackets: `(:block | :log) -> bool`, not
+  `:block | :log -> bool` (which is an overloaded-function type). Naming
+  the union in a `types:` alias avoids the question.
+
+## Flow-Sensitive Narrowing and User-Defined Branchers
+
+### `=>` (Clause) vs `//=>` (Assertion)
+
+The `=>` / `⇒` operator (precedence 15) builds a `cond` clause
+(`condition => result`).  It looks similar to the assertion meta-operator
+`//=>` (precedence 5) but has a completely different purpose:
+
+```eu,notest
+# CLAUSE — builds a cond branch; result is a list element
+cond[x > 0 => "positive", "non-positive"]
+
+# ASSERTION — checks a value equals the RHS at meta-evaluation time
+` { result //=> "positive" }
+result: "positive"
+```
+
+Mixing these up produces confusing type or parse errors.
+
+### Non-Structural Brancher Wrappers Disable Narrowing
+
+Flow-sensitive narrowing only applies when the checker can verify that
+a user function is a **structural pass-through** of `if` — i.e. its
+body is exactly `if(condition, true-branch, false-branch)` with
+arguments forwarded in order.  A wrapper that ignores one branch, reorders
+arguments, or adds logic is treated as an opaque function:
+
+```eu,notest
+# STRUCTURAL — recognised as If-shaped; narrowing fires
+my-if(c, t, f): if(c, t, f)
+
+` { type: "(number | string) → number" }
+safe-add(x): my-if(x number?, x + 1, 0)   # no warning
+
+# NON-STRUCTURAL — not a brancher; narrowing does NOT fire
+always-true(c, t, _f): t
+
+` { type: "(number | string) → number" }
+safe2(x): always-true(x number?, x + 1, 0)   # x is still number|string in body
+```
+
+The second example does not produce false-positive warnings because
+`always-true` is not narrowing-aware — `x` retains its declared type
+`number | string` throughout the body, which is type-safe here.
+
+## `head` on an Empty List Produces a Type Warning
+
+The type checker tracks list emptiness.  `[]` synthesises as `List(Never)`,
+which means `head []` is flagged as a potential error:
+
+```eu,notest
+# WARNING — [] is List(Never); head on an empty list
+bad: [] head
+
+# OK — non-empty literal is Tuple([number]); head gives number
+ok: [42] head
+```
+
+To use `head` safely on a list of unknown size, guard with `nil?`:
+
+```eu,notest
+` { type: "[number] → number" }
+safe-head(xs): if(xs nil?, 0, xs head)   # xs is NonEmpty([number]) in the false branch
+```
+
+Or annotate the input as `NonEmpty([T])` when the caller guarantees
+non-emptiness.
+
+## `:suppress` Leaks Through References
+
+`` ` :suppress `` hides a binding from output, but the flag travels with
+the binding's **value**. Reference that value somewhere else and the field
+it lands in silently disappears too.
+
+```eu,notest
+# WRONG — log4j is suppressed, so the @id field it feeds is dropped
+` :suppress
+log4j: "pkg:maven/log4j-core@2.17.1"
+
+entry: { '@id': log4j }     # renders as {} — @id silently gone
+```
+
+Suppress a **block** rather than a value you reference; members looked up
+out of it are clean:
+
+```eu,notest
+` :suppress
+purls: { log4j: "pkg:maven/log4j-core@2.17.1" }
+
+entry: { '@id': purls.log4j }   # => { "@id": "pkg:maven/log4j-core@2.17.1" }
+```
+
+**Rule**: only `` ` :suppress `` a binding you don't reference elsewhere; to
+hide values you *do* reference, group them in a block and suppress that.
 
 ---
 
-<!-- Source: docs/appendices/cheat-sheet.md -->
+## Idiot Bracket Gotchas
 
-# Syntax Cheat Sheet
+### Single-Item Idiot Brackets Still Pass a List
 
-A dense single-page reference covering all syntax forms, operators,
-common patterns, and key prelude functions.
-
-## Primitives
-
-| Type | Syntax | Examples |
-|------|--------|----------|
-| Integer | digits | `42`, `-7`, `0` |
-| Float | digits with `.` | `3.14`, `-0.5` |
-| String | double quotes | `"hello"`, `"line\nbreak"` |
-| Symbol | colon prefix | `:key`, `:name` |
-| Boolean | literals | `true`, `false` |
-| Null | literal | `null` |
-| ZDT | `t"..."` prefix | `t"2024-03-15"`, `t"2024-03-15T14:30:00Z"` |
-
-## Blocks
+Idiot brackets always collect their contents into a **list** before
+calling the function, even when there is only one item:
 
 ```eu,notest
-# Property declaration
-name: expression
+⟦ xs ⟧: xs        # xs is always a list
 
-# Function declaration
-f(x, y): expression
-
-# Operator declaration (binary)
-(l ++ r): expression
-
-# Operator declaration (prefix / postfix)
-(! x): expression
-(x ******): expression
-
-# Block literal
-{ a: 1 b: 2 c: 3 }
-
-# Commas are optional
-{ a: 1, b: 2, c: 3 }
-
-# Nested blocks
-{ outer: { inner: "value" } }
+single: ⟦ 42 ⟧   # calls ⟦⟧([42]), not ⟦⟧(42)
+# single => [42], not 42
 ```
 
-**Top-level unit**: the file itself is an implicit block (no braces needed).
-
-## Lists
+If you expect a scalar, extract the head or use a named parameter with
+destructuring:
 
 ```eu,notest
-# List literal
-[1, 2, 3]
-
-# Empty list
-[]
-
-# Mixed types
-[1, "two", :three, true]
+# Extract the head to use a single item as a scalar
+⌈ [x] ⌉: x ceiling   # destructure the single element
+⌈ 3.7 ⌉              # => 4
 ```
 
-## String Interpolation
+The prelude `⌈⌉` and `⌊⌋` bracket pairs do this automatically:
+they destructure `[x]` so `⌈3.7⌉` works as expected.
+
+### Multi-Token Items Must Be Parenthesised
+
+Items inside idiot brackets are separated by whitespace. A compound
+expression such as `x + 1` is two items (`x` and `+ 1`), not one:
 
 ```eu,notest
-# Insert expressions with {braces}
-"Hello, {name}!"
+⟦ xs ⟧: xs
 
-# String anaphora (defines a function)
-"#{}"           # one-parameter function
-"{0} and {1}"   # two-parameter function
+# THREE items — x, +, 1
+result: ⟦ x + 1 ⟧     # => [x, +, 1]  (+ is the section (+ _))
+
+# ONE item — the expression x + 1
+result: ⟦ (x + 1) ⟧   # => [x + 1]
 ```
 
-## Comments
+Parenthesise any expression that should be treated as a single item.
+
+### Juxtaposed Call After a Bracket Expression
+
+A bracket expression can be followed immediately by `[args]` or
+`{block}` to call the result with a further argument. This is valid
+syntax, but be aware that the `[...]` is **not** parsed as list syntax
+here — it is a juxtaposed call with a list argument:
 
 ```eu,notest
-# Line comment (to end of line)
-x: 42 # inline comment
+⟦ g ⟧[xs]    # evaluate ⟦g⟧, then call the result with list xs
 ```
 
-## Declarations
+---
 
-| Form | Syntax | Notes |
-|------|--------|-------|
-| Property | `name: expr` | Defines a named value |
-| Function | `f(x, y): expr` | Named function with parameters |
-| Block pattern | `f({x y}): expr` | Destructures block argument fields |
-| Block rename | `f({x: a  y: b}): expr` | Destructures with renamed bindings |
-| List pattern | `f([a, b, c]): expr` | Destructures fixed-length list |
-| Cons pattern | `f([h : t]): expr` | Destructures head and tail of list |
-| Binary operator | `(l op r): expr` | Infix operator |
-| Prefix operator | `(op x): expr` | Unary prefix |
-| Postfix operator | `(x op): expr` | Unary postfix |
-| Idiot bracket | `⟦ xs ⟧: expr` | Custom Unicode bracket pair |
+## Monad Bracket Restrictions
 
-## Idiot Brackets
+### Empty Monad Brackets Are an Error
 
-Idiot brackets allow custom Unicode bracket pairs that collect their
-content items into a list and pass it to a function.
+Monad brackets (e.g. `⟦⟧`) **cannot** be empty. An empty monadic block
+has no declarations to bind, so it is meaningless. The desugarer
+produces an `EmptyMonadicBlock` error:
 
 ```eu,notest
-# Declare a bracket pair function (xs receives a list)
-⟦ xs ⟧: xs map(_ * 2)
+# ERROR — empty monad brackets
+result: ⟦⟧.42
 
-# Items are collected as a list: ⟦ a b c ⟧ = ⟦⟧([a, b, c])
-result: ⟦ 3 4 5 ⟧  # [6, 8, 10]
+# CORRECT — at least one declaration required
+result: ⟦ x: some-action ⟧.x
 ```
 
-Any matching Unicode bracket pair works, e.g. `⟦⟧`, `⟨⟩`, `⟪⟫`, `⌈⌉`, `⌊⌋`, `‹›`, `⦃⦄`, `⦇⦈`, `⦉⦊`, `«»`,
-`【】`, `〔〕`, `〖〗`, `〘〙`, `〚〛`.
-
-The prelude defines `⌈⌉` and `⌊⌋` for ceiling and floor:
+This also applies to block-metadata monadic blocks:
 
 ```eu,notest
-⌈3.2⌉    # 4
-⌊3.8⌋    # 3
-⌈-1.5⌉   # -1
-⌊-1.5⌋   # -2
+# ERROR — empty monadic block
+result: { :io }.42
+
+# CORRECT
+result: { :io r: io.return(42) }.r
 ```
 
-## Monadic Blocks
+---
 
-Monadic sequencing (like `do`-notation) is supported via bracket pairs or block
-metadata.  A bracket block or annotated block followed by `.expr` desugars to a
-bind chain.
+# Migration from v0.2 to v0.3
 
-```eu,notest
-# Bracket pair definition — explicit functions
-⟦{}⟧: { :monad bind: my-bind  return: my-return }
+*Migration guide is under construction.*
 
-# Bracket pair definition — namespace reference
-⟦{}⟧: { :monad namespace: my-monad }
+Key changes in v0.3:
 
-# Block metadata forms (all followed by .return_expr):
-{ :name decls }.expr                          # Form 1: bare symbol namespace
-{ { monad: name } decls }.expr               # Form 2: monad key
-{ { :monad namespace: name } decls }.expr    # Form 3: tagged namespace
-{ { :monad bind: f return: r } decls }.expr  # Form 4: explicit inline
-
-# ⟦ a: ma  b: mb ⟧.return_expr
-# desugars to: bind(ma, (a): bind(mb, (b): return(return_expr)))
-result: ⟦ a: ma  b: mb ⟧.(a + b)
-```
-
-All declarations are bind steps whose names are in scope for later declarations
-and the return expression.  The return expression follows the closing bracket (or
-block) as `.name`, `.(expr)`, or `.[list]`.
-
-**Built-in monadic namespaces:**
-
-| Tag | Monad | Result type |
-|-----|-------|-------------|
-| `:io` | IO effects | IO action |
-| `:random` | Random state | Random action |
-| `:state` | Block state (import `state.eu`) | State action |
-| `:let` | Identity (sequential bindings) | Value |
-| `:for` | List (comprehensions) | List |
-
-```eu,notest
-# List comprehension: cartesian product with filter
-{ :for x: [1, 2, 3], _: [x] filter(> 1) }.(x * 10)
-# => [20, 30]
-```
-
-## Metadata Annotations
-
-```eu,notest
-# Declaration metadata (backtick prefix)
-` "Documentation string"
-name: value
-
-# Structured metadata
-` { doc: "description" associates: :left precedence: 50 }
-(l op r): expr
-
-# Unit-level metadata (first expression in file)
-{ :doc "Unit description" }
-a: 1
-```
-
-**Special metadata keys**: `:target`, `:suppress`, `:main`,
-`associates`, `precedence`, `import`.
-
-## Function Application
-
-```eu,notest
-# Parenthesised application (no whitespace before paren)
-f(x, y)
-
-# Catenation (pipeline style, single argument)
-x f              # equivalent to f(x)
-x f g h          # equivalent to h(g(f(x)))
-
-# Partial application (curried)
-add(1)           # returns a function adding 1
-
-# Sections (operator with gaps)
-(+ 1)            # function: add 1
-(* 2)            # function: multiply by 2
-(/)              # function: floor divide (two params)
-(÷)              # function: precise divide (two params)
-```
-
-## Lookup and Generalised Lookup
-
-```eu,notest
-# Simple lookup
-block.key
-
-# Generalised lookup (evaluate RHS in block's scope)
-{ a: 3 b: 4 }.(a + b)        # 7
-{ a: 3 b: 4 }.[a, b]         # [3, 4]
-{ a: 3 b: 4 }."{a} and {b}"  # "3 and 4"
-```
-
-## Anaphora (Implicit Parameters)
-
-| Type | Numbered | Unnumbered | Scope |
-|------|----------|------------|-------|
-| Expression | `_0`, `_1`, `_2` | `_` (each use = new param) | Expression |
-| Block | `•0`, `•1`, `•2` | `•` (each use = new param) | Block |
-| String | `{0}`, `{1}`, `{2}` | `{}` (each use = new param) | String |
-
-```eu,notest
-# Expression anaphora
-map(_0 * _0)        # square each element
-map(_ + 1)          # increment (each _ is a new param)
-
-# Block anaphora (bullet = Option-8 on Mac)
-{ x: •0 y: •1 }    # two-parameter block function
-
-# String anaphora
-map("item: {}")     # format each element
-```
-
-## Operator Precedence Table
-
-From highest to lowest binding:
-
-| Prec | Name | Assoc | Operators | Description |
-|------|------|-------|-----------|-------------|
-| 95 | -- | prefix | `↑` | Tight prefix (head) |
-| 90 | lookup | left | `.` | Field access / lookup |
-| 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
-| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
-| 85 | exp | right | `^`, `∘`, `;` | Power, composition |
-| 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
-| 75 | sum | left | `+`, `-` | Addition, subtraction |
-| 55 | -- | right | `‖` | List cons (prepend element) |
-| 50 | cmp | left | `<`, `>`, `<=`, `>=` | Comparison |
-| 45 | append | right | `++`, `<<` | List append, deep merge |
-| 42 | map | left | `<$>` | Functor map |
-| 40 | eq | left | `=`, `!=` | Equality |
-| 35 | bool-prod | left | `&&`, `∧` | Logical AND |
-| 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
-| 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
-| 10 | apply | right | `@` | Function application |
-| 5 | meta | right | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata / assertions |
-
-**User-defined operators** default to left-associative, precedence 50.
-Set custom values via metadata: `` ` { precedence: 75 associates: :right } ``
-
-**Named precedence levels** for use in metadata: `lookup`, `call`,
-`bool-unary`, `exp`, `prod`, `sum`, `shift`, `bitwise`, `cmp`,
-`append`, `map`, `eq`, `bool-prod`, `bool-sum`, `cat`, `apply`, `meta`.
-
-## Block Merge
-
-```eu,notest
-# Catenation of blocks performs a shallow merge
-{ a: 1 } { b: 2 }       # { a: 1 b: 2 }
-{ a: 1 } { a: 2 }       # { a: 2 }
-
-# Deep merge operator
-{ a: { x: 1 } } << { a: { y: 2 } }  # { a: { x: 1 y: 2 } }
-```
-
-## Imports
-
-```eu,notest
-# Unit-level import
-{ import: "lib.eu" }
-
-# Named import
-{ import: "cfg=config.eu" }
-
-# Multiple imports
-{ import: ["dep-a.eu", "dep-b.eu"] }
-
-# Format override
-{ import: "yaml@data.txt" }
-
-# Git import
-{ import: { git: "https://..." commit: "sha..." import: "file.eu" } }
-```
-
-## Key Prelude Functions
-
-### Lists
-
-| Function | Description |
-|----------|-------------|
-| `head` | First element |
-| `tail` | All but first |
-| `cons(x, xs)` | Prepend element |
-| `map(f)` | Transform each element |
-| `filter(p?)` | Keep elements matching predicate |
-| `foldl(f, init)` | Left fold |
-| `foldr(f, init)` | Right fold |
-| `sort-by(f)` | Sort by key function |
-| `take(n)` | First n elements |
-| `drop(n)` | Remove first n |
-| `zip` | Pair elements from two lists |
-| `zip-with(f)` | Combine elements with function |
-| `flatten` | Flatten nested lists one level |
-| `reverse` | Reverse a list |
-| `count` | Number of elements |
-| `range(a, b)` | Integers from a to b-1 |
-| `nil?` | Is the list empty? |
-| `any?(p?)` | Does any element match? |
-| `all?(p?)` | Do all elements match? |
-| `unique` | Remove duplicates |
-
-### Blocks
-
-| Function | Description |
-|----------|-------------|
-| `lookup(key)` | Look up a key (symbol) |
-| `lookup-or(key, default)` | Look up with default |
-| `has(key)` | Does block contain key? |
-| `keys` | List of keys (as symbols) |
-| `values` | List of values |
-| `elements` | List of `{key, value}` pairs |
-| `map-keys(f)` | Transform keys |
-| `map-values(f)` | Transform values |
-| `select(keys)` | Keep only listed keys |
-| `dissoc(keys)` | Remove listed keys |
-| `merge(b)` | Shallow merge |
-| `deep-merge(b)` | Deep recursive merge |
-| `sort-keys` | Sort by key name |
-
-### Strings (`str` namespace)
-
-| Function | Description |
-|----------|-------------|
-| `str.len(s)` | String length |
-| `str.upper(s)` | Upper case |
-| `str.lower(s)` | Lower case |
-| `str.starts-with?(prefix)` | Starts with prefix? |
-| `str.ends-with?(suffix)` | Ends with suffix? |
-| `str.contains?(sub)` | Contains substring? |
-| `str.matches?(regex)` | Matches regex? |
-| `str.split(sep)` | Split by separator |
-| `str.join(sep)` | Join list with separator |
-| `str.replace(from, to)` | Replace occurrences |
-| `str.trim` | Remove surrounding whitespace |
-
-### Serialisation and Parsing
-
-| Function | Description |
-|----------|-------------|
-| `render(value)` | Serialise to YAML string |
-| `render-as(fmt, value)` | Serialise to string in named format |
-| `parse-as(fmt, str)` | Parse string as structured data (inverse of `render-as`) |
-
-Formats for `render-as`: `:yaml`, `:json`, `:toml`, `:text`, `:edn`, `:html`.
-Formats for `parse-as`: `:json`, `:yaml`, `:toml`, `:csv`, `:xml`, `:edn`, `:jsonl`.
-
-`parse-as` is safe for untrusted input — YAML `!eu` tags are never evaluated.
-
-### Combinators
-
-| Function | Description |
-|----------|-------------|
-| `identity` | Returns its argument unchanged |
-| `const(k)` | Always returns k |
-| `compose(f, g)` or `f ∘ g` | Compose functions |
-| `flip(f)` | Swap argument order |
-| `complement(p?)` | Negate a predicate |
-| `curry(f)` | Curry a function taking a pair |
-| `uncurry(f)` | Uncurry to take a pair |
-
-### Numbers
-
-| Function | Description |
-|----------|-------------|
-| `num` | Parse string to number |
-| `abs` | Absolute value |
-| `negate` | Negate number |
-| `inc` / `dec` | Increment / decrement |
-| `max(a, b)` / `min(a, b)` | Maximum / minimum |
-| `even?` / `odd?` | Parity predicates |
-| `zero?` / `pos?` / `neg?` | Sign predicates |
-| `floor` / `ceiling` / `⌊n⌋` / `⌈n⌉` | Rounding (no `round`) |
-
-### Arrays (`arr` namespace)
-
-| Function | Description |
-|----------|-------------|
-| `arr.zeros(shape)` | Create array of zeros; `shape` is a list of integers |
-| `arr.fill(shape, val)` | Create array filled with `val` |
-| `arr.from-flat(shape, vals)` | Create array from flat list of numbers |
-| `a arr.get(coords)` | Element at coordinate list `coords` |
-| `a arr.set(coords, val)` | New array with element at `coords` set to `val` |
-| `arr.shape(a)` | Shape as list of integers |
-| `arr.rank(a)` | Number of dimensions |
-| `arr.length(a)` | Total number of elements |
-| `arr.to-list(a)` | Flat list of elements in row-major order |
-| `arr.array?(x)` / `is-array?(x)` | Is `x` an array? |
-| `arr.transpose(a)` | Reverse all axes |
-| `a arr.reshape(shape)` | Reshape (total elements must match) |
-| `a arr.slice(axis, idx)` | Slice along `axis` at `idx` (reduces rank by 1) |
-| `arr.add(a, b)` / `arr.sub` / `arr.mul` / `arr.div` | Element-wise arithmetic; `b` may be scalar |
-| `a !! coords` | Index operator; for arrays, `coords` is a list e.g. `[row, col]` |
-| `arr.indices(a)` | List of coordinate lists for every element (row-major) |
-| `arr.map(f, a)` | Apply `f` to each element; same shape |
-| `arr.map-indexed(f, a)` | Apply `f(coords, val)` to each element; same shape |
-| `arr.fold(f, init, a)` | Left-fold over all elements in row-major order |
-| `a arr.neighbours(coords, offsets)` | Values at valid in-bounds neighbours given offset vectors |
-
-The standard `+`, `-`, `*`, `/` operators are polymorphic and apply element-wise when
-either operand is an array. Scalar broadcasting is supported.
-
-### IO
-
-| Binding / Function | Description |
-|--------------------|-------------|
-| `io.env` | Block of environment variables |
-| `io.epoch-time` | Unix timestamp at launch |
-| `io.args` | Command-line arguments (after `--`) |
-| `io.random` | Infinite lazy stream of random floats |
-| `io.RANDOM_SEED` | Current random seed |
-| `io.return(a)` | Wrap a pure value in the IO monad |
-| `io.bind(action, cont)` | Sequence two IO actions |
-| `io.shell(cmd)` | Run `cmd` via `sh -c`; returns `{stdout, stderr, exit-code}` |
-| `io.shell-with(opts, cmd)` | Run `cmd` with extra options (e.g. `{stdin: s, timeout: 60}`). Pipeline: `"cmd" shell-with(opts)` |
-| `io.exec([cmd : args])` | Run `cmd` directly (no shell); argument is a list `[cmd, arg1, arg2, ...]` |
-| `io.exec-with(opts, [cmd : args])` | Run `cmd` directly with extra options. Pipeline: `["git", "log"] exec-with(opts)` |
-| `io.check(result)` | Fail with stderr if `exit-code` is non-zero; otherwise return result |
-| `io.map(f, action)` | Apply pure function to result of IO action (fmap) |
-
-## Test / Assertion Operators
-
-**Test expectations** (panic in normal mode, return `false` in test mode):
-
-| Operator | Description |
-|----------|-------------|
-| `e //= v` | Expect `e` equals `v`, return `true`/`false` |
-| `e //=? f` | Expect `f(e)` is `true`, return `true`/`false` |
-| `e //!` | Expect `e` is `true`, return `true`/`false` |
-
-**Assertions** (return `e`, panic on failure in normal mode):
-
-| Operator | Description |
-|----------|-------------|
-| `e //=> v` | Assert `e` equals `v`, return `e` |
-| `e //=?> f` | Assert `f(e)` is `true`, return `e` |
-
-## Command Line Quick Reference
-
-```sh
-eu file.eu                  # Evaluate file, output YAML
-eu -j file.eu               # Output JSON
-eu -x text file.eu          # Output plain text
-eu -e 'expression'          # Evaluate expression
-eu a.yaml b.eu              # Merge inputs
-eu -t target file.eu        # Render specific target
-eu list-targets file.eu     # List targets
-eu --seed 42 file.eu        # Deterministic random
-eu -Q file.eu               # Suppress prelude
-eu fmt file.eu              # Format source
-eu dump stg file.eu         # Dump STG syntax
-eu -- arg1 arg2             # Pass arguments (io.args)
-eu check file.eu            # Type-check, report warnings
-eu check --strict file.eu   # Treat type warnings as errors
-eu --type-check file.eu     # Check then evaluate
-```
-
-## Type Checking
-
-Type annotations live in declaration metadata alongside doc strings.
-All annotations are optional — unannotated code is treated as `any`.
-
-### Annotation syntax
-
-```eu,notest
-` { doc: "`double(x)` - double a number."
-    type: "number -> number" }
-double(x): x * 2
-
-# Operator
-` { doc: "..."
-    type: "a -> (a -> b) -> b"
-    associates: :left
-    precedence: 20 }
-(x |> f): f(x)
-```
-
-### Type aliases
-
-```eu,notest
-# In unit metadata
-{ types: { Person: "{name: string, age: number, ..}" } }
-
-# Via type-def: on a canonical instance
-` { type-def: "Point" }
-origin: { x: 0, y: 0 }
-```
-
-### Type forms
-
-| Syntax             | Meaning                                |
-|--------------------|----------------------------------------|
-| `number`           | number                                 |
-| `string`           | string                                 |
-| `symbol`           | symbol                                 |
-| `bool`             | boolean                                |
-| `null`             | null                                   |
-| `datetime`         | zoned date-time                        |
-| `any`              | gradual/unknown — no type errors       |
-| `[T]`              | homogeneous list of T                  |
-| `(A, B)`           | 2-tuple; `(A, B, C)` for triple        |
-| `(A,)`             | 1-tuple                                |
-| `{k: T}`           | closed record                          |
-| `{k: T, ..}`       | open record (at least k: T)            |
-| `block`            | any block (no known shape)             |
-| `A -> B`           | function                               |
-| `A \| B`           | union                                  |
-| `a`, `b`, `s`      | type variable (lowercase)              |
-| `IO(T)`            | IO action producing T                  |
-| `Lens(a, b)`       | lens focusing on b within a            |
-| `Traversal(a, b)`  | traversal over b's within a            |
-| `set`              | ordered set of primitives              |
-| `vec`              | flat vector of primitives              |
-| `array`            | n-dimensional number array             |
+- Subcommand structure: `eu test` replaces `-T`, `eu dump` replaces
+  `-p`/`--dump-xxx`
+- All existing command patterns continue to work (backward compatible)
+- New `eu fmt` and `eu lsp` subcommands

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -450,8 +450,9 @@ config.db.host
 ```
 
 **Warning:** `.` binds very tightly (precedence 90). `list head.name`
-parses as `list (head.name)`, not `(list head).name`. Use parentheses:
-`(list head).name`.
+groups `head.name` into one unit first, and *that unit* — not `list`
+— is what gets applied: it parses as `head.name(list)`, not
+`(list head).name`. Use parentheses: `(list head).name`.
 
 ### 1.8 Anaphora (Implicit Parameters)
 
@@ -1106,18 +1107,25 @@ define a partial: `sum: foldl(+, 0)` then `[1,2,3] sum`.
 `.` has precedence 90 vs catenation at 20. So:
 
 ```eu,notest
-list head.name    # WRONG: parses as list (head.name)
+list head.name    # WRONG: parses as head.name(list)
 (list head).name  # RIGHT: get head, then lookup .name
 ```
 
 The `↑` prefix operator (precedence 95) binds even tighter: `↑xs.name`
 = `(↑xs).name`.
 
-### 5.3 No Whitespace Before Parentheses in Calls
+### 5.3 No Whitespace in Call Syntax
+
+Whether `(`, `[`, or `{` immediately follows the callee (no space) is
+what distinguishes a call from catenation:
 
 ```eu,notest
 f(x)    # function call
 f (x)   # catenation: applies f to (x) as pipeline
+f[1,2]  # juxtaposed call with list argument
+f [1,2] # catenation: applies f to [1,2] as pipeline
+f{a: 1} # juxtaposed call with block argument
+f {a: 1}# catenation: applies f to {a: 1} as pipeline
 ```
 
 ### 5.4 map vs mapcat
@@ -1211,7 +1219,6 @@ generalised lookup.
 
 The following are commonly assumed but are **not** in the prelude:
 
-- `str.trim` — does not exist
 - `flatten` — use `concat` (flattens one level)
 - `unique` — does not exist in prelude
 - `even?` / `odd?` — do not exist (use `x % 2 = 0`)
@@ -1221,6 +1228,7 @@ The following are commonly assumed but are **not** in the prelude:
 
 These **do exist** and are commonly available:
 
+- `str.trim(s)` — trims leading/trailing whitespace
 - `str.replace(pattern, replacement, s)` — replaces all regex matches
 - `str.contains?(pattern, s)` — true if `s` contains a match for regex `pattern`
 - `str.starts-with?(re, s)` — true if `s` starts with regex match

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -915,7 +915,7 @@ Returns defaults block with parsed values overridden, plus `args` key for positi
 
 **Supported forms:** `--key value`, `--key=value`, `--flag`, `-x`, `-xy` (combined shorts), positionals, `--help`.
 
-See `docs/reference/prelude/args.md` for full documentation.
+See `docs/reference/prelude/io.md` for full documentation.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes stale/incorrect claims: type-checking has been unconditional since 0.11 (spec `docs/superpowers/specs/2026-06-25-ty-typing-default-on.md`), not opt-in via `--type-check` (now a documented no-op per the binary's own `--help`); `src/core/` incorrectly listed a `syntax/` subdirectory that doesn't exist (the parser lives at top-level `src/syntax/rowan/`); the `eu dump` table was missing the `split`/`demands`/`reflatten` phases; `driver/`/`import/`/`export/` listings were incomplete; `cargo xtask` and `eu doc` were entirely undocumented.
- Fixes a genuinely wrong (not just imprecise) notation used throughout the docs for depicting catenation groupings: `xs f(a) + 1` was documented as "parses as `xs(f(a) + 1)`", which reads as ordinary call syntax (call `xs` with argument `f(a)+1`) but means the opposite — verified directly against `eu dump cooked`: it's actually `(f(a) + 1)(xs)`, i.e. `f(a)+1` is the callee and `xs` is its argument (receiver-last). Fixed everywhere this notation appeared: CLAUDE.md, `docs/eucalypt-style.md`, `docs/faq.md`, `docs/guide/expressions-and-pipelines.md`, `docs/appendices/syntax-gotchas.md`, `docs/reference/agent-reference.md`.
- Fixes a real bug found while doing that: `agent-reference.md` §5.11 claimed `str.trim` "does not exist" — it does (`lib/prelude.eu:1083`).
- Fixes two dangling doc links: `docs/SUMMARY.md` pointed at `reference/prelude/arrays.md`, deleted in `94e0f2d` but never removed from the TOC (silently broke every `llms-full.txt` regeneration since); `agent-reference.md` pointed at the similarly-deleted `reference/prelude/args.md` (content now lives in `io.md`).
- Adds the `↑` (head) prefix operator, precedence 95 — tighter than `.` (90) — to every dot-vs-catenation gotcha section that was missing it (CLAUDE.md, `faq.md`, `syntax-gotchas.md`), matching where it was already documented (`agent-reference.md`, `expressions-and-pipelines.md`).
- Regenerates `docs/llms-full.txt` from current source docs — the committed version was badly stale (nearly the entire ~15,700-line file changed). Verified as a complete, non-corrupt regeneration: output line count (15734) exactly equals sum of source file lines (15575) + header (6) + 51 file-separator blocks (3 lines each). Also independently verified `docs/reference/prelude/` (the prelude reference docs) against the actual `docs-freshness` CI check (`eu doc --prelude --output-dir` + diff) — passes clean.
- Promotes "Writing Eucalypt Code" from ~57% down the file to immediately after the Overview.
- Removes CLAUDE.md's "Critical Rules" list (16 items) entirely, rather than continuing to patch it piecemeal: every fact in it duplicated — and, as this review repeatedly found, sometimes drifted wrong versus — the mandatory-reading source docs (`agent-reference.md` §5 "Common Pitfalls", `syntax-gotchas.md`). A condensed copy of mandatory reading is a maintenance liability, not a convenience; agents are already required to read the source docs first.
- Net CLAUDE.md: 240 → 186 lines.

Two related findings tracked separately (out of scope for this PR):
- `eu-9uhq`: `eu dump`/`--embed` embeds the full live process environment (`__io.ENV`), including real secrets in this session's shell — a genuine leak vector, needs a design discussion.
- `eu-p7tk`: broader `llms-full.txt` staleness discovery, tracked in case CI/pre-commit wiring is wanted to prevent this drifting again.

## Test plan
- [x] Verified the corrected catenation notation directly against the compiler (`eu dump cooked`, secrets-scrubbed environment)
- [x] Verified `str.trim` exists in `lib/prelude.eu`
- [x] Verified `docs/reference/prelude/` freshness against the actual CI `docs-freshness` job command
- [x] Verified `llms-full.txt` regeneration is complete/non-corrupt (line-count reconciliation)
- [ ] Read through the diff for accuracy against current `src/` layout and CLI behaviour
- [ ] Confirm nothing load-bearing was cut with the "Critical Rules" list removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)