### PR TITLE
feat(bytecode): BV1 machine-wiring — BytecodeMachine + Bif dispatch spine (eu-vi3a)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -81,12 +81,14 @@ So the next unit is the **machine wiring**: a `BytecodeMachine`/run-context owni
 
 - `1fda104d` Phase 2 — **PAP trampoline templates** in the arena (`BytecodeProgram.pap` + `pap_offset(supplied,pending)`, `PAP_MAX_ARITY=16`). Ready to wire into `return_fun`'s Less case once handlers take the program.
 - `7c4c84d9` **fix(deps)** — bump `quick-xml` 0.25→0.41 (RUSTSEC-2026-0194/0195, newly-published, unrelated to BV1) + migrate `src/import/xml.rs` API. Fixed the PR's Security Audit CI failure. XML harness test byte-identical; `cargo audit` clean.
+- `5048ecde` **PR #927 merged** to `integration/0.12.0` (feat branch rebased onto the merge tip; work continues on `feat/bv1-bytecode-vm`).
+- `ac2f11aa` **Machine-wiring steps 1–2**: threaded `&BytecodeProgram` through `step`/`handle_op`/`return_fun` (handlers now reach `templates`/`blackhole`/`pap`); wired **PAP** (`return_fun` `Ordering::Less`) via a `partially_apply` helper building the `[f, supplied…]` env over `prog.pap_offset(supplied,pending)` with arity `pending`. New end-to-end test `run_partial_application` (`letrec k=\x y.x; p=k(5) in p(6)` → 5). 37 bytecode tests green, clippy clean.
 
 ### Machine-wiring integration — ordered plan + two refinements to settle in-flight
 The core machine is complete + tested (all return_* handlers; Atom/Cons/Case/Seq/Ann/App/DirectApp/Let/LetRec; thunk memoisation; Bif capture; data + blackhole + pap templates; value model + GC + decoders). Remaining is one coherent integration:
-1. **Refactor** `step`/`handle_op`/`return_fun` to take `&BytecodeProgram` (not `&[u8]`) so handlers reach `templates`/`blackhole`/`pap`. (Mechanical; update tests.)
-2. **Wire PAP** (`return_fun` Less) via `prog.pap_offset` + a `partially_apply` building the PAP closure env `[f, supplied…]`.
-3. **`BytecodeMachine`** owning heap/intrinsics/emitter/metrics/symbol-pool + the program + `BcMachineState`; `run` loop (500-tick GC poll; `pending_bif` dispatch tail; capture lifecycle).
+1. **[DONE `ac2f11aa`]** **Refactor** `step`/`handle_op`/`return_fun` to take `&BytecodeProgram` (not `&[u8]`) so handlers reach `templates`/`blackhole`/`pap`. (Mechanical; update tests.)
+2. **[DONE `ac2f11aa`]** **Wire PAP** (`return_fun` Less) via `prog.pap_offset` + a `partially_apply` building the PAP closure env `[f, supplied…]`.
+3. **[NEXT] `BytecodeMachine`** owning heap/intrinsics/emitter/metrics/symbol-pool + the program + `BcMachineState`; `run` loop (500-tick GC poll; `pending_bif` dispatch tail; capture lifecycle).
 4. **Bif dispatch** — a `BcBifContext` impl of `IntrinsicMachine`: neutral methods over `BcValue`+templates; the 5 `SynClosure`-typed methods `panic!` (bytecode never calls them; unmigrated intrinsics surface via the harness). Convert `pending_bif_args` (`DecodedRef`) → `&[Ref]` for `execute`.
    - **REFINEMENT A (resolve_closure vs native):** `AbiClosure` is `Heap(SynClosure)|Byte(BcClosure)`, but a bytecode ref can resolve to a bare `Native` (not a closure). Plan: change `AbiClosure::Byte` to hold a `BcValue` (Closure|Native) so `resolve_closure`/`set_result`/`force` round-trip natives too. (My call; implement during Bif dispatch.)
 5. **Globals + prelude**: build the globals frame from `GlobalForm`s (intrinsic wrappers) + encode the prelude to bytecode (Task 3.2). 

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -39,12 +39,20 @@
 
 ## Progress Ledger (living — durable source of truth; update every increment)
 
-**Position (2026-07-02):** Phases 0, 1, 1.6 complete; Phase 1.5 (intrinsic ABI)
-partially done; **pivoting to Phase 2 (bytecode machine)**, completing the
-remaining intrinsic migrations alongside it and verifying via the differential
-harness. **Branch:** `integration/0.12.0` (worktree
-`eucalypt-worktrees/integration-0.12.0`). **Toolchain:** prepend
-`~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` to PATH. Nothing pushed.
+**Position (2026-07-02, later):** Phases 0, 1, 1.6 complete; Phase 1.5
+(intrinsic ABI) partially done. **Phase 2 machine now runs end-to-end**: the
+`BytecodeMachine` (run/step loop + GC roots), globals frame, PAP, and the
+**`Bif` dispatch spine** (`BcBifContext: IntrinsicMachine`) are landed and
+tested — `__ADD(2,3)`/`let x=2 in __ADD(x,3)` execute through the real runtime
+intrinsics. **Next:** widen `BcBifContext`'s neutral overrides
+(`return_unit`/`return_boxed_num`/`return_bool`/`resolve_closure`/`data_*`/
+`force`), `evaluate_to_whnf`, the `Meta`/`DeMeta`/`LookupLit` arms, then encode
+the **full runtime globals + prelude** and wire the `EU_BYTECODE` flag path in
+`driver/eval.rs` → differential harness (synthetic-first per REFINEMENT B) →
+day11 gate. **Branch:** `feat/bv1-bytecode-vm` → PRs to `integration/0.12.0`
+(PR #927 merged). Worktree `eucalypt-worktrees/integration-0.12.0`.
+**Toolchain:** prepend `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin`
+to PATH. Committed on the feature branch; not yet PR'd.
 
 ### Done (commit → what)
 - `9cbb2a0c` Phase 0 scaffold (module + `EU_BYTECODE` flag)
@@ -83,15 +91,18 @@ So the next unit is the **machine wiring**: a `BytecodeMachine`/run-context owni
 - `7c4c84d9` **fix(deps)** — bump `quick-xml` 0.25→0.41 (RUSTSEC-2026-0194/0195, newly-published, unrelated to BV1) + migrate `src/import/xml.rs` API. Fixed the PR's Security Audit CI failure. XML harness test byte-identical; `cargo audit` clean.
 - `5048ecde` **PR #927 merged** to `integration/0.12.0` (feat branch rebased onto the merge tip; work continues on `feat/bv1-bytecode-vm`).
 - `ac2f11aa` **Machine-wiring steps 1–2**: threaded `&BytecodeProgram` through `step`/`handle_op`/`return_fun` (handlers now reach `templates`/`blackhole`/`pap`); wired **PAP** (`return_fun` `Ordering::Less`) via a `partially_apply` helper building the `[f, supplied…]` env over `prog.pap_offset(supplied,pending)` with arity `pending`. New end-to-end test `run_partial_application` (`letrec k=\x y.x; p=k(5) in p(6)` → 5). 37 bytecode tests green, clippy clean.
+- `1aa2a4fa` **Machine-wiring step 3a — `BytecodeMachine`**: owns heap/program/state/metrics/clock; `run` loop mirroring `Machine::run` (500-tick GC poll → `gc_collect`, tick metering, `exit_code`); `dispatch()` drives the free `step`. `impl GcScannable for BcMachineState` (marks globals/root_env, scans `current`+stack inline, scans the constant pool via `scan_const`/`update_const`). Tests incl. `machine_survives_forced_gc` (step → force collect → run → 5). 40 green.
+- `eef945f0` **Step 3b-i — globals frame**: `BytecodeMachine::new` takes `&[GlobalForm]` and builds the globals frame (one closure per form via `form_info`, closed over `root_env`; cross-global refs are `Ref::G`). Test `machine_resolves_global_ref` (`id(7)` via G-ref). NB global-thunk memoisation deferred (pure → values agree). 41 green.
+- `dc8fe6ea` **Step 3b-ii — `Bif` dispatch spine**: machine gains intrinsics table / symbol pool / rcache / emitter / test-mode. `dispatch()` tail materialises `pending_bif_args` → `&[Ref]` and runs the intrinsic through **`BcBifContext: IntrinsicMachine`** (overrides `resolve_native` incl. `OP_ATOM` indirection via `native_from_value`, and `return_native`; the 5 HeapSyn-typed methods + capture lifecycle panic/error → unmigrated intrinsics surface via the harness). Tests `machine_dispatches_add_intrinsic` + `..._with_local_arg`. 43 bytecode + full lib (1228) green.
 
 ### Machine-wiring integration — ordered plan + two refinements to settle in-flight
 The core machine is complete + tested (all return_* handlers; Atom/Cons/Case/Seq/Ann/App/DirectApp/Let/LetRec; thunk memoisation; Bif capture; data + blackhole + pap templates; value model + GC + decoders). Remaining is one coherent integration:
 1. **[DONE `ac2f11aa`]** **Refactor** `step`/`handle_op`/`return_fun` to take `&BytecodeProgram` (not `&[u8]`) so handlers reach `templates`/`blackhole`/`pap`. (Mechanical; update tests.)
 2. **[DONE `ac2f11aa`]** **Wire PAP** (`return_fun` Less) via `prog.pap_offset` + a `partially_apply` building the PAP closure env `[f, supplied…]`.
-3. **[NEXT] `BytecodeMachine`** owning heap/intrinsics/emitter/metrics/symbol-pool + the program + `BcMachineState`; `run` loop (500-tick GC poll; `pending_bif` dispatch tail; capture lifecycle).
-4. **Bif dispatch** — a `BcBifContext` impl of `IntrinsicMachine`: neutral methods over `BcValue`+templates; the 5 `SynClosure`-typed methods `panic!` (bytecode never calls them; unmigrated intrinsics surface via the harness). Convert `pending_bif_args` (`DecodedRef`) → `&[Ref]` for `execute`.
-   - **REFINEMENT A (resolve_closure vs native):** `AbiClosure` is `Heap(SynClosure)|Byte(BcClosure)`, but a bytecode ref can resolve to a bare `Native` (not a closure). Plan: change `AbiClosure::Byte` to hold a `BcValue` (Closure|Native) so `resolve_closure`/`set_result`/`force` round-trip natives too. (My call; implement during Bif dispatch.)
-5. **Globals + prelude**: build the globals frame from `GlobalForm`s (intrinsic wrappers) + encode the prelude to bytecode (Task 3.2). 
+3. **[DONE `1aa2a4fa`+`eef945f0`] `BytecodeMachine`** owning heap/intrinsics/emitter/metrics/symbol-pool + the program + `BcMachineState`; `run` loop (500-tick GC poll; `pending_bif` dispatch tail; capture lifecycle). *(Globals frame done; emitter capture lifecycle still stubbed — errors on use.)*
+4. **[SPINE DONE `dc8fe6ea`] Bif dispatch** — a `BcBifContext` impl of `IntrinsicMachine`: neutral methods over `BcValue`+templates; the 5 `SynClosure`-typed methods `panic!`. Convert `pending_bif_args` (`DecodedRef`) → `&[Ref]` for `execute`. *(Done for `resolve_native`/`return_native`; REMAINING overrides: `return_unit`/`return_boxed_num`/`return_bool` (templates + globals TRUE/FALSE), `resolve_closure`/`resolve_callable_closure`/`set_result`/`force` (needs `evaluate_to_whnf` + REFINEMENT A), `data_tag`/`data_field`/`field_native`.)*
+   - **REFINEMENT A (resolve_closure vs native):** `AbiClosure` is `Heap(SynClosure)|Byte(BcClosure)`, but a bytecode ref can resolve to a bare `Native` (not a closure). Plan: change `AbiClosure::Byte` to hold a `BcValue` (Closure|Native) so `resolve_closure`/`set_result`/`force` round-trip natives too. (My call; implement when wiring those overrides.)
+5. **[NEXT] Globals + prelude**: encode the **full runtime globals** (intrinsic wrappers + prelude) to bytecode + build the full globals frame (unblocks `return_bool` TRUE/FALSE, prelude G-refs, real programs). Also global-thunk memoisation (Atom `Global` arm: blackhole + Update into the globals frame).
    - **REFINEMENT B (harness-first):** stand up the differential harness on tiny **synthetic** programs (no prelude) first — validate the core end-to-end through both engines — *before* encoding the full prelude. (My call; do harness-first.)
 6. **Meta/DeMeta/LookupLit** arms (+ `return_meta`, bytecode block navigator for LookupLit/MERGE).
 7. **`EU_BYTECODE` flag path** in `driver/eval.rs`; full differential harness → day11 gate (§8).

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -12,10 +12,17 @@ use std::cmp::Ordering;
 
 use crate::common::sourcemap::Smid;
 use crate::eval::error::ExecutionError;
+use crate::eval::machine::metrics::{Clock, Metrics, ThreadOccupation};
+use crate::eval::machine::vm::interrupted;
 use crate::eval::memory::alloc::ScopedAllocator;
 use crate::eval::memory::array::Array;
+use crate::eval::memory::collect::{
+    collect as gc_collect, CollectorHeapView, CollectorScope, GcScannable, ScanPtr,
+};
+use crate::eval::memory::heap::Heap;
 use crate::eval::memory::infotable::{InfoTable, InfoTagged};
 use crate::eval::memory::mutator::MutatorHeapView;
+use crate::eval::memory::symbol::SymbolPool;
 use crate::eval::memory::syntax::{Native, Ref, RefPtr};
 use crate::eval::stg::tags::{DataConstructor, Tag};
 
@@ -216,6 +223,104 @@ impl BcMachineState {
             capture_end_pending: false,
             yielded_io: false,
             blackhole: 0,
+        }
+    }
+}
+
+/// Mark the heap pointers embedded in a prepared constant (`Ref::V(native)`).
+/// Mirrors `syntax::mark_ref_heap_pointers` for the bytecode constant pool,
+/// which is an off-heap root set rather than part of the code graph.
+fn scan_const<'a>(
+    r: &'a Ref,
+    scope: &'a dyn CollectorScope,
+    marker: &mut CollectorHeapView<'a>,
+    out: &mut Vec<ScanPtr<'a>>,
+) {
+    match r {
+        Ref::V(Native::Str(ptr)) if marker.mark(*ptr) => {
+            out.push(ScanPtr::from_non_null(scope, *ptr));
+        }
+        Ref::V(Native::Set(ptr)) => {
+            marker.mark(*ptr);
+        }
+        Ref::V(Native::NdArray(ptr)) => {
+            marker.mark(*ptr);
+        }
+        Ref::V(Native::Vec(ptr)) => {
+            marker.mark(*ptr);
+        }
+        _ => {}
+    }
+}
+
+/// Update forwarded heap pointers in a prepared constant (mirrors
+/// `syntax::update_ref_heap_pointers`).
+fn update_const(r: &mut Ref, heap: &CollectorHeapView<'_>) {
+    match r {
+        Ref::V(Native::Str(ptr)) => {
+            if let Some(new) = heap.forwarded_to(*ptr) {
+                *ptr = new;
+            }
+        }
+        Ref::V(Native::Set(ptr)) => {
+            if let Some(new) = heap.forwarded_to(*ptr) {
+                *ptr = new;
+            }
+        }
+        Ref::V(Native::NdArray(ptr)) => {
+            if let Some(new) = heap.forwarded_to(*ptr) {
+                *ptr = new;
+            }
+        }
+        Ref::V(Native::Vec(ptr)) => {
+            if let Some(new) = heap.forwarded_to(*ptr) {
+                *ptr = new;
+            }
+        }
+        _ => {}
+    }
+}
+
+impl GcScannable for BcMachineState {
+    fn scan<'a>(
+        &'a self,
+        scope: &'a dyn CollectorScope,
+        marker: &mut CollectorHeapView<'a>,
+        out: &mut Vec<ScanPtr<'a>>,
+    ) {
+        if marker.mark(self.globals) {
+            out.push(ScanPtr::from_non_null(scope, self.globals));
+        }
+        if marker.mark(self.root_env) {
+            out.push(ScanPtr::from_non_null(scope, self.root_env));
+        }
+        // The current value ranges over `BcValue` (a closure or native); its
+        // `GcScannable` impl marks the env pointer / heap-backed native.
+        out.push(ScanPtr::new(scope, &self.current));
+        // Continuations live inline in the `Vec` (off the eucalypt heap); scan
+        // their internal heap pointers directly (mirrors `MachineState::scan`).
+        for cont in &self.stack {
+            cont.scan(scope, marker, out);
+        }
+        // The prepared constant pool is a root set of heap-backed natives.
+        for r in &self.constants {
+            scan_const(r, scope, marker, out);
+        }
+    }
+
+    fn scan_and_update(&mut self, heap: &CollectorHeapView<'_>) {
+        if let Some(new) = heap.forwarded_to(self.root_env) {
+            self.root_env = new;
+        }
+        if let Some(new) = heap.forwarded_to(self.globals) {
+            self.globals = new;
+        }
+        self.current.scan_and_update(heap);
+        for cont in &mut self.stack {
+            cont.scan_and_update(heap);
+        }
+        for r in &mut self.constants {
+            update_const(r, heap);
         }
     }
 }
@@ -957,6 +1062,155 @@ pub fn step(
     }
 }
 
+/// The bytecode execution machine: owns the heap, program and machine state,
+/// and drives the `step` dispatch loop with periodic GC (spec §6). The
+/// parallel-engine counterpart to the HeapSyn `Machine`.
+///
+/// This increment runs self-contained programs (no globals/prelude, no `Bif`
+/// dispatch); intrinsic dispatch, the globals frame and the emitter/capture
+/// lifecycle are wired in the following increments.
+pub struct BytecodeMachine {
+    heap: Heap,
+    program: BytecodeProgram,
+    state: BcMachineState,
+    metrics: Metrics,
+    clock: Clock,
+    dump_heap: bool,
+}
+
+impl BytecodeMachine {
+    /// Build a machine for an encoded program rooted at `root_off`. A
+    /// `heap_limit_mib` of 0 means an unbounded managed heap.
+    pub fn new(
+        program: BytecodeProgram,
+        root_off: CodeRef,
+        heap_limit_mib: usize,
+    ) -> Result<Self, ExecutionError> {
+        let heap = if heap_limit_mib == 0 {
+            Heap::new()
+        } else {
+            Heap::with_limit(heap_limit_mib)
+        };
+        let mut pool = SymbolPool::new();
+        let (constants, root_env) = {
+            let view = MutatorHeapView::new(&heap);
+            let constants = program.prepare_constants(view, &mut pool);
+            let root_env = view.alloc(BcEnvFrame::default())?.as_ptr();
+            (constants, root_env)
+        };
+        // No prelude yet: globals is the empty root frame (wired next increment).
+        let globals = root_env;
+        let mut state = BcMachineState::new(
+            BcValue::Closure(BcClosure::new(root_off, root_env)),
+            globals,
+            root_env,
+            constants,
+        );
+        state.blackhole = program.blackhole;
+        Ok(BytecodeMachine {
+            heap,
+            program,
+            state,
+            metrics: Metrics::default(),
+            clock: Clock::default(),
+            dump_heap: false,
+        })
+    }
+
+    /// Run to termination (or `limit` ticks), returning the process exit
+    /// code. Polls for GC every 500 ticks (mirrors `Machine::run`, spec §6).
+    pub fn run(&mut self, limit: Option<usize>) -> Result<Option<u8>, ExecutionError> {
+        self.clock.switch(ThreadOccupation::Mutator);
+        let gc_check_freq: u32 = 500;
+        let mut gc_countdown: u32 = gc_check_freq;
+
+        while !self.state.terminated {
+            if let Some(limit) = limit {
+                if self.metrics.ticks() as usize >= limit {
+                    return Err(ExecutionError::DidntTerminate(limit));
+                }
+            }
+            gc_countdown -= 1;
+            if gc_countdown == 0 {
+                gc_countdown = gc_check_freq;
+                if interrupted() {
+                    return Err(ExecutionError::Interrupted);
+                }
+                if self.heap.policy_requires_collection() {
+                    gc_collect(
+                        &mut self.state,
+                        &mut self.heap,
+                        &mut self.clock,
+                        self.dump_heap,
+                    );
+                    self.clock.switch(ThreadOccupation::Mutator);
+                }
+            }
+            self.dispatch()?;
+        }
+
+        if self.heap.policy_requires_collection() {
+            gc_collect(
+                &mut self.state,
+                &mut self.heap,
+                &mut self.clock,
+                self.dump_heap,
+            );
+        }
+        self.clock.stop();
+        Ok(self.exit_code())
+    }
+
+    /// One dispatch step over the shared machine state (the free `step`).
+    fn dispatch(&mut self) -> Result<(), ExecutionError> {
+        self.metrics.tick();
+        let view = MutatorHeapView::new(&self.heap);
+        step(&mut self.state, view, &self.program)?;
+        // Bif dispatch is wired in the next increment; until then a captured
+        // pending BIF is an explicit error rather than a silent no-op.
+        if self.state.pending_bif.take().is_some() {
+            return Err(ExecutionError::Panic(
+                self.state.annotation,
+                "bytecode: Bif dispatch not yet wired (needs globals + intrinsics)".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// The process exit code from a terminated machine's result value
+    /// (mirrors `Machine::exit_code`: a numeric result is the code, a
+    /// tag-0 success constructor exits 0, anything else exits 1).
+    fn exit_code(&self) -> Option<u8> {
+        if !self.state.terminated {
+            return None;
+        }
+        Some(match &self.state.current {
+            BcValue::Native(Native::Num(n)) => {
+                n.as_i64().and_then(|i| u8::try_from(i).ok()).unwrap_or(1)
+            }
+            BcValue::Native(_) => 1,
+            BcValue::Closure(c) => {
+                let mut pc = c.code() as usize;
+                match Op::from_u8(read_u8(&self.program.code, &mut pc)) {
+                    Some(Op::Cons) if read_u8(&self.program.code, &mut pc) == 0 => 0,
+                    _ => 1,
+                }
+            }
+        })
+    }
+
+    /// Force a collection now (tests: prove the root set survives GC).
+    #[cfg(test)]
+    fn gc_now(&mut self) {
+        gc_collect(
+            &mut self.state,
+            &mut self.heap,
+            &mut self.clock,
+            self.dump_heap,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1356,5 +1610,32 @@ mod tests {
             Native::Num(n) => assert_eq!(n.as_i64(), Some(5)),
             _ => panic!("expected num"),
         }
+    }
+
+    #[test]
+    fn machine_runs_atom_to_exit_code() {
+        // A numeric top-level result becomes the process exit code.
+        let (prog, root, _) = encode(&dsl::atom(dsl::num(0)), &[]);
+        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(0));
+    }
+
+    #[test]
+    fn machine_returns_numeric_exit_code() {
+        let (prog, root, _) = encode(&dsl::atom(dsl::num(5)), &[]);
+        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn machine_survives_forced_gc() {
+        // let x = 5 in x, forcing a collection after the Let allocates its
+        // env frame: the machine's root set must keep the frame live.
+        let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
+        let (prog, root, _) = encode(&syn, &[]);
+        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        m.dispatch().unwrap(); // execute the Let (allocates the env frame)
+        m.gc_now(); // roots must survive
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
     }
 }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -9,11 +9,18 @@
 //! reference resolution used by every dispatch arm.
 
 use std::cmp::Ordering;
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use regex::Regex;
 
 use crate::common::sourcemap::Smid;
+use crate::eval::emit::Emitter;
 use crate::eval::error::ExecutionError;
+use crate::eval::machine::env::{EnvFrame, SynClosure};
+use crate::eval::machine::intrinsic::{IntrinsicMachine, StgIntrinsic};
 use crate::eval::machine::metrics::{Clock, Metrics, ThreadOccupation};
-use crate::eval::machine::vm::interrupted;
+use crate::eval::machine::vm::{interrupted, HeapNavigator};
 use crate::eval::memory::alloc::ScopedAllocator;
 use crate::eval::memory::array::Array;
 use crate::eval::memory::collect::{
@@ -1072,26 +1079,41 @@ pub fn step(
 /// and drives the `step` dispatch loop with periodic GC (spec §6). The
 /// parallel-engine counterpart to the HeapSyn `Machine`.
 ///
-/// This increment runs self-contained programs (no globals/prelude, no `Bif`
-/// dispatch); intrinsic dispatch, the globals frame and the emitter/capture
-/// lifecycle are wired in the following increments.
-pub struct BytecodeMachine {
+/// Intrinsic (`Bif`) dispatch runs through a neutral [`BcBifContext`]. The
+/// emitter/capture lifecycle and re-entrant `evaluate_to_whnf` are wired in
+/// following increments; intrinsics that reach those (or the HeapSyn-typed
+/// ABI methods) surface via the differential harness for migration.
+pub struct BytecodeMachine<'a> {
     heap: Heap,
     program: BytecodeProgram,
     state: BcMachineState,
     metrics: Metrics,
     clock: Clock,
     dump_heap: bool,
+    /// Symbol pool (interned symbols), shared with intrinsic dispatch.
+    symbol_pool: SymbolPool,
+    /// Regex cache used by string intrinsics.
+    rcache: LruCache<String, Regex>,
+    /// Whether `__EXPECT` failures return `false` rather than panicking.
+    test_mode: bool,
+    /// Intrinsic implementations, indexed by intrinsic index (spec §6.3).
+    intrinsics: Vec<&'a dyn StgIntrinsic>,
+    /// Output emitter.
+    emitter: Box<dyn Emitter + 'a>,
 }
 
-impl BytecodeMachine {
+impl<'a> BytecodeMachine<'a> {
     /// Build a machine for an encoded program rooted at `root_off`. A
-    /// `heap_limit_mib` of 0 means an unbounded managed heap.
+    /// `heap_limit_mib` of 0 means an unbounded managed heap. `intrinsics`
+    /// must be indexed by intrinsic index (e.g. `runtime.intrinsics()`).
     pub fn new(
         program: BytecodeProgram,
         root_off: CodeRef,
         global_forms: &[GlobalForm],
+        intrinsics: Vec<&'a dyn StgIntrinsic>,
+        emitter: Box<dyn Emitter + 'a>,
         heap_limit_mib: usize,
+        test_mode: bool,
     ) -> Result<Self, ExecutionError> {
         let heap = if heap_limit_mib == 0 {
             Heap::new()
@@ -1137,6 +1159,13 @@ impl BytecodeMachine {
             metrics: Metrics::default(),
             clock: Clock::default(),
             dump_heap: false,
+            symbol_pool: pool,
+            rcache: LruCache::new(
+                NonZeroUsize::new(100).expect("regex cache size must be non-zero"),
+            ),
+            test_mode,
+            intrinsics,
+            emitter,
         })
     }
 
@@ -1184,18 +1213,47 @@ impl BytecodeMachine {
         Ok(self.exit_code())
     }
 
-    /// One dispatch step over the shared machine state (the free `step`).
+    /// One dispatch step over the shared machine state (the free `step`),
+    /// followed by the deferred `Bif` dispatch tail (spec §6.3): when the
+    /// `Bif` arm captured an intrinsic, run it through a [`BcBifContext`].
     fn dispatch(&mut self) -> Result<(), ExecutionError> {
         self.metrics.tick();
-        let view = MutatorHeapView::new(&self.heap);
-        step(&mut self.state, view, &self.program)?;
-        // Bif dispatch is wired in the next increment; until then a captured
-        // pending BIF is an explicit error rather than a silent no-op.
-        if self.state.pending_bif.take().is_some() {
-            return Err(ExecutionError::Panic(
-                self.state.annotation,
-                "bytecode: Bif dispatch not yet wired (needs globals + intrinsics)".to_string(),
-            ));
+        {
+            let view = MutatorHeapView::new(&self.heap);
+            step(&mut self.state, view, &self.program)?;
+        }
+
+        if let Some(idx) = self.state.pending_bif.take() {
+            // Materialise the captured arg refs. There is no live code node to
+            // re-read (unlike HeapSyn), so we translate the decoded refs back
+            // into `Ref`s the intrinsic ABI understands.
+            let args: Vec<Ref> = std::mem::take(&mut self.state.pending_bif_args)
+                .iter()
+                .map(|d| match *d {
+                    DecodedRef::Local(i) => Ref::L(i as usize),
+                    DecodedRef::Global(i) => Ref::G(i as usize),
+                    DecodedRef::Value(k) => self.state.constants[k as usize].clone(),
+                })
+                .collect();
+            // The Bif closure is still `current`; its env holds the (strict,
+            // pre-evaluated) args that `Ref::L` operands index into.
+            let env = self
+                .state
+                .current
+                .as_closure()
+                .map(|c| c.env())
+                .unwrap_or(self.state.root_env);
+            let bif = self.intrinsics[idx as usize];
+            let view = MutatorHeapView::new(&self.heap);
+            let mut ctx = BcBifContext {
+                state: &mut self.state,
+                program: &self.program,
+                symbol_pool: &mut self.symbol_pool,
+                rcache: &mut self.rcache,
+                test_mode: self.test_mode,
+                env,
+            };
+            bif.execute(&mut ctx, view, self.emitter.as_mut(), &args)?;
         }
         Ok(())
     }
@@ -1234,13 +1292,182 @@ impl BytecodeMachine {
     }
 }
 
+/// The `IntrinsicMachine` implementation for the bytecode engine (spec §5.5).
+///
+/// It overrides the neutral, code-type-agnostic ABI methods to operate over
+/// `BcValue`s (resolving refs against the Bif closure's env / the globals
+/// frame / the constant pool, and returning results by mutating the machine
+/// `current`). The HeapSyn-typed methods (`nav`/`set_closure`/`root_env`/
+/// `env`/`evaluate_to_whnf`) are unreachable on this path and panic; an
+/// intrinsic still using them (or the not-yet-wired capture lifecycle)
+/// surfaces via the differential harness for migration.
+struct BcBifContext<'ctx> {
+    state: &'ctx mut BcMachineState,
+    program: &'ctx BytecodeProgram,
+    symbol_pool: &'ctx mut SymbolPool,
+    rcache: &'ctx mut LruCache<String, Regex>,
+    test_mode: bool,
+    /// Environment of the Bif closure (indexed by `Ref::L` arg operands).
+    env: RefPtr<BcEnvFrame>,
+}
+
+impl BcBifContext<'_> {
+    /// Resolve a runtime value to a native, following `OP_ATOM` indirections
+    /// (the bytecode analogue of `HeapNavigator::resolve_native`).
+    fn native_from_value(
+        &self,
+        view: MutatorHeapView<'_>,
+        value: BcValue,
+    ) -> Result<Native, ExecutionError> {
+        match value {
+            BcValue::Native(n) => Ok(n),
+            BcValue::Closure(c) => {
+                let code = self.program.code.as_slice();
+                let mut pc = c.code() as usize;
+                if Op::from_u8(read_u8(code, &mut pc)) == Some(Op::Atom) {
+                    let dref = read_ref(code, &mut pc)?;
+                    let inner = resolve_ref(
+                        view,
+                        &self.state.constants,
+                        c.env(),
+                        self.state.globals,
+                        dref,
+                    )?;
+                    self.native_from_value(view, inner)
+                } else {
+                    Err(ExecutionError::NotValue(
+                        self.state.annotation,
+                        "expected a native value".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+}
+
+impl IntrinsicMachine for BcBifContext<'_> {
+    fn rcache(&mut self) -> &mut LruCache<String, Regex> {
+        self.rcache
+    }
+
+    fn symbol_pool(&self) -> &SymbolPool {
+        self.symbol_pool
+    }
+
+    fn symbol_pool_mut(&mut self) -> &mut SymbolPool {
+        self.symbol_pool
+    }
+
+    fn annotation(&self) -> Smid {
+        self.state.annotation
+    }
+
+    fn test_mode(&self) -> bool {
+        self.test_mode
+    }
+
+    // ── HeapSyn-typed methods: unreachable on the bytecode path ──────
+    // These name `SynClosure`/`EnvFrame`, which the bytecode engine never
+    // produces. An intrinsic reaching one has not been migrated to the
+    // neutral ABI and is caught by the differential harness.
+
+    fn set_closure(&mut self, _closure: SynClosure) -> Result<(), ExecutionError> {
+        panic!("bytecode BifContext: set_closure(SynClosure) — intrinsic uses the HeapSyn ABI")
+    }
+
+    fn nav<'guard>(&'guard self, _view: MutatorHeapView<'guard>) -> HeapNavigator<'guard> {
+        panic!("bytecode BifContext: nav — intrinsic uses the HeapSyn ABI")
+    }
+
+    fn root_env(&self) -> RefPtr<EnvFrame> {
+        panic!("bytecode BifContext: root_env — intrinsic uses the HeapSyn ABI")
+    }
+
+    fn env(&self, _view: MutatorHeapView) -> RefPtr<EnvFrame> {
+        panic!("bytecode BifContext: env — intrinsic uses the HeapSyn ABI")
+    }
+
+    // ── Emitter capture lifecycle: not yet wired ────────────────────
+
+    fn start_capture(&mut self, _format: &str) -> Result<(), ExecutionError> {
+        Err(ExecutionError::Panic(
+            self.state.annotation,
+            "bytecode: emit capture not yet wired".to_string(),
+        ))
+    }
+
+    fn push_capture_end(&mut self, _view: MutatorHeapView<'_>) -> Result<(), ExecutionError> {
+        Err(ExecutionError::Panic(
+            self.state.annotation,
+            "bytecode: emit capture not yet wired".to_string(),
+        ))
+    }
+
+    fn take_capture_result(&mut self) -> Result<String, ExecutionError> {
+        Err(ExecutionError::Panic(
+            self.state.annotation,
+            "bytecode: emit capture not yet wired".to_string(),
+        ))
+    }
+
+    // ── Neutral ABI over `BcValue` (spec §5.5) ──────────────────────
+
+    fn resolve_native(
+        &self,
+        view: MutatorHeapView<'_>,
+        arg: &Ref,
+    ) -> Result<Native, ExecutionError> {
+        let value = match arg {
+            Ref::V(n) => return Ok(n.clone()),
+            Ref::L(i) => view
+                .scoped(self.env)
+                .get(&view, *i)
+                .ok_or(ExecutionError::BadEnvironmentIndex(*i))?,
+            Ref::G(i) => view
+                .scoped(self.state.globals)
+                .get(&view, *i)
+                .ok_or(ExecutionError::BadGlobalIndex(*i))?,
+        };
+        self.native_from_value(view, value)
+    }
+
+    fn return_native(
+        &mut self,
+        _view: MutatorHeapView<'_>,
+        native: Native,
+    ) -> Result<(), ExecutionError> {
+        self.state.current = BcValue::Native(native);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::eval::bytecode::{encode, BcClosure, BcEnvBuilder};
+    use crate::eval::emit::NullEmitter;
     use crate::eval::memory::alloc::ScopedAllocator;
     use crate::eval::memory::heap::Heap;
     use crate::eval::stg::syntax::dsl;
+
+    /// A machine with no intrinsics and a null emitter (self-contained
+    /// programs).
+    fn bare_machine(
+        program: BytecodeProgram,
+        root_off: CodeRef,
+        global_forms: &[GlobalForm],
+    ) -> BytecodeMachine<'static> {
+        BytecodeMachine::new(
+            program,
+            root_off,
+            global_forms,
+            Vec::new(),
+            Box::new(NullEmitter),
+            0,
+            false,
+        )
+        .unwrap()
+    }
 
     #[test]
     fn read_ref_decodes_tags() {
@@ -1639,14 +1866,14 @@ mod tests {
     fn machine_runs_atom_to_exit_code() {
         // A numeric top-level result becomes the process exit code.
         let (prog, root, gforms) = encode(&dsl::atom(dsl::num(0)), &[]);
-        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
+        let mut m = bare_machine(prog, root, &gforms);
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(0));
     }
 
     #[test]
     fn machine_returns_numeric_exit_code() {
         let (prog, root, gforms) = encode(&dsl::atom(dsl::num(5)), &[]);
-        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
+        let mut m = bare_machine(prog, root, &gforms);
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
     }
 
@@ -1656,7 +1883,7 @@ mod tests {
         // env frame: the machine's root set must keep the frame live.
         let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
         let (prog, root, gforms) = encode(&syn, &[]);
-        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
+        let mut m = bare_machine(prog, root, &gforms);
         m.dispatch().unwrap(); // execute the Let (allocates the env frame)
         m.gc_now(); // roots must survive
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
@@ -1668,7 +1895,51 @@ mod tests {
         let globals = vec![dsl::lambda(1, dsl::local(0))];
         let root = dsl::app(dsl::gref(0), vec![dsl::num(7)]);
         let (prog, root_off, gforms) = encode(&root, &globals);
-        let mut m = BytecodeMachine::new(prog, root_off, &gforms, 0).unwrap();
+        let mut m = bare_machine(prog, root_off, &gforms);
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(7));
+    }
+
+    #[test]
+    fn machine_dispatches_add_intrinsic() {
+        // A bare `__ADD(2, 3)` Bif node dispatched through BcBifContext -> 5.
+        use crate::common::sourcemap::SourceMap;
+        use crate::eval::intrinsics;
+        use crate::eval::stg::{make_standard_runtime, runtime::Runtime};
+
+        let mut source_map = SourceMap::new();
+        let runtime = make_standard_runtime(&mut source_map);
+        let intrinsics = runtime.intrinsics();
+        let add = intrinsics::index("ADD").expect("ADD intrinsic") as u8;
+
+        let syn = dsl::app_bif(add, vec![dsl::num(2), dsl::num(3)]);
+        let (prog, root, _gforms) = encode(&syn, &[]);
+        let mut m =
+            BytecodeMachine::new(prog, root, &[], intrinsics, Box::new(NullEmitter), 0, false)
+                .unwrap();
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn machine_dispatches_add_with_local_arg() {
+        // let x = 2 in __ADD(x, 3) — exercises resolve_native's L-ref path
+        // (env slot -> OP_ATOM indirection -> native) in BcBifContext.
+        use crate::common::sourcemap::SourceMap;
+        use crate::eval::intrinsics;
+        use crate::eval::stg::{make_standard_runtime, runtime::Runtime};
+
+        let mut source_map = SourceMap::new();
+        let runtime = make_standard_runtime(&mut source_map);
+        let intrinsics = runtime.intrinsics();
+        let add = intrinsics::index("ADD").expect("ADD intrinsic") as u8;
+
+        let syn = dsl::let_(
+            vec![dsl::value(dsl::atom(dsl::num(2)))],
+            dsl::app_bif(add, vec![dsl::lref(0), dsl::num(3)]),
+        );
+        let (prog, root, _gforms) = encode(&syn, &[]);
+        let mut m =
+            BytecodeMachine::new(prog, root, &[], intrinsics, Box::new(NullEmitter), 0, false)
+                .unwrap();
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
     }
 }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -28,8 +28,8 @@ use crate::eval::stg::tags::{DataConstructor, Tag};
 
 use super::program::{read_u16, read_u32, read_u8};
 use super::{
-    BcClosure, BcContinuation, BcEnvBuilder, BcEnvFrame, BcValue, BytecodeProgram, CodeRef, Op,
-    FORM_LAMBDA, FORM_THUNK, NO_BRANCH, REF_G, REF_L, REF_V,
+    BcClosure, BcContinuation, BcEnvBuilder, BcEnvFrame, BcValue, BytecodeProgram, CodeRef,
+    GlobalForm, Op, FORM_LAMBDA, FORM_THUNK, NO_BRANCH, REF_G, REF_L, REF_V,
 };
 
 /// A decoded inline `Ref` operand from the byte stream.
@@ -733,13 +733,19 @@ fn make_arg_array(
     Ok(array)
 }
 
+/// Build the static part of a closure from a form kind/arity/annotation
+/// and its body offset (shared by let bindings and global forms).
+fn form_info(kind: u8, arity: u8, smid: Smid, body: CodeRef) -> InfoTagged<CodeRef> {
+    match kind {
+        FORM_THUNK => InfoTagged::thunk(body),
+        FORM_LAMBDA => InfoTagged::new(arity, body, smid),
+        _ => InfoTagged::value(body), // FORM_VALUE
+    }
+}
+
 /// Build the static part of a closure from a decoded form header.
 fn bc_info(h: &FormHeader) -> InfoTagged<CodeRef> {
-    match h.kind {
-        FORM_THUNK => InfoTagged::thunk(h.body),
-        FORM_LAMBDA => InfoTagged::new(h.arity, h.body, h.smid),
-        _ => InfoTagged::value(h.body), // FORM_VALUE
-    }
+    form_info(h.kind, h.arity, h.smid, h.body)
 }
 
 /// Read a `Let`/`LetRec` binding-header list (`u16` count then that many
@@ -1084,6 +1090,7 @@ impl BytecodeMachine {
     pub fn new(
         program: BytecodeProgram,
         root_off: CodeRef,
+        global_forms: &[GlobalForm],
         heap_limit_mib: usize,
     ) -> Result<Self, ExecutionError> {
         let heap = if heap_limit_mib == 0 {
@@ -1092,14 +1099,30 @@ impl BytecodeMachine {
             Heap::with_limit(heap_limit_mib)
         };
         let mut pool = SymbolPool::new();
-        let (constants, root_env) = {
+        let (constants, root_env, globals) = {
             let view = MutatorHeapView::new(&heap);
             let constants = program.prepare_constants(view, &mut pool);
             let root_env = view.alloc(BcEnvFrame::default())?.as_ptr();
-            (constants, root_env)
+            // The globals frame holds one closure per encoded global form.
+            // Cross-global references compile to `Ref::G(i)` (resolved against
+            // this frame), so the closures need only close over `root_env`.
+            let globals = if global_forms.is_empty() {
+                root_env
+            } else {
+                view.from_values(
+                    global_forms.iter().map(|gf| {
+                        BcValue::Closure(BcClosure::close(
+                            &form_info(gf.kind, gf.arity, gf.smid, gf.entry),
+                            root_env,
+                        ))
+                    }),
+                    global_forms.len(),
+                    root_env,
+                    Smid::default(),
+                )?
+            };
+            (constants, root_env, globals)
         };
-        // No prelude yet: globals is the empty root frame (wired next increment).
-        let globals = root_env;
         let mut state = BcMachineState::new(
             BcValue::Closure(BcClosure::new(root_off, root_env)),
             globals,
@@ -1615,15 +1638,15 @@ mod tests {
     #[test]
     fn machine_runs_atom_to_exit_code() {
         // A numeric top-level result becomes the process exit code.
-        let (prog, root, _) = encode(&dsl::atom(dsl::num(0)), &[]);
-        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        let (prog, root, gforms) = encode(&dsl::atom(dsl::num(0)), &[]);
+        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(0));
     }
 
     #[test]
     fn machine_returns_numeric_exit_code() {
-        let (prog, root, _) = encode(&dsl::atom(dsl::num(5)), &[]);
-        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        let (prog, root, gforms) = encode(&dsl::atom(dsl::num(5)), &[]);
+        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
     }
 
@@ -1632,10 +1655,20 @@ mod tests {
         // let x = 5 in x, forcing a collection after the Let allocates its
         // env frame: the machine's root set must keep the frame live.
         let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
-        let (prog, root, _) = encode(&syn, &[]);
-        let mut m = BytecodeMachine::new(prog, root, 0).unwrap();
+        let (prog, root, gforms) = encode(&syn, &[]);
+        let mut m = BytecodeMachine::new(prog, root, &gforms, 0).unwrap();
         m.dispatch().unwrap(); // execute the Let (allocates the env frame)
         m.gc_now(); // roots must survive
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn machine_resolves_global_ref() {
+        // globals = [ id = \x. x ]; root = id(7) via a G-ref.
+        let globals = vec![dsl::lambda(1, dsl::local(0))];
+        let root = dsl::app(dsl::gref(0), vec![dsl::num(7)]);
+        let (prog, root_off, gforms) = encode(&root, &globals);
+        let mut m = BytecodeMachine::new(prog, root_off, &gforms, 0).unwrap();
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(7));
     }
 }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -21,8 +21,8 @@ use crate::eval::stg::tags::{DataConstructor, Tag};
 
 use super::program::{read_u16, read_u32, read_u8};
 use super::{
-    BcClosure, BcContinuation, BcEnvBuilder, BcEnvFrame, BcValue, CodeRef, Op, FORM_LAMBDA,
-    FORM_THUNK, NO_BRANCH, REF_G, REF_L, REF_V,
+    BcClosure, BcContinuation, BcEnvBuilder, BcEnvFrame, BcValue, BytecodeProgram, CodeRef, Op,
+    FORM_LAMBDA, FORM_THUNK, NO_BRANCH, REF_G, REF_L, REF_V,
 };
 
 /// A decoded inline `Ref` operand from the byte stream.
@@ -464,6 +464,7 @@ pub fn return_native(
 pub fn return_fun(
     state: &mut BcMachineState,
     view: MutatorHeapView<'_>,
+    prog: &BytecodeProgram,
 ) -> Result<(), ExecutionError> {
     let Some(cont) = state.stack.pop() else {
         state.terminated = true;
@@ -481,10 +482,11 @@ pub fn return_fun(
                     state.current = BcValue::Closure(view.saturate_with_array(&fun, args)?);
                 }
                 Ordering::Less => {
-                    return Err(ExecutionError::Panic(
-                        annotation,
-                        "bytecode: partial application (PAP) not yet implemented".to_string(),
-                    ));
+                    // Partial application: build a PAP trampoline closure. Its
+                    // env is `[f, supplied…]` chaining onto `f`'s env; its code
+                    // is the pre-encoded `App(L(pending), …)` template; its
+                    // arity is the number still pending (spec §6.1).
+                    state.current = BcValue::Closure(partially_apply(view, prog, &fun, args)?);
                 }
                 Ordering::Greater => {
                     let (quorum, surplus) = args.as_slice().split_at(args.len() - excess as usize);
@@ -553,6 +555,42 @@ pub fn return_fun(
         }
     }
     Ok(())
+}
+
+/// Build a partial-application (PAP) trampoline closure for a function
+/// applied to too few args. The result closes `[f, supplied…]` over `f`'s
+/// env and points at the pre-encoded `App(L(pending), …)` template
+/// (`prog.pap`); its arity is the count still pending. Mirrors the HeapSyn
+/// `partially_apply` (`env_builder.rs`).
+fn partially_apply(
+    view: MutatorHeapView<'_>,
+    prog: &BytecodeProgram,
+    fun: &BcClosure,
+    args: Array<BcValue>,
+) -> Result<BcClosure, ExecutionError> {
+    let supplied = args.len();
+    let pending = fun.arity() as usize - supplied;
+    let tmpl = prog.pap_offset(supplied, pending).ok_or_else(|| {
+        ExecutionError::Panic(
+            fun.annotation(),
+            format!(
+                "bytecode: PAP arity out of range (supplied {supplied}, pending {pending}, max {})",
+                super::PAP_MAX_ARITY
+            ),
+        )
+    })?;
+    let env = view.from_values(
+        std::iter::once(BcValue::Closure(*fun)).chain(args.as_slice().iter().cloned()),
+        supplied + 1,
+        fun.env(),
+        fun.annotation(),
+    )?;
+    Ok(BcClosure::new_annotated_lambda(
+        tmpl,
+        pending as u8,
+        env,
+        fun.annotation(),
+    ))
 }
 
 /// Decode the field ref of an arg atom-offset (skip the `OP_ATOM` byte and
@@ -670,8 +708,9 @@ fn enter_callable(
 pub fn handle_op(
     state: &mut BcMachineState,
     view: MutatorHeapView<'_>,
-    code: &[u8],
+    prog: &BytecodeProgram,
 ) -> Result<(), ExecutionError> {
+    let code = prog.code.as_slice();
     let closure = *state.current.as_closure().ok_or_else(|| {
         ExecutionError::Panic(state.annotation, "handle_op on a native value".to_string())
     })?;
@@ -899,7 +938,7 @@ pub fn handle_op(
 pub fn step(
     state: &mut BcMachineState,
     view: MutatorHeapView<'_>,
-    code: &[u8],
+    prog: &BytecodeProgram,
 ) -> Result<(), ExecutionError> {
     enum Dispatch {
         Native(Native),
@@ -913,8 +952,8 @@ pub fn step(
     };
     match dispatch {
         Dispatch::Native(n) => return_native(state, view, n),
-        Dispatch::Fun => return_fun(state, view),
-        Dispatch::Op => handle_op(state, view, code),
+        Dispatch::Fun => return_fun(state, view, prog),
+        Dispatch::Op => handle_op(state, view, prog),
     }
 }
 
@@ -1155,7 +1194,7 @@ mod tests {
             annotation: Default::default(),
         });
 
-        return_fun(&mut state, view).unwrap();
+        return_fun(&mut state, view, &BytecodeProgram::default()).unwrap();
 
         let c = state.current.as_closure().unwrap();
         assert_eq!(c.code(), 10);
@@ -1182,7 +1221,7 @@ mod tests {
             annotation: Default::default(),
         });
 
-        return_fun(&mut state, view).unwrap();
+        return_fun(&mut state, view, &BytecodeProgram::default()).unwrap();
 
         assert_eq!(state.current.as_closure().unwrap().code(), 10);
         assert_eq!(state.stack.len(), 1);
@@ -1213,7 +1252,7 @@ mod tests {
         state.blackhole = prog.blackhole;
         let mut guard = 0;
         while !state.terminated && guard < 1000 {
-            step(&mut state, view, &prog.code).unwrap();
+            step(&mut state, view, &prog).unwrap();
             guard += 1;
         }
         assert!(state.terminated, "machine did not terminate");
@@ -1283,7 +1322,7 @@ mod tests {
             root_env,
             constants,
         );
-        handle_op(&mut state, view, &prog.code).unwrap();
+        handle_op(&mut state, view, &prog).unwrap();
         assert_eq!(state.pending_bif, Some(3));
         assert_eq!(state.pending_bif_args.len(), 2);
     }
@@ -1294,6 +1333,24 @@ mod tests {
         let syn = dsl::let_(
             vec![dsl::lambda(1, dsl::local(0))],
             dsl::direct_app(Default::default(), dsl::lref(0), vec![dsl::num(5)]),
+        );
+        match run_to_end(&syn) {
+            Native::Num(n) => assert_eq!(n.as_i64(), Some(5)),
+            _ => panic!("expected num"),
+        }
+    }
+
+    #[test]
+    fn run_partial_application() {
+        // letrec k = \x y. x        -- a binary const
+        //        p = k(5)           -- thunk: too few args -> PAP of arity 1
+        // in p(6)                   -- saturate the PAP -> k(5, 6) -> 5
+        let syn = dsl::letrec_(
+            vec![
+                dsl::lambda(2, dsl::local(0)),
+                dsl::thunk(dsl::app(dsl::lref(0), vec![dsl::num(5)])),
+            ],
+            dsl::app(dsl::lref(1), vec![dsl::num(6)]),
         );
         match run_to_end(&syn) {
             Native::Num(n) => assert_eq!(n.as_i64(), Some(5)),


### PR DESCRIPTION
## BV1 machine-wiring: BytecodeMachine + intrinsic dispatch spine

Continues the BV1 bytecode-VM work (eu-vi3a) on top of the merged #927. This
lands the **machine-wiring integration** — the parallel bytecode machine now
executes real intrinsic-bearing programs end-to-end. Durable status is the
ledger at the top of `docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md`.

### What's in this PR (6 commits)

- **PAP (steps 1–2, `ac2f11aa`)** — threaded `&BytecodeProgram` through
  `step`/`handle_op`/`return_fun` so handlers reach `templates`/`blackhole`/
  `pap`; wired partial application (`return_fun` too-few-args) via a
  `partially_apply` building the `[f, supplied…]` env over
  `prog.pap_offset(supplied, pending)` with arity `pending`.
- **`BytecodeMachine` (step 3a, `1aa2a4fa`)** — owns heap/program/state/
  metrics/clock; `run` loop mirrors `Machine::run` (500-tick GC poll →
  `gc_collect`, tick metering, exit-code). Adds `GcScannable for
  BcMachineState` so the collector traces the machine roots (globals/root_env,
  `current`, the continuation stack inline, and the constant pool).
- **Globals frame (step 3b-i, `eef945f0`)** — `BytecodeMachine::new` builds
  the globals frame from the encoded `&[GlobalForm]`; G-refs resolve against it.
- **`Bif` dispatch spine (step 3b-ii, `dc8fe6ea`)** — the dispatch tail
  materialises the captured `pending_bif_args` → `&[Ref]` and runs the
  intrinsic through **`BcBifContext: IntrinsicMachine`** (overrides the neutral
  `resolve_native` incl. `OP_ATOM` indirection, and `return_native`). The five
  HeapSyn-typed ABI methods and the not-yet-wired capture lifecycle panic/error,
  so any unmigrated intrinsic surfaces (rather than silently misbehaving) once
  the differential harness runs.

### Tests (all new, alongside the existing bytecode suite)

- `run_partial_application` — `letrec k=\x y.x; p=k(5) in p(6)` → 5 (full PAP
  build + saturate + trampoline path).
- `machine_survives_forced_gc` — step → force a collection → run → 5 (root set
  survives GC).
- `machine_resolves_global_ref` — `id(7)` via a G-ref through the globals frame.
- `machine_dispatches_add_intrinsic` / `machine_dispatches_add_with_local_arg` —
  `__ADD(2,3)` and `let x=2 in __ADD(x,3)` dispatched through the real
  `make_standard_runtime` intrinsics (exercising the V-const and L-ref
  env-resolution paths).

### Verification

- `cargo test --lib` — **1228 passed** (43 in `eval::bytecode`).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

### Scope / not yet in this PR

This is the machine + intrinsic spine, not the full day11 gate. Still to come
(tracked in the ledger): widening `BcBifContext`'s neutral overrides
(`return_bool`/`unit`/`boxed_num`, `resolve_closure`/`data_*`/`force`),
`evaluate_to_whnf`, the `Meta`/`DeMeta`/`LookupLit` arms, full runtime globals +
prelude encoding, the `EU_BYTECODE` flag path in `driver/eval.rs`, and the
differential harness. No user-visible behaviour changes — the bytecode engine
is still gated off (no flag path wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee
