### PR TITLE
fix(build): restore eu.build.url after metadata sanitisation

### DIFF
--- a/build-meta.yaml
+++ b/build-meta.yaml
@@ -1,14 +1,18 @@
 ---
-version: 0.11.1+dev
+version: 0.0.0.dev
 commit: working-copy
-url: "https://github.com/curvelogic/eucalypt/runs/0"
-banner: eu - Eucalypt v0.11.1+dev
+url: "https://github.com/curvelogic/eucalypt/runs"
+banner: "eu - Eucalypt v0.0.0.dev"
 eu-build:
   number: dev
   commit: working-copy
-  url: "https://github.com/curvelogic/eucalypt/runs/0"
+  url: "https://github.com/curvelogic/eucalypt/runs"
   arch: unknown
-  rust: unknown
-  profile: release
-  prelude-blob: "true"
-  time: 1782921726
+  os: unknown
+  epoch-time: 1620386599
+  github-env:
+    GITHUB_SERVER_URL: "https://github.com"
+    GITHUB_REPOSITORY: curvelogic/eucalypt
+    GITHUB_RUN_ID: 0
+    GITHUB_RUN_NUMBER: dev
+    GITHUB_SHA: working-copy

--- a/build-meta.yaml
+++ b/build-meta.yaml
@@ -1,18 +1,14 @@
 ---
-version: 0.0.0.dev
+version: 0.11.1+dev
 commit: working-copy
-url: "https://github.com/curvelogic/eucalypt/runs"
-banner: "eu - Eucalypt v0.0.0.dev"
+url: "https://github.com/curvelogic/eucalypt/runs/0"
+banner: eu - Eucalypt v0.11.1+dev
 eu-build:
   number: dev
   commit: working-copy
-  url: "https://github.com/curvelogic/eucalypt/runs"
+  url: "https://github.com/curvelogic/eucalypt/runs/0"
   arch: unknown
-  os: unknown
-  epoch-time: 1620386599
-  github-env:
-    GITHUB_SERVER_URL: "https://github.com"
-    GITHUB_REPOSITORY: curvelogic/eucalypt
-    GITHUB_RUN_ID: 0
-    GITHUB_RUN_NUMBER: dev
-    GITHUB_SHA: working-copy
+  rust: unknown
+  profile: release
+  prelude-blob: "true"
+  time: 1782921726

--- a/build.eu
+++ b/build.eu
@@ -66,6 +66,7 @@ new-version: "{version.major}.{version.minor}.{version.patch}+{build.number str.
 build-meta: {
   version: new-version
   commit: build.commit
+  url: build.url
   banner: "eu - Eucalypt v{version}"
   eu-build: build
 }


### PR DESCRIPTION
## Summary

Master CI has been red on every Release job (Linux x86_64, Linux aarch64, Windows) since PR #917 (2026-06-27) — 5 days, across PRs #917-#924 — because the eu.build metadata sanitisation moved `url` into a nested `eu-build: {...}` sub-block but dropped it from the top level of `build-meta`. `tests/harness/010_prelude.eu` reads `eu.build.url` directly and fails: `key 'url' not found in block`.

This only surfaces once the prelude blob and `build-meta.yaml` are freshly regenerated (`eu build.eu -t build-meta` → `cargo xtask prelude-compile` → `cargo build --release`) — exactly what the three Release jobs do and nothing else does. Every other CI job (Test Suite ×3, GC-verified, source-prelude, aarch64-sequential) builds against the stale checked-in `build-meta.yaml` placeholder, which still has the pre-#917 flat shape with a top-level `url`, so they stayed green and masked the regression.

Also regenerates the checked-in `build-meta.yaml` placeholder to match the current `build.eu` output shape (it still had the old `github-env`-leaking structure PR #917 was written to eliminate).

Bead: eu-8oz5 (P0)

## Test plan
- [x] Reproduced the exact CI failure sequence locally (temp `eu` install → `eu build.eu -t build-meta` → `cargo xtask prelude-compile` → `cargo build --release` → `eu test --allow-io tests/harness`) — confirmed `010_prelude...FAIL` before the fix, `010_prelude...PASS` after
- [x] Full harness clean after fix: `eu test --allow-io tests/harness` exits 0, 176/176 pass
- [x] `cargo test --lib --test harness_test --test lsp_test --release`: 1188 + 477 + 111 passed, 0 failed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)