### PR TITLE
Make web-setup beads bootstrap resilient to unusable ssh sync.remote

### DIFF
--- a/scripts/setup-claude-web-env.sh
+++ b/scripts/setup-claude-web-env.sh
@@ -161,10 +161,41 @@ install_eucalypt() {
 # ---------------------------------------------------------------------------
 # The git-tracked issue data lives in .beads/issues.jsonl; the dolt/ runtime
 # store is gitignored, so a fresh checkout has no usable database until it is
-# rebuilt. `bd bootstrap` is beads' purpose-built command for this: it clones
-# from the configured sync.remote when reachable and otherwise falls back to
-# the git-tracked JSONL. (The old `bd sync` this script used to call no longer
-# exists in beads >= 1.0.)
+# rebuilt. `bd bootstrap` is beads' purpose-built command for this. (The old
+# `bd sync` this script used to call no longer exists in beads >= 1.0.)
+#
+# Caveat that this function works around: `bd bootstrap` is priority-ordered,
+# and a configured `sync.remote` is the FIRST rule — it clones from that remote
+# and short-circuits every fallback (git-origin dolt data, backup, JSONL). This
+# repo pins `sync.remote: git+ssh://…`, but the Claude-web container has no ssh
+# binary and dolt shells out to ssh directly (bypassing the proxy's git-ssh
+# rewrite), so the clone dead-ends and leaves an empty store — every later `bd`
+# call then reports "database … not found". The fallback below neutralises
+# `sync.remote` and retries, so bd falls through to the git origin (https via
+# the agent proxy) or the git-tracked issues.jsonl.
+
+# True when the beads store is materialised (`bd list` exits 0 only then).
+_beads_store_ok() { ( cd "$1" && bd list >/dev/null 2>&1 ); }
+
+# Retry bootstrap with `sync.remote` temporarily disabled so bd uses the git
+# origin / JSONL instead of the unusable ssh remote. Always restores
+# config.yaml (a git-tracked file) so the working tree — and the ssh remote
+# relied on for local dev — is left untouched, even on error under `set -e`.
+_bootstrap_without_ssh_remote() {
+    # Separate `local` statements: a single `local a=… b="$a"` expands every
+    # RHS before assigning, so `$repo` would be unbound under `set -u`.
+    local repo="$1"
+    local cfg="$repo/.beads/config.yaml"
+    local bak
+    [ -f "$cfg" ] && grep -q '^[[:space:]]*sync\.remote:' "$cfg" || return 1
+    bak="$(mktemp)"
+    cp "$cfg" "$bak"
+    # shellcheck disable=SC2064
+    trap "cp '$bak' '$cfg'; rm -f '$bak'; trap - RETURN" RETURN
+    sed -i 's/^\([[:space:]]*\)sync\.remote:/\1# sync.remote:/' "$cfg"
+    ( cd "$repo" && bd bootstrap --yes ) || true
+}
+
 bootstrap_beads() {
     [ "$BEADS_SYNC" = "1" ] || return 0
     command -v bd >/dev/null 2>&1 || return 0
@@ -179,18 +210,28 @@ bootstrap_beads() {
     log "Bootstrapping beads store ($repo)"
     chmod 700 "$repo/.beads" 2>/dev/null || true
 
-    # Idempotency guard: `bd list` exits 0 only when the store is materialised.
-    # `bd bootstrap` is NOT self-idempotent when sync.remote is set — a second
-    # run re-attempts the clone and errors with "database exists" — so skip it
-    # once the store is already usable.
-    if ( cd "$repo" && bd list >/dev/null 2>&1 ); then
+    # Idempotency guard: skip once the store is already usable. `bd bootstrap`
+    # is NOT self-idempotent when sync.remote is set — a second run re-attempts
+    # the clone and errors with "database exists".
+    if _beads_store_ok "$repo"; then
         echo "beads store already materialised; skipping bootstrap."
         return 0
     fi
 
-    # Non-fatal: git/network access may be unavailable at provision time.
-    ( cd "$repo" && bd bootstrap --yes ) \
-        || echo "WARNING: 'bd bootstrap' failed (network/git access?); run 'bd bootstrap' later."
+    # First attempt: honour the configured sync.remote (ssh, for local dev).
+    ( cd "$repo" && bd bootstrap --yes ) || true
+
+    # Fallback for the no-ssh container: retry over the git origin / JSONL.
+    if ! _beads_store_ok "$repo"; then
+        echo "bootstrap via sync.remote failed; retrying over the git origin (no ssh)."
+        _bootstrap_without_ssh_remote "$repo" || true
+    fi
+
+    if _beads_store_ok "$repo"; then
+        echo "beads store materialised."
+    else
+        echo "WARNING: 'bd bootstrap' failed (network/git access?); run 'bd bootstrap' later."
+    fi
 }
 
 main() {


### PR DESCRIPTION
## Problem

On Claude Code on the web, the beads database was unusable for the whole session — every `bd` call reported `database beads_eu not found`.

Root cause is in `scripts/setup-claude-web-env.sh`'s `bootstrap_beads()`:

1. It materialises the dolt store with `bd bootstrap`.
2. `bd bootstrap` is **priority-ordered**: a configured `sync.remote` is the *first* rule and short-circuits every fallback (git-origin dolt data, backup, git-tracked `issues.jsonl`).
3. This repo pins `sync.remote: git+ssh://git@github.com/curvelogic/eucalypt.git`, but the web setup phase has **no `ssh` binary**, and dolt shells out to `ssh` directly (bypassing the proxy's git-ssh→https rewrite). The clone hard-fails (`cannot run ssh: No such file or directory`) and leaves an **empty store**.
4. The failure is swallowed (`|| echo WARNING`), so provisioning "succeeds" while the DB is broken.

## Fix

Add a fallback in `bootstrap_beads()`: if the store is still unusable after the first `bd bootstrap`, retry with `sync.remote` temporarily neutralised so bd falls through to the git origin (https via the agent proxy) or `issues.jsonl`.

- `config.yaml` is a **git-tracked** file, so it is always restored via a `RETURN` trap — the ssh remote relied on for local dev is left untouched, and the working tree stays clean.
- The first attempt still honours the ssh `sync.remote`, so nothing changes where ssh *is* available.

Also fixes a latent `set -u` unbound-variable bug in the multi-assignment `local repo=… cfg="$repo/…"` (bash expands all RHS words before assigning, so `$repo` was unbound).

## Verification

Exercised end-to-end by stopping the dolt server, wiping `.beads/dolt`, and re-running the real functions:

- **ssh-succeeds path** (proxy rewrites `git+ssh://` in interactive sessions): first attempt re-materialises the store; `config.yaml` untouched (zero git diff).
- **ssh-fails path** (forced): fallback neutralises `sync.remote`, bootstraps over `git+http://local_proxy…/git/curvelogic/eucalypt`, store healthy; `config.yaml` restored with the ssh remote intact.
- **idempotency**: with a healthy store, `bootstrap_beads` skips (`already materialised`).
- Restored store integrity confirmed (56 issues present).

`bash -n` clean. (No `shellcheck` in the environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B44kWc9DXBKyAeByCjyjU5