### PR TITLE
feat(bytecode): BV1 — migrate ParseString + TypeToData to neutral data construction (eu-9p9g)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -10,7 +10,9 @@
 > `~/.cargo/bin/cargo` symlink is broken). One feature branch per increment →
 > PR to `integration/0.12.0`. Owner reviews/merges PRs; do not merge your own.
 > Current working branch: `feat/bv1-migrate-intrinsics` (off the post-#941 merge
-> `25166517`).
+> `25166517`). **eu-9p9g increment (2026-07-02, branch
+> `feat/bv1-parse-typedata-data2`, off the #942 merge `06c6ee19`): ParseString +
+> TypeToData migrated — see dated ledger entry below.**
 >
 > **State:** **The bytecode engine works end-to-end.** Real `.eu` programs run
 > under `EU_BYTECODE=1`, **byte-identical to the HeapSyn engine** (blocks, lists,
@@ -45,6 +47,11 @@
 > migration below unblocked ~101. Sweep script: `scratchpad/bv_sweep.sh`
 > (compares stdout of both engines per file).
 >
+> **CORPUS TALLY UPDATE (eu-9p9g, 2026-07-02): 144 → 160 PASS**, 8 residual
+> DIFFs (down from 19). `ParseString`/`TypeToData`/`TypeFromString` are fully
+> migrated off `load()` — see the dated ledger entry below for the remaining 8
+> and why they're out of this bead's scope.
+>
 > **DONE this PR (all neutral-ABI, byte-identical both engines):**
 > - `debug.rs` — DbgRepr/Dbg/TraceEntry/TraceExit + render/peek/trace helpers.
 > - `support.rs` — resolve_native_unboxing, machine_return_str_iter,
@@ -64,24 +71,38 @@
 > **⚠️ Neutral-ABI trap:** don't assume a resolved closure is WHNF; use
 > `value_native` (now non-panicking) for possibly-unforced values.
 >
-> **REMAINING 19 — all need RUNTIME CODE SYNTHESIS (a design decision, not more
-> mechanical ports):**
-> - `parse_string::ParseString` (10) and `typedata::TypeToData` (6): both call
->   `load()` — compile a core/STG expression and materialise it *runnable* on
->   the heap at runtime. On HeapSyn `load()` yields a HeapSyn tree the tree-walk
->   runs directly; the bytecode engine has no runtime encoder, so this needs a
->   **runtime bytecode-encode/append** (JIT a fragment into the code arena) or a
->   neutral "materialise this compiled data value" path. This is the genuinely
->   hard case the plan always flagged.
+> **REMAINING (post eu-9p9g) — 6 files, two categories:**
+> - ~~`parse_string::ParseString` (10) and `typedata::TypeToData` (6)~~ **DONE
+>   (eu-9p9g, 2026-07-02)** — both were pure data-literal `load()` calls (no
+>   computation), so they're now built directly via the neutral
+>   `data_value`/`native_value`/`return_closure_list`/`meta_value` ABI, with no
+>   STG compilation and no `load()`. See the dated ledger entry below.
 > - `block::MergeWith` / DEEPMERGE (4): build a lazy `f(ov, nv)` **application
 >   thunk** as a stored value (not a tail call). Needs a neutral "build an
 >   application closure value" primitive (bytecode: an `App(L0,[L1,L2])` template
 >   over env `[f, ov, nv]`). Smaller than full `load()` but still code synthesis.
 > - `stream_intrinsic::ProducerNext` (1): `load()` **plus** a self-referential
 >   updatable BIF thunk (`PRODUCER_NEXT(handle)` tail) — both synthesis forms.
+> - `block.rs` inspector sites (1, `015_block_fns.eu`): a still-unmigrated
+>   `HeapSyn`-typed block intrinsic — panics with "bytecode closure handed to
+>   the HeapSyn intrinsic engine". Not yet root-caused to a specific function;
+>   needs triage.
 >
 > These share one root: the bytecode path cannot yet synthesise *code* at
 > runtime, only *data* (`data_value`/`return_closure_list`).
+>
+> **⚠️ NEWLY DISCOVERED (eu-9p9g): assertion/`//=>` diagnostic rendering
+> differs on bytecode.** `125_expectations.eu`, `175_sv2_to_spec.eu`,
+> `183_widen_type_def_literals.eu` all show the SAME symptom: a failing
+> `//=>`/`//=` expectation renders a full multi-line diagnostic trace on
+> HeapSyn but just `---\n{}\n` on bytecode — the underlying assertion is
+> failing identically on **both** engines (confirmed via a standalone repro:
+> `union-spec: s"string | number" as-spec` + `match?` returns `false` on both
+> engines — a separate, pre-existing `reflect`-library/union-matching bug,
+> unrelated to bytecode). The bytecode-vs-HeapSyn *rendering* gap is in the
+> `__EXPECT`/error-diagnostic path, not in data construction — out of scope for
+> ParseString/TypeToData (eu-9p9g) and for the union-matching bug itself; needs
+> its own bead.
 >
 > **⚠️ ARENA-GROWTH ANALYSIS (owner's concern, 2026-07-02): the code arena
 > (`BytecodeProgram.code`) is off-heap and NEVER GC-collected. Appending a fresh
@@ -91,13 +112,17 @@
 > code:**
 > - **`ParseString` / `TypeToData` value output is pure DATA** (a block/list/
 >   scalar tree — `load()` there materialises a data-literal, no computation).
->   Build it directly via the neutral `data_value`/`native_value`/
->   `return_closure_list` ABI on the **GC heap** (collectable). ZERO arena growth.
->   This is the plan's "value representation" route — preferred over parse-to-
->   bytecode for these. (TypeToData: verify `type_to_rcexpr` emits only data
->   constructors, not prelude function applications; if it applies functions,
->   the SHAPE is bounded by the finite type-DSL grammar → a small fixed template
->   set, still not per-call-unique.)
+>   Built directly via the neutral `data_value`/`native_value`/
+>   `return_closure_list`/`meta_value` ABI on the **GC heap** (collectable).
+>   ZERO arena growth. **DONE (eu-9p9g, 2026-07-02)** — see the dated ledger
+>   entry below. `type_to_rcexpr` **confirmed** to emit only data constructors
+>   (`Expr::Literal`/`List`/`Block`), never function application — no template
+>   fallback was needed. `read_to_core_data_only`'s output needed two more
+>   shapes handled: `Let(_, _, DefaultBlockLet)` (every parsed block is
+>   wrapped this way, resolved via proper de Bruijn indexing — no name-based
+>   substitution, so nested same-named scopes can't collide) and `Meta`
+>   (EDN tagged elements / YAML custom tags — a new `meta_value` neutral
+>   primitive was added to `IntrinsicMachine`, HeapSyn-only for now).
 > - **`MergeWith` `f(ov,nv)` and `ProducerNext`'s tail thunk are FIXED-SHAPE
 >   applications** (`App(L0,[L1,L2])`, `AppBif(idx,[L0])`). Pre-encode ONE
 >   template each into the arena at init (exactly like the existing constructor/
@@ -124,6 +149,57 @@
 > history; the engine is well past them.)*
 
 ## Progress Ledger (living — durable source of truth; update every increment)
+
+### eu-9p9g (2026-07-02, branch `feat/bv1-parse-typedata-data2`, off #942 merge `06c6ee19`) — ParseString + TypeToData migrated to neutral data construction
+Migrated `parse_string::ParseString`, `typedata::TypeToData` and
+`typedata::TypeFromString` off the `Compiler::compile` + `memory::loader::load`
+path entirely (for **both** engines — this isn't an engine-specific override,
+the old code path is gone) onto the neutral data-construction ABI:
+- **New module `src/eval/stg/data_literal.rs`**: `build_value(machine, view,
+  &RcExpr) -> Result<AbiClosure, ExecutionError>` recursively materialises a
+  data-literal Core expression as a value, shared by both intrinsics.
+  Verified `type_to_rcexpr` (`typedata.rs`) emits only `Expr::Literal`/`List`/
+  `Block` — no function application — so the "fixed template" fallback the
+  plan flagged as a fork was never needed. `read_to_core_data_only`'s output
+  needed two more shapes: every parsed block is wrapped in
+  `Expr::Let(_, _, LetType::DefaultBlockLet)` (confirmed via `yaml.rs`'s
+  `end_block`/`default_let` — not just an anchor-sharing special case, the
+  *general* block representation), and EDN tagged elements / YAML custom tags
+  use `Expr::Meta`. Both handled: `Let`/`DefaultBlockLet` via **proper de
+  Bruijn evaluation** (an `env: Vec<Vec<AbiClosure>>` scope stack indexed by
+  `BoundVar{scope,binder}`, exactly mirroring the STG compiler's own
+  `close_expr_vars`/`open_expr_vars` scheme) rather than name-based
+  Free-var substitution — sidesteps the shadowing pitfall `substs`'s own
+  doc comment warns about when the same key name nests at multiple levels.
+  YAML anchors/aliases are resolved by the *parser* itself (direct `RcExpr`
+  cloning via its own `anchors: HashMap<usize, RcExpr>`), not via `Var`
+  references, so no additional sharing logic was needed there.
+- **New `IntrinsicMachine::meta_value` primitive** (`intrinsic.rs`), mirroring
+  `data_value`: wraps a value with metadata (`HeapSyn::Meta{meta,body}`),
+  HeapSyn-only default for now (no bytecode override yet — nothing in the
+  corpus exercises it on the bytecode path; a bytecode override would follow
+  the exact pattern of `native_value`/`data_value`'s in `bytecode/machine.rs`).
+- `parse_string.rs` / `typedata.rs`: each `execute()` shrinks to parse/convert
+  → `data_literal::build_value` → `machine.set_result`. Dropped `Compiler`,
+  `RenderType`, `load`, `RefCell` — all now unused.
+- Two new differential tests in `differential.rs`: `agree_on_parse_string_json`
+  (`RENDER_DOC(PARSE_STRING(:json, "{\"x\": 1}"))`) and `agree_on_type_to_data`
+  (`RENDER_DOC(TYPE_TO_DATA(boxed "number"))`), both byte-identical.
+- **Corpus: 144 → 160 PASS** (exactly the ~16 the bead estimated), **19 → 8
+  residual DIFFs**. Verified stable across two independent sweep runs
+  (`scratchpad/bv_sweep.sh`, gitignored — recreate per the bead's sweep
+  script) and under `EU_GC_VERIFY=2 EU_GC_STRESS=1` on all 9
+  `tests/harness/*parse_as*.eu` + `174_sv1_typedata.eu` +
+  `177_sv_optional_fields_to_data.eu`, on both engines.
+- **Residual 8, confirmed out of scope** (see the "REMAINING" + "NEWLY
+  DISCOVERED" notes in the RESUME header above): 4 MergeWith/DEEPMERGE, 1
+  ProducerNext/streams, 1 unmigrated `block.rs` inspector
+  (`015_block_fns.eu`), and 2 (`175_sv2_to_spec.eu`,
+  `183_widen_type_def_literals.eu`) that hit a *newly surfaced* (previously
+  masked by `TypeFromString`'s panic) assertion-diagnostic-rendering gap
+  shared with `125_expectations.eu` — not a data-construction issue.
+- `cargo test --lib` 1250 green (1247 baseline + 2 differential + 1
+  pre-existing unaccounted); clippy `--all-targets` + fmt clean.
 
 ### ⚠️ PERF CAVEAT — block-index optimisation DISABLED on the bytecode path
 `LookupOr`/`SafeLookup` cache a `SymbolId→position` map for a block and reuse it

--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -453,4 +453,51 @@ mod tests {
             Some(3)
         );
     }
+
+    #[test]
+    fn agree_on_parse_string_json() {
+        // RENDER_DOC(PARSE_STRING(:json, "{\"x\": 1}")) -> byte-identical YAML
+        // block. Exercises the neutral data-literal builder
+        // (`data_literal::build_value`, eu-9p9g) end-to-end: the parsed JSON
+        // is a `DefaultBlockLet`-wrapped block, materialised directly as a
+        // value with no STG compilation / runtime code loading.
+        let parse_string = crate::eval::intrinsics::index_u8("PARSE_STRING");
+        let render_doc = crate::eval::intrinsics::index("RENDER_DOC").expect("RENDER_DOC");
+        let syn = dsl::let_(
+            vec![dsl::value(dsl::app_bif(
+                parse_string,
+                vec![dsl::sym("json"), dsl::str("{\"x\": 1}")],
+            ))],
+            dsl::app(dsl::gref(render_doc), vec![dsl::lref(0)]),
+        );
+        let out = assert_engines_render_agree(syn);
+        assert!(
+            out.contains('1'),
+            "expected the parsed value in output, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn agree_on_type_to_data() {
+        // RENDER_DOC(TYPE_TO_DATA(boxed type-data "number")) -> byte-identical
+        // `[t-prim, number]` list. Exercises `data_literal::build_value` over
+        // `type_to_rcexpr`'s output (list/symbol literals only).
+        let type_to_data = crate::eval::intrinsics::index_u8("TYPE_TO_DATA");
+        let render_doc = crate::eval::intrinsics::index("RENDER_DOC").expect("RENDER_DOC");
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::data(
+                    DataConstructor::BoxedTypeData.tag(),
+                    vec![dsl::str("number")],
+                )), // 0: boxed type-data "number"
+                dsl::value(dsl::app_bif(type_to_data, vec![dsl::lref(0)])), // 1: TYPE_TO_DATA(0)
+            ],
+            dsl::app(dsl::gref(render_doc), vec![dsl::lref(1)]),
+        );
+        let out = assert_engines_render_agree(syn);
+        assert!(
+            out.contains("t-prim") && out.contains("number"),
+            "expected t-prim/number in output, got {out:?}"
+        );
+    }
 }

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -344,6 +344,30 @@ pub trait IntrinsicMachine {
         Ok(AbiClosure::Heap(SynClosure::new(code, frame)))
     }
 
+    /// Wrap a value with metadata, returned as a value handle (does not set
+    /// the machine result). Mirrors `HeapSyn::Meta { meta, body }`.
+    fn meta_value(
+        &self,
+        view: MutatorHeapView<'_>,
+        meta: AbiClosure,
+        body: AbiClosure,
+    ) -> Result<AbiClosure, ExecutionError> {
+        let env = self.root_env();
+        let frame = view.from_closures(
+            [meta.as_heap().clone(), body.as_heap().clone()].into_iter(),
+            2,
+            env,
+            Smid::default(),
+        )?;
+        let code = view
+            .alloc(HeapSyn::Meta {
+                meta: Ref::L(0),
+                body: Ref::L(1),
+            })?
+            .as_ptr();
+        Ok(AbiClosure::Heap(SynClosure::new(code, frame)))
+    }
+
     /// Set the machine result to a cons-list of the given value handles.
     fn return_closure_list(
         &mut self,

--- a/src/eval/stg/data_literal.rs
+++ b/src/eval/stg/data_literal.rs
@@ -1,0 +1,162 @@
+//! Materialise a data-literal Core expression directly as a runtime value,
+//! via the neutral data-construction ABI (`native_value`/`data_value`/
+//! `return_closure_list`/`meta_value` — BV1 §5.5), with zero runtime code
+//! synthesis.
+//!
+//! `PARSE_STRING` (parsing untrusted input via the import readers in
+//! `data_only` mode) and `TYPE_TO_DATA` (`typedata::type_to_rcexpr`) both
+//! produce a self-contained `RcExpr` built only from data-literal shapes —
+//! literals, lists, blocks, `DefaultBlockLet` wrappers and metadata — with
+//! no free variables and no intrinsic/function application. That means the
+//! value can be built directly rather than compiled to STG and `load()`ed
+//! as runtime code, which would anchor it to `HeapSyn` and, on the bytecode
+//! engine, require synthesising fresh code per call (the arena-growth
+//! problem the plan explicitly rules out).
+//!
+//! Supported shapes: `Literal` (str/sym/num/bool/null/type-data), `List`,
+//! `Block`, `Let` with `LetType::DefaultBlockLet` (as produced by the import
+//! readers for ordinary blocks — every binding is itself var-free, so a
+//! simple, non-recursive de Bruijn evaluation suffices), `Meta` (e.g. EDN
+//! tagged elements / YAML custom tags), and the `Var::Bound` references a
+//! `DefaultBlockLet`'s generated body makes into its own bindings.
+
+use crate::{
+    core::{
+        binding::Var,
+        expr::{Expr, LetType, Primitive, RcExpr},
+    },
+    eval::{
+        error::ExecutionError,
+        machine::intrinsic::{AbiClosure, IntrinsicMachine},
+        memory::{
+            mutator::MutatorHeapView,
+            syntax::{Native, Ref, StgBuilder},
+        },
+        stg::{support::list_value, tags::DataConstructor},
+    },
+};
+
+/// Materialise a data-literal `RcExpr` as a value handle, engine-neutrally.
+pub fn build_value(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    expr: &RcExpr,
+) -> Result<AbiClosure, ExecutionError> {
+    build(machine, view, expr, &mut Vec::new())
+}
+
+/// `env` is a stack of `Let` scope frames (innermost last). A `Var::Bound`
+/// reference's `scope` counts outward from the innermost frame and
+/// `binder` indexes within that frame — the same de Bruijn scheme the STG
+/// compiler itself uses, so no name-based substitution (and its shadowing
+/// pitfalls) is needed.
+fn build(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    expr: &RcExpr,
+    env: &mut Vec<Vec<AbiClosure>>,
+) -> Result<AbiClosure, ExecutionError> {
+    match &*expr.inner {
+        Expr::Literal(_, prim) => build_literal(machine, view, prim),
+        Expr::List(_, items) => {
+            let mut vals = Vec::with_capacity(items.len());
+            for item in items {
+                vals.push(build(machine, view, item, env)?);
+            }
+            list_value(machine, view, vals)
+        }
+        Expr::Block(_, block_map) => build_block(machine, view, block_map.iter(), env),
+        Expr::Let(_, scope, LetType::DefaultBlockLet) => {
+            let mut frame = Vec::with_capacity(scope.pattern.len());
+            for binding in &scope.pattern {
+                frame.push(build(machine, view, &binding.expr, env)?);
+            }
+            env.push(frame);
+            let result = build(machine, view, &scope.body, env);
+            env.pop();
+            result
+        }
+        Expr::Meta(_, body, meta) => {
+            let b = build(machine, view, body, env)?;
+            let m = build(machine, view, meta, env)?;
+            machine.meta_value(view, m, b)
+        }
+        Expr::Var(smid, Var::Bound(bv)) => {
+            let frame_idx = env.len().checked_sub(1 + bv.scope as usize);
+            let value = frame_idx.and_then(|i| env[i].get(bv.binder as usize));
+            value.cloned().ok_or_else(|| {
+                ExecutionError::Panic(*smid, "data literal: unbound variable".to_string())
+            })
+        }
+        other => Err(ExecutionError::Panic(
+            machine.annotation(),
+            format!("data literal: unsupported core expression shape ({other:?})"),
+        )),
+    }
+}
+
+fn build_literal(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    prim: &Primitive,
+) -> Result<AbiClosure, ExecutionError> {
+    match prim {
+        Primitive::Num(n) => {
+            let native = machine.native_value(view, Native::Num(n.clone()))?;
+            machine.data_value(view, DataConstructor::BoxedNumber.tag(), &[native])
+        }
+        Primitive::Str(s) => {
+            let Ref::V(native) = view.str_ref(s)? else {
+                unreachable!("str_ref yields a value ref")
+            };
+            let boxed = machine.native_value(view, native)?;
+            machine.data_value(view, DataConstructor::BoxedString.tag(), &[boxed])
+        }
+        Primitive::Sym(s) => {
+            let Ref::V(native) = view.sym_ref(machine.symbol_pool_mut(), s)? else {
+                unreachable!("sym_ref yields a value ref")
+            };
+            let boxed = machine.native_value(view, native)?;
+            machine.data_value(view, DataConstructor::BoxedSymbol.tag(), &[boxed])
+        }
+        Primitive::TypeData(s) => {
+            let Ref::V(native) = view.str_ref(s)? else {
+                unreachable!("str_ref yields a value ref")
+            };
+            let boxed = machine.native_value(view, native)?;
+            machine.data_value(view, DataConstructor::BoxedTypeData.tag(), &[boxed])
+        }
+        Primitive::Bool(b) => {
+            let tag = if *b {
+                DataConstructor::BoolTrue
+            } else {
+                DataConstructor::BoolFalse
+            };
+            machine.data_value(view, tag.tag(), &[])
+        }
+        Primitive::Null => machine.data_value(view, DataConstructor::Unit.tag(), &[]),
+    }
+}
+
+/// Build a `Block` value from `(key, value-expr)` pairs, in insertion order
+/// — a `BlockPair` cons-list wrapped with the no-index sentinel, matching
+/// `Compiler::compile_block` exactly (`stg/compiler.rs`).
+fn build_block<'a>(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    entries: impl Iterator<Item = (&'a String, &'a RcExpr)>,
+    env: &mut Vec<Vec<AbiClosure>>,
+) -> Result<AbiClosure, ExecutionError> {
+    let mut pairs = Vec::new();
+    for (k, v) in entries {
+        let value = build(machine, view, v, env)?;
+        let Ref::V(sym_native) = view.sym_ref(machine.symbol_pool_mut(), k)? else {
+            unreachable!("sym_ref yields a value ref")
+        };
+        let key = machine.native_value(view, sym_native)?;
+        pairs.push(machine.data_value(view, DataConstructor::BlockPair.tag(), &[key, value])?);
+    }
+    let kv_list = list_value(machine, view, pairs)?;
+    let no_index = machine.native_value(view, Native::Num(serde_json::Number::from(0)))?;
+    machine.data_value(view, DataConstructor::Block.tag(), &[kv_list, no_index])
+}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -11,6 +11,7 @@ pub mod block;
 pub mod boolean;
 pub mod compiler;
 pub mod constant;
+pub mod data_literal;
 pub mod debug;
 pub mod embed;
 pub mod emit;

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -3,13 +3,14 @@
 //! `PARSE_STRING(fmt_sym, str)` is the inverse of `RENDER_TO_STRING`.
 //! It accepts a format symbol and a string, parses the string using the
 //! appropriate import parser with `data_only: true` (so no `!eu` evaluation
-//! or ZDT.PARSE calls occur), compiles the resulting `RcExpr` to STG, loads
-//! it onto the heap, and sets it as the new machine closure.
+//! or ZDT.PARSE calls occur), and materialises the resulting `RcExpr`
+//! directly as a value via the neutral data-construction ABI (BV1 §5.5,
+//! `data_literal::build_value`) — the parsed expression is a pure data
+//! literal (no free variables, no intrinsic application), so no STG
+//! compilation or runtime code loading is needed.
 //!
 //! Supported format symbols: `yaml`, `json`, `toml`, `csv`, `xml`, `edn`,
 //! `jsonl`, `text`.  `:json` and `:yaml` share the same parser.
-
-use std::{cell::RefCell, rc::Rc};
 
 use codespan_reporting::files::SimpleFiles;
 
@@ -18,15 +19,11 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::{
-            env::SynClosure,
-            intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
-        },
-        memory::{loader::load, mutator::MutatorHeapView, syntax::Ref},
+        machine::intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
+        memory::{mutator::MutatorHeapView, syntax::Ref},
         stg::{
-            compiler::Compiler,
+            data_literal,
             support::{str_arg, sym_arg},
-            RenderType,
         },
     },
     import,
@@ -34,9 +31,8 @@ use crate::{
 
 /// PARSE_STRING(fmt_sym, str) → value
 ///
-/// Parses `str` using the import parser for `fmt_sym` with `data_only: true`,
-/// compiles the resulting core expression to STG, and evaluates it inline by
-/// setting it as the machine's new closure.
+/// Parses `str` using the import parser for `fmt_sym` with `data_only: true`
+/// and builds the resulting data literal directly as a value.
 ///
 /// Both arguments are strict: the format symbol and string must already be
 /// at WHNF before this intrinsic is called.
@@ -56,7 +52,6 @@ impl StgIntrinsic for ParseString {
     ) -> Result<(), ExecutionError> {
         // args[0] = format symbol (strict)
         // args[1] = string to parse (strict)
-        let smid = machine.annotation();
         let format_name = sym_arg(machine, view, &args[0])?;
         let input = str_arg(machine, view, &args[1])?;
 
@@ -75,33 +70,8 @@ impl StgIntrinsic for ParseString {
                     )
                 })?;
 
-        // Compile the data-only RcExpr to STG.
-        // We use an empty intrinsics list because data-only expressions
-        // contain no bif references (all code-execution paths are suppressed).
-        // suppress_inlining=true and suppress_optimiser=false are safe choices
-        // for data literals.
-        let compiler = Compiler::new(
-            false, // generate_annotations
-            RenderType::Headless,
-            false,  // suppress_updates
-            true,   // suppress_inlining (no intrinsics to inline)
-            false,  // suppress_optimiser
-            vec![], // intrinsics (none needed for data literals)
-            None,   // prelude_globals (data literals have no free prelude refs)
-        );
-        let syntax: Rc<_> = compiler
-            .compile(core_expr)
-            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as compile error: {e}")))?;
-
-        // Load the compiled STG onto the machine heap and set as closure.
-        let pool = RefCell::new(machine.symbol_pool_mut().clone());
-        let heap_ptr = load(&view, &mut pool.borrow_mut(), syntax)
-            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as load error: {e}")))?;
-
-        // Update the machine's symbol pool with any new symbols interned during load
-        *machine.symbol_pool_mut() = pool.into_inner();
-
-        machine.set_closure(SynClosure::new(heap_ptr, machine.root_env()))
+        let value = data_literal::build_value(machine, view, &core_expr)?;
+        machine.set_result(value)
     }
 }
 

--- a/src/eval/stg/typedata.rs
+++ b/src/eval/stg/typedata.rs
@@ -6,8 +6,6 @@
 //!
 //! Together these power the `to-data` / `from-data` round-trip in the prelude.
 
-use std::{cell::RefCell, rc::Rc};
-
 use crate::eval::memory::syntax::{Native, StgBuilder};
 use crate::{
     common::sourcemap::Smid,
@@ -18,16 +16,12 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::{
-            env::SynClosure,
-            intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
-        },
-        memory::{array::Array, loader::load, mutator::MutatorHeapView, syntax::Ref},
+        machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+        memory::{mutator::MutatorHeapView, syntax::Ref},
         stg::{
-            compiler::Compiler,
+            data_literal,
             support::{resolve_native_unboxing, str_arg},
             tags::DataConstructor,
-            RenderType,
         },
     },
 };
@@ -154,7 +148,10 @@ fn type_to_rcexpr(ty: &Type) -> RcExpr {
 /// 1. Extracts the canonical type-DSL string from the `BoxedTypeData` wrapper.
 /// 2. Parses it via `parse_type`.
 /// 3. Converts the resulting `Type` to the `t-*` vocabulary using `type_to_rcexpr`.
-/// 4. Compiles the resulting core expression to STG and loads it onto the heap.
+/// 4. Builds the resulting core expression directly as a value (BV1 §5.5,
+///    `data_literal::build_value`) — `type_to_rcexpr` emits only data
+///    constructors (literals/lists/blocks), never function application, so
+///    no STG compilation or runtime code loading is needed.
 pub struct TypeToData;
 
 impl StgIntrinsic for TypeToData {
@@ -187,31 +184,10 @@ impl StgIntrinsic for TypeToData {
         let ty = parse_type(&type_str)
             .map_err(|e| ExecutionError::Panic(smid, format!("TYPE_TO_DATA: parse error: {e}")))?;
 
-        // Convert to t-* core expression.
+        // Convert to t-* core expression and build it directly as a value.
         let core_expr = type_to_rcexpr(&ty);
-
-        // Compile to STG.  Data-literal expressions have no free variables or
-        // intrinsic references, so we can use an empty intrinsics list.
-        let compiler = Compiler::new(
-            false, // generate_annotations
-            RenderType::Headless,
-            false,  // suppress_updates
-            true,   // suppress_inlining
-            false,  // suppress_optimiser
-            vec![], // intrinsics — none needed for data literals
-            None,   // prelude_globals
-        );
-        let syntax: Rc<_> = compiler.compile(core_expr).map_err(|e| {
-            ExecutionError::Panic(smid, format!("TYPE_TO_DATA: compile error: {e}"))
-        })?;
-
-        // Load onto heap and return as closure.
-        let pool = RefCell::new(machine.symbol_pool_mut().clone());
-        let heap_ptr = load(&view, &mut pool.borrow_mut(), syntax)
-            .map_err(|e| ExecutionError::Panic(smid, format!("TYPE_TO_DATA: load error: {e}")))?;
-        *machine.symbol_pool_mut() = pool.into_inner();
-
-        machine.set_closure(SynClosure::new(heap_ptr, machine.root_env()))
+        let value = data_literal::build_value(machine, view, &core_expr)?;
+        machine.set_result(value)
     }
 }
 
@@ -223,7 +199,8 @@ impl CallGlobal1 for TypeToData {}
 ///
 /// 1. Validates the input string via `parse_type`.
 /// 2. Normalises to canonical form via the `Type` `Display` impl.
-/// 3. Returns a `BoxedTypeData` (tag 17) wrapping the canonical string.
+/// 3. Returns a `BoxedTypeData` (tag 17) wrapping the canonical string, built
+///    directly via the neutral data-construction ABI (BV1 §5.5).
 ///
 /// Used by the prelude `from-data` function as the final wrapping step.
 pub struct TypeFromString;
@@ -249,16 +226,13 @@ impl StgIntrinsic for TypeFromString {
         })?;
         let canonical = format!("{ty}");
 
-        // Allocate BoxedTypeData on the heap.
-        let s_ref = view.str_ref(canonical)?;
-        let ptr = view
-            .data(
-                DataConstructor::BoxedTypeData.tag(),
-                Array::from_slice(&view, &[s_ref]),
-            )?
-            .as_ptr();
-
-        machine.set_closure(SynClosure::new(ptr, machine.root_env()))
+        // Build BoxedTypeData as a value via the neutral ABI.
+        let Ref::V(native) = view.str_ref(canonical)? else {
+            unreachable!("str_ref yields a value ref")
+        };
+        let boxed = machine.native_value(view, native)?;
+        let value = machine.data_value(view, DataConstructor::BoxedTypeData.tag(), &[boxed])?;
+        machine.set_result(value)
     }
 }
 


### PR DESCRIPTION
## Summary

Part of eu-vi3a (BV1 full bytecode VM). Migrates `parse_string::ParseString`, `typedata::TypeToData`, and `typedata::TypeFromString` off the `Compiler::compile` + `memory::loader::load` runtime-code-synthesis path onto the neutral data-construction ABI (`data_value`/`native_value`/`return_closure_list`/`meta_value`), per the plan's arena-growth analysis: their output is a pure data literal (block/list/scalar tree), so it can be built directly on the GC heap with zero code-arena growth, instead of compiling to STG and loading it as `HeapSyn` code (which the bytecode engine cannot execute).

- New shared module `src/eval/stg/data_literal.rs`: `build_value(machine, view, &RcExpr) -> Result<AbiClosure, ExecutionError>` recursively materialises a data-literal Core expression as a value. Handles `Literal`/`List`/`Block`, `Let(_, _, LetType::DefaultBlockLet)` (the general block representation produced by the import readers — resolved via proper de Bruijn indexing, not name-based substitution, avoiding a shadowing pitfall), and `Meta` (EDN tagged elements / YAML custom tags).
- Confirmed `typedata::type_to_rcexpr` emits only data constructors (`Literal`/`List`/`Block`), never function application, so the "fixed template" fallback the plan flagged as a possible design fork was not needed.
- New `IntrinsicMachine::meta_value` primitive (`intrinsic.rs`), mirroring `data_value`, for `HeapSyn::Meta{meta,body}` — HeapSyn-only default for now (nothing in the corpus exercises it on bytecode yet).
- Two new differential tests in `differential.rs`: `agree_on_parse_string_json`, `agree_on_type_to_data`.

## Results

- **Corpus: 144 → 160 PASS** under the `EU_BYTECODE=1` differential sweep (19 → 8 residual DIFFs), verified stable across two independent sweep runs and under `EU_GC_VERIFY=2 EU_GC_STRESS=1` on both engines for all `parse-as`/typedata harness tests.
- Residual 8 DIFFs confirmed **out of scope / pre-existing**: 4 MergeWith/DEEPMERGE, 1 ProducerNext/streams, 1 unmigrated `block.rs` inspector, and 2 that hit a newly-surfaced (previously masked by `TypeFromString`'s panic) assertion-diagnostic-rendering gap shared with `125_expectations.eu` — confirmed via a standalone repro that the underlying assertion (`match?` on a union spec) fails identically on both engines; only the failure *rendering* differs, unrelated to data construction.
- `cargo test --lib`: 1250 green (1247 baseline + 2 new differential tests + 1 pre-existing).
- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --all`: clean.

Ledger updated in `docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md` (dated eu-9p9g entry + RESUME header updates).

## Test plan
- [x] `cargo test --lib` (1250 passed)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all` (clean)
- [x] Full `tests/harness/*.eu` differential sweep (EU_BYTECODE=1 vs HeapSyn): 160 PASS / 8 DIFF
- [x] `EU_GC_VERIFY=2 EU_GC_STRESS=1` on both engines for parse-as/typedata harness tests

Refs eu-vi3a, eu-9p9g

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee