### PR TITLE
fix(bytecode): BV1 — port LOOKUP_FAIL key collection to the neutral ABI (eu-ter9)

### DIFF
--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -104,6 +104,71 @@ fn assert_engines_render_agree(syntax: Rc<StgSyn>) -> String {
     heap_out
 }
 
+/// Run `syntax` — which must raise a `LookupFailure` — through both engines and
+/// assert they agree on the failing key, its suggestions and the available
+/// keys. Regression guard for the `LOOKUP_FAIL` diagnostic path on the bytecode
+/// engine (eu-ter9): its key collection must go through the neutral ABI, not
+/// the HeapSyn-only `nav` navigator (which panics on the bytecode engine).
+fn assert_engines_lookup_fail_agree(syntax: Rc<StgSyn>, bifs: Vec<Box<dyn StgIntrinsic>>) {
+    use crate::eval::error::ExecutionError;
+
+    let mut rt = StandardRuntime::default();
+    for b in bifs {
+        rt.add(b);
+    }
+    rt.prepare(&mut SourceMap::default());
+    let settings = StgSettings::default();
+
+    // Reference: the HeapSyn tree-walk machine.
+    let heap_err = {
+        let mut m = standard_machine(&settings, syntax.clone(), Box::new(NullEmitter), &rt)
+            .expect("build HeapSyn machine");
+        m.run(Some(1_000_000))
+            .expect_err("HeapSyn should raise LookupFailure")
+    };
+
+    // Under test: the bytecode machine, sharing the same runtime globals.
+    let bc_err = {
+        let globals = rt.globals();
+        let (prog, root, gforms) = encode(&syntax, &globals);
+        let mut m = BytecodeMachine::new(
+            prog,
+            root,
+            &gforms,
+            rt.intrinsics(),
+            Box::new(NullEmitter),
+            0,
+            false,
+        )
+        .expect("build bytecode machine");
+        m.run(Some(1_000_000))
+            .expect_err("bytecode should raise LookupFailure")
+    };
+
+    // The HeapSyn machine wraps raised errors in `Traced`; unwrap to compare
+    // the underlying diagnostic on equal terms with the bytecode engine.
+    fn unwrap_traced(e: &ExecutionError) -> &ExecutionError {
+        match e {
+            ExecutionError::Traced(inner, _, _) => unwrap_traced(inner),
+            other => other,
+        }
+    }
+
+    match (unwrap_traced(&heap_err), unwrap_traced(&bc_err)) {
+        (
+            ExecutionError::LookupFailure(_, hk, hs, ha),
+            ExecutionError::LookupFailure(_, bk, bs, ba),
+        ) => {
+            assert_eq!(hk, bk, "engines disagree on the failing key");
+            assert_eq!(hs, bs, "engines disagree on the suggestions");
+            assert_eq!(ha, ba, "engines disagree on the available keys");
+        }
+        _ => {
+            panic!("expected LookupFailure from both engines, got heap={heap_err:?} bc={bc_err:?}")
+        }
+    }
+}
+
 mod tests {
     use super::*;
     use crate::eval::stg::arith::{Add, Lt};
@@ -127,6 +192,32 @@ mod tests {
                 dsl::atom(dsl::num(9)),
             ),
         )
+    }
+
+    #[test]
+    fn agree_on_lookup_failure_suggestions() {
+        use crate::eval::stg::block::LookupFail;
+
+        // A block `{ foo: 1, bar: 2 }`; look up the missing key `bax`. Both
+        // engines must raise the same `LookupFailure`, with `bar` suggested
+        // (edit distance 1). This exercises `collect_block_keys` on the
+        // bytecode engine, which pre-fix panicked in `nav` (eu-ter9).
+        let lookup_fail = crate::eval::intrinsics::index_u8("LOOKUP_FAIL");
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::pair("foo", dsl::num(1))),
+                dsl::value(dsl::pair("bar", dsl::num(2))),
+                dsl::value(dsl::nil()),
+                // [bar]
+                dsl::value(dsl::cons(dsl::lref(1), dsl::lref(2))),
+                // [foo, bar]
+                dsl::value(dsl::cons(dsl::lref(0), dsl::lref(3))),
+                // block over the kv-list
+                dsl::value(dsl::block(dsl::lref(4))),
+            ],
+            dsl::app_bif(lookup_fail, vec![dsl::sym("bax"), dsl::lref(5)]),
+        );
+        assert_engines_lookup_fail_agree(syn, vec![Box::new(LookupFail)]);
     }
 
     #[test]

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1300,10 +1300,11 @@ impl StgIntrinsic for LookupFail {
     ) -> Result<(), ExecutionError> {
         // Resolve the key symbol to a string. The sym arg may arrive as
         // either a direct Ref::V(Native::Sym) or as a closure wrapping
-        // a native value.
+        // a native value. Uses the neutral `resolve_native` ABI so it
+        // serves both the HeapSyn and bytecode engines.
         let key_name = match &args[0] {
             Ref::V(Native::Sym(id)) => machine.symbol_pool().resolve(*id).to_string(),
-            other => match machine.nav(view).resolve_native(other) {
+            other => match machine.resolve_native(view, other) {
                 Ok(Native::Sym(id)) => machine.symbol_pool().resolve(id).to_string(),
                 _ => "<unknown>".to_string(),
             },
@@ -1312,7 +1313,7 @@ impl StgIntrinsic for LookupFail {
         // Collect keys from the block. The block arg has been forced by
         // the wrapper, so it should be a Block cons cell accessible via
         // resolve.
-        let available_keys = collect_block_keys_from_args(machine, view, &args[1]);
+        let available_keys = collect_block_keys(machine, view, &args[1]);
 
         // Compute suggestions via edit distance
         let max_distance = (key_name.len() / 2).clamp(2, 4);
@@ -1330,54 +1331,72 @@ impl StgIntrinsic for LookupFail {
 
 impl CallGlobal2 for LookupFail {}
 
-/// Collect all key names from a block that has been resolved to a closure.
+/// Collect the key names of a (forced) block value, engine-neutrally.
 ///
-/// The closure should point to a `Block` cons cell. This is the main
-/// implementation used by both the BIF args path and direct closure path.
-fn collect_block_keys_from_closure(
-    machine: &dyn IntrinsicMachine,
-    view: MutatorHeapView<'_>,
-    closure: &SynClosure,
-) -> Vec<String> {
-    let nav = machine.nav(view);
-    let code = view.scoped(closure.code());
-    let blocklist_ref = match &*code {
-        HeapSyn::Cons { tag, args } if *tag == DataConstructor::Block.tag() => match args.get(0) {
-            Some(r) => r.clone(),
-            None => return vec![],
-        },
-        _ => return vec![],
-    };
-
-    let list_closure = match nav.resolve_in_closure(closure, blocklist_ref) {
-        Some(c) => c,
-        None => return vec![],
-    };
-
-    let iter = BlockListIterator {
-        closure: list_closure,
-        nav: &nav,
-        done: false,
-    };
-
-    iter.filter_map(|pair| {
-        let sym_id = pair_key_symbol_id(view, &pair)?;
-        Some(machine.symbol_pool().resolve(sym_id).to_string())
-    })
-    .collect()
-}
-
-/// Collect block keys from a BIF arg ref. Resolves the ref to a closure
-/// first, then delegates to `collect_block_keys_from_closure`.
-fn collect_block_keys_from_args(
-    machine: &dyn IntrinsicMachine,
+/// Walks the block's `ListCons`/`ListNil` spine of `BlockPair`s via the
+/// neutral `data_tag`/`data_field`/`value_native` ABI (forcing each spine
+/// cell), so it serves both the HeapSyn and bytecode engines. This is
+/// best-effort — it feeds the "did you mean?" hint on a lookup failure, so
+/// any structural surprise simply yields the keys gathered so far.
+fn collect_block_keys(
+    machine: &mut dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
     block_ref: &Ref,
 ) -> Vec<String> {
-    let nav = machine.nav(view);
-    match nav.resolve(block_ref) {
-        Ok(closure) => collect_block_keys_from_closure(machine, view, &closure),
-        Err(_) => vec![],
+    let mut keys = Vec::new();
+
+    // Resolve and force the block to WHNF; it should be a `Block` cell whose
+    // field 0 is the kv-pair list.
+    let block = match machine.resolve_closure(view, block_ref) {
+        Ok(c) => c,
+        Err(_) => return keys,
+    };
+    let block = match machine.force(block) {
+        Ok(c) => c,
+        Err(_) => return keys,
+    };
+    if machine.data_tag(view, &block) != Some(DataConstructor::Block.tag()) {
+        return keys;
+    }
+    let mut current = match machine.data_field(view, &block, 0) {
+        Some(c) => c,
+        None => return keys,
+    };
+
+    // Walk the list spine, reading each pair's key (field 0).
+    while let Ok(cell) = machine.force(current) {
+        if machine.data_tag(view, &cell) != Some(DataConstructor::ListCons.tag()) {
+            break; // ListNil or an unexpected shape
+        }
+        if let Some(key) = pair_key_name(machine, view, &cell) {
+            keys.push(key);
+        }
+        match machine.data_field(view, &cell, 1) {
+            Some(tail) => current = tail,
+            None => break,
+        }
+    }
+
+    keys
+}
+
+/// Best-effort read of a kv-list cell's head `BlockPair` key as a string,
+/// via the neutral ABI. Returns `None` on any non-`BlockPair` / non-symbol
+/// shape.
+fn pair_key_name(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    cell: &AbiClosure,
+) -> Option<String> {
+    let head = machine.data_field(view, cell, 0)?;
+    let head = machine.force(head).ok()?;
+    if machine.data_tag(view, &head) != Some(DataConstructor::BlockPair.tag()) {
+        return None;
+    }
+    let key = machine.data_field(view, &head, 0)?;
+    match machine.value_native(view, &key)? {
+        Native::Sym(id) => Some(machine.symbol_pool().resolve(id).to_string()),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

The `LOOKUP_FAIL` intrinsic — which builds the "key not found" / "did you mean?" diagnostic — collected the block's available keys via the HeapSyn-only `nav` navigator. On the bytecode engine `nav` panics (`bytecode BifContext: nav — intrinsic uses the HeapSyn ABI`), **aborting the process** for every key-not-found lookup. This was category A of the eu-enyv STEP-1 investigation (11 harness panics).

## What changed

- Replaced `collect_block_keys_from_args` / `collect_block_keys_from_closure` (and their `BlockListIterator` + `nav.resolve_in_closure` walk) with a single engine-neutral `collect_block_keys` that walks the block's `ListCons`/`ListNil` spine of `BlockPair`s via the neutral `resolve_closure`/`force`/`data_tag`/`data_field`/`value_native` ABI, forcing each spine cell.
- Switched the key-symbol resolution in `LookupFail::execute` from `nav().resolve_native` to the neutral `resolve_native`.
- Added a differential regression test (`agree_on_lookup_failure_suggestions`) that builds a block, does a failing lookup, and asserts **both engines** agree on the `LookupFailure` key, suggestions and available-keys.

The HeapSyn path is behaviourally unchanged (the neutral ABI has HeapSyn defaults); the bytecode path now produces byte-identical diagnostics.

## Results

Fixes error tests **020, 034, 067, 068, 070, 084, 130, 144, 145, 146, 147** under `EU_BYTECODE=1`.

| Suite | Before | After |
|---|---|---|
| `EU_BYTECODE=1 cargo test --test harness_test` | 445 / 477 (32 fail) | **456 / 477 (21 fail)** |
| `cargo test --test harness_test` (HeapSyn default) | 477 | **477** (no regression) |
| `cargo test --lib` | 1252 | **1253** (+1 regression test) |

The remaining 21 bytecode failures are the **IO / world path** (bead eu-lka7, 8 harness + several error tests) and **diagnostic-rendering parity** (bead eu-v6c4) — out of scope for this bead.

## Validation

- `EU_GC_VERIFY=2 EU_GC_STRESS=1` clean across all 11 target tests and the differential suite.
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all` clean.

Refs eu-ter9, eu-vi3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee