### PR TITLE
feat(bytecode): BV1 — migrate ParseString + TypeToData to neutral data construction (eu-9p9g)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -38,12 +38,14 @@
 >   `let…in` (use `:let` blocks); `/` is floor division (`÷` exact); catenation
 >   precedence is very low.
 >
-> **CORPUS TALLY (branch `feat/bv1-migrate-intrinsics`, PR #942):** sweeping the
-> full `tests/harness/*.eu` under `EU_BYTECODE=1` vs HeapSyn: **144 PASS
-> (byte-identical), 0 DIFF**, 4 both-fail (pre-existing), **19 bytecode-only
-> fails** remaining. Was **43 PASS** at the start of this PR — the intrinsic
-> migration below unblocked ~101. Sweep script: `scratchpad/bv_sweep.sh`
-> (compares stdout of both engines per file).
+> **CORPUS TALLY (branch `feat/bv1-parse-typedata`, PR eu-9p9g):** sweeping the
+> full `tests/harness/*.eu` under `EU_BYTECODE=1` vs HeapSyn (comparing stdout +
+> exit code): **160 PASS, 8 DIFF** (was 146 PASS / 22 DIFF before this PR). The
+> 8 remaining DIFFs: `015_block_fns`, `085_deep_merge_dynamic`,
+> `135_dynamic_key_merge`, `127_merge_metadata` (MergeWith/DeepMerge),
+> `079_streams` (ProducerNext), `125_expectations`, and `175_sv2_to_spec` +
+> `183_widen_type_def_literals` (both fail on the *reference* HeapSyn engine —
+> pre-existing prelude bug). Sweep: stdout+exit of both engines per file.
 >
 > **DONE this PR (all neutral-ABI, byte-identical both engines):**
 > - `debug.rs` — DbgRepr/Dbg/TraceEntry/TraceExit + render/peek/trace helpers.
@@ -64,15 +66,28 @@
 > **⚠️ Neutral-ABI trap:** don't assume a resolved closure is WHNF; use
 > `value_native` (now non-panicking) for possibly-unforced values.
 >
-> **REMAINING 19 — all need RUNTIME CODE SYNTHESIS (a design decision, not more
-> mechanical ports):**
-> - `parse_string::ParseString` (10) and `typedata::TypeToData` (6): both call
->   `load()` — compile a core/STG expression and materialise it *runnable* on
->   the heap at runtime. On HeapSyn `load()` yields a HeapSyn tree the tree-walk
->   runs directly; the bytecode engine has no runtime encoder, so this needs a
->   **runtime bytecode-encode/append** (JIT a fragment into the code arena) or a
->   neutral "materialise this compiled data value" path. This is the genuinely
->   hard case the plan always flagged.
+> **✅ DONE 2026-07-02 (eu-9p9g, branch `feat/bv1-parse-typedata`):
+> `parse_string::ParseString` + `typedata::{TypeToData, TypeFromString}`** —
+> migrated off `load()` via the **value-representation route** (NO runtime code
+> synthesis, zero arena growth). New shared `stg/materialise.rs::materialise_data`
+> walks the compiled data-only STG (a flat/nested letrec of value-form
+> `Cons`/`Meta`/`Atom` cells with backward refs) and rebuilds the value directly
+> through the neutral `native_value`/`data_value`/`meta_value`/`resolve_closure`
+> ABI — engine-agnostic, on the GC heap. Verified `type_to_rcexpr` emits **only
+> data constructors** (no function applications) → data-only confirmed, no split
+> needed. One new neutral primitive `meta_value` (HeapSyn default builds
+> `HeapSyn::Meta`; bytecode override builds a `Meta` value over a new pre-encoded
+> `meta_template` in the arena — the "small fixed template" route, bounded).
+> Corpus **146→160 PASS** (fixed all 9 `parse_as_*`, `128_parse_args`, and
+> `174/177/178/182`), **zero new DIFFs**. Differential tests
+> `agree_on_parse_string_json` + `agree_on_type_to_data`. `EU_GC_VERIFY=2 +
+> EU_GC_STRESS=1` clean both engines. **NB `175_sv2_to_spec` and
+> `183_widen_type_def_literals` still DIFF — but they fail an assertion/warning
+> on the *reference HeapSyn* engine too (pre-existing prelude `union-spec`/
+> `result-def` bug), diverging only in partial pre-error emit; unrelated to this
+> migration.**
+>
+> **REMAINING (need code synthesis — not data):**
 > - `block::MergeWith` / DEEPMERGE (4): build a lazy `f(ov, nv)` **application
 >   thunk** as a stored value (not a tail call). Needs a neutral "build an
 >   application closure value" primitive (bytecode: an `App(L0,[L1,L2])` template
@@ -256,6 +271,29 @@ to PATH. Committed on the feature branch; not yet PR'd.
 - `0a010546` Phase 2 — **App arm + thunk memoisation + blackhole template + Let/LetRec**. `make_arg_array` (lazy/eager CG3), `enter_local`/`enter_callable` (blackhole slot + push Update for thunks), blackhole template in the arena (`BytecodeProgram.blackhole`, `state.blackhole`). End-to-end: `let x=5 in x`→5; `let id=\x.x in id(5)`→5.
 - `2c48cf2f` Phase 2 — **DirectApp arm** (CG1: inline smid, exact-arity fast-path saturate skipping ApplyTo, thunk/fallback). End-to-end: `id(5)` via DirectApp→5.
 - `0b6cb09a` Phase 2 — **Bif arm (capture)**: decode intrinsic index + arg refs into `pending_bif`/`pending_bif_args` (spec §6.3) for deferred dispatch. Tested (capture only; dispatch pending — see below).
+
+### Increment (2026-07-02, eu-9p9g) — ParseString + TypeToData/TypeFromString via value representation
+- **New `src/eval/stg/materialise.rs`** — `materialise_data(machine, view, pool,
+  syn, frame)` walks a compiled *data-only* STG value (letrec of value-form
+  `Cons`/`Meta`/`Atom` cells, backward refs, empty-list global) and rebuilds it
+  on the GC heap through the neutral ABI (`native_value`/`data_value`/
+  `meta_value`/`resolve_closure`). Errors cleanly on any code-bearing form
+  (`App`/`Bif`/`Case`/lambda/forward-ref) so a non-data input can never yield a
+  wrong value. Nested structures are self-contained fresh frames.
+- **New neutral primitive `meta_value`** (`intrinsic.rs`): HeapSyn default builds
+  `HeapSyn::Meta` over env `[meta, body]`; **bytecode override** builds a `Meta`
+  value over a new pre-encoded **`meta_template`** (`BytecodeProgram.meta_template`,
+  `encode.rs` emits `Meta L0 L1` once after blackhole). Bounded — one template,
+  no per-call arena growth. Needed for YAML `!tag` scalars (`115_parse_as_data_only`).
+- **`parse_string.rs` / `typedata.rs`** now `materialise_data` + `set_result`
+  instead of `load()` + `set_closure(SynClosure)`. `TypeFromString` builds its
+  `BoxedTypeData` cell via `data_value`/`native_value`. Same code runs on both
+  engines. Verified `type_to_rcexpr` is data-only (no fn-application → no split).
+- **Corpus 146→160 PASS**, zero new DIFFs. `cargo test --lib` 1250 green; clippy
+  `--all-targets` + fmt clean; `EU_GC_VERIFY=2 + EU_GC_STRESS=1` clean both engines.
+- **Follow-up:** MergeWith/DeepMerge (4) + ProducerNext (1) still need the
+  application/thunk *code* templates (not data). `175`/`183` are a pre-existing
+  prelude assertion bug on HeapSyn (out of scope here).
 
 ### ARCHITECTURAL BOUNDARY (2026-07-02) — handlers need machine/program context
 The self-contained handler arms are done (Atom/Cons/Case/Seq/Ann/App/DirectApp/Let/LetRec + all three return_* + thunk memoisation). The machine executes real expressions end-to-end. The REMAINING features all need broader context than the current free-fn handlers `(state, view, code)` take:

--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -437,6 +437,47 @@ mod tests {
     }
 
     #[test]
+    fn agree_on_parse_string_json() {
+        // RENDER_DOC(PARSE_STRING(:json, "{\"x\":1,\"y\":2}")) — parse a JSON
+        // string to a block and render it. The parsed value is rebuilt through
+        // the neutral value-construction ABI (materialise_data), so it must
+        // render byte-identically on both engines.
+        let parse = crate::eval::intrinsics::index("PARSE_STRING").expect("PARSE_STRING");
+        let render_doc = crate::eval::intrinsics::index("RENDER_DOC").expect("RENDER_DOC");
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::box_sym("json")),
+                dsl::value(dsl::box_str("{\"x\":1,\"y\":2}")),
+                dsl::value(dsl::app(dsl::gref(parse), vec![dsl::lref(0), dsl::lref(1)])),
+            ],
+            dsl::app(dsl::gref(render_doc), vec![dsl::lref(2)]),
+        );
+        let out = assert_engines_render_agree(syn);
+        assert!(out.contains("x") && out.contains('1'), "got {out:?}");
+    }
+
+    #[test]
+    fn agree_on_type_to_data() {
+        // RENDER_DOC(TYPE_TO_DATA(s"number")) — project a type-data value to a
+        // `[:t-prim :number]` tagged list, rebuilt via the neutral ABI. Both
+        // engines must render byte-identically.
+        let ttd = crate::eval::intrinsics::index("TYPE_TO_DATA").expect("TYPE_TO_DATA");
+        let render_doc = crate::eval::intrinsics::index("RENDER_DOC").expect("RENDER_DOC");
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::box_type_data("number")),
+                dsl::value(dsl::app(dsl::gref(ttd), vec![dsl::lref(0)])),
+            ],
+            dsl::app(dsl::gref(render_doc), vec![dsl::lref(1)]),
+        );
+        let out = assert_engines_render_agree(syn);
+        assert!(
+            out.contains("t-prim") && out.contains("number"),
+            "got {out:?}"
+        );
+    }
+
+    #[test]
     fn agree_on_force_whnf() {
         // let t = __ADD(1, 2) in __FORCE_WHNF(t) -> 3
         let add = crate::eval::intrinsics::index_u8("ADD");

--- a/src/eval/bytecode/encode.rs
+++ b/src/eval/bytecode/encode.rs
@@ -428,6 +428,9 @@ pub fn encode(
     let templates = enc.encode_templates();
     let blackhole = enc.here();
     enc.emit_op(Op::BlackHole);
+    // A single `Meta L0 L1` template: a runtime metadata value closes a fresh
+    // env `[meta, body]` over it (mirrors the constructor templates).
+    let meta_template = enc.encode_node(&dsl::with_meta(dsl::lref(0), dsl::lref(1)));
     let pap = enc.encode_pap_templates();
 
     let global_forms: Vec<GlobalForm> = globals
@@ -452,6 +455,7 @@ pub fn encode(
         global_entries: global_forms.iter().map(|f| f.entry).collect(),
         templates,
         blackhole,
+        meta_template,
         pap,
     };
     (program, root_off, global_forms)

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2194,6 +2194,30 @@ impl IntrinsicMachine for BcBifContext<'_, '_> {
         Ok(AbiClosure::Byte(self.build_data(view, tag, &bc_fields)?))
     }
 
+    fn meta_value(
+        &self,
+        view: MutatorHeapView<'_>,
+        meta: AbiClosure,
+        body: AbiClosure,
+    ) -> Result<AbiClosure, ExecutionError> {
+        let unwrap = |c: AbiClosure| match c {
+            AbiClosure::Byte(v) => v,
+            AbiClosure::Heap(_) => {
+                panic!("bytecode BifContext: meta_value with a HeapSyn field")
+            }
+        };
+        let env = view.from_values(
+            [unwrap(meta), unwrap(body)].into_iter(),
+            2,
+            self.state.root_env,
+            self.state.annotation,
+        )?;
+        Ok(AbiClosure::Byte(BcValue::Closure(BcClosure::new(
+            self.program.meta_template,
+            env,
+        ))))
+    }
+
     fn return_closure_list(
         &mut self,
         view: MutatorHeapView<'_>,

--- a/src/eval/bytecode/program.rs
+++ b/src/eval/bytecode/program.rs
@@ -39,6 +39,11 @@ pub struct BytecodeProgram {
     /// Offset of a shared `OP_BLACKHOLE` node, used to overwrite a thunk's
     /// env slot while it is being forced (cycle detection).
     pub blackhole: CodeRef,
+    /// Offset of a pre-encoded `OP_META L0 L1` node. A runtime
+    /// metadata-annotated value is a `BcClosure(meta_template, env{[meta,
+    /// body]})`, letting intrinsics rebuild `Meta` values (e.g. from parsed
+    /// YAML `!tag` scalars) with no per-call code allocation.
+    pub meta_template: CodeRef,
     /// Partial-application (PAP) trampoline templates, indexed
     /// `(supplied-1) * PAP_MAX_ARITY + (pending-1)`. Each is an
     /// `App(L(pending), [supplied+pending refs])` node used to build the

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -344,6 +344,36 @@ pub trait IntrinsicMachine {
         Ok(AbiClosure::Heap(SynClosure::new(code, frame)))
     }
 
+    /// Wrap a body value with metadata, returned as a (WHNF) `Meta` value
+    /// handle (does not set the machine result).
+    ///
+    /// Used when rebuilding a metadata-annotated data value (e.g. a YAML
+    /// `!tag`-carrying scalar produced by `parse-as`) directly through the
+    /// neutral ABI. The HeapSyn default builds a `HeapSyn::Meta` node over an
+    /// env frame `[meta, body]`; the bytecode engine overrides this to build a
+    /// `Meta` value over its pre-encoded meta template.
+    fn meta_value(
+        &self,
+        view: MutatorHeapView<'_>,
+        meta: AbiClosure,
+        body: AbiClosure,
+    ) -> Result<AbiClosure, ExecutionError> {
+        let env = self.root_env();
+        let frame = view.from_closures(
+            [meta.expect_heap(), body.expect_heap()].into_iter(),
+            2,
+            env,
+            Smid::default(),
+        )?;
+        let code = view
+            .alloc(HeapSyn::Meta {
+                meta: Ref::L(0),
+                body: Ref::L(1),
+            })?
+            .as_ptr();
+        Ok(AbiClosure::Heap(SynClosure::new(code, frame)))
+    }
+
     /// Set the machine result to a cons-list of the given value handles.
     fn return_closure_list(
         &mut self,

--- a/src/eval/stg/materialise.rs
+++ b/src/eval/stg/materialise.rs
@@ -1,0 +1,131 @@
+//! Materialise a pure-data compiled STG value onto the GC heap via the
+//! neutral value-construction ABI (BV1 spec §5.5), engine-agnostically.
+//!
+//! `PARSE_STRING` and `TYPE_TO_DATA` turn parsed input / a type into a core
+//! expression that is a pure DATA literal — blocks, lists, boxed scalars, and
+//! (for parsed input) metadata-annotated scalars, with no runtime-varying
+//! computation. The compiler lowers that to a (possibly nested) letrec of
+//! value-form data cells (`Cons`/`Meta`/`Atom`) whose references only ever
+//! point *backwards* within their own frame (the compiler builds each cell
+//! bottom-up) plus the empty-list global.
+//!
+//! The HeapSyn engine can `load()` that tree and tree-walk it directly, but
+//! the bytecode engine has no runtime tree-walker for `HeapSyn`. Rather than
+//! synthesise per-call bytecode (which would grow the off-heap code arena
+//! without bound), we walk the compiled STG here and rebuild the value
+//! *directly* through the neutral `native_value`/`data_value`/`meta_value`/
+//! `resolve_closure` methods. Each engine's implementation of those builds its
+//! own value representation on the shared GC heap, so the result is
+//! collectable and renders byte-identically on both engines with zero code
+//! arena growth.
+//!
+//! Only the pure-data value subset is supported; any code-bearing form
+//! (`App`/`Bif`/`Case`/lambda/…) or a forward/cross-frame reference returns an
+//! `ExecutionError`, so a non-data input fails cleanly rather than producing a
+//! wrong value.
+
+use std::rc::Rc;
+
+use crate::common::sourcemap::Smid;
+use crate::eval::{
+    error::ExecutionError,
+    machine::intrinsic::{AbiClosure, IntrinsicMachine},
+    memory::{
+        mutator::MutatorHeapView,
+        symbol::SymbolPool,
+        syntax::{Native as HeapNative, Ref as HeapRef, StgBuilder},
+    },
+    stg::syntax::{LambdaForm, Native, Ref, StgSyn},
+};
+
+fn unsupported(smid: Smid, what: &str) -> ExecutionError {
+    ExecutionError::Panic(
+        smid,
+        format!("materialise-data: unsupported compiled form ({what})"),
+    )
+}
+
+/// Resolve a compiled-STG reference to a materialised value handle.
+///
+/// * `L(i)` indexes the values already built in the current letrec frame
+///   (backward references only).
+/// * `G(i)` is resolved against the machine's globals (the empty-list global
+///   is the only global these data literals reference).
+/// * `V(native)` is wrapped as a scalar value, interning symbols and
+///   heap-allocating strings.
+fn resolve_ref(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    pool: &mut SymbolPool,
+    frame: &[AbiClosure],
+    smid: Smid,
+    r: &Ref,
+) -> Result<AbiClosure, ExecutionError> {
+    match r {
+        Ref::L(i) => frame
+            .get(*i)
+            .cloned()
+            .ok_or_else(|| unsupported(smid, "forward or out-of-range local reference")),
+        Ref::G(i) => machine.resolve_closure(view, &HeapRef::G(*i)),
+        Ref::V(Native::Num(n)) => machine.native_value(view, HeapNative::Num(n.clone())),
+        Ref::V(Native::Str(s)) => {
+            let ptr = view.str(s.as_str())?.as_ptr();
+            machine.native_value(view, HeapNative::Str(ptr))
+        }
+        Ref::V(Native::Sym(s)) => {
+            let id = pool.intern(s.as_str());
+            machine.native_value(view, HeapNative::Sym(id))
+        }
+        Ref::V(Native::Zdt(d)) => machine.native_value(view, HeapNative::Zdt(*d)),
+    }
+}
+
+/// Materialise a compiled-STG data value into a value handle on the heap.
+///
+/// `frame` holds the values already built for the enclosing letrec (empty at
+/// the top level). Nested `Let`/`LetRec` structures are self-contained: each
+/// opens a fresh frame that its own bindings and body reference.
+pub fn materialise_data(
+    machine: &dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    pool: &mut SymbolPool,
+    syn: &Rc<StgSyn>,
+    frame: &[AbiClosure],
+) -> Result<AbiClosure, ExecutionError> {
+    let smid = machine.annotation();
+    match &**syn {
+        StgSyn::Atom { evaluand } => resolve_ref(machine, view, pool, frame, smid, evaluand),
+        StgSyn::Cons { tag, args } => {
+            let mut fields = Vec::with_capacity(args.len());
+            for a in args {
+                fields.push(resolve_ref(machine, view, pool, frame, smid, a)?);
+            }
+            machine.data_value(view, *tag, &fields)
+        }
+        StgSyn::Let { bindings, body } | StgSyn::LetRec { bindings, body } => {
+            let mut new_frame: Vec<AbiClosure> = Vec::with_capacity(bindings.len());
+            for b in bindings {
+                let body = match b {
+                    LambdaForm::Value { body } | LambdaForm::Thunk { body } => body,
+                    LambdaForm::Lambda { .. } => return Err(unsupported(smid, "lambda binding")),
+                };
+                let value = materialise_data(machine, view, pool, body, &new_frame)?;
+                new_frame.push(value);
+            }
+            materialise_data(machine, view, pool, body, &new_frame)
+        }
+        StgSyn::Ann { body, .. } => materialise_data(machine, view, pool, body, frame),
+        StgSyn::Meta { meta, body } => {
+            let meta = resolve_ref(machine, view, pool, frame, smid, meta)?;
+            let body = resolve_ref(machine, view, pool, frame, smid, body)?;
+            machine.meta_value(view, meta, body)
+        }
+        StgSyn::Case { .. } => Err(unsupported(smid, "case")),
+        StgSyn::App { .. } | StgSyn::DirectApp { .. } => Err(unsupported(smid, "application")),
+        StgSyn::Bif { .. } => Err(unsupported(smid, "intrinsic call")),
+        StgSyn::DeMeta { .. } => Err(unsupported(smid, "demeta")),
+        StgSyn::Seq { .. } => Err(unsupported(smid, "seq")),
+        StgSyn::LookupLit { .. } => Err(unsupported(smid, "lookup")),
+        StgSyn::BlackHole => Err(unsupported(smid, "blackhole")),
+    }
+}

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -22,6 +22,7 @@ pub mod graph;
 pub mod io;
 pub mod json_to_stg;
 pub mod list;
+pub mod materialise;
 pub mod meta;
 pub mod null;
 pub mod optimiser;

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -9,7 +9,7 @@
 //! Supported format symbols: `yaml`, `json`, `toml`, `csv`, `xml`, `edn`,
 //! `jsonl`, `text`.  `:json` and `:yaml` share the same parser.
 
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 use codespan_reporting::files::SimpleFiles;
 
@@ -18,13 +18,11 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::{
-            env::SynClosure,
-            intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
-        },
-        memory::{loader::load, mutator::MutatorHeapView, syntax::Ref},
+        machine::intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
+        memory::{mutator::MutatorHeapView, syntax::Ref},
         stg::{
             compiler::Compiler,
+            materialise::materialise_data,
             support::{str_arg, sym_arg},
             RenderType,
         },
@@ -93,15 +91,18 @@ impl StgIntrinsic for ParseString {
             .compile(core_expr)
             .map_err(|e| ExecutionError::Panic(smid, format!("parse-as compile error: {e}")))?;
 
-        // Load the compiled STG onto the machine heap and set as closure.
-        let pool = RefCell::new(machine.symbol_pool_mut().clone());
-        let heap_ptr = load(&view, &mut pool.borrow_mut(), syntax)
-            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as load error: {e}")))?;
+        // The compiled STG is a pure data literal. Rebuild it directly on the
+        // GC heap through the neutral value-construction ABI (engine-agnostic,
+        // no runtime code synthesis) rather than loading a HeapSyn tree that
+        // only the tree-walk engine can run.
+        let mut pool = machine.symbol_pool_mut().clone();
+        let value = materialise_data(&*machine, view, &mut pool, &syntax, &[])
+            .map_err(|e| ExecutionError::Panic(smid, format!("parse-as materialise error: {e}")))?;
 
-        // Update the machine's symbol pool with any new symbols interned during load
-        *machine.symbol_pool_mut() = pool.into_inner();
+        // Publish any symbols interned while materialising the value.
+        *machine.symbol_pool_mut() = pool;
 
-        machine.set_closure(SynClosure::new(heap_ptr, machine.root_env()))
+        machine.set_result(value)
     }
 }
 

--- a/src/eval/stg/typedata.rs
+++ b/src/eval/stg/typedata.rs
@@ -6,7 +6,7 @@
 //!
 //! Together these power the `to-data` / `from-data` round-trip in the prelude.
 
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 use crate::eval::memory::syntax::{Native, StgBuilder};
 use crate::{
@@ -18,13 +18,11 @@ use crate::{
     eval::{
         emit::Emitter,
         error::ExecutionError,
-        machine::{
-            env::SynClosure,
-            intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
-        },
-        memory::{array::Array, loader::load, mutator::MutatorHeapView, syntax::Ref},
+        machine::intrinsic::{CallGlobal1, IntrinsicMachine, StgIntrinsic},
+        memory::{mutator::MutatorHeapView, syntax::Ref},
         stg::{
             compiler::Compiler,
+            materialise::materialise_data,
             support::{resolve_native_unboxing, str_arg},
             tags::DataConstructor,
             RenderType,
@@ -205,13 +203,18 @@ impl StgIntrinsic for TypeToData {
             ExecutionError::Panic(smid, format!("TYPE_TO_DATA: compile error: {e}"))
         })?;
 
-        // Load onto heap and return as closure.
-        let pool = RefCell::new(machine.symbol_pool_mut().clone());
-        let heap_ptr = load(&view, &mut pool.borrow_mut(), syntax)
-            .map_err(|e| ExecutionError::Panic(smid, format!("TYPE_TO_DATA: load error: {e}")))?;
-        *machine.symbol_pool_mut() = pool.into_inner();
+        // `type_to_rcexpr` emits only data constructors (lists of symbols/
+        // strings + record blocks) — never function applications — so the
+        // compiled STG is a pure data literal. Rebuild it directly on the GC
+        // heap through the neutral value-construction ABI (engine-agnostic, no
+        // runtime code synthesis).
+        let mut pool = machine.symbol_pool_mut().clone();
+        let value = materialise_data(&*machine, view, &mut pool, &syntax, &[]).map_err(|e| {
+            ExecutionError::Panic(smid, format!("TYPE_TO_DATA: materialise error: {e}"))
+        })?;
+        *machine.symbol_pool_mut() = pool;
 
-        machine.set_closure(SynClosure::new(heap_ptr, machine.root_env()))
+        machine.set_result(value)
     }
 }
 
@@ -249,16 +252,12 @@ impl StgIntrinsic for TypeFromString {
         })?;
         let canonical = format!("{ty}");
 
-        // Allocate BoxedTypeData on the heap.
-        let s_ref = view.str_ref(canonical)?;
-        let ptr = view
-            .data(
-                DataConstructor::BoxedTypeData.tag(),
-                Array::from_slice(&view, &[s_ref]),
-            )?
-            .as_ptr();
-
-        machine.set_closure(SynClosure::new(ptr, machine.root_env()))
+        // Build the BoxedTypeData value through the neutral ABI so it runs on
+        // both engines (a single data cell wrapping the canonical string).
+        let str_ptr = view.str(canonical)?.as_ptr();
+        let field = machine.native_value(view, Native::Str(str_ptr))?;
+        let value = machine.data_value(view, DataConstructor::BoxedTypeData.tag(), &[field])?;
+        machine.set_result(value)
     }
 }
 


### PR DESCRIPTION
## Summary

Migrates `ParseString`, `TypeToData` and `TypeFromString` off the
`load()` + `set_closure(SynClosure)` path so they run on the bytecode
engine, **byte-identically to HeapSyn**, with **zero code-arena growth**.

Refs eu-vi3a (BV1) and eu-9p9g.

## Approach — value representation (no runtime code synthesis)

Both intrinsics compile parsed input / a type to a core expression that is
a **pure DATA literal**. The compiler lowers that to a (nested) letrec of
value-form data cells (`Cons`/`Meta`/`Atom`) with **backward** references.

New shared `src/eval/stg/materialise.rs::materialise_data` walks that
compiled STG and rebuilds the value directly through the neutral
value-construction ABI (`native_value`/`data_value`/`meta_value`/
`resolve_closure`). Each engine builds its own representation on the GC
heap; the value renders identically on both. Any code-bearing form
(`App`/`Bif`/`Case`/lambda/forward-ref) errors cleanly — never a wrong value.

**TypeToData verification (requested):** `type_to_rcexpr` emits **only data
constructors** (lists of symbols/strings + record blocks), never function
applications → data-only confirmed, **no template split needed**.

**Metadata:** new neutral primitive `meta_value` rebuilds YAML `!tag`
scalars. HeapSyn default builds `HeapSyn::Meta`; the bytecode engine builds
a `Meta` value over a new pre-encoded `meta_template` (the "small fixed
template" route — one template, no per-call arena growth).

## Correctness gate — differential sweep

Full `tests/harness/*.eu`, `EU_BYTECODE=1` vs HeapSyn (stdout + exit):

| | PASS | DIFF |
|---|---|---|
| before | 146 | 22 |
| after  | **160** | **8** |

Fixed all 9 `parse_as_*`, `128_parse_args`, and `174/177/178/182`.
**Zero new DIFFs.**

The 8 remaining DIFFs were all DIFF before this PR and are out of scope:
`015`/`085`/`135`/`127` (MergeWith/DeepMerge), `079` (ProducerNext),
`125` (expectations), plus `175_sv2_to_spec` and `183_widen_type_def_literals`
— which **fail an assertion/warning on the reference HeapSyn engine too**
(pre-existing prelude `union-spec`/`result-def` bug), diverging only in
partial pre-error emit; unrelated to this migration.

## Quality gates

- `cargo test --lib`: **1250 green** (+ `agree_on_parse_string_json`,
  `agree_on_type_to_data`)
- `cargo test --test harness_test`: **477 green** (HeapSyn path unchanged)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all`: clean
- `EU_GC_VERIFY=2 EU_GC_STRESS=1`: clean on **both** engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee