### PR TITLE
feat(bytecode): BV1 — migrate intrinsics to neutral ABI, corpus 43→144 byte-identical (eu-vi3a)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -2,13 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a deep translation of intricate existing code, not greenfield — where a step says "translate `vm.rs:NNN-MMM`", read that arm and port its semantics; the differential harness (Phase 2) is the exact correctness gate for every such translation.
 
-> ## ▶ RESUME HERE (cold-start header — read this first) · updated 2026-07-02
+> ## ▶ RESUME HERE (cold-start header — read this first) · updated 2026-07-02 (post-#941)
 >
 > **Where:** worktree `/Users/greg/dev/curvelogic/eucalypt-worktrees/integration-0.12.0`,
 > integration branch `integration/0.12.0`. **Toolchain:** prepend
 > `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` to `PATH` (the
 > `~/.cargo/bin/cargo` symlink is broken). One feature branch per increment →
 > PR to `integration/0.12.0`. Owner reviews/merges PRs; do not merge your own.
+> Current working branch: `feat/bv1-migrate-intrinsics` (off the post-#941 merge
+> `25166517`).
 >
 > **State:** **The bytecode engine works end-to-end.** Real `.eu` programs run
 > under `EU_BYTECODE=1`, **byte-identical to the HeapSyn engine** (blocks, lists,
@@ -21,9 +23,9 @@
 > **Merged PRs (in order):** #927, #930 (machine spine + PAP + globals + Bif),
 > #932 (evaluate_to_whnf + closure ABI), #933 (differential harness), #934 (data
 > ABI), #935 (Meta/DeMeta/LookupLit), #937 (emit/render), #939 (Increment C/D:
-> iterators + list builders). **Open:** #941 (flag path + block-index gating —
-> the "real .eu runs" milestone). *(When resuming: check `gh pr list` for #941's
-> state and sync `git reset --hard origin/integration/0.12.0`.)*
+> iterators + list builders), **#941 (MERGED 2026-07-02 — flag path + block-index
+> gating, the "real .eu runs" milestone; merge commit `25166517`).**
+> *(All BV1 PRs to date are merged into `integration/0.12.0`.)*
 >
 > **How to run/verify the bytecode engine:**
 > - `EU_BYTECODE=1 timeout 90 ./target/debug/eu <file.eu>` vs the same without

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -39,39 +39,54 @@
 >   precedence is very low.
 >
 > **CORPUS TALLY (branch `feat/bv1-migrate-intrinsics`, PR #942):** sweeping the
-> full `tests/harness/*.eu` under `EU_BYTECODE=1` vs HeapSyn: **96 PASS
-> (byte-identical), 0 DIFF**, 4 both-fail (pre-existing), **68 bytecode-only
-> fails** remaining. Was 43 PASS before this increment — `debug.rs` (DbgRepr &
-> trace) migration unblocked ~53. Sweep script:
-> `scratchpad/bv_sweep.sh` (compares stdout of both engines per file).
+> full `tests/harness/*.eu` under `EU_BYTECODE=1` vs HeapSyn: **144 PASS
+> (byte-identical), 0 DIFF**, 4 both-fail (pre-existing), **19 bytecode-only
+> fails** remaining. Was **43 PASS** at the start of this PR — the intrinsic
+> migration below unblocked ~101. Sweep script: `scratchpad/bv_sweep.sh`
+> (compares stdout of both engines per file).
 >
-> **NEXT (data-driven):** migrate the remaining bytecode-only panics, in
-> impact order (culprit → #tests it blocks, from the sweep backtraces):
-> `support::machine_return_str_iter` (9), `block::Merge` — "block application
-> (MERGE) not yet implemented" (8), `support::resolve_native_unboxing` (7),
-> `render_to_string::RenderToString` (7), `parse_string::ParseString` (5, the
-> hard `load()` runtime-synthesis case), `block::IsBlock` (4), then the
-> singles (vec/time/typedata/stream_prng/stream_intrinsic). The port pattern:
-> `machine.nav(view).resolve(x)` → `machine.resolve_closure(view, x)`;
-> `nav().resolve_native` → `resolve_native`; `HeapSyn::Cons` code-matching →
-> `data_tag`/`data_field`/`field_native`/`value_native`; `set_closure` →
-> `set_result`; `evaluate_to_whnf(SynClosure)` → `force(AbiClosure)`; list/data
-> construction → `data_value`/`native_value`/`return_closure_list`. Then the IO
-> path (`io_run`/world-injection not ported; flag path is pure-programs-only)
-> and an automated `.eu`-corpus differential test.
+> **DONE this PR (all neutral-ABI, byte-identical both engines):**
+> - `debug.rs` — DbgRepr/Dbg/TraceEntry/TraceExit + render/peek/trace helpers.
+> - `support.rs` — resolve_native_unboxing, machine_return_str_iter,
+>   machine_return_num_list_of_lists, machine_return_block_pair_closure_list,
+>   cons_tag_of; added `list_value` helper.
+> - `block.rs` — **block-application MERGE dispatch** in the bytecode machine
+>   (`return_data` ApplyTo → append block, enter MERGE global), plus
+>   Merge/IsBlock/deconstruct.
+> - `render_to_string.rs`, `time.rs` (ZdtFields), `vec.rs` (VecOf/VecNth/
+>   VecToList), `set.rs` (SetToList), `stream_prng.rs` (all stream returns).
+> - **Two new neutral primitives:** (1) `IntrinsicMachine::tail_apply_global`
+>   (tail-call a global on runtime args — HeapSyn builds the App, bytecode
+>   pushes ApplyTo + enters the global); (2) `try_navigate_local_native` so the
+>   HeapSyn `value_native` default no longer panics on an unforced `Atom{L}`
+>   (matches bytecode). Differential test `agree_on_dbg_repr` added.
 >
-> **⚠️ Neutral-ABI trap (learned this increment):** the HeapSyn `value_native`
-> default previously called `navigate_local_native`, which *panics* on a
-> non-native local (unevaluated `Atom{L}`). A non-forcing peek trips this. Fixed
-> by `try_navigate_local_native` (returns `Option`) so HeapSyn matches the
-> bytecode engine. When you port an intrinsic that inspects *unforced* values,
-> prefer `value_native` (now safe) and never assume a resolved closure is WHNF.
+> **⚠️ Neutral-ABI trap:** don't assume a resolved closure is WHNF; use
+> `value_native` (now non-panicking) for possibly-unforced values.
 >
-> **DONE this increment (PR #942, eu-0sst):** `debug.rs` fully on the neutral
-> ABI (DbgRepr/Dbg/TraceEntry/TraceExit + helpers), byte-identical both engines;
-> `value_native` panic fix; `agree_on_dbg_repr` differential test. Follow-up
-> filed: `__DBG` fires a different #times on stderr per engine (thunk-update
-> difference, not render) — see beads.
+> **REMAINING 19 — all need RUNTIME CODE SYNTHESIS (a design decision, not more
+> mechanical ports):**
+> - `parse_string::ParseString` (10) and `typedata::TypeToData` (6): both call
+>   `load()` — compile a core/STG expression and materialise it *runnable* on
+>   the heap at runtime. On HeapSyn `load()` yields a HeapSyn tree the tree-walk
+>   runs directly; the bytecode engine has no runtime encoder, so this needs a
+>   **runtime bytecode-encode/append** (JIT a fragment into the code arena) or a
+>   neutral "materialise this compiled data value" path. This is the genuinely
+>   hard case the plan always flagged.
+> - `block::MergeWith` / DEEPMERGE (4): build a lazy `f(ov, nv)` **application
+>   thunk** as a stored value (not a tail call). Needs a neutral "build an
+>   application closure value" primitive (bytecode: an `App(L0,[L1,L2])` template
+>   over env `[f, ov, nv]`). Smaller than full `load()` but still code synthesis.
+> - `stream_intrinsic::ProducerNext` (1): `load()` **plus** a self-referential
+>   updatable BIF thunk (`PRODUCER_NEXT(handle)` tail) — both synthesis forms.
+>
+> These share one root: the bytecode path cannot yet synthesise *code* at
+> runtime, only *data* (`data_value`/`return_closure_list`). Next step is a
+> design decision on how to add runtime code (encoder-append vs. a small set of
+> pre-encoded apply/thunk templates vs. keeping these few on a HeapSyn shim).
+>
+> **Follow-up filed:** `__DBG` fires a different #times on stderr per engine
+> (thunk-update difference, not render) — see beads eu-… .
 >
 > **⚠️ Before any perf work:** see the PERF CAVEAT below — the block-index
 > optimisation is OFF on the bytecode path (O(n) lookups), so block-heavy

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -38,20 +38,40 @@
 >   `let…in` (use `:let` blocks); `/` is floor division (`÷` exact); catenation
 >   precedence is very low.
 >
-> **NEXT (data-driven):** run more of `tests/harness/*.eu` under `EU_BYTECODE=1`,
-> and migrate whatever intrinsic panics with "…HeapSyn ABI" — the pattern is:
+> **CORPUS TALLY (branch `feat/bv1-migrate-intrinsics`, PR #942):** sweeping the
+> full `tests/harness/*.eu` under `EU_BYTECODE=1` vs HeapSyn: **96 PASS
+> (byte-identical), 0 DIFF**, 4 both-fail (pre-existing), **68 bytecode-only
+> fails** remaining. Was 43 PASS before this increment — `debug.rs` (DbgRepr &
+> trace) migration unblocked ~53. Sweep script:
+> `scratchpad/bv_sweep.sh` (compares stdout of both engines per file).
+>
+> **NEXT (data-driven):** migrate the remaining bytecode-only panics, in
+> impact order (culprit → #tests it blocks, from the sweep backtraces):
+> `support::machine_return_str_iter` (9), `block::Merge` — "block application
+> (MERGE) not yet implemented" (8), `support::resolve_native_unboxing` (7),
+> `render_to_string::RenderToString` (7), `parse_string::ParseString` (5, the
+> hard `load()` runtime-synthesis case), `block::IsBlock` (4), then the
+> singles (vec/time/typedata/stream_prng/stream_intrinsic). The port pattern:
 > `machine.nav(view).resolve(x)` → `machine.resolve_closure(view, x)`;
 > `nav().resolve_native` → `resolve_native`; `HeapSyn::Cons` code-matching →
 > `data_tag`/`data_field`/`field_native`/`value_native`; `set_closure` →
-> `set_result`; list/data construction → `data_value`/`native_value`/
-> `return_closure_list` (already added — no runtime code synthesis). Then the IO
-> path (`io_run`/world-injection not ported; flag path is pure-programs-only),
-> and an automated `.eu`-corpus differential test. **Remaining HeapSyn-typed
-> intrinsic files** (panic on bytecode until migrated): block.rs builders/merge
-> (`deconstruct`, `machine_return_block_pair_closure_list`), debug.rs (20,
-> diagnostic), vec/time/typedata/stream_prng/set(`SetToList`)/parse_string
-> (`load()` = runtime HeapSyn synthesis, the one genuinely hard case),
-> assert.rs `format_ref` (diagnostic).
+> `set_result`; `evaluate_to_whnf(SynClosure)` → `force(AbiClosure)`; list/data
+> construction → `data_value`/`native_value`/`return_closure_list`. Then the IO
+> path (`io_run`/world-injection not ported; flag path is pure-programs-only)
+> and an automated `.eu`-corpus differential test.
+>
+> **⚠️ Neutral-ABI trap (learned this increment):** the HeapSyn `value_native`
+> default previously called `navigate_local_native`, which *panics* on a
+> non-native local (unevaluated `Atom{L}`). A non-forcing peek trips this. Fixed
+> by `try_navigate_local_native` (returns `Option`) so HeapSyn matches the
+> bytecode engine. When you port an intrinsic that inspects *unforced* values,
+> prefer `value_native` (now safe) and never assume a resolved closure is WHNF.
+>
+> **DONE this increment (PR #942, eu-0sst):** `debug.rs` fully on the neutral
+> ABI (DbgRepr/Dbg/TraceEntry/TraceExit + helpers), byte-identical both engines;
+> `value_native` panic fix; `agree_on_dbg_repr` differential test. Follow-up
+> filed: `__DBG` fires a different #times on stderr per engine (thunk-update
+> difference, not render) — see beads.
 >
 > **⚠️ Before any perf work:** see the PERF CAVEAT below — the block-index
 > optimisation is OFF on the bytecode path (O(n) lookups), so block-heavy

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -81,9 +81,37 @@
 >   updatable BIF thunk (`PRODUCER_NEXT(handle)` tail) — both synthesis forms.
 >
 > These share one root: the bytecode path cannot yet synthesise *code* at
-> runtime, only *data* (`data_value`/`return_closure_list`). Next step is a
-> design decision on how to add runtime code (encoder-append vs. a small set of
-> pre-encoded apply/thunk templates vs. keeping these few on a HeapSyn shim).
+> runtime, only *data* (`data_value`/`return_closure_list`).
+>
+> **⚠️ ARENA-GROWTH ANALYSIS (owner's concern, 2026-07-02): the code arena
+> (`BytecodeProgram.code`) is off-heap and NEVER GC-collected. Appending a fresh
+> fragment per `load()` call would leak unboundedly (e.g. parsing 1M JSON records
+> in a loop → 1M fragments). SO WE MUST NOT do naive runtime encode-append.
+> Analysis shows almost none of the remaining 19 actually needs unique runtime
+> code:**
+> - **`ParseString` / `TypeToData` value output is pure DATA** (a block/list/
+>   scalar tree — `load()` there materialises a data-literal, no computation).
+>   Build it directly via the neutral `data_value`/`native_value`/
+>   `return_closure_list` ABI on the **GC heap** (collectable). ZERO arena growth.
+>   This is the plan's "value representation" route — preferred over parse-to-
+>   bytecode for these. (TypeToData: verify `type_to_rcexpr` emits only data
+>   constructors, not prelude function applications; if it applies functions,
+>   the SHAPE is bounded by the finite type-DSL grammar → a small fixed template
+>   set, still not per-call-unique.)
+> - **`MergeWith` `f(ov,nv)` and `ProducerNext`'s tail thunk are FIXED-SHAPE
+>   applications** (`App(L0,[L1,L2])`, `AppBif(idx,[L0])`). Pre-encode ONE
+>   template each into the arena at init (exactly like the existing constructor/
+>   PAP templates); at runtime allocate only a **GC-heap env frame** `[f,ov,nv]`
+>   / `[handle]` over the fixed template. ZERO per-call arena growth.
+> - **Genuinely-dynamic unique code** (arbitrary runtime-varying computation) is
+>   the ONLY case that would need arena append — and none of the remaining 19
+>   clearly requires it. If one does, bound it (dedup/cache by content, or cap)
+>   and `log()` the cap; never append unboundedly.
+>
+> **Conclusion: build NO general runtime encoder. Use (a) neutral data
+> construction for data-literal `load()`, and (b) a small fixed set of pre-
+> encoded apply/thunk templates for the fixed-shape thunks. Arena stays bounded
+> and the GC still owns all per-call allocation.**
 >
 > **Follow-up filed:** `__DBG` fires a different #times on stderr per engine
 > (thunk-update difference, not render) — see beads eu-… .

--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -343,6 +343,27 @@ mod tests {
     }
 
     #[test]
+    fn agree_on_dbg_repr() {
+        // RENDER_DOC(DBG_REPR(boxed 42)) — the debug-repr intrinsic, migrated
+        // to the neutral ABI (resolve_closure/data_tag/data_field/value_native),
+        // must render byte-identically on both engines.
+        let dbg_repr = crate::eval::intrinsics::index("DBG_REPR").expect("DBG_REPR");
+        let render_doc = crate::eval::intrinsics::index("RENDER_DOC").expect("RENDER_DOC");
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::data(
+                    DataConstructor::BoxedNumber.tag(),
+                    vec![dsl::num(42)],
+                )), // 0: boxed 42
+                dsl::value(dsl::app(dsl::gref(dbg_repr), vec![dsl::lref(0)])), // 1: DBG_REPR(0)
+            ],
+            dsl::app(dsl::gref(render_doc), vec![dsl::lref(1)]),
+        );
+        let out = assert_engines_render_agree(syn);
+        assert!(out.contains("42"), "expected 42 in output, got {out:?}");
+    }
+
+    #[test]
     fn agree_on_islist_true() {
         // __ISLIST(nil) -> true -> 1. Exercises the migrated list predicate
         // (resolve_closure + data_tag) on the bytecode path.

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -596,19 +596,41 @@ pub fn return_data(
             let cur = state.current.clone();
             view.scoped(environment).update(&view, index, cur)?;
         }
-        BcContinuation::ApplyTo { annotation, .. } => {
-            // Block application delegates to the MERGE global; needs the
-            // globals frame + a G-ref entry (wired with the machine loop).
-            let type_name = DataConstructor::try_from(tag)
-                .map(|dc| dc.to_string())
-                .unwrap_or_else(|()| format!("data (tag {tag})"));
+        BcContinuation::ApplyTo {
+            args: apply_args,
+            annotation,
+        } => {
+            // Block application: blocks are callable as functions, delegating
+            // to the MERGE global. This is the only data type with callable
+            // semantics. Append the block (the callable, held in
+            // `state.current`) as MERGE's final argument, re-push the ApplyTo,
+            // and enter MERGE — it is then applied to [applied-args…, block].
+            // Mirrors `vm.rs` return_data.
             if tag == DataConstructor::Block.tag() {
-                return Err(ExecutionError::Panic(
+                let block_val = state.current.clone();
+                let mut merged: Vec<BcValue> = apply_args.as_slice().to_vec();
+                merged.push(block_val);
+                state.stack.push(BcContinuation::ApplyTo {
+                    args: Array::from_slice(&view, &merged),
                     annotation,
-                    "bytecode: block application (MERGE) not yet implemented".to_string(),
-                ));
+                });
+                // Restore the application-site annotation so any type-mismatch
+                // raised inside the MERGE wrapper carries the user's location.
+                state.annotation = annotation;
+                let merge_idx = crate::eval::intrinsics::index("MERGE")
+                    .expect("MERGE intrinsic must be registered");
+                enter_callable(
+                    state,
+                    view,
+                    state.root_env,
+                    DecodedRef::Global(merge_idx as u32),
+                )?;
+            } else {
+                let type_name = DataConstructor::try_from(tag)
+                    .map(|dc| dc.to_string())
+                    .unwrap_or_else(|()| format!("data (tag {tag})"));
+                return Err(ExecutionError::NotCallable(annotation, type_name));
             }
-            return Err(ExecutionError::NotCallable(annotation, type_name));
         }
         BcContinuation::DeMeta {
             or_else,

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2055,6 +2055,33 @@ impl IntrinsicMachine for BcBifContext<'_, '_> {
         }
     }
 
+    fn tail_apply_global(
+        &mut self,
+        view: MutatorHeapView<'_>,
+        global_idx: usize,
+        arg_refs: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // Resolve the args in the current (bif) env, push an `ApplyTo` for
+        // them, then enter the global closure — the machine's `return_fun`
+        // applies it, mirroring `Op::App`. No runtime code synthesis.
+        let global = view
+            .scoped(self.state.globals)
+            .get(&view, global_idx)
+            .ok_or(ExecutionError::BadGlobalIndex(global_idx))?;
+        if !arg_refs.is_empty() {
+            let args: Vec<BcValue> = arg_refs
+                .iter()
+                .map(|r| self.resolve_value(view, r))
+                .collect::<Result<_, _>>()?;
+            self.state.stack.push(BcContinuation::ApplyTo {
+                args: Array::from_slice(&view, &args),
+                annotation: self.state.annotation,
+            });
+        }
+        self.state.current = global;
+        Ok(())
+    }
+
     fn force(&mut self, closure: AbiClosure) -> Result<AbiClosure, ExecutionError> {
         match closure {
             // A native is already WHNF.

--- a/src/eval/machine/env.rs
+++ b/src/eval/machine/env.rs
@@ -134,6 +134,38 @@ impl Closing<RefPtr<HeapSyn>> {
         }
         panic!("could not navigate to native")
     }
+
+    /// Non-panicking variant of [`Self::navigate_local_native`].
+    ///
+    /// Follows `Atom` indirections through the local environment to a native
+    /// value, returning `None` — rather than panicking — when the chain ends
+    /// at a non-native (e.g. an unevaluated thunk, a data constructor, an
+    /// out-of-range or global ref). Used by the neutral `value_native` ABI so
+    /// that inspecting an unforced value (debug peek) cannot crash, matching
+    /// the bytecode engine's behaviour.
+    pub fn try_navigate_local_native(&self, guard: &dyn MutatorScope, arg: Ref) -> Option<Native> {
+        let i = match arg {
+            Ref::L(i) => i,
+            Ref::G(_) => return None,
+            Ref::V(n) => return Some(n),
+        };
+        let mut closure = {
+            let env = &*ScopedPtr::from_non_null(guard, self.env());
+            env.get(guard, i)?
+        };
+        let mut code_ptr = ScopedPtr::from_non_null(guard, closure.code());
+        while let HeapSyn::Atom { evaluand: r } = &*code_ptr {
+            let next_i = match r {
+                Ref::L(i) => *i,
+                Ref::G(_) => return None,
+                Ref::V(n) => return Some(n.clone()),
+            };
+            let env = &*ScopedPtr::from_non_null(guard, closure.env());
+            closure = env.get(guard, next_i)?;
+            code_ptr = ScopedPtr::from_non_null(guard, closure.code());
+        }
+        None
+    }
 }
 
 pub struct ScopeAndClosure<'guard>(pub &'guard dyn MutatorScope, pub &'guard SynClosure);

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -274,10 +274,8 @@ pub trait IntrinsicMachine {
         let sc = closure.as_heap();
         let code = view.scoped(sc.code());
         match &*code {
-            HeapSyn::Atom { evaluand } => Some(sc.navigate_local_native(&view, evaluand.clone())),
-            HeapSyn::Cons { args, .. } => {
-                Some(sc.navigate_local_native(&view, args.get(0)?.clone()))
-            }
+            HeapSyn::Atom { evaluand } => sc.try_navigate_local_native(&view, evaluand.clone()),
+            HeapSyn::Cons { args, .. } => sc.try_navigate_local_native(&view, args.get(0)?.clone()),
             _ => None,
         }
     }

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -209,6 +209,30 @@ pub trait IntrinsicMachine {
         self.set_closure(closure.expect_heap())
     }
 
+    /// Tail-call the global at `global_idx` applied to `arg_refs` (resolved in
+    /// the current environment), replacing the machine's closure with that
+    /// application. Used by intrinsics that delegate to another global (e.g.
+    /// `RENDER_TO_STRING` → `RENDER_DOC`) without runtime code synthesis on the
+    /// bytecode path.
+    fn tail_apply_global(
+        &mut self,
+        view: MutatorHeapView<'_>,
+        global_idx: usize,
+        arg_refs: &[Ref],
+    ) -> Result<(), ExecutionError> {
+        // HeapSyn default: build an `App(G(idx), arg_refs)` closure in the
+        // current environment and enter it.
+        let app = view
+            .alloc(HeapSyn::App {
+                callable: Ref::G(global_idx),
+                args: Array::from_slice(&view, arg_refs),
+                eager_args: false,
+            })?
+            .as_ptr();
+        let env = self.env(view);
+        self.set_closure(SynClosure::new(app, env))
+    }
+
     /// Force a closure handle to WHNF.
     fn force(&mut self, closure: AbiClosure) -> Result<AbiClosure, ExecutionError> {
         Ok(AbiClosure::Heap(

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -13,7 +13,9 @@ use crate::{
         machine::{
             env::SynClosure,
             env_builder::EnvBuilder,
-            intrinsic::{CallGlobal1, CallGlobal2, CallGlobal3, IntrinsicMachine, StgIntrinsic},
+            intrinsic::{
+                AbiClosure, CallGlobal1, CallGlobal2, CallGlobal3, IntrinsicMachine, StgIntrinsic,
+            },
             vm::HeapNavigator,
         },
         memory::{
@@ -28,10 +30,7 @@ use super::{
     eq::Eq,
     panic::Panic,
     runtime::NativeVariant,
-    support::{
-        call, data_list_arg, machine_return_block_pair_closure_list, machine_return_bool,
-        machine_return_closure_list,
-    },
+    support::{call, data_list_arg, machine_return_block_pair_closure_list, machine_return_bool},
     syntax::{
         dsl::{self},
         LambdaForm, StgSyn,
@@ -1388,103 +1387,48 @@ fn collect_block_keys_from_args(
 /// from r overriding those in l
 pub struct Merge;
 
-/// Extract the symbol name from a block pair key, handling both raw
-/// symbol natives and boxed symbols (as produced by dynamically
-/// constructed blocks via `block()`).
-fn resolve_pair_key_symbol(
-    view: MutatorHeapView,
-    pool: &crate::eval::memory::symbol::SymbolPool,
-    pair_closure: &SynClosure,
-    k: Ref,
-) -> Result<String, ExecutionError> {
-    use crate::eval::memory::syntax;
-
-    // Fast path: key is a direct native value
-    if let Ref::V(syntax::Native::Sym(id)) = &k {
-        return Ok(pool.resolve(*id).to_string());
-    }
-
-    // Follow the key reference to its closure, unwrapping any Ann
-    // (source-location annotation) nodes along the way.
-    let mut key_closure = pair_closure.navigate_local(&view, k);
-    loop {
-        let key_code = view.scoped(key_closure.code());
-        match &*key_code {
-            // Raw atom containing a symbol
-            syntax::HeapSyn::Atom {
-                evaluand: Ref::V(syntax::Native::Sym(id)),
-            } => return Ok(pool.resolve(*id).to_string()),
-            // Boxed symbol (from dynamically-constructed blocks)
-            syntax::HeapSyn::Cons { tag, args } if *tag == DataConstructor::BoxedSymbol.tag() => {
-                let inner = args.get(0).ok_or_else(|| {
-                    ExecutionError::Panic(
-                        Smid::default(),
-                        "empty boxed symbol in block pair key".to_string(),
-                    )
-                })?;
-                let native = key_closure.navigate_local_native(&view, inner);
-                if let syntax::Native::Sym(id) = native {
-                    return Ok(pool.resolve(id).to_string());
-                } else {
-                    return Err(ExecutionError::Panic(
-                        Smid::default(),
-                        "boxed symbol contained non-symbol native".to_string(),
-                    ));
-                }
-            }
-            // Annotation wrapper — follow through to the body
-            syntax::HeapSyn::Ann { body, .. } => {
-                key_closure = SynClosure::new(*body, key_closure.env());
-            }
-            _ => {
-                return Err(ExecutionError::Panic(
-                    Smid::default(),
-                    "bad block_pair passed to merge intrinsic: non-symbolic key".to_string(),
-                ))
-            }
-        }
-    }
-}
-
 /// Items are passed to the MERGE intrinsic as block_pairs of k and
 /// the kv closure and to the MERGEWITH intrinsic as block_pairs of k
 /// and v. The same function can deconstruct either.
+///
+/// Engine-neutral: reads the pair's key (field 0) and value (field 1) via the
+/// `data_tag`/`data_field`/`value_native` ABI, so it serves both engines.
 fn deconstruct(
-    machine: &dyn IntrinsicMachine,
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView,
-    pool: &crate::eval::memory::symbol::SymbolPool,
-    pair_closure: &SynClosure,
-) -> Result<(String, SynClosure), ExecutionError> {
-    use crate::eval::memory::syntax;
-
-    let code = view.scoped(pair_closure.code());
-    match &*code {
-        syntax::HeapSyn::Cons { tag, args } if *tag == DataConstructor::BlockPair.tag() => {
-            let k = args.get(0).unwrap();
-            let kv = args.get(1).unwrap();
-
-            let sym = resolve_pair_key_symbol(view, pool, pair_closure, k)?;
-
-            // Data constructor args can be any ref type (Ref::L,
-            // Ref::G for global constants like [], Ref::V for inline
-            // natives).  Use resolve_in_closure which handles all.
-            let kv_closure = machine
-                .nav(view)
-                .resolve_in_closure(pair_closure, kv)
-                .ok_or_else(|| {
-                    ExecutionError::Panic(
-                        Smid::default(),
-                        "failed to resolve block pair value in merge".to_string(),
-                    )
-                })?;
-
-            Ok((sym, kv_closure))
-        }
-        _ => Err(ExecutionError::Panic(
+    pair: &AbiClosure,
+) -> Result<(String, AbiClosure), ExecutionError> {
+    if machine.data_tag(view, pair) != Some(DataConstructor::BlockPair.tag()) {
+        return Err(ExecutionError::Panic(
             Smid::default(),
             "bad block_pair passed to merge intrinsic: non-data type".to_string(),
-        )),
+        ));
     }
+
+    // Key (field 0): a raw or boxed symbol, surfaced as a `Native::Sym` by
+    // `value_native`.
+    let key = machine.data_field(view, pair, 0).ok_or_else(|| {
+        ExecutionError::Panic(Smid::default(), "block pair missing key".to_string())
+    })?;
+    let sym = match machine.value_native(view, &key) {
+        Some(Native::Sym(id)) => machine.symbol_pool().resolve(id).to_string(),
+        _ => {
+            return Err(ExecutionError::Panic(
+                Smid::default(),
+                "bad block_pair passed to merge intrinsic: non-symbolic key".to_string(),
+            ))
+        }
+    };
+
+    // Value (field 1): the kv closure (MERGE) or bare value (MERGEWITH).
+    let value = machine.data_field(view, pair, 1).ok_or_else(|| {
+        ExecutionError::Panic(
+            Smid::default(),
+            "failed to resolve block pair value in merge".to_string(),
+        )
+    })?;
+
+    Ok((sym, value))
 }
 
 impl StgIntrinsic for Merge {
@@ -1616,23 +1560,15 @@ impl StgIntrinsic for Merge {
         let l = data_list_arg(machine, view, args[0].clone())?;
         let r = data_list_arg(machine, view, args[1].clone())?;
 
-        let mut merge: IndexMap<String, SynClosure> = IndexMap::new();
-
-        // NB the downstream (deconstruct / machine_return_closure_list) is
-        // still HeapSyn-typed (list construction needs runtime code synthesis);
-        // `as_heap()` bridges until the list-builder templates land, so block
-        // merge runs on HeapSyn only for now.
-        for item in &l {
-            let (k, kv) = deconstruct(machine, view, machine.symbol_pool(), item.as_heap())?;
+        // Engine-neutral: dedup pairs by key (RHS wins) and rebuild the
+        // kv-list via `return_closure_list` — no runtime code synthesis.
+        let mut merge: IndexMap<String, AbiClosure> = IndexMap::new();
+        for item in l.iter().chain(r.iter()) {
+            let (k, kv) = deconstruct(machine, view, item)?;
             merge.insert(k, kv);
         }
 
-        for item in &r {
-            let (k, kv) = deconstruct(machine, view, machine.symbol_pool(), item.as_heap())?;
-            merge.insert(k, kv);
-        }
-
-        machine_return_closure_list(machine, view, merge.into_iter().map(|(_, v)| v).collect())
+        machine.return_closure_list(view, merge.into_iter().map(|(_, v)| v).collect())
     }
 }
 
@@ -1726,15 +1662,20 @@ impl StgIntrinsic for MergeWith {
         let r = data_list_arg(machine, view, args[1].clone())?;
         let f = args[2].clone();
 
+        // NB: the value-combining step below builds an `f(ov, nv)` application
+        // thunk via `view.app` (runtime code synthesis), which has no neutral
+        // ABI equivalent yet, so MERGEWITH/DEEPMERGE remain HeapSyn-only for
+        // now — `as_heap()` bridges the neutral `deconstruct` results.
         let mut merge: IndexMap<String, SynClosure> = IndexMap::new();
 
         for item in &l {
-            let (key, value) = deconstruct(machine, view, machine.symbol_pool(), item.as_heap())?;
-            merge.insert(key, value);
+            let (key, value) = deconstruct(machine, view, item)?;
+            merge.insert(key, value.as_heap().clone());
         }
 
         for item in &r {
-            let (key, nv) = deconstruct(machine, view, machine.symbol_pool(), item.as_heap())?;
+            let (key, nv) = deconstruct(machine, view, item)?;
+            let nv = nv.as_heap().clone();
             if let Some(ov) = merge.get_mut(&key) {
                 let args = [ov.clone(), nv];
                 let mut combined = SynClosure::new(
@@ -1868,13 +1809,8 @@ impl StgIntrinsic for IsBlock {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        use crate::eval::memory::syntax;
-        let closure = machine.nav(view).resolve(&args[0])?;
-        let code = view.scoped(closure.code());
-        let is_block = matches!(
-            &*code,
-            syntax::HeapSyn::Cons { tag, .. } if *tag == DataConstructor::Block.tag()
-        );
+        let closure = machine.resolve_closure(view, &args[0])?;
+        let is_block = machine.data_tag(view, &closure) == Some(DataConstructor::Block.tag());
         machine_return_bool(machine, view, is_block)
     }
 }

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1,6 +1,6 @@
 //! Block intrinsics
 
-use std::{mem::swap, rc::Rc};
+use std::rc::Rc;
 
 use indexmap::IndexMap;
 
@@ -1666,19 +1666,18 @@ impl StgIntrinsic for MergeWith {
         // thunk via `view.app` (runtime code synthesis), which has no neutral
         // ABI equivalent yet, so MERGEWITH/DEEPMERGE remain HeapSyn-only for
         // now — `as_heap()` bridges the neutral `deconstruct` results.
-        let mut merge: IndexMap<String, SynClosure> = IndexMap::new();
+        let mut merge: IndexMap<String, AbiClosure> = IndexMap::new();
 
         for item in &l {
             let (key, value) = deconstruct(machine, view, item)?;
-            merge.insert(key, value.as_heap().clone());
+            merge.insert(key, value);
         }
 
         for item in &r {
             let (key, nv) = deconstruct(machine, view, item)?;
-            let nv = nv.as_heap().clone();
             if let Some(ov) = merge.get_mut(&key) {
-                let args = [ov.clone(), nv];
-                let mut combined = SynClosure::new(
+                let args = [ov.as_heap().clone(), nv.as_heap().clone()];
+                let combined = AbiClosure::Heap(SynClosure::new(
                     view.app(f.bump(2), Array::from_slice(&view, &[Ref::L(0), Ref::L(1)]))?
                         .as_ptr(),
                     view.from_closures(
@@ -1687,8 +1686,8 @@ impl StgIntrinsic for MergeWith {
                         machine.env(view),
                         Smid::default(),
                     )?,
-                );
-                swap(ov, &mut combined);
+                ));
+                *ov = combined;
             } else {
                 merge.insert(key, nv);
             }

--- a/src/eval/stg/debug.rs
+++ b/src/eval/stg/debug.rs
@@ -5,19 +5,22 @@
 //! - `__DBG(label, value)` — print value to stderr and return it transparently
 //! - `__TRACE_ENTRY(name, args_list, strict)` — print entry trace to stderr
 //! - `__TRACE_EXIT(name, value, strict)` — print exit trace to stderr, return value
+//!
+//! All value inspection here goes through the engine-neutral intrinsic ABI
+//! (`resolve_closure`/`data_tag`/`data_field`/`value_native`/`force`), so these
+//! intrinsics run identically on the HeapSyn and bytecode engines.
 
 use std::convert::TryInto;
 
 use crate::eval::{
     emit::Emitter,
     error::ExecutionError,
-    machine::{
-        env::SynClosure,
-        intrinsic::{CallGlobal1, CallGlobal3, CallGlobal4, IntrinsicMachine, StgIntrinsic},
+    machine::intrinsic::{
+        AbiClosure, CallGlobal1, CallGlobal3, CallGlobal4, IntrinsicMachine, StgIntrinsic,
     },
     memory::{
         mutator::MutatorHeapView,
-        syntax::{HeapSyn, Native, Ref},
+        syntax::{Native, Ref},
     },
     stg::support::{machine_return_str, str_arg},
 };
@@ -26,88 +29,57 @@ use crate::common::sourcemap::Smid;
 
 use super::tags::DataConstructor;
 
-/// Render a eucalypt value from a resolved closure to a compact debug string.
-///
-/// Inner helper shared by `render_debug_repr` (takes `&Ref`) and the tracing
-/// intrinsics (which work with resolved `SynClosure` objects).
-fn render_debug_repr_closure(
+/// The `DataConstructor` of a resolved value handle, if it is a data
+/// constructor in WHNF.
+fn data_constructor(
     machine: &dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    closure: SynClosure,
-) -> String {
-    let code = view.scoped(closure.code());
-    let env = view.scoped(closure.env());
-
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            match dc {
-                Ok(DataConstructor::BoolTrue) => "true".to_string(),
-                Ok(DataConstructor::BoolFalse) => "false".to_string(),
-                Ok(DataConstructor::Unit) => "null".to_string(),
-                Ok(DataConstructor::ListNil) => "[]".to_string(),
-                Ok(DataConstructor::ListCons) => "[list]".to_string(),
-                Ok(DataConstructor::Block)
-                | Ok(DataConstructor::BlockPair)
-                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
-                Ok(DataConstructor::BoxedNumber) => args
-                    .get(0)
-                    .and_then(|inner| render_inner(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<number>".to_string()),
-                Ok(DataConstructor::BoxedString) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<string>".to_string()),
-                Ok(DataConstructor::BoxedSymbol) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_symbol(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<symbol>".to_string()),
-                Ok(DataConstructor::BoxedZdt) => args
-                    .get(0)
-                    .and_then(|inner| render_inner(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<datetime>".to_string()),
-                Ok(DataConstructor::BoxedTypeData) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<type-data>".to_string()),
-                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
-                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
-                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
-                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
-                Ok(DataConstructor::Clause) => "<clause>".to_string(),
-                Err(_) => "<value>".to_string(),
-            }
-        }
-        HeapSyn::Atom {
-            evaluand: Ref::V(n),
-        } => render_native(n, view, machine),
-        _ => "<unevaluated>".to_string(),
-    }
+    clo: &AbiClosure,
+) -> Option<DataConstructor> {
+    machine
+        .data_tag(view, clo)
+        .and_then(|tag| tag.try_into().ok())
 }
 
-/// Render a eucalypt value to a compact, human-readable debug string.
+/// The native payload of a boxed scalar's field 0.
 ///
-/// Scalars are rendered in their literal form:
-/// - Numbers: `42`, `3.14`
-/// - Strings: `"hello"` (with surrounding quotes)
-/// - Symbols: `:foo`
-/// - Booleans: `true`, `false`
-/// - Null: `null`
-///
-/// Structured types produce a type label: `[list]`, `{block}`.
-/// Unevaluated thunks produce `<unevaluated>`.
-pub fn render_debug_repr(
-    machine: &dyn IntrinsicMachine,
+/// With `force`, an unevaluated inner thunk (e.g. the string-concat thunk
+/// inside a `BoxedString` produced by interpolation) is evaluated to WHNF
+/// first; without it, such a thunk yields `None` (the non-forcing peek).
+fn boxed_native(
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    r: &Ref,
+    clo: &AbiClosure,
+    force: bool,
+) -> Option<Native> {
+    let field = machine.data_field(view, clo, 0)?;
+    let field = if force {
+        machine.force(field).ok()?
+    } else {
+        field
+    };
+    machine.value_native(view, &field)
+}
+
+/// Render a boxed scalar's inner value, falling back to `placeholder` when the
+/// inner native is not (yet) available.
+fn boxed_scalar(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    clo: &AbiClosure,
+    force: bool,
+    placeholder: &str,
 ) -> String {
-    match machine.nav(view).resolve(r) {
-        Ok(closure) => render_debug_repr_closure(machine, view, closure),
-        Err(_) => "<error>".to_string(),
+    match boxed_native(machine, view, clo, force) {
+        Some(native) => render_native(&native, view, machine),
+        None => placeholder.to_string(),
     }
 }
 
 /// Render a native value to a debug string.
+///
+/// Scalars are rendered in their literal form: numbers `42`/`3.14`, strings
+/// `"hello"` (quoted), symbols `:foo`, datetimes as RFC-3339.
 fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicMachine) -> String {
     match n {
         Native::Num(num) => num.to_string(),
@@ -138,222 +110,124 @@ fn render_native(n: &Native, view: MutatorHeapView<'_>, machine: &dyn IntrinsicM
     }
 }
 
-/// Render an inner argument ref (from a boxed constructor) as a debug string.
-fn render_inner(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native(view, env, r)?;
-    Some(render_native(&native, view, machine))
-}
-
-/// Render an inner string arg with surrounding double quotes.
-fn render_inner_quoted(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native(view, env, r)?;
-    match &native {
-        Native::Str(s) => {
-            let scoped = view.scoped(*s);
-            Some(format!("{:?}", (*scoped).as_str()))
-        }
-        _ => Some(render_native(&native, view, machine)),
-    }
-}
-
-/// Render an inner symbol arg with `:` prefix.
-fn render_inner_symbol(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native(view, env, r)?;
-    match &native {
-        Native::Sym(id) => Some(format!(":{}", machine.symbol_pool().resolve(*id))),
-        _ => Some(render_native(&native, view, machine)),
-    }
-}
-
-/// Extract a native value from a ref, following local environment lookups.
-fn extract_native(
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<Native> {
-    match r {
-        Ref::V(n) => Some(n.clone()),
-        Ref::L(idx) => {
-            let closure = env.get(&view, *idx)?;
-            let code = view.scoped(closure.code());
-            match &*code {
-                HeapSyn::Atom {
-                    evaluand: Ref::V(n),
-                } => Some(n.clone()),
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
-
-/// Extract a native value from a ref, forcing unevaluated thunks via
-/// `evaluate_to_whnf` when the cheap path fails.
+/// Render a resolved value handle to a compact debug string.
 ///
-/// This is the forcing variant of `extract_native`, used when rendering
-/// actual values in assertion failure messages.  It evaluates inner thunks
-/// that `extract_native` cannot reach — for example, the string
-/// concatenation BIF application inside an interpolated `BoxedString`.
-fn extract_native_forced(
+/// Scalars are rendered in literal form; structured types produce a type label
+/// (`[list]`, `{block}`). Unevaluated values render as `<unevaluated>`. With
+/// `force`, inner scalar thunks (e.g. an interpolated `BoxedString`) are
+/// evaluated so the rendered output is accurate rather than `<string>`.
+fn render_value(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<Native> {
-    // Fast path: cheap extraction succeeds.
-    if let Some(n) = extract_native(view, env, r) {
-        return Some(n);
-    }
-
-    // Slow path: resolve the closure and force it to WHNF.
-    let closure = match r {
-        Ref::L(idx) => env.get(&view, *idx)?,
-        Ref::G(idx) => machine.nav(view).global(*idx).ok()?,
-        Ref::V(_) => return None, // already tried in fast path
+    clo: &AbiClosure,
+    force: bool,
+) -> String {
+    let Some(dc) = data_constructor(machine, view, clo) else {
+        // Not a data constructor: a bare native atom renders as its literal,
+        // anything else is still a thunk.
+        return match machine.value_native(view, clo) {
+            Some(native) => render_native(&native, view, machine),
+            None => "<unevaluated>".to_string(),
+        };
     };
 
-    let forced = machine.evaluate_to_whnf(closure).ok()?;
-    let forced_code = view.scoped(forced.code());
-    match &*forced_code {
-        HeapSyn::Atom {
-            evaluand: Ref::V(n),
-        } => Some(n.clone()),
-        _ => None,
-    }
-}
-
-/// Render an inner argument ref as a debug string, forcing thunks if needed.
-fn render_inner_forced(
-    machine: &mut dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native_forced(machine, view, env, r)?;
-    Some(render_native(&native, view, machine))
-}
-
-/// Render an inner string arg with surrounding double quotes, forcing thunks.
-fn render_inner_quoted_forced(
-    machine: &mut dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native_forced(machine, view, env, r)?;
-    match &native {
-        Native::Str(s) => {
-            let scoped = view.scoped(*s);
-            Some(format!("{:?}", (*scoped).as_str()))
+    match dc {
+        DataConstructor::BoolTrue => "true".to_string(),
+        DataConstructor::BoolFalse => "false".to_string(),
+        DataConstructor::Unit => "null".to_string(),
+        DataConstructor::ListNil => "[]".to_string(),
+        DataConstructor::ListCons => "[list]".to_string(),
+        DataConstructor::Block | DataConstructor::BlockPair | DataConstructor::BlockKvList => {
+            "{block}".to_string()
         }
-        _ => Some(render_native(&native, view, machine)),
+        DataConstructor::BoxedNumber => boxed_scalar(machine, view, clo, force, "<number>"),
+        DataConstructor::BoxedString => boxed_scalar(machine, view, clo, force, "<string>"),
+        DataConstructor::BoxedSymbol => boxed_scalar(machine, view, clo, force, "<symbol>"),
+        DataConstructor::BoxedZdt => boxed_scalar(machine, view, clo, force, "<datetime>"),
+        DataConstructor::BoxedTypeData => boxed_scalar(machine, view, clo, force, "<type-data>"),
+        DataConstructor::IoReturn => "<io-return>".to_string(),
+        DataConstructor::IoBind => "<io-bind>".to_string(),
+        DataConstructor::IoAction => "<io-action>".to_string(),
+        DataConstructor::IoFail => "<io-fail>".to_string(),
+        DataConstructor::Clause => "<clause>".to_string(),
     }
 }
 
-/// Render an inner symbol arg with `:` prefix, forcing thunks.
-fn render_inner_symbol_forced(
-    machine: &mut dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = extract_native_forced(machine, view, env, r)?;
-    match &native {
-        Native::Sym(id) => Some(format!(":{}", machine.symbol_pool().resolve(*id))),
-        _ => Some(render_native(&native, view, machine)),
-    }
-}
-
-/// Render a eucalypt value from a resolved closure, forcing inner thunks.
+/// Render a eucalypt value to a compact, human-readable debug string.
 ///
-/// Unlike `render_debug_repr_closure`, this variant evaluates unevaluated
-/// inner refs (e.g. the string concat thunk inside a `BoxedString` produced
-/// by string interpolation) via `evaluate_to_whnf`.  Use this in contexts
-/// where `&mut dyn IntrinsicMachine` is available (intrinsic `execute` methods).
-fn render_debug_repr_closure_forced(
+/// Non-forcing: lazy inner scalars render as `<number>`/`<string>` etc.  Use
+/// [`render_debug_repr_forced`] when inner thunks should be evaluated.
+pub fn render_debug_repr(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    closure: crate::eval::machine::env::SynClosure,
+    r: &Ref,
 ) -> String {
-    let code = view.scoped(closure.code());
-    let env = view.scoped(closure.env());
-
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            match dc {
-                Ok(DataConstructor::BoolTrue) => "true".to_string(),
-                Ok(DataConstructor::BoolFalse) => "false".to_string(),
-                Ok(DataConstructor::Unit) => "null".to_string(),
-                Ok(DataConstructor::ListNil) => "[]".to_string(),
-                Ok(DataConstructor::ListCons) => "[list]".to_string(),
-                Ok(DataConstructor::Block)
-                | Ok(DataConstructor::BlockPair)
-                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
-                Ok(DataConstructor::BoxedNumber) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_forced(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<number>".to_string()),
-                Ok(DataConstructor::BoxedString) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_quoted_forced(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<string>".to_string()),
-                Ok(DataConstructor::BoxedSymbol) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_symbol_forced(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<symbol>".to_string()),
-                Ok(DataConstructor::BoxedZdt) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_forced(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<datetime>".to_string()),
-                Ok(DataConstructor::BoxedTypeData) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_quoted_forced(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<type-data>".to_string()),
-                Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
-                Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
-                Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
-                Ok(DataConstructor::IoFail) => "<io-fail>".to_string(),
-                Ok(DataConstructor::Clause) => "<clause>".to_string(),
-                Err(_) => "<value>".to_string(),
-            }
-        }
-        HeapSyn::Atom {
-            evaluand: Ref::V(n),
-        } => render_native(n, view, machine),
-        _ => "<unevaluated>".to_string(),
+    match machine.resolve_closure(view, r) {
+        Ok(clo) => render_value(machine, view, &clo, false),
+        Err(_) => "<error>".to_string(),
     }
 }
 
 /// Render a eucalypt value to a compact debug string, forcing inner thunks.
 ///
-/// This is the forcing variant of `render_debug_repr`, suitable for use in
-/// intrinsic `execute` methods (which have `&mut dyn IntrinsicMachine` access).
-/// It evaluates lazy inner refs (e.g. string interpolation results inside a
-/// `BoxedString`) via `evaluate_to_whnf`, so the rendered output is accurate
-/// rather than showing `<string>` or `<number>` for lazy scalar values.
+/// The forcing variant of [`render_debug_repr`], suitable for intrinsic
+/// `execute` methods.  It evaluates lazy inner refs (e.g. string-interpolation
+/// results inside a `BoxedString`) via [`IntrinsicMachine::force`], so scalar
+/// values render accurately rather than as `<string>`/`<number>`.
 pub fn render_debug_repr_forced(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     r: &Ref,
 ) -> String {
-    match machine.nav(view).resolve(r) {
-        Ok(closure) => render_debug_repr_closure_forced(machine, view, closure),
+    match machine.resolve_closure(view, r) {
+        Ok(clo) => render_value(machine, view, &clo, true),
+        Err(_) => "<error>".to_string(),
+    }
+}
+
+/// Render a value without forcing evaluation (non-strict peek).
+///
+/// - Native scalars are rendered as by [`render_debug_repr`].
+/// - Structured types show only their outer shape: `[...]` for non-empty lists,
+///   `{...}` for blocks.
+/// - Anything unevaluated renders as `<thunk>`.
+fn peek_value(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    clo: &AbiClosure,
+) -> String {
+    let Some(dc) = data_constructor(machine, view, clo) else {
+        return match machine.value_native(view, clo) {
+            Some(native) => render_native(&native, view, machine),
+            None => "<thunk>".to_string(),
+        };
+    };
+
+    match dc {
+        DataConstructor::BoolTrue => "true".to_string(),
+        DataConstructor::BoolFalse => "false".to_string(),
+        DataConstructor::Unit => "null".to_string(),
+        DataConstructor::ListNil => "[]".to_string(),
+        DataConstructor::ListCons => "[...]".to_string(),
+        DataConstructor::Block | DataConstructor::BlockPair | DataConstructor::BlockKvList => {
+            "{...}".to_string()
+        }
+        DataConstructor::BoxedNumber => boxed_scalar(machine, view, clo, false, "<number>"),
+        DataConstructor::BoxedString => boxed_scalar(machine, view, clo, false, "<string>"),
+        DataConstructor::BoxedSymbol => boxed_scalar(machine, view, clo, false, "<symbol>"),
+        DataConstructor::BoxedZdt => boxed_scalar(machine, view, clo, false, "<datetime>"),
+        _ => "<value>".to_string(),
+    }
+}
+
+/// Render a value without forcing evaluation (non-strict peek).
+pub fn peek_debug_repr(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    r: &Ref,
+) -> String {
+    match machine.resolve_closure(view, r) {
+        Ok(clo) => peek_value(machine, view, &clo),
         Err(_) => "<error>".to_string(),
     }
 }
@@ -426,128 +300,40 @@ impl StgIntrinsic for Dbg {
         }
 
         // Return args[2] (original value) transparently
-        let closure = machine.nav(view).resolve(&args[2])?;
-        machine.set_closure(closure)
+        let closure = machine.resolve_closure(view, &args[2])?;
+        machine.set_result(closure)
     }
 }
 
 impl CallGlobal3 for Dbg {}
-
-/// Render a value without forcing evaluation (non-strict peek).
-///
-/// - Native scalars (numbers, strings, symbols, booleans, null) are rendered
-///   using the same format as `render_debug_repr`.
-/// - Data constructors that represent structured types show their outer
-///   shape without recursing into contents: `[...]` for non-empty lists,
-///   `{...}` for blocks.
-/// - Anything unevaluated (thunks, applications, case expressions, etc.)
-///   renders as `<thunk>`.
-pub fn peek_debug_repr(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    r: &Ref,
-) -> String {
-    match machine.nav(view).resolve(r) {
-        Ok(closure) => peek_debug_repr_closure(machine, view, closure),
-        Err(_) => "<error>".to_string(),
-    }
-}
-
-/// Inner helper for `peek_debug_repr` that works on an already-resolved closure.
-fn peek_debug_repr_closure(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    closure: SynClosure,
-) -> String {
-    let code = view.scoped(closure.code());
-    let env = view.scoped(closure.env());
-
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            match dc {
-                Ok(DataConstructor::BoolTrue) => "true".to_string(),
-                Ok(DataConstructor::BoolFalse) => "false".to_string(),
-                Ok(DataConstructor::Unit) => "null".to_string(),
-                Ok(DataConstructor::ListNil) => "[]".to_string(),
-                Ok(DataConstructor::ListCons) => "[...]".to_string(),
-                Ok(DataConstructor::Block)
-                | Ok(DataConstructor::BlockPair)
-                | Ok(DataConstructor::BlockKvList) => "{...}".to_string(),
-                Ok(DataConstructor::BoxedNumber) => args
-                    .get(0)
-                    .and_then(|inner| render_inner(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<number>".to_string()),
-                Ok(DataConstructor::BoxedString) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_quoted(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<string>".to_string()),
-                Ok(DataConstructor::BoxedSymbol) => args
-                    .get(0)
-                    .and_then(|inner| render_inner_symbol(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<symbol>".to_string()),
-                Ok(DataConstructor::BoxedZdt) => args
-                    .get(0)
-                    .and_then(|inner| render_inner(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<datetime>".to_string()),
-                _ => "<value>".to_string(),
-            }
-        }
-        HeapSyn::Atom {
-            evaluand: Ref::V(n),
-        } => render_native(n, view, machine),
-        _ => "<thunk>".to_string(),
-    }
-}
 
 /// Resolve a strict bool argument to a Rust `bool`.
 ///
 /// Since the arg must be declared strict in the intrinsic catalogue, it will
 /// have been evaluated to WHNF (a `BoolTrue` or `BoolFalse` constructor)
 /// before `execute` runs.
-fn resolve_bool(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> bool {
-    let closure = match machine.nav(view).resolve(r) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let code = view.scoped(closure.code());
-    match &*code {
-        HeapSyn::Cons { tag, .. } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            matches!(dc, Ok(DataConstructor::BoolTrue))
-        }
-        _ => false,
+fn resolve_bool(machine: &mut dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> bool {
+    match machine.resolve_closure(view, r) {
+        Ok(clo) => matches!(
+            data_constructor(machine, view, &clo),
+            Some(DataConstructor::BoolTrue)
+        ),
+        Err(_) => false,
     }
 }
 
-/// Extract a string value from a closure representing a string literal.
+/// Extract a string value from a resolved closure representing a string.
 ///
-/// Handles both unboxed atoms (`Atom { Ref::V(Native::Str(…)) }`) and
-/// boxed string constructors (`Cons(BoxedString, [inner_ref])`).
-/// Returns `None` if the closure does not hold a string.
-fn extract_str_from_closure(view: MutatorHeapView<'_>, closure: &SynClosure) -> Option<String> {
-    let code = view.scoped(closure.code());
-    let env = view.scoped(closure.env());
-
-    match &*code {
-        HeapSyn::Atom {
-            evaluand: Ref::V(Native::Str(s)),
-        } => Some((*view.scoped(*s)).as_str().to_string()),
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = DataConstructor::try_from(*tag);
-            match dc {
-                Ok(DataConstructor::BoxedString) => {
-                    let inner = args.get(0)?;
-                    let native = extract_native(view, &env, &inner)?;
-                    if let Native::Str(s) = native {
-                        Some((*view.scoped(s)).as_str().to_string())
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            }
-        }
+/// Handles both unboxed native strings and boxed `BoxedString` constructors
+/// (both surface a `Native::Str` through `value_native`).  Returns `None` if
+/// the closure does not hold a string.
+fn extract_str(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    clo: &AbiClosure,
+) -> Option<String> {
+    match machine.value_native(view, clo)? {
+        Native::Str(s) => Some((*view.scoped(s)).as_str().to_string()),
         _ => None,
     }
 }
@@ -555,150 +341,77 @@ fn extract_str_from_closure(view: MutatorHeapView<'_>, closure: &SynClosure) -> 
 /// Traverse a cons-list to the element at `index`, returning its closure.
 ///
 /// The list is always re-resolved from `list_ref` (a stable `Ref` into the
-/// machine's env frame), so this is safe to call after a `evaluate_to_whnf`
-/// call that may have triggered GC.
+/// machine's env frame), so this is safe to call after a `force` call that may
+/// have triggered GC — the caller re-invokes it each iteration rather than
+/// holding resolved element closures across a force.
 ///
 /// Returns an error if the list is shorter than `index + 1` elements or if
 /// the structure is malformed.
 fn get_list_element_at(
-    machine: &dyn IntrinsicMachine,
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     list_ref: &Ref,
     index: usize,
-) -> Result<SynClosure, ExecutionError> {
-    let mut current = machine.nav(view).resolve(list_ref)?;
+) -> Result<AbiClosure, ExecutionError> {
+    let malformed =
+        |what: &str| ExecutionError::Panic(Smid::default(), format!("TRACE args_list: {what}"));
+    let too_short = || {
+        ExecutionError::Panic(
+            Smid::default(),
+            format!("TRACE args_list too short: expected element at index {index}"),
+        )
+    };
 
+    let mut current = machine.resolve_closure(view, list_ref)?;
     for _ in 0..index {
-        let code = view.scoped(current.code());
-        match &*code {
-            HeapSyn::Cons { tag, args } => {
-                let dc: Result<DataConstructor, _> = (*tag).try_into();
-                match dc {
-                    Ok(DataConstructor::ListCons) => {
-                        let t_ref = args.get(1).ok_or_else(|| {
-                            ExecutionError::Panic(
-                                Smid::default(),
-                                "malformed TRACE args_list cons cell (missing tail)".to_string(),
-                            )
-                        })?;
-                        current = machine
-                            .nav(view)
-                            .resolve_in_closure(&current, t_ref.clone())
-                            .ok_or_else(|| {
-                                ExecutionError::Panic(
-                                    Smid::default(),
-                                    "TRACE args_list: invalid tail ref in cons cell".to_string(),
-                                )
-                            })?;
-                    }
-                    Ok(DataConstructor::ListNil) => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
-                            format!("TRACE args_list too short: expected element at index {index}"),
-                        ))
-                    }
-                    _ => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
-                            "TRACE args_list: unexpected data constructor".to_string(),
-                        ))
-                    }
-                }
+        match data_constructor(machine, view, &current) {
+            Some(DataConstructor::ListCons) => {
+                current = machine
+                    .data_field(view, &current, 1)
+                    .ok_or_else(|| malformed("invalid tail ref in cons cell"))?;
             }
-            _ => {
-                return Err(ExecutionError::Panic(
-                    Smid::default(),
-                    "TRACE args_list: expected cons cell, found unevaluated closure".to_string(),
-                ))
-            }
+            Some(DataConstructor::ListNil) => return Err(too_short()),
+            _ => return Err(malformed("expected cons cell")),
         }
     }
 
-    // Extract the head at the current position.
-    let code = view.scoped(current.code());
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            match dc {
-                Ok(DataConstructor::ListCons) => {
-                    let h_ref = args.get(0).ok_or_else(|| {
-                        ExecutionError::Panic(
-                            Smid::default(),
-                            "malformed TRACE args_list cons cell (missing head)".to_string(),
-                        )
-                    })?;
-                    machine
-                        .nav(view)
-                        .resolve_in_closure(&current, h_ref.clone())
-                        .ok_or_else(|| {
-                            ExecutionError::Panic(
-                                Smid::default(),
-                                "TRACE args_list: invalid head ref in cons cell".to_string(),
-                            )
-                        })
-                }
-                Ok(DataConstructor::ListNil) => Err(ExecutionError::Panic(
-                    Smid::default(),
-                    format!("TRACE args_list too short: expected element at index {index}"),
-                )),
-                _ => Err(ExecutionError::Panic(
-                    Smid::default(),
-                    "TRACE args_list: unexpected data constructor".to_string(),
-                )),
-            }
-        }
-        _ => Err(ExecutionError::Panic(
-            Smid::default(),
-            "TRACE args_list: expected cons cell, found unevaluated closure".to_string(),
-        )),
+    match data_constructor(machine, view, &current) {
+        Some(DataConstructor::ListCons) => machine
+            .data_field(view, &current, 0)
+            .ok_or_else(|| malformed("invalid head ref in cons cell")),
+        Some(DataConstructor::ListNil) => Err(too_short()),
+        _ => Err(malformed("expected cons cell")),
     }
 }
 
 /// Count the number of elements in a cons-list without forcing any values.
 fn count_list_elements(
-    machine: &dyn IntrinsicMachine,
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     list_ref: &Ref,
 ) -> Result<usize, ExecutionError> {
+    let malformed = || {
+        ExecutionError::Panic(
+            Smid::default(),
+            "malformed cons cell in TRACE args_list".to_string(),
+        )
+    };
+
     let mut count = 0usize;
-    let mut current = machine.nav(view).resolve(list_ref)?;
+    let mut current = machine.resolve_closure(view, list_ref)?;
     loop {
-        let code = view.scoped(current.code());
-        match &*code {
-            HeapSyn::Cons { tag, args } => {
-                let dc: Result<DataConstructor, _> = (*tag).try_into();
-                match dc {
-                    Ok(DataConstructor::ListNil) => break,
-                    Ok(DataConstructor::ListCons) => {
-                        count += 1;
-                        let t_ref = args.get(1).ok_or_else(|| {
-                            ExecutionError::Panic(
-                                Smid::default(),
-                                "malformed cons cell in TRACE args_list".to_string(),
-                            )
-                        })?;
-                        current = machine
-                            .nav(view)
-                            .resolve_in_closure(&current, t_ref.clone())
-                            .ok_or_else(|| {
-                                ExecutionError::Panic(
-                                    Smid::default(),
-                                    "TRACE args_list: invalid tail ref in cons cell".to_string(),
-                                )
-                            })?;
-                    }
-                    _ => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
-                            "unexpected data constructor in TRACE args_list".to_string(),
-                        ))
-                    }
-                }
+        match data_constructor(machine, view, &current) {
+            Some(DataConstructor::ListNil) => break,
+            Some(DataConstructor::ListCons) => {
+                count += 1;
+                current = machine
+                    .data_field(view, &current, 1)
+                    .ok_or_else(malformed)?;
             }
             _ => {
                 return Err(ExecutionError::Panic(
                     Smid::default(),
-                    "expected cons cell in TRACE args_list, found unevaluated closure".to_string(),
+                    "unexpected data constructor in TRACE args_list".to_string(),
                 ))
             }
         }
@@ -741,25 +454,25 @@ impl StgIntrinsic for TraceEntry {
         let n_elements = count_list_elements(machine, view, &args[1])?;
         let n_pairs = n_elements / 2;
 
-        // Pass 1: collect names (no GC — no evaluate_to_whnf calls here).
+        // Pass 1: collect names (no forcing — no GC here).
         let mut arg_names: Vec<String> = Vec::with_capacity(n_pairs);
         for i in 0..n_pairs {
             let name_closure = get_list_element_at(machine, view, &args[1], 2 * i)?;
-            let s = extract_str_from_closure(view, &name_closure)
-                .unwrap_or_else(|| "<arg>".to_string());
+            let s =
+                extract_str(machine, view, &name_closure).unwrap_or_else(|| "<arg>".to_string());
             arg_names.push(s);
         }
 
-        // Pass 2: render values (may trigger GC via evaluate_to_whnf in strict mode).
+        // Pass 2: render values (may trigger GC via `force` in strict mode).
         // Each iteration re-traverses from args[1] to remain GC-safe.
         let mut arg_reprs: Vec<String> = Vec::with_capacity(n_pairs);
         for i in 0..n_pairs {
             let value_closure = get_list_element_at(machine, view, &args[1], 2 * i + 1)?;
             let repr = if strict {
-                let forced = machine.evaluate_to_whnf(value_closure)?;
-                render_debug_repr_closure(machine, view, forced)
+                let forced = machine.force(value_closure)?;
+                render_value(machine, view, &forced, false)
             } else {
-                peek_debug_repr_closure(machine, view, value_closure)
+                peek_value(machine, view, &value_closure)
             };
             arg_reprs.push(repr);
         }
@@ -773,8 +486,8 @@ impl StgIntrinsic for TraceEntry {
         eprintln!("\u{2192} {name}({})", arg_strs.join(", "));
 
         // Return the body unchanged.
-        let body = machine.nav(view).resolve(&args[3])?;
-        machine.set_closure(body)
+        let body = machine.resolve_closure(view, &args[3])?;
+        machine.set_result(body)
     }
 }
 
@@ -811,18 +524,18 @@ impl StgIntrinsic for TraceExit {
         let strict = resolve_bool(machine, view, &args[2]);
 
         let result_closure = if strict {
-            let value_closure = machine.nav(view).resolve(&args[1])?;
-            let forced = machine.evaluate_to_whnf(value_closure)?;
-            let repr = render_debug_repr_closure(machine, view, forced.clone());
+            let value_closure = machine.resolve_closure(view, &args[1])?;
+            let forced = machine.force(value_closure)?;
+            let repr = render_value(machine, view, &forced, false);
             eprintln!("\u{2190} {name}: {repr}");
             forced
         } else {
             let repr = peek_debug_repr(machine, view, &args[1]);
             eprintln!("\u{2190} {name}: {repr}");
-            machine.nav(view).resolve(&args[1])?
+            machine.resolve_closure(view, &args[1])?
         };
 
-        machine.set_closure(result_closure)
+        machine.set_result(result_closure)
     }
 }
 

--- a/src/eval/stg/render_to_string.rs
+++ b/src/eval/stg/render_to_string.rs
@@ -16,8 +16,6 @@ use crate::{
         intrinsics,
         machine::intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
         memory::{
-            alloc::ScopedAllocator,
-            array::Array,
             mutator::MutatorHeapView,
             syntax::{HeapSyn, Ref},
         },
@@ -134,21 +132,13 @@ impl StgIntrinsic for RenderToString {
         // pops the capture emitter and produces the result string.
         machine.push_capture_end(view)?;
 
-        // Set closure to RENDER_DOC(value).
+        // Tail-call RENDER_DOC(value): the CaptureEnd continuation pushed above
+        // sits below the application, so the rendered doc is captured to a
+        // string when RENDER_DOC returns. Engine-neutral (no code synthesis).
         let render_doc_idx = intrinsics::index("RENDER_DOC").ok_or_else(|| {
             ExecutionError::Panic(machine.annotation(), "RENDER_DOC not found".to_string())
         })?;
-        let app = view
-            .alloc(HeapSyn::App {
-                callable: Ref::G(render_doc_idx),
-                args: Array::from_slice(&view, &[args[0].clone()]),
-                eager_args: false,
-            })?
-            .as_ptr();
-        machine.set_closure(crate::eval::machine::env::SynClosure::new(
-            app,
-            machine.env(view),
-        ))
+        machine.tail_apply_global(view, render_doc_idx, &[args[0].clone()])
     }
 }
 

--- a/src/eval/stg/set.rs
+++ b/src/eval/stg/set.rs
@@ -16,7 +16,7 @@ use crate::{
         memory::{
             mutator::MutatorHeapView,
             set::HeapSet,
-            syntax::{HeapSyn, Native, Ref},
+            syntax::{Native, Ref},
         },
         stg::tags::DataConstructor,
     },
@@ -164,25 +164,13 @@ impl StgIntrinsic for SetToList {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        use crate::eval::memory::{
-            alloc::ScopedAllocator, array::Array, syntax::LambdaForm, syntax::StgBuilder,
-        };
-
         let set = set_arg(machine, view, &args[0])?;
         let sorted = set.sorted_elements();
 
-        // Build a list of boxed values in reverse
-        let mut bindings = vec![LambdaForm::value(
-            view.alloc(HeapSyn::Cons {
-                tag: DataConstructor::ListNil.tag(),
-                args: Array::default(),
-            })?
-            .as_ptr(),
-        )];
-
-        for prim in sorted.into_iter().rev() {
+        // Box each element and assemble the (sorted) list via the neutral ABI.
+        let mut items = Vec::with_capacity(sorted.len());
+        for prim in sorted {
             let native = set_primitive_to_native(machine, view, prim)?;
-            // Determine the box tag
             let box_tag = match &native {
                 Native::Num(_) => DataConstructor::BoxedNumber.tag(),
                 Native::Str(_) => DataConstructor::BoxedString.tag(),
@@ -194,36 +182,11 @@ impl StgIntrinsic for SetToList {
                     ))
                 }
             };
-            // Box the value
-            bindings.push(LambdaForm::value(
-                view.alloc(HeapSyn::Cons {
-                    tag: box_tag,
-                    args: Array::from_slice(&view, &[Ref::V(native)]),
-                })?
-                .as_ptr(),
-            ));
-            // Cons it onto the list
-            let len = bindings.len();
-            bindings.push(LambdaForm::value(
-                view.alloc(HeapSyn::Cons {
-                    tag: DataConstructor::ListCons.tag(),
-                    args: Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-                })?
-                .as_ptr(),
-            ));
+            let boxed = machine.native_value(view, native)?;
+            items.push(machine.data_value(view, box_tag, &[boxed])?);
         }
 
-        let list_index = bindings.len() - 1;
-        let syn = view
-            .letrec(
-                Array::from_slice(&view, &bindings),
-                view.atom(Ref::L(list_index))?,
-            )?
-            .as_ptr();
-        machine.set_closure(crate::eval::machine::env::SynClosure::new(
-            syn,
-            machine.root_env(),
-        ))
+        machine.return_closure_list(view, items)
     }
 }
 

--- a/src/eval/stg/stream_prng.rs
+++ b/src/eval/stg/stream_prng.rs
@@ -19,10 +19,8 @@ use crate::{
         error::ExecutionError,
         machine::intrinsic::{CallGlobal1, CallGlobal2, IntrinsicMachine, StgIntrinsic},
         memory::{
-            alloc::ScopedAllocator,
-            array::Array,
             mutator::MutatorHeapView,
-            syntax::{LambdaForm, Native, Ref, StgBuilder},
+            syntax::{Native, Ref},
         },
     },
 };
@@ -40,7 +38,7 @@ fn prng_arg(
     view: MutatorHeapView<'_>,
     arg: &Ref,
 ) -> Result<u64, ExecutionError> {
-    let native = machine.nav(view).resolve_native(arg)?;
+    let native = machine.resolve_native(view, arg)?;
     if let Native::Prng(state) = native {
         Ok(state)
     } else {
@@ -59,14 +57,8 @@ fn machine_return_stream(
     view: MutatorHeapView<'_>,
     state: u64,
 ) -> Result<(), ExecutionError> {
-    use crate::eval::memory::syntax::HeapSyn;
-    machine.set_closure(crate::eval::machine::env::SynClosure::new(
-        view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Prng(state)),
-        })?
-        .as_ptr(),
-        machine.root_env(),
-    ))
+    let v = machine.native_value(view, Native::Prng(state))?;
+    machine.set_result(v)
 }
 
 /// Build and return a two-element list `[first, second]` where both
@@ -77,56 +69,9 @@ fn machine_return_stream_pair(
     first: u64,
     second: u64,
 ) -> Result<(), ExecutionError> {
-    use crate::eval::memory::syntax::HeapSyn;
-    // Bindings (built in reverse for cons-list construction):
-    // [0] nil
-    // [1] Atom(Stream(second))
-    // [2] ListCons(L(1), L(0))   — [second]
-    // [3] Atom(Stream(first))
-    // [4] ListCons(L(3), L(2))   — [first, second]
-    let mut bindings = vec![LambdaForm::value(view.nil()?.as_ptr())];
-
-    bindings.push(LambdaForm::value(
-        view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Prng(second)),
-        })?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    bindings.push(LambdaForm::value(
-        view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Prng(first)),
-        })?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    let list_index = bindings.len() - 1;
-    let syn = view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr();
-    machine.set_closure(crate::eval::machine::env::SynClosure::new(
-        syn,
-        machine.root_env(),
-    ))
+    let a = machine.native_value(view, Native::Prng(first))?;
+    let b = machine.native_value(view, Native::Prng(second))?;
+    machine.return_closure_list(view, vec![a, b])
 }
 
 /// Build and return a two-element list `[float, stream]`.
@@ -138,62 +83,13 @@ fn machine_return_float_stream(
     float_val: f64,
     stream_state: u64,
 ) -> Result<(), ExecutionError> {
-    use crate::eval::memory::syntax::HeapSyn;
-
     let n = Number::from_f64(float_val).ok_or_else(|| {
         ExecutionError::Panic(Smid::default(), "STREAM produced invalid float".to_string())
     })?;
-
-    // Bindings:
-    // [0] nil
-    // [1] Atom(Stream(stream_state))
-    // [2] ListCons(L(1), L(0))           — [stream]
-    // [3] BoxedNumber(Num(float_val))
-    // [4] ListCons(L(3), L(2))           — [float, stream]
-    let mut bindings = vec![LambdaForm::value(view.nil()?.as_ptr())];
-
-    bindings.push(LambdaForm::value(
-        view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Prng(stream_state)),
-        })?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::BoxedNumber.tag(),
-            Array::from_slice(&view, &[Ref::V(Native::Num(n))]),
-        )?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    let list_index = bindings.len() - 1;
-    let syn = view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr();
-    machine.set_closure(crate::eval::machine::env::SynClosure::new(
-        syn,
-        machine.root_env(),
-    ))
+    let num = machine.native_value(view, Native::Num(n))?;
+    let boxed = machine.data_value(view, DataConstructor::BoxedNumber.tag(), &[num])?;
+    let stream = machine.native_value(view, Native::Prng(stream_state))?;
+    machine.return_closure_list(view, vec![boxed, stream])
 }
 
 /// Build and return a two-element list `[int, stream]`.
@@ -205,58 +101,10 @@ fn machine_return_int_stream(
     int_val: u64,
     stream_state: u64,
 ) -> Result<(), ExecutionError> {
-    use crate::eval::memory::syntax::HeapSyn;
-
-    // Bindings:
-    // [0] nil
-    // [1] Atom(Stream(stream_state))
-    // [2] ListCons(L(1), L(0))            — [stream]
-    // [3] BoxedNumber(Num(int_val as i64))
-    // [4] ListCons(L(3), L(2))            — [int, stream]
-    let mut bindings = vec![LambdaForm::value(view.nil()?.as_ptr())];
-
-    bindings.push(LambdaForm::value(
-        view.alloc(HeapSyn::Atom {
-            evaluand: Ref::V(Native::Prng(stream_state)),
-        })?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::BoxedNumber.tag(),
-            Array::from_slice(&view, &[Ref::V(Native::Num(Number::from(int_val as i64)))]),
-        )?
-        .as_ptr(),
-    ));
-    let len = bindings.len();
-    bindings.push(LambdaForm::value(
-        view.data(
-            DataConstructor::ListCons.tag(),
-            Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-        )?
-        .as_ptr(),
-    ));
-
-    let list_index = bindings.len() - 1;
-    let syn = view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr();
-    machine.set_closure(crate::eval::machine::env::SynClosure::new(
-        syn,
-        machine.root_env(),
-    ))
+    let num = machine.native_value(view, Native::Num(Number::from(int_val as i64)))?;
+    let boxed = machine.data_value(view, DataConstructor::BoxedNumber.tag(), &[num])?;
+    let stream = machine.native_value(view, Native::Prng(stream_state))?;
+    machine.return_closure_list(view, vec![boxed, stream])
 }
 
 // ─── STREAM_NEW ──────────────────────────────────────────────────────────────

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -410,9 +410,9 @@ pub fn resolve_native_unboxing(
             | DataConstructor::BoxedSymbol
             | DataConstructor::BoxedZdt
             | DataConstructor::BoxedTypeData,
-        ) => machine.value_native(view, &closure).ok_or_else(|| {
-            ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())
-        }),
+        ) => machine
+            .value_native(view, &closure)
+            .ok_or_else(|| ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())),
         Some(_) => Err(ExecutionError::NotValue(
             machine.annotation(),
             "non-boxed constructor".to_string(),

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -8,10 +8,9 @@ use serde_json::Number;
 
 use crate::eval::{
     error::ExecutionError,
-    machine::{env::SynClosure, env_builder::EnvBuilder, intrinsic::*},
+    machine::{env::SynClosure, intrinsic::*},
     memory::{
         alloc::{ScopedAllocator, ScopedPtr},
-        array::Array,
         mutator::MutatorHeapView,
         ndarray::HeapNdArray,
         set::HeapSet,
@@ -709,60 +708,25 @@ pub fn machine_return_closure_list(
     machine.return_closure_list(view, list.into_iter().map(AbiClosure::Heap).collect())
 }
 
-/// Return a list of closures from intrinsic
+/// Return a block's kv-list (a cons-list of `BlockPair(sym, value)`) from an
+/// intrinsic, engine-neutrally.
+///
+/// Each key is interned to a symbol native and each pair built via `data_value`;
+/// the list is assembled with `return_closure_list` — no runtime code synthesis.
 pub fn machine_return_block_pair_closure_list(
     machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView,
-    block: IndexMap<String, SynClosure>,
+    block: IndexMap<String, AbiClosure>,
 ) -> Result<(), ExecutionError> {
-    // env of values
-    let values: Vec<_> = block.values().cloned().collect();
-    let value_frame = view.from_closures(
-        values.iter().cloned(),
-        values.len(),
-        machine.env(view),
-        Smid::default(),
-    )?;
-    let len = block.len();
-
-    // env of pairs
-    let mut pairs = vec![];
-    for (i, k) in block.keys().enumerate() {
-        pairs.push(SynClosure::new(
-            view.data(
-                DataConstructor::BlockPair.tag(),
-                Array::from_slice(
-                    &view,
-                    &[view.sym_ref(machine.symbol_pool_mut(), k)?, Ref::L(i)],
-                ),
-            )?
-            .as_ptr(),
-            value_frame,
-        ));
+    let mut pairs = Vec::with_capacity(block.len());
+    for (k, value) in block {
+        let Ref::V(sym_native) = view.sym_ref(machine.symbol_pool_mut(), &k)? else {
+            unreachable!("sym_ref yields a value ref")
+        };
+        let key = machine.native_value(view, sym_native)?;
+        pairs.push(machine.data_value(view, DataConstructor::BlockPair.tag(), &[key, value])?);
     }
-    let pair_frame = view.from_closures(
-        pairs.iter().cloned(),
-        pairs.len(),
-        value_frame,
-        Smid::default(),
-    )?;
-
-    // env of links [lnull, l0, l1 ..] [p0 p1 p2...] [v0 v1 ..]
-    let mut bindings = vec![LambdaForm::value(view.nil()?.as_ptr())];
-    for i in (0..len + 1).rev() {
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::ListCons.tag(),
-                Array::from_slice(&view, &[Ref::L(len + i + 1), Ref::L(len - i)]),
-            )?
-            .as_ptr(),
-        ));
-    }
-
-    let syn = view
-        .letrec(Array::from_slice(&view, &bindings), view.atom(Ref::L(len))?)?
-        .as_ptr();
-    machine.set_closure(SynClosure::new(syn, pair_frame))
+    machine.return_closure_list(view, pairs)
 }
 
 pub mod call {

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -80,13 +80,8 @@ fn cons_tag_of(
     view: MutatorHeapView<'_>,
     arg: &Ref,
 ) -> Option<u8> {
-    let nav = machine.nav(view);
-    let closure = nav.resolve(arg).ok()?;
-    let code = view.scoped(closure.code());
-    match &*code {
-        HeapSyn::Cons { tag, .. } => Some(*tag),
-        _ => None,
-    }
+    let closure = machine.resolve_closure(view, arg).ok()?;
+    machine.data_tag(view, &closure)
 }
 
 /// Helper for intrinsics to access a numeric arg.
@@ -397,41 +392,54 @@ pub fn resolve_native_unboxing(
     arg: &Ref,
 ) -> Result<Native, ExecutionError> {
     // First try the standard resolve path
-    let nav = machine.nav(view);
-    if let Ok(native) = nav.resolve_native(arg) {
+    if let Ok(native) = machine.resolve_native(view, arg) {
         return Ok(native);
     }
 
-    // If that failed, the value may be a boxed constructor — resolve
-    // the closure and check for a Cons with a box tag.
-    let closure = nav.resolve(arg)?;
-    let code = view.scoped(closure.code());
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
-            match dc {
-                Ok(DataConstructor::BoxedNumber)
-                | Ok(DataConstructor::BoxedString)
-                | Ok(DataConstructor::BoxedSymbol)
-                | Ok(DataConstructor::BoxedZdt)
-                | Ok(DataConstructor::BoxedTypeData) => {
-                    let inner_ref = args.get(0).ok_or_else(|| {
-                        ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())
-                    })?;
-                    let native = closure.navigate_local_native(&view, inner_ref);
-                    Ok(native)
-                }
-                _ => Err(ExecutionError::NotValue(
-                    machine.annotation(),
-                    "non-boxed constructor".to_string(),
-                )),
-            }
-        }
-        _ => Err(ExecutionError::NotValue(
+    // If that failed, the value may be a boxed constructor — resolve the
+    // closure and, if it is a boxed scalar, read its inner native via the
+    // neutral ABI (`value_native` unboxes a boxed Cons's field 0).
+    let closure = machine.resolve_closure(view, arg)?;
+    let dc: Option<DataConstructor> = machine
+        .data_tag(view, &closure)
+        .and_then(|tag| tag.try_into().ok());
+    match dc {
+        Some(
+            DataConstructor::BoxedNumber
+            | DataConstructor::BoxedString
+            | DataConstructor::BoxedSymbol
+            | DataConstructor::BoxedZdt
+            | DataConstructor::BoxedTypeData,
+        ) => machine.value_native(view, &closure).ok_or_else(|| {
+            ExecutionError::Panic(Smid::default(), "empty boxed value".to_string())
+        }),
+        Some(_) => Err(ExecutionError::NotValue(
+            machine.annotation(),
+            "non-boxed constructor".to_string(),
+        )),
+        None => Err(ExecutionError::NotValue(
             machine.annotation(),
             "expected native value".to_string(),
         )),
     }
+}
+
+/// Build a cons-list value handle from item handles, engine-neutrally.
+///
+/// Folds `ListCons` over the items from a `ListNil` tail using `data_value`,
+/// so the result works on both the HeapSyn and bytecode engines (no runtime
+/// code synthesis). Unlike `return_closure_list`, this returns the list as a
+/// value handle rather than setting the machine result.
+pub fn list_value(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    items: Vec<AbiClosure>,
+) -> Result<AbiClosure, ExecutionError> {
+    let mut acc = machine.data_value(view, DataConstructor::ListNil.tag(), &[])?;
+    for item in items.into_iter().rev() {
+        acc = machine.data_value(view, DataConstructor::ListCons.tag(), &[item, acc])?;
+    }
+    Ok(acc)
 }
 
 /// Convert a Native value to a set Primitive
@@ -608,42 +616,6 @@ pub fn collect_num_list(
     Ok(numbers)
 }
 
-/// Build a heap cons-list of boxed numbers from a slice of f64, returning
-/// the raw heap pointer to the head of the list.
-///
-/// Used internally to construct inner lists for `machine_return_num_list_of_lists`.
-fn build_num_list_ptr(
-    view: MutatorHeapView<'_>,
-    nums: &[f64],
-) -> Result<RefPtr<HeapSyn>, ExecutionError> {
-    let mut bindings: Vec<LambdaForm> = vec![LambdaForm::value(view.nil()?.as_ptr())];
-    for &item in nums.iter().rev() {
-        let n = Number::from_f64(item).unwrap_or_else(|| Number::from(0));
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::BoxedNumber.tag(),
-                Array::from_slice(&view, &[Ref::V(Native::Num(n))]),
-            )?
-            .as_ptr(),
-        ));
-        let len = bindings.len();
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::ListCons.tag(),
-                Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-            )?
-            .as_ptr(),
-        ));
-    }
-    let list_index = bindings.len() - 1;
-    Ok(view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr())
-}
-
 /// Return a list of number-lists from an intrinsic.
 ///
 /// Used for `ARRAY.INDICES` which returns a list of coordinate lists.
@@ -652,33 +624,19 @@ pub fn machine_return_num_list_of_lists(
     view: MutatorHeapView<'_>,
     lists: Vec<Vec<f64>>,
 ) -> Result<(), ExecutionError> {
-    // Build each inner list as a heap object and collect raw pointers.
-    let inner_ptrs: Vec<RefPtr<HeapSyn>> = lists
-        .iter()
-        .map(|inner| build_num_list_ptr(view, inner))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // Build the outer cons list from these pointers.
-    let mut bindings: Vec<LambdaForm> = vec![LambdaForm::value(view.nil()?.as_ptr())];
-    for ptr in inner_ptrs.into_iter().rev() {
-        bindings.push(LambdaForm::value(ptr));
-        let len = bindings.len();
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::ListCons.tag(),
-                Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-            )?
-            .as_ptr(),
-        ));
+    // Build each inner list as a value handle via the neutral ABI, then the
+    // outer list over those handles.
+    let mut outer = Vec::with_capacity(lists.len());
+    for inner in lists {
+        let mut items = Vec::with_capacity(inner.len());
+        for x in inner {
+            let n = Number::from_f64(x).unwrap_or_else(|| Number::from(0));
+            let native = machine.native_value(view, Native::Num(n))?;
+            items.push(machine.data_value(view, DataConstructor::BoxedNumber.tag(), &[native])?);
+        }
+        outer.push(list_value(machine, view, items)?);
     }
-    let list_index = bindings.len() - 1;
-    let syn = view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr();
-    machine.set_closure(SynClosure::new(syn, machine.root_env()))
+    machine.return_closure_list(view, outer)
 }
 
 /// Return a number list from intrinsic, following the same pattern
@@ -708,39 +666,17 @@ pub fn machine_return_str_iter(
     view: MutatorHeapView,
     iter: impl Iterator<Item = String>,
 ) -> Result<(), ExecutionError> {
-    // Allocate each string on the heap as it arrives from the iterator,
-    // collecting only the small Ref pointers (not full Strings).
-    let refs: Vec<Ref> = iter
-        .map(|s| view.str_ref(s))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // Build the cons list in reverse from the heap refs
-    let mut bindings = vec![LambdaForm::value(view.nil()?.as_ptr())];
-    for str_ref in refs.into_iter().rev() {
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::BoxedString.tag(),
-                Array::from_slice(&view, &[str_ref]),
-            )?
-            .as_ptr(),
-        ));
-        let len = bindings.len();
-        bindings.push(LambdaForm::value(
-            view.data(
-                DataConstructor::ListCons.tag(),
-                Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-            )?
-            .as_ptr(),
-        ));
+    // Box each string as a value handle via the neutral ABI, then build the
+    // cons-list over those handles (works on both engines).
+    let mut items = Vec::new();
+    for s in iter {
+        let Ref::V(native) = view.str_ref(s)? else {
+            unreachable!("str_ref yields a value ref")
+        };
+        let boxed = machine.native_value(view, native)?;
+        items.push(machine.data_value(view, DataConstructor::BoxedString.tag(), &[boxed])?);
     }
-    let list_index = bindings.len() - 1;
-    let syn = view
-        .letrec(
-            Array::from_slice(&view, &bindings),
-            view.atom(Ref::L(list_index))?,
-        )?
-        .as_ptr();
-    machine.set_closure(SynClosure::new(syn, machine.root_env()))
+    machine.return_closure_list(view, items)
 }
 
 /// Return a string list from intrinsic

--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -15,14 +15,12 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::{
-            env::SynClosure,
-            intrinsic::{CallGlobal1, CallGlobal7, IntrinsicMachine, StgIntrinsic},
+        machine::intrinsic::{
+            AbiClosure, CallGlobal1, CallGlobal7, IntrinsicMachine, StgIntrinsic,
         },
         memory::{
-            array::Array,
             mutator::MutatorHeapView,
-            syntax::{Ref, StgBuilder},
+            syntax::{Native, Ref, StgBuilder},
         },
     },
 };
@@ -153,6 +151,29 @@ impl StgIntrinsic for Zdt {
 
 impl CallGlobal7 for Zdt {}
 
+/// Build a `BoxedNumber` value handle via the neutral ABI.
+fn boxed_num(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    n: Number,
+) -> Result<AbiClosure, ExecutionError> {
+    let nv = machine.native_value(view, Native::Num(n))?;
+    machine.data_value(view, DataConstructor::BoxedNumber.tag(), &[nv])
+}
+
+/// Build a `BoxedString` value handle via the neutral ABI.
+fn boxed_str(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    s: String,
+) -> Result<AbiClosure, ExecutionError> {
+    let Ref::V(native) = view.str_ref(s)? else {
+        unreachable!("str_ref yields a value ref")
+    };
+    let sv = machine.native_value(view, native)?;
+    machine.data_value(view, DataConstructor::BoxedString.tag(), &[sv])
+}
+
 /// ZDT.FIELDS - convert ZDT to (sym, val) pairs (which can be
 /// converted to block)
 ///
@@ -180,89 +201,27 @@ impl StgIntrinsic for ZdtFields {
         let sec = (dt.second() as f64) + (dt.timestamp_subsec_millis() as f64) / 1000f64;
         let tz = dt.offset().to_string().replace(':', "");
 
-        let mut fields = IndexMap::new();
-        fields.insert(
-            "y".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(&view, &[Ref::num(y)]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
-        );
-        fields.insert(
-            "m".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(&view, &[Ref::num(m)]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
-        );
-        fields.insert(
-            "d".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(&view, &[Ref::num(d)]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
-        );
+        let mut fields: IndexMap<String, AbiClosure> = IndexMap::new();
+        fields.insert("y".to_string(), boxed_num(machine, view, Number::from(y))?);
+        fields.insert("m".to_string(), boxed_num(machine, view, Number::from(m))?);
+        fields.insert("d".to_string(), boxed_num(machine, view, Number::from(d))?);
         fields.insert(
             "H".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(&view, &[Ref::num(hour)]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
+            boxed_num(machine, view, Number::from(hour))?,
         );
         fields.insert(
             "M".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(&view, &[Ref::num(min)]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
+            boxed_num(machine, view, Number::from(min))?,
         );
         fields.insert(
             "S".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedNumber.tag(),
-                    Array::from_slice(
-                        &view,
-                        &[Ref::num(
-                            Number::from_f64(sec).expect("seconds must be finite"),
-                        )],
-                    ),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
+            boxed_num(
+                machine,
+                view,
+                Number::from_f64(sec).expect("seconds must be finite"),
+            )?,
         );
-        fields.insert(
-            "Z".to_string(),
-            SynClosure::new(
-                view.data(
-                    DataConstructor::BoxedString.tag(),
-                    Array::from_slice(&view, &[view.str_ref(tz)?]),
-                )?
-                .as_ptr(),
-                machine.root_env(),
-            ),
-        );
+        fields.insert("Z".to_string(), boxed_str(machine, view, tz)?);
 
         machine_return_block_pair_closure_list(machine, view, fields)
     }

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -17,13 +17,11 @@ use crate::eval::{
     stg::tags::DataConstructor,
 };
 
-use crate::eval::machine::env::SynClosure;
-
 use super::{
     force::{SeqList, SeqNumList},
     support::{
-        collect_num_list, machine_return_num, machine_return_vec, native_to_set_primitive,
-        resolve_native_unboxing, set_primitive_to_native, vec_arg,
+        collect_num_list, data_list_arg, machine_return_num, machine_return_vec,
+        native_to_set_primitive, resolve_native_unboxing, set_primitive_to_native, vec_arg,
     },
     syntax::{
         dsl::{app_bif, force, lambda, lref},
@@ -36,59 +34,6 @@ use crate::eval::memory::{
     array::Array,
     syntax::{LambdaForm as HeapLambdaForm, StgBuilder},
 };
-
-/// Resolve a ref from within a cons closure context.
-///
-/// Delegates to `HeapNavigator::resolve_in_closure` which handles all
-/// ref types: `Ref::L` (local), `Ref::G` (global constant like nil),
-/// and `Ref::V` (inline native value).
-fn resolve_list_ref(
-    closure: &SynClosure,
-    machine: &mut dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    r: &Ref,
-) -> Result<SynClosure, ExecutionError> {
-    machine
-        .nav(view)
-        .resolve_in_closure(closure, r.clone())
-        .ok_or_else(|| {
-            ExecutionError::Panic(
-                Smid::default(),
-                "failed to resolve list ref in vec conversion".to_string(),
-            )
-        })
-}
-
-/// Extract a primitive from a closure representing a list element.
-///
-/// Handles both raw atom closures (`Atom { Ref::V(native) }`) and
-/// boxed constructor closures (`Cons { BoxedNumber | BoxedString | … }`).
-fn extract_primitive(
-    item_closure: &SynClosure,
-    machine: &mut dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-) -> Result<Primitive, ExecutionError> {
-    let smid = machine.annotation();
-    let code = view.scoped(item_closure.code());
-    match &*code {
-        HeapSyn::Atom { evaluand } => {
-            let native = item_closure.navigate_local_native(&view, evaluand.clone());
-            native_to_set_primitive(smid, view, &native)
-        }
-        HeapSyn::Cons { args: cargs, .. } => {
-            // Handle boxed values (BoxedNumber, BoxedString, BoxedSymbol, BoxedZdt)
-            let inner_ref = cargs.get(0).ok_or_else(|| {
-                ExecutionError::Panic(Smid::default(), "empty boxed value in vec".to_string())
-            })?;
-            let native = item_closure.navigate_local_native(&view, inner_ref.clone());
-            native_to_set_primitive(smid, view, &native)
-        }
-        _ => Err(ExecutionError::Panic(
-            Smid::default(),
-            "non-primitive value in vec construction".to_string(),
-        )),
-    }
-}
 
 /// VEC.OF — convert a list of primitives to a vec.
 pub struct VecOf;
@@ -118,55 +63,16 @@ impl StgIntrinsic for VecOf {
         _emitter: &mut dyn Emitter,
         args: &[Ref],
     ) -> Result<(), ExecutionError> {
-        // Resolve the list closure using the machine navigator (handles L, G, V).
-        let mut current = machine.nav(view).resolve(&args[0])?;
-        let mut primitives = Vec::new();
-
-        loop {
-            let code = view.scoped(current.code());
-            match &*code {
-                HeapSyn::Cons {
-                    tag,
-                    args: cons_args,
-                } => match (*tag).try_into() {
-                    Ok(DataConstructor::ListCons) => {
-                        let h_ref = cons_args
-                            .get(0)
-                            .ok_or_else(|| {
-                                ExecutionError::Panic(
-                                    Smid::default(),
-                                    "malformed cons cell".to_string(),
-                                )
-                            })?
-                            .clone();
-                        let t_ref = cons_args
-                            .get(1)
-                            .ok_or_else(|| {
-                                ExecutionError::Panic(
-                                    Smid::default(),
-                                    "malformed cons cell".to_string(),
-                                )
-                            })?
-                            .clone();
-                        let head = resolve_list_ref(&current, machine, view, &h_ref)?;
-                        primitives.push(extract_primitive(&head, machine, view)?);
-                        current = resolve_list_ref(&current, machine, view, &t_ref)?;
-                    }
-                    Ok(DataConstructor::ListNil) => break,
-                    _ => {
-                        return Err(ExecutionError::Panic(
-                            Smid::default(),
-                            "expected list in vec.of".to_string(),
-                        ))
-                    }
-                },
-                _ => {
-                    return Err(ExecutionError::Panic(
-                        Smid::default(),
-                        "expected list data in vec.of".to_string(),
-                    ))
-                }
-            }
+        // The wrapper has deep-forced the spine, so walk it via the neutral
+        // list ABI and read each element's native primitive with `value_native`.
+        let smid = machine.annotation();
+        let items = data_list_arg(machine, view, args[0].clone())?;
+        let mut primitives = Vec::with_capacity(items.len());
+        for item in &items {
+            let native = machine.value_native(view, item).ok_or_else(|| {
+                ExecutionError::Panic(smid, "non-primitive value in vec construction".to_string())
+            })?;
+            primitives.push(native_to_set_primitive(smid, view, &native)?);
         }
 
         machine_return_vec(

--- a/src/eval/stg/vec.rs
+++ b/src/eval/stg/vec.rs
@@ -11,7 +11,7 @@ use crate::eval::{
     memory::{
         mutator::MutatorHeapView,
         set::Primitive,
-        syntax::{HeapSyn, Native, Ref},
+        syntax::{Native, Ref},
         vec::HeapVec,
     },
     stg::tags::DataConstructor,
@@ -27,12 +27,6 @@ use super::{
         dsl::{app_bif, force, lambda, lref},
         LambdaForm,
     },
-};
-
-use crate::eval::memory::{
-    alloc::ScopedAllocator,
-    array::Array,
-    syntax::{LambdaForm as HeapLambdaForm, StgBuilder},
 };
 
 /// VEC.OF — convert a list of primitives to a vec.
@@ -161,14 +155,9 @@ impl StgIntrinsic for VecNth {
                 ))
             }
         };
-        machine.set_closure(crate::eval::machine::env::SynClosure::new(
-            view.alloc(HeapSyn::Cons {
-                tag: box_tag,
-                args: Array::from_slice(&view, &[Ref::V(native)]),
-            })?
-            .as_ptr(),
-            machine.root_env(),
-        ))
+        let boxed = machine.native_value(view, native)?;
+        let value = machine.data_value(view, box_tag, &[boxed])?;
+        machine.set_result(value)
     }
 }
 
@@ -361,16 +350,9 @@ impl StgIntrinsic for VecToList {
     ) -> Result<(), ExecutionError> {
         let elements: Vec<Primitive> = vec_arg(machine, view, &args[0])?.elements().to_vec();
 
-        // Build a list of boxed values in reverse (same pattern as SetToList)
-        let mut bindings = vec![HeapLambdaForm::value(
-            view.alloc(HeapSyn::Cons {
-                tag: DataConstructor::ListNil.tag(),
-                args: Array::default(),
-            })?
-            .as_ptr(),
-        )];
-
-        for prim in elements.into_iter().rev() {
+        // Box each element and assemble the list via the neutral ABI.
+        let mut items = Vec::with_capacity(elements.len());
+        for prim in elements {
             let native = set_primitive_to_native(machine, view, &prim)?;
             let box_tag = match &native {
                 Native::Num(_) => DataConstructor::BoxedNumber.tag(),
@@ -383,34 +365,11 @@ impl StgIntrinsic for VecToList {
                     ))
                 }
             };
-            bindings.push(HeapLambdaForm::value(
-                view.alloc(HeapSyn::Cons {
-                    tag: box_tag,
-                    args: Array::from_slice(&view, &[Ref::V(native)]),
-                })?
-                .as_ptr(),
-            ));
-            let len = bindings.len();
-            bindings.push(HeapLambdaForm::value(
-                view.alloc(HeapSyn::Cons {
-                    tag: DataConstructor::ListCons.tag(),
-                    args: Array::from_slice(&view, &[Ref::L(len - 1), Ref::L(len - 2)]),
-                })?
-                .as_ptr(),
-            ));
+            let boxed = machine.native_value(view, native)?;
+            items.push(machine.data_value(view, box_tag, &[boxed])?);
         }
 
-        let list_index = bindings.len() - 1;
-        let syn = view
-            .letrec(
-                Array::from_slice(&view, &bindings),
-                view.atom(Ref::L(list_index))?,
-            )?
-            .as_ptr();
-        machine.set_closure(crate::eval::machine::env::SynClosure::new(
-            syn,
-            machine.root_env(),
-        ))
+        machine.return_closure_list(view, items)
     }
 }
 


### PR DESCRIPTION
## Summary

Continues **BV1** (eu-vi3a) after #941. Data-driven migration of the intrinsic layer off the HeapSyn-typed `nav()→HeapSyn::Cons` ABI onto the engine-neutral ABI, so real `.eu` programs run under `EU_BYTECODE=1` byte-identically to HeapSyn.

**Corpus (full `tests/harness/*.eu`, stdout of both engines):** **43 → 144 PASS byte-identical, 0 differences.** `cargo test --lib` = 1248 green; `clippy --all-targets` + fmt clean throughout.

## What's migrated (all neutral ABI, byte-identical on both engines)

- **`debug.rs`** — DbgRepr / Dbg / TraceEntry / TraceExit + all render/peek/trace helpers.
- **`block.rs`** — **block-application MERGE dispatch** in the bytecode machine (`return_data` ApplyTo → append the block, enter the MERGE global; mirrors `vm.rs`), plus Merge / IsBlock / `deconstruct`.
- **`support.rs`** — `resolve_native_unboxing`, `machine_return_str_iter`, `machine_return_num_list_of_lists`, `machine_return_block_pair_closure_list`, `cons_tag_of`; new `list_value` helper.
- **`render_to_string.rs`**, **`time.rs`** (ZdtFields), **`vec.rs`** (VecOf / VecNth / VecToList), **`set.rs`** (SetToList), **`stream_prng.rs`** (all stream returns).

### Two new neutral primitives
1. **`IntrinsicMachine::tail_apply_global`** — tail-call a global applied to runtime arg refs. HeapSyn builds the `App` closure; bytecode pushes `ApplyTo` + enters the global. Fills the "delegate to another global" gap (used by RenderToString → RENDER_DOC).
2. **`try_navigate_local_native`** — the HeapSyn `value_native` default previously called `navigate_local_native`, which *panics* on an unforced `Atom{L}`. A non-forcing debug peek trips this. Now returns `Option`, matching the bytecode engine — fixes a divergence the port newly exposed on the **reference** engine (159/161_trace).

New differential test `agree_on_dbg_repr`.

## Remaining (19 fails) — all need runtime **code** synthesis

Deliberately **not** in this PR; they're a design decision, not more mechanical ports:
- `ParseString` (10), `TypeToData` (6): call `load()` — compile + materialise a *runnable* expression at runtime. Needs a runtime bytecode encoder (or a neutral "materialise compiled value" path).
- `MergeWith` / DEEPMERGE (4): build a lazy `f(ov,nv)` **application thunk** value — needs a neutral "build application closure" primitive.
- `ProducerNext` (1): `load()` + a self-referential BIF thunk.

The bytecode path can synthesise *data* (`data_value`/`return_closure_list`) but not *code* yet. See the plan ledger for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)