### PR TITLE
beads: reliable read-only bootstrap in Claude-web sessions

### DIFF
--- a/scripts/beads-bootstrap-if-needed.sh
+++ b/scripts/beads-bootstrap-if-needed.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# beads-bootstrap-if-needed.sh - Ensure the beads Dolt store is materialised.
+#
+# The authoritative issue store is Dolt (refs/dolt/data on the remote); the
+# runtime dolt/ store under .beads is gitignored, so a fresh checkout has no
+# usable database until it is rebuilt with `bd bootstrap`. This script does
+# that rebuild, but only when it is actually needed, so it is safe to run on
+# every session start and safe to re-run.
+#
+# It is deliberately READ-ONLY with respect to the remote: it makes `bd list`
+# work. It never pushes. (Pushing dolt-native data needs a write to the
+# refs/dolt/* namespace, which the Claude-web git proxy blocks with 403 - see
+# .beads/config.yaml. That is a separate, unsolved problem.)
+#
+# Why a dedicated https remote for the no-ssh case:
+#   - The tracked sync.remote is git+ssh://…, but the Claude-web container has
+#     no ssh binary, so `bd bootstrap` over it dead-ends and (worse) can leave
+#     an empty beads_eu shell that blocks a retry.
+#   - The git origin's http URL carries a per-session proxy port that is not up
+#     during the environment setup phase, so it is unreliable there.
+#   - git+https://github.com/<repo>.git is stable, port-independent, and
+#     reachable via the agent proxy in BOTH the setup phase and interactive
+#     sessions. Reads over it work (verified); only writes are blocked.
+#
+# The tracked config.yaml (which pins the ssh remote for local dev) is always
+# restored, so a dev machine is left untouched and keeps using ssh.
+
+set -euo pipefail
+
+# Stable, port-independent https remote reachable without ssh.
+BEADS_HTTPS_REMOTE="${BEADS_HTTPS_REMOTE:-git+https://github.com/curvelogic/eucalypt.git}"
+
+# Tools we need. Absent tools => nothing to do (exit 0 so we never wedge
+# session start or the setup script under `set -e`).
+command -v bd   >/dev/null 2>&1 || exit 0
+command -v dolt >/dev/null 2>&1 || exit 0
+
+# Locate the repo (the dir containing .beads). Prefer this script's location;
+# fall back to well-known paths and the caller's cwd.
+find_repo_root() {
+    local src="${BASH_SOURCE[0]:-}"
+    if [ -n "$src" ] && [ -f "$src" ]; then
+        local d; d="$(cd "$(dirname "$src")/.." && pwd)"
+        [ -d "$d/.beads" ] && { printf '%s\n' "$d"; return 0; }
+    fi
+    local cand
+    for cand in /home/user/eucalypt "$HOME/eucalypt" "$PWD"; do
+        [ -d "$cand/.beads" ] && { printf '%s\n' "$cand"; return 0; }
+    done
+    return 1
+}
+
+REPO="$(find_repo_root)" || { echo "beads-bootstrap: no .beads checkout found; skipping."; exit 0; }
+
+# True when the store is materialised (`bd list` exits 0 only then).
+_store_ok() { ( cd "$REPO" && bd list >/dev/null 2>&1 ); }
+
+# Idempotency guard: skip once the store is usable. `bd bootstrap` is NOT
+# self-idempotent when a remote is configured - a second run re-attempts the
+# clone and errors "database exists".
+if _store_ok; then
+    exit 0
+fi
+
+echo "beads-bootstrap: store not materialised; bootstrapping ($REPO)."
+chmod 700 "$REPO/.beads" 2>/dev/null || true
+
+# On a dev machine (ssh present) honour the configured ssh sync.remote.
+# In the no-ssh container skip straight to https: attempting the ssh remote
+# there only fails and can leave a partial beads_eu shell that blocks the
+# https retry with "database exists".
+if command -v ssh >/dev/null 2>&1; then
+    ( cd "$REPO" && bd bootstrap --yes ) || true
+fi
+
+# https fallback: bootstrap with sync.remote temporarily repointed at the
+# stable https remote. config.yaml is git-tracked, so restore it unconditionally
+# (even on error under `set -e`) to leave the ssh remote in place for local dev.
+if ! _store_ok; then
+    cfg="$REPO/.beads/config.yaml"
+    if [ -f "$cfg" ] && grep -q '^[[:space:]]*sync\.remote:' "$cfg"; then
+        bak="$(mktemp)"
+        cp "$cfg" "$bak"
+        # shellcheck disable=SC2064
+        trap "cp '$bak' '$cfg'; rm -f '$bak'; trap - EXIT" EXIT
+        sed -i 's#^\([[:space:]]*\)sync\.remote:.*#\1sync.remote: "'"$BEADS_HTTPS_REMOTE"'"#' "$cfg"
+        echo "beads-bootstrap: bootstrapping over $BEADS_HTTPS_REMOTE"
+        ( cd "$REPO" && bd bootstrap --yes ) || true
+        cp "$bak" "$cfg"; rm -f "$bak"; trap - EXIT
+    fi
+fi
+
+if _store_ok; then
+    echo "beads-bootstrap: store materialised."
+else
+    echo "beads-bootstrap: WARNING - bootstrap failed (network/git access?); run 'bd bootstrap' later." >&2
+fi

--- a/scripts/setup-claude-web-env.sh
+++ b/scripts/setup-claude-web-env.sh
@@ -162,39 +162,15 @@ install_eucalypt() {
 # The authoritative issue store is Dolt (refs/dolt/data on the remote); the
 # dolt/ runtime store is gitignored, so a fresh checkout has no usable database
 # until it is rebuilt. `bd bootstrap` is beads' purpose-built command for this.
-# (The old `bd sync` this script used to call no longer exists in beads >= 1.0.)
 #
-# Caveat that this function works around: `bd bootstrap` is priority-ordered,
-# and a configured `sync.remote` is the FIRST rule — it clones from that remote
-# and short-circuits every fallback (git-origin dolt data, backup, JSONL). This
-# repo pins `sync.remote: git+ssh://…`, but the Claude-web container has no ssh
-# binary and dolt shells out to ssh directly (bypassing the proxy's git-ssh
-# rewrite), so the clone dead-ends and leaves an empty store — every later `bd`
-# call then reports "database … not found". The fallback below neutralises
-# `sync.remote` and retries, so bd falls through to the git origin (the same
-# refs/dolt/data, reached as https via the agent proxy).
+# The bootstrap itself lives in scripts/beads-bootstrap-if-needed.sh (idempotent,
+# read-only, safe to re-run). See that file's header for the full rationale; in
+# short: the pinned ssh `sync.remote` is unusable in the no-ssh container, and
+# the git-origin http URL carries a per-session proxy port that is not up during
+# this setup phase, so it bootstraps over the stable git+https remote instead.
 
 # True when the beads store is materialised (`bd list` exits 0 only then).
 _beads_store_ok() { ( cd "$1" && bd list >/dev/null 2>&1 ); }
-
-# Retry bootstrap with `sync.remote` temporarily disabled so bd uses the git
-# origin / JSONL instead of the unusable ssh remote. Always restores
-# config.yaml (a git-tracked file) so the working tree — and the ssh remote
-# relied on for local dev — is left untouched, even on error under `set -e`.
-_bootstrap_without_ssh_remote() {
-    # Separate `local` statements: a single `local a=… b="$a"` expands every
-    # RHS before assigning, so `$repo` would be unbound under `set -u`.
-    local repo="$1"
-    local cfg="$repo/.beads/config.yaml"
-    local bak
-    [ -f "$cfg" ] && grep -q '^[[:space:]]*sync\.remote:' "$cfg" || return 1
-    bak="$(mktemp)"
-    cp "$cfg" "$bak"
-    # shellcheck disable=SC2064
-    trap "cp '$bak' '$cfg'; rm -f '$bak'; trap - RETURN" RETURN
-    sed -i 's/^\([[:space:]]*\)sync\.remote:/\1# sync.remote:/' "$cfg"
-    ( cd "$repo" && bd bootstrap --yes ) || true
-}
 
 bootstrap_beads() {
     [ "$BEADS_SYNC" = "1" ] || return 0
@@ -208,30 +184,7 @@ bootstrap_beads() {
     fi
 
     log "Bootstrapping beads store ($repo)"
-    chmod 700 "$repo/.beads" 2>/dev/null || true
-
-    # Idempotency guard: skip once the store is already usable. `bd bootstrap`
-    # is NOT self-idempotent when sync.remote is set — a second run re-attempts
-    # the clone and errors with "database exists".
-    if _beads_store_ok "$repo"; then
-        echo "beads store already materialised; skipping bootstrap."
-        return 0
-    fi
-
-    # First attempt: honour the configured sync.remote (ssh, for local dev).
-    ( cd "$repo" && bd bootstrap --yes ) || true
-
-    # Fallback for the no-ssh container: retry over the git origin / JSONL.
-    if ! _beads_store_ok "$repo"; then
-        echo "bootstrap via sync.remote failed; retrying over the git origin (no ssh)."
-        _bootstrap_without_ssh_remote "$repo" || true
-    fi
-
-    if _beads_store_ok "$repo"; then
-        echo "beads store materialised."
-    else
-        echo "WARNING: 'bd bootstrap' failed (network/git access?); run 'bd bootstrap' later."
-    fi
+    bash "$repo/scripts/beads-bootstrap-if-needed.sh" || true
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Beads was unusable in Claude Code web sessions: a fresh container came up with the Dolt store unmaterialised, so `bd list` / `bd show` / `bd ready` all failed until someone bootstrapped it by hand.

Two root causes, both in the setup path:

1. **Setup bootstrapped against the ssh `sync.remote`.** The tracked config pins `sync.remote: git+ssh://…`, but the Claude-web container has no `ssh` binary, so `bd bootstrap` dead-ends. Worse, the failed attempt can leave an empty `beads_eu` shell that then blocks a retry with "database exists".
2. **The fallback relied on the git-origin http URL.** That URL carries a *per-session* proxy port (`127.0.0.1:<port>`) which is not up during the environment setup phase, so the fallback couldn't reach it either.

## Fix

Reads over the **stable** `git+https://github.com/curvelogic/eucalypt.git` remote work in both the setup phase and interactive sessions — verified by a clean-slate teardown + bootstrap (1006 issues restored). So:

- New `scripts/beads-bootstrap-if-needed.sh`: idempotent (no-op when `bd list` already works), read-only w.r.t. the remote, and it always restores the git-tracked `config.yaml` so local dev keeps its ssh remote untouched. In the no-ssh container it skips the doomed ssh attempt and bootstraps straight over the stable https URL; on a dev machine (ssh present) it honours the configured ssh remote.
- `scripts/setup-claude-web-env.sh` now delegates to that script instead of its old ssh-then-comment-out-sync.remote logic.

## Scope / what this does NOT do

This fixes **read** access only. Pushing dolt-native data from a web session still fails: the web git proxy returns **HTTP 403** on any push to the `refs/dolt/*` namespace (it permits `refs/heads/*` and `refs/tags/*` only), and that's where dolt-native sync writes `refs/dolt/data`. GitHub itself allows it (the ssh path from a dev machine syncs fine), so the block is the proxy, not GitHub. Making web sessions push-capable is a separate, unsolved problem tracked for follow-up.

## Testing

- Cold bootstrap from a torn-down store over `git+https` → store materialised, 1006 issues.
- Idempotent re-run → fast no-op, exit 0.
- `config.yaml` left clean (still ssh) after every run.
- `bash -n` clean on both scripts; no dangling references to the removed helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpHMesBbV4UWJyvXw5n1Qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpHMesBbV4UWJyvXw5n1Qo)_