### PR TITLE
feat(bytecode): BV1 — real .eu runs on bytecode (flag path + block-index gating) (eu-vi3a)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -69,16 +69,30 @@ engine can't mutate that way — a block is `BcClosure{code, env}` where the `Co
 currently **gated off** (`block_index_enabled()` = `false` for `BcBifContext`)
 and lookups fall back to the **STG find loop** (O(n), same result).
 
-**This was a deliberate deferral, NOT a hard limitation.** The bytecode engine
-*can* mutate the field *values* — they live in the (shared, GC-heap) `env`
-frame, so `env.update(index_slot, Native::Index(map))` would propagate to all
-holders. Reinstating a bytecode-native index needs: (1) migrate the index
-machinery (`build_index`/`walk_list_to_position`/`store_index_in_block`/
-`count_list`/`BlockListIterator`) off the `SynClosure`-typed ABI, and (2) point
-`store_index_in_block` at the block closure's env slot instead of the heap node's
-arg array. It was skipped only because it's a pure perf optimisation (correctness
-is fine via the find loop) and gating it was the minimal change to unblock the
-whole corpus.
+**This was a deliberate deferral, NOT a hard limitation — but the reinstatement
+is subtler than "update the env slot", because it depends on how a block was
+created:**
+- **Dynamically-built blocks** (intrinsic output via `build_data`/`data_value`):
+  every field, including the index slot, is a `BcValue` in the shared GC-heap
+  `env` frame, so `env.update(index_slot, Native::Index(map))` works and
+  propagates. Mutable. ✓
+- **Static block literals** (`{a: 1}` in source): the encoder bakes the `Cons`
+  into the arena and compiles the index field (`no_index()` = `num(0)`) as a
+  **`V`-const reference into the constant pool, inline in the immutable arena
+  node** — there is no mutable env slot to overwrite. ✗ *(VERIFY in `encode.rs`
+  / the block compiler before designing the fix — this is reasoned from the
+  value model, not yet confirmed.)* Contrast HeapSyn, where even a literal is
+  loaded into a **heap** `Cons` node at runtime, so its arg array is always
+  mutable — which is why HeapSyn can cache the index regardless of origin.
+
+Reinstatement options: (1) migrate the index machinery (`build_index`/
+`walk_list_to_position`/`store_index_in_block`/`count_list`/`BlockListIterator`)
+off the `SynClosure`-typed ABI; **and** for literal blocks either (2a) change
+the encoder to give a block's index field a real mutable env slot even for
+literals, (2b) use a **side table keyed by block identity** (env pointer), or
+(2c) cache only dynamic blocks and leave literals on the find loop. Skipped for
+now only because it's pure perf (correctness is fine via the find loop) and
+gating was the minimal change to unblock the whole corpus.
 
 **When BV2–5 benchmark bytecode vs HeapSyn, this is NOT apples-to-apples for
 block-heavy programs** — either reinstate the bytecode index (above) or also

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -61,19 +61,30 @@
 ## Progress Ledger (living — durable source of truth; update every increment)
 
 ### ⚠️ PERF CAVEAT — block-index optimisation DISABLED on the bytecode path
-`LookupOr`/`SafeLookup` cache a `SymbolId→position` map inside a block (mutating
-its index slot in place). The bytecode engine **cannot** do that in-place
-mutation (blocks are template closures), so `block_index_enabled()` returns
-`false` for `BcBifContext` and the bytecode engine falls back to the **STG-level
-find loop** for every block lookup — **O(n) per lookup instead of O(1)**.
-Correct (same result) but slower on lookup-heavy blocks.
-**When BV2–5 benchmark bytecode vs HeapSyn, this is NOT an apples-to-apples
-comparison for block-heavy programs** — either (a) reinstate a bytecode-native
-block index (needs a way to mutate/replace a data value's field or a side table
-keyed by block identity), or (b) also disable the index on the HeapSyn side for
-the comparison run. Do not attribute any bytecode block-lookup slowdown to the
-dispatch engine without controlling for this. (Tracked in the code via the
-`block_index_enabled` doc comment.)
+`LookupOr`/`SafeLookup` cache a `SymbolId→position` map for a block and reuse it
+on later lookups (O(1) vs an O(n) linear scan). On HeapSyn it caches by mutating
+the block's `Cons` node arg array in place (`store_index_in_block`). The bytecode
+engine can't mutate that way — a block is `BcClosure{code, env}` where the `Cons`
+*structure* lives in the **immutable off-heap code arena** — so the index is
+currently **gated off** (`block_index_enabled()` = `false` for `BcBifContext`)
+and lookups fall back to the **STG find loop** (O(n), same result).
+
+**This was a deliberate deferral, NOT a hard limitation.** The bytecode engine
+*can* mutate the field *values* — they live in the (shared, GC-heap) `env`
+frame, so `env.update(index_slot, Native::Index(map))` would propagate to all
+holders. Reinstating a bytecode-native index needs: (1) migrate the index
+machinery (`build_index`/`walk_list_to_position`/`store_index_in_block`/
+`count_list`/`BlockListIterator`) off the `SynClosure`-typed ABI, and (2) point
+`store_index_in_block` at the block closure's env slot instead of the heap node's
+arg array. It was skipped only because it's a pure perf optimisation (correctness
+is fine via the find loop) and gating it was the minimal change to unblock the
+whole corpus.
+
+**When BV2–5 benchmark bytecode vs HeapSyn, this is NOT apples-to-apples for
+block-heavy programs** — either reinstate the bytecode index (above) or also
+disable it on HeapSyn for the comparison run. Do not attribute a bytecode
+block-lookup slowdown to the dispatch engine without controlling for this.
+(Tracked in code via the `block_index_enabled` doc comment.)
 
 ### 🎉 MILESTONE (branch `feat/bv1-migrate-block-builders`): real `.eu` runs on bytecode
 The **`EU_BYTECODE=1` flag path** is wired in `driver/eval.rs` (pure programs:

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -2,40 +2,61 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a deep translation of intricate existing code, not greenfield — where a step says "translate `vm.rs:NNN-MMM`", read that arm and port its semantics; the differential harness (Phase 2) is the exact correctness gate for every such translation.
 
-> ## STATUS (revised 2026-07-02)
+> ## ▶ RESUME HERE (cold-start header — read this first) · updated 2026-07-02
 >
-> **Phase 0 (scaffolding) and Phase 1 (encoder + core types): COMPLETE** on
-> `integration/0.12.0`, all lib tests green (1198) + `clippy --all-targets`
-> clean. Commits `9cbb2a0c..10176820` (8). Delivered: `src/eval/bytecode/`
-> {`mod`, `opcode`, `program` (incl. a fully-implemented `prepare_constants`,
-> not the stub the plan called for), `encode`, `closure`, `cont`,
-> `env_builder`}; `env.rs` generalised `EnvironmentFrame`'s `StgObject`/
-> `GcScannable` over `C` + added `Closing::set_env` (behaviourally identical on
-> the SynClosure path).
+> **Where:** worktree `/Users/greg/dev/curvelogic/eucalypt-worktrees/integration-0.12.0`,
+> integration branch `integration/0.12.0`. **Toolchain:** prepend
+> `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` to `PATH` (the
+> `~/.cargo/bin/cargo` symlink is broken). One feature branch per increment →
+> PR to `integration/0.12.0`. Owner reviews/merges PRs; do not merge your own.
 >
-> **Design decisions settled during Phase 1** (now in spec §4.2 note / §5.5):
-> - **Operand encoding:** args are pre-emitted `OP_ATOM` nodes referenced by
->   `u32` offset (lazy arg closure = `BcClosure(atom_off, env)`, zero
->   per-dispatch code alloc; ref recoverable at `atom_off+1`). Encoder rewritten
->   accordingly (commit `10176820`). Case tables densified at encode time.
-> - **Deferred to later phases:** `create_arg_array`/`_eager`, `partially_apply`
->   (pap trampoline), `from_let`/`from_letrec` builders — completed when their
->   dispatch arms are written.
+> **State:** **The bytecode engine works end-to-end.** Real `.eu` programs run
+> under `EU_BYTECODE=1`, **byte-identical to the HeapSyn engine** (blocks, lists,
+> arithmetic, block lookups, strings — verified via the `eu` binary). Complete:
+> the whole day11 opcode set, GC roots + `evaluate_to_whnf`, the neutral
+> intrinsic ABI, rendering, the list/data builders, and the `EU_BYTECODE` flag
+> path in `driver/eval.rs`. HeapSyn is untouched (bytecode is behind the flag).
+> `cargo test --lib` = **1247 green**; clippy `--all-targets` + fmt clean.
 >
-> **NEW Phase 1.5 (intrinsic layer) inserted before Phase 2.** Implementation
-> review found spec §3's "192 intrinsics reused for free" is wrong: the intrinsic
-> ABI is `SynClosure`-typed and `support.rs` return helpers synthesise `HeapSyn`
-> at runtime. This blocks *every* `Bif` (hence day11) and must be solved before
-> the dispatch loop. See the new Phase 1.5 section and spec §5.5. This is real,
-> previously-unscoped work — expect Phase 1.5 to be comparable in size to Phase 2.
+> **Merged PRs (in order):** #927, #930 (machine spine + PAP + globals + Bif),
+> #932 (evaluate_to_whnf + closure ABI), #933 (differential harness), #934 (data
+> ABI), #935 (Meta/DeMeta/LookupLit), #937 (emit/render), #939 (Increment C/D:
+> iterators + list builders). **Open:** #941 (flag path + block-index gating —
+> the "real .eu runs" milestone). *(When resuming: check `gh pr list` for #941's
+> state and sync `git reset --hard origin/integration/0.12.0`.)*
 >
-> **Update (later 2026-07-02).** Phase 1.5 progress: neutral scalar + closure
-> intrinsic ABI added and `force`/`eq`/`arith`/`string`/`array` migrated
-> (HeapSyn byte-identical throughout); **Task 1.5.2 (arena constructor
-> templates) done**. A second spec correction surfaced: **the value model is
-> `BcValue = Closure | Native`, not `Closing<CodeRef>`** (a runtime native has no
-> home in an off-heap code offset). **NEW Phase 1.6** reworks the Phase 1 closure
-> types to `BcValue` before the machine. See spec §3 revision.
+> **How to run/verify the bytecode engine:**
+> - `EU_BYTECODE=1 timeout 90 ./target/debug/eu <file.eu>` vs the same without
+>   the env var → compare output (must be identical).
+> - Synthetic differential tests: `src/eval/bytecode/differential.rs`
+>   (`assert_engines_agree` = exit code; `assert_engines_render_agree` = YAML).
+>   `cargo test --lib bytecode::differential`.
+> - **Test-eu gotchas** (read `docs/appendices/syntax-gotchas.md`): use
+>   declaration files (`a: 1` / `b: 2`), NOT inline `{ }` in `eu -e`; no
+>   `let…in` (use `:let` blocks); `/` is floor division (`÷` exact); catenation
+>   precedence is very low.
+>
+> **NEXT (data-driven):** run more of `tests/harness/*.eu` under `EU_BYTECODE=1`,
+> and migrate whatever intrinsic panics with "…HeapSyn ABI" — the pattern is:
+> `machine.nav(view).resolve(x)` → `machine.resolve_closure(view, x)`;
+> `nav().resolve_native` → `resolve_native`; `HeapSyn::Cons` code-matching →
+> `data_tag`/`data_field`/`field_native`/`value_native`; `set_closure` →
+> `set_result`; list/data construction → `data_value`/`native_value`/
+> `return_closure_list` (already added — no runtime code synthesis). Then the IO
+> path (`io_run`/world-injection not ported; flag path is pure-programs-only),
+> and an automated `.eu`-corpus differential test. **Remaining HeapSyn-typed
+> intrinsic files** (panic on bytecode until migrated): block.rs builders/merge
+> (`deconstruct`, `machine_return_block_pair_closure_list`), debug.rs (20,
+> diagnostic), vec/time/typedata/stream_prng/set(`SetToList`)/parse_string
+> (`load()` = runtime HeapSyn synthesis, the one genuinely hard case),
+> assert.rs `format_ref` (diagnostic).
+>
+> **⚠️ Before any perf work:** see the PERF CAVEAT below — the block-index
+> optimisation is OFF on the bytecode path (O(n) lookups), so block-heavy
+> benchmarks are not apples-to-apples.
+>
+> *(Historical Phase 0/1/1.5/1.6 notes preserved in the Done ledger + git
+> history; the engine is well past them.)*
 
 ## Progress Ledger (living — durable source of truth; update every increment)
 

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -39,6 +39,21 @@
 
 ## Progress Ledger (living — durable source of truth; update every increment)
 
+### ⚠️ PERF CAVEAT — block-index optimisation DISABLED on the bytecode path
+`LookupOr`/`SafeLookup` cache a `SymbolId→position` map inside a block (mutating
+its index slot in place). The bytecode engine **cannot** do that in-place
+mutation (blocks are template closures), so `block_index_enabled()` returns
+`false` for `BcBifContext` and the bytecode engine falls back to the **STG-level
+find loop** for every block lookup — **O(n) per lookup instead of O(1)**.
+Correct (same result) but slower on lookup-heavy blocks.
+**When BV2–5 benchmark bytecode vs HeapSyn, this is NOT an apples-to-apples
+comparison for block-heavy programs** — either (a) reinstate a bytecode-native
+block index (needs a way to mutate/replace a data value's field or a side table
+keyed by block identity), or (b) also disable the index on the HeapSyn side for
+the comparison run. Do not attribute any bytecode block-lookup slowdown to the
+dispatch engine without controlling for this. (Tracked in the code via the
+`block_index_enabled` doc comment.)
+
 ### 🎉 MILESTONE (branch `feat/bv1-migrate-block-builders`): real `.eu` runs on bytecode
 The **`EU_BYTECODE=1` flag path** is wired in `driver/eval.rs` (pure programs:
 recompile with `RenderType::RenderDoc`, encode + full runtime globals, run the

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -39,6 +39,21 @@
 
 ## Progress Ledger (living — durable source of truth; update every increment)
 
+### 🎉 MILESTONE (branch `feat/bv1-migrate-block-builders`): real `.eu` runs on bytecode
+The **`EU_BYTECODE=1` flag path** is wired in `driver/eval.rs` (pure programs:
+recompile with `RenderType::RenderDoc`, encode + full runtime globals, run the
+`BytecodeMachine`). Gating the block-index optimisation (`LookupOr`/`SafeLookup`
+via a neutral `block_index_enabled` capability — bytecode returns `ListNil` →
+STG find loop, same result) removed the #1 corpus blocker. **Verified through
+the real `eu` binary, byte-identical to HeapSyn:** blocks (`a:1 b:2`), lists
+(`[1,2,3]`), arithmetic + block lookup (`sum: a + 10` → 11), strings. HeapSyn
+untouched (branch/capability only active under bytecode). Next: widen coverage
+by running more of the harness corpus under `EU_BYTECODE=1` and migrating
+whatever panics (data-driven), + IO path, + an automated `.eu` differential
+test. To test eucalypt: declaration files not inline `{}` in `-e`; no
+`let…in` (`:let` blocks); `/` = floor.
+
+
 ### Increment C/D migration — in progress (branch `feat/bv1-migrate-support-list`, PR #939)
 - **DONE** (byte-identical on HeapSyn, now working on bytecode):
   - list.rs 7 type predicates (`IS{LIST,NUMBER,STRING,SYMBOL,BOOL,TYPEDATA,ZDT}`

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -14,7 +14,7 @@ use crate::{
     eval::{
         error::ExecutionError,
         machine::standard_machine,
-        stg::{self, make_standard_runtime, RenderType, StgSettings},
+        stg::{self, make_standard_runtime, runtime::Runtime, RenderType, StgSettings},
     },
     export,
 };
@@ -396,6 +396,40 @@ impl<'a> Executor<'a> {
             if opt.dump_stg() {
                 println!("{}", prettify::prettify(&*syn));
                 Ok(None)
+            } else if crate::eval::bytecode::bytecode_enabled() {
+                // Experimental parallel bytecode engine (EU_BYTECODE=1).
+                //
+                // Pure programs only: recompile with a self-contained
+                // RenderDoc wrapper (the bytecode engine has no runtime code
+                // synthesis for the headless-render path) and run the
+                // BytecodeMachine. IO / world-injection is not yet ported;
+                // intrinsics still on the HeapSyn-typed ABI will panic and
+                // surface which ones the corpus needs.
+                let bc_settings = StgSettings {
+                    render_type: RenderType::RenderDoc,
+                    ..stg_settings.clone()
+                };
+                let bc_syn = stg::compile(&bc_settings, self.evaluand.clone(), rt.as_ref())?;
+                let globals = rt.globals();
+                let (prog, root, gforms) = crate::eval::bytecode::encode(&bc_syn, &globals);
+                emitter.stream_start();
+                let heap_mib = stg_settings.heap_limit_mib.unwrap_or(0);
+                let mut m = crate::eval::bytecode::BytecodeMachine::new(
+                    prog,
+                    root,
+                    &gforms,
+                    rt.intrinsics(),
+                    emitter,
+                    heap_mib,
+                    stg_settings.test_mode,
+                )?;
+                let t_exec = Instant::now();
+                let ret = m.run(None);
+                stats
+                    .timings_mut()
+                    .record("bytecode-eval", t_exec.elapsed());
+                m.take_emitter().stream_end();
+                ret
             } else {
                 emitter.stream_start();
                 let mut machine = standard_machine(&stg_settings, syn, emitter, rt.as_ref())?;

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -1919,6 +1919,12 @@ impl IntrinsicMachine for BcBifContext<'_, '_> {
         self.test_mode
     }
 
+    fn block_index_enabled(&self) -> bool {
+        // Bytecode blocks are template closures with no in-place mutation; use
+        // the STG find-loop fallback for lookups (same result).
+        false
+    }
+
     // ── HeapSyn-typed methods: unreachable on the bytecode path ──────
     // These name `SynClosure`/`EnvFrame`, which the bytecode engine never
     // produces. An intrinsic reaching one has not been migrated to the

--- a/src/eval/bytecode/mod.rs
+++ b/src/eval/bytecode/mod.rs
@@ -30,10 +30,8 @@ pub use machine::*;
 #[cfg(test)]
 mod differential;
 
-/// Whether the bytecode engine is selected for this run. Reads the
-/// `EU_BYTECODE` env var; a CLI flag is added in Phase 2.
-// Removed when wired in Phase 2; inert scaffolding for now.
-#[allow(dead_code)]
+/// Whether the experimental bytecode engine is selected for this run
+/// (`EU_BYTECODE=1`). Wired into `driver/eval.rs` for pure programs.
 pub fn bytecode_enabled() -> bool {
     std::env::var("EU_BYTECODE").as_deref() == Ok("1")
 }

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -372,6 +372,17 @@ pub trait IntrinsicMachine {
     /// panicking, allowing test harnesses to collect results.
     fn test_mode(&self) -> bool;
 
+    /// Whether the mutable block-index optimisation is available.
+    ///
+    /// The optimisation caches a `SymbolId → position` map inside a block by
+    /// mutating its index slot in place. The HeapSyn engine supports this; the
+    /// bytecode engine does not (blocks are template closures), so `LookupOr`/
+    /// `SafeLookup` skip the index and fall back to the STG-level find loop —
+    /// same result, no in-place mutation. Defaults to `true`.
+    fn block_index_enabled(&self) -> bool {
+        true
+    }
+
     /// Evaluate a closure to WHNF, safely handling a non-empty continuation stack.
     ///
     /// Moves the current stack to a GC-visible location, runs the sub-evaluation,

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -608,6 +608,11 @@ impl StgIntrinsic for LookupOr {
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
         // args: [sym_key, blocklist, blockindex, block]
+        // When the mutable block-index optimisation is unavailable (bytecode
+        // engine), skip it and return ListNil to signal the STG find loop.
+        if !machine.block_index_enabled() {
+            return machine.return_closure_list(view, vec![]);
+        }
         // Check for an existing index — use ok() for sym key since it
         // may be an unforced thunk (BIF can't force thunks)
         if let Ok(Native::Index(ref map)) = machine.nav(view).resolve_native(&args[2]) {
@@ -1164,6 +1169,9 @@ impl StgIntrinsic for SafeLookup {
         // args: [sym_key, blocklist, blockindex, block]
         // Same BIF logic as LookupOr: return ListCons on hit, ListNil on miss.
         // The wrapper handles the null-propagation for non-block values.
+        if !machine.block_index_enabled() {
+            return machine.return_closure_list(view, vec![]);
+        }
         if let Ok(Native::Index(ref map)) = machine.nav(view).resolve_native(&args[2]) {
             if let Ok(Native::Sym(sym_id)) = machine.nav(view).resolve_native(&args[0]) {
                 if let Some(&position) = map.get(&sym_id) {


### PR DESCRIPTION
## BV1: real eucalypt programs run on the bytecode engine 🎉

Continues BV1 (eu-vi3a) on top of #939. **Milestone: real `.eu` programs now
execute end-to-end on the bytecode engine, byte-identical to HeapSyn.**

### What's in this PR

1. **`EU_BYTECODE` flag path** (`driver/eval.rs`) — behind `EU_BYTECODE=1`, for a
   pure program the driver recompiles the core with a self-contained
   `RenderType::RenderDoc` wrapper (the bytecode engine has no runtime code
   synthesis for the driver's headless-render path), encodes it + the full
   runtime globals, and runs the `BytecodeMachine` to the emitter. IO /
   world-injection is not yet ported.

2. **Block-index optimisation gated** — `LookupOr`/`SafeLookup` cache a
   `SymbolId→position` map by mutating a block's index slot *in place*, which the
   bytecode engine can't do (blocks are template closures). A neutral
   `block_index_enabled` capability (default `true`; `BcBifContext` `false`) lets
   them skip the index and return `ListNil`, delegating to the STG-level find
   loop — **same result**, no in-place mutation. This was the #1 corpus blocker,
   surfaced data-driven by the flag path.

### Verified through the real `eu` binary (both engines identical)

| program | output |
|---|---|
| `a: 1` / `b: 2` | `a: 1` / `b: 2` |
| `x: [1, 2, 3]` | YAML sequence |
| `a: 1` / `sum: a + 10` | `sum: 11` (block lookup + arithmetic) |
| `greeting: "hello"` | `greeting: hello` |

### Verification
- `cargo test --lib` — **1247 passed**; clippy `--all-targets` clean; fmt clean.
- HeapSyn path unchanged (the flag branch + `block_index_enabled=false` are only
  active under `EU_BYTECODE=1`).

### Next
Run more of the harness corpus under `EU_BYTECODE=1` and migrate whatever panics
(data-driven), the IO path, and add an automated `.eu`-corpus differential test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee
