### PR TITLE
Fix web env setup: export EUCALYPT_VERSION to the piped installer

### DIFF
--- a/scripts/setup-claude-web-env.sh
+++ b/scripts/setup-claude-web-env.sh
@@ -147,8 +147,11 @@ install_eucalypt() {
     if command -v eu >/dev/null 2>&1 && eu version 2>/dev/null | grep -qE "v${EUCALYPT_VERSION}([^0-9]|$)"; then
         echo "eu $EUCALYPT_VERSION already present"
     else
-        EUCALYPT_VERSION="$EUCALYPT_VERSION" \
-            curl -sSfL https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
+        # The version must be exported so the piped `sh` (which runs install.sh)
+        # inherits it; a prefix on `curl` would only set it for curl, leaving
+        # install.sh to resolve "latest" via the GitHub API (which 403s here).
+        export EUCALYPT_VERSION
+        curl -sSfL https://raw.githubusercontent.com/curvelogic/eucalypt/master/install.sh | sh
     fi
     command -v eu >/dev/null 2>&1 && eu version || echo "WARNING: eu not on PATH"
 }


### PR DESCRIPTION
## Summary

Follow-up to #928. The setup script now runs (the `curl … | bash` entry fixed the working-directory problem), but provisioning failed at the eucalypt install step:

```
=== Installing eucalypt (eu 0.11.1) ===
Detected platform: Linux/x86_64
Querying latest release...
curl: (22) The requested URL returned error: 403
Error: could not determine latest release version.
Setup script failed with exit code 1.
```

## Root cause

The install step piped `install.sh` to `sh` with the version as a prefix on `curl`:

```sh
EUCALYPT_VERSION="$EUCALYPT_VERSION" curl -sSfL …/install.sh | sh
```

A variable prefix applies only to the command it prefixes — here `curl`, not the `sh` that actually runs `install.sh`. So `install.sh` never saw `EUCALYPT_VERSION`, fell back to resolving "latest" via the GitHub API, and 403'd in the environment setup phase.

This slipped through earlier local testing because `eu` was already installed in the interactive session, so the install branch was skipped; and when it *did* run in that session, the "latest" lookup happened to succeed (the API was reachable there and returned 0.11.1), masking the bug. The real setup phase 403s that lookup.

## Fix

Export `EUCALYPT_VERSION` before the pipe so the `sh` subprocess inherits it, pinning the version and skipping the latest-release lookup entirely (matching the original inline setup, which used a separate `export EUCALYPT_VERSION=0.11.1`).

## Testing

- `bash -n` passes; full script runs cleanly via `cat … | bash`.
- Deterministic mechanism test with a stand-in installer that echoes the received variable:
  - old form (`VAR=… curl | sh`) → installer sees `EUCALYPT_VERSION=[UNSET]` (reproduces the "latest"/403 path)
  - new form (`export VAR; curl | sh`) → installer sees `EUCALYPT_VERSION=[0.11.1]`

## Note

Unrelated environment scoping still applies: the `dolt` download (`dolthub/dolt`) remains non-fatal and needs that repo granted to the environment to succeed; likewise `curvelogic/yaml-rust` must be in scope for `cargo build` to run in web sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8GzjHf6ctQ4Z2UPQQosRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8GzjHf6ctQ4Z2UPQQosRi)_