### PR TITLE
feat(bytecode): port IO / world-injection loop to bytecode driver (eu-lka7 / eu-vi3a)

### DIFF
--- a/src/driver/bytecode_io_run.rs
+++ b/src/driver/bytecode_io_run.rs
@@ -1,0 +1,422 @@
+//! IO monad interpret loop for the bytecode engine (BV1; eu-lka7).
+//!
+//! A faithful mirror of the HeapSyn io-run driver (`driver::io_run`) over the
+//! [`BytecodeMachine`] instead of the HeapSyn `Machine`. It interprets the IO
+//! data constructors (`IoReturn`, `IoBind`, `IoAction`, `IoFail`) that the
+//! bytecode machine yields on, drives the shell-execution side effects (via the
+//! shared [`crate::driver::io_common`] executor), and re-enters the machine
+//! with results.
+//!
+//! The control flow, GC-stash discipline, and world-injection / RENDER_DOC
+//! render steps match the HeapSyn driver one-for-one. The differences are all
+//! in the *representation*: values are [`BcValue`]s navigated / synthesised via
+//! the `BytecodeMachine` io-run API rather than HeapSyn `SynClosure`s built by
+//! heap mutators.
+//!
+//! ## Deviation from HeapSyn (deliberate)
+//!
+//! The HeapSyn driver extracts the action tag (`io-shell` / `io-exec` /
+//! `io-fail`) from the spec block's metadata symbol via `peel_meta`. In the
+//! bytecode engine a metadata-annotated value has its `Meta` wrapper **stripped
+//! during forcing** (a `Meta` reaching the top of an empty continuation stack
+//! flows straight to its body — `machine::return_meta`), so the tag symbol is
+//! gone by the time the block is in WHNF. We therefore infer the tag from the
+//! evaluated field set, which is unambiguous for the four prelude IO actions:
+//! `io-exec` has an `args` field, `io-shell` has `cmd` (no `args`), and
+//! `io-fail` has `message` (no `cmd`). This matches the HeapSyn driver's own
+//! field-based fallback for parameterised (App-thunk) spec blocks.
+
+use std::collections::HashMap;
+
+use crate::driver::io_common::{run_spec, ActionSpec, IoRunError};
+use crate::eval::bytecode::{BcValue, BytecodeMachine};
+use crate::eval::error::ExecutionError;
+use crate::eval::intrinsics;
+use crate::eval::memory::infotable::InfoTable;
+use crate::eval::stg::tags::DataConstructor;
+
+// ─── Spec-block evaluation ────────────────────────────────────────────────────
+
+/// Build an [`ActionSpec`] from an `IoAction` spec block by forcing it to WHNF
+/// (a `Block`, metadata stripped) and evaluating each field. Mirrors
+/// `io_run::evaluate_spec_block`.
+fn evaluate_spec_block(
+    machine: &mut BytecodeMachine<'_>,
+    spec_block: BcValue,
+) -> Result<ActionSpec, IoRunError> {
+    // Statically peel the `Meta` wrapper (see `BytecodeMachine::peel_io_spec`):
+    // an inline spec block is a `let`-bound `Meta` whose body ref is relative
+    // to the let frame, so it cannot be forced naively — we resolve the block
+    // body against the container frame first. App-thunk specs pass through
+    // unchanged. Then force the (block) body to WHNF.
+    let body = machine.peel_io_spec(spec_block);
+    let block = machine
+        .evaluate_to_whnf_for_io(body)
+        .map_err(IoRunError::from)?;
+
+    // Read the raw (unevaluated) field value closures from the block.
+    let raw_fields = machine
+        .block_field_values(&block)
+        .map_err(IoRunError::from)?;
+
+    // Stash all field values before the per-field WHNF loop: each
+    // `evaluate_to_whnf_for_io` runs the machine and may evacuate, leaving any
+    // `BcValue` copies held on the Rust stack dangling. The stash is a GC root
+    // set that the collector traces and updates. Push in reverse so the forward
+    // pop order matches the field order.
+    for (_, v) in raw_fields.iter().rev() {
+        machine.stash_push(v.clone());
+    }
+
+    let mut eval_fields: HashMap<String, Option<String>> = HashMap::new();
+    for (key, _) in &raw_fields {
+        let raw = machine.stash_pop();
+        let whnf = force_field(machine, raw)?;
+
+        // List-valued fields (e.g. `args`) need each element forced and
+        // rendered, then joined with NUL as a separator.
+        let value_str = if machine.value_is_list(&whnf) {
+            let elements = machine
+                .list_element_values(&whnf)
+                .map_err(IoRunError::from)?;
+            // Stash all element closures before the loop (same GC reason as the
+            // fields above); push in reverse for forward pop order.
+            for e in elements.iter().rev() {
+                machine.stash_push(e.clone());
+            }
+            let mut parts: Vec<String> = Vec::new();
+            for _ in 0..elements.len() {
+                let elem = machine.stash_pop();
+                let elem_whnf = force_field(machine, elem)?;
+                if let Some(s) = machine.whnf_scalar_string(&elem_whnf) {
+                    parts.push(s);
+                }
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\x00"))
+            }
+        } else {
+            machine.whnf_scalar_string(&whnf)
+        };
+        eval_fields.insert(key.clone(), value_str);
+    }
+
+    build_action_spec(machine, eval_fields)
+}
+
+/// Force a spec-block field to WHNF, peeling a boxed scalar whose inner field
+/// is still an unevaluated thunk (e.g. a `BoxedString` wrapping a format-expr).
+/// Mirrors the `peel_box_inner` re-evaluation in `io_run::evaluate_spec_block`.
+fn force_field(machine: &mut BytecodeMachine<'_>, value: BcValue) -> Result<BcValue, IoRunError> {
+    let whnf = machine
+        .evaluate_to_whnf_for_io(value)
+        .map_err(IoRunError::from)?;
+    if let Some(inner) = machine.peel_box_inner(&whnf) {
+        machine
+            .evaluate_to_whnf_for_io(inner)
+            .map_err(IoRunError::from)
+    } else {
+        Ok(whnf)
+    }
+}
+
+/// Turn the evaluated spec fields into an [`ActionSpec`], inferring the action
+/// tag from the field set (see module docs).
+fn build_action_spec(
+    machine: &BytecodeMachine<'_>,
+    eval_fields: HashMap<String, Option<String>>,
+) -> Result<ActionSpec, IoRunError> {
+    let timeout_secs = eval_fields
+        .get("timeout")
+        .and_then(|opt| opt.as_deref())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(30);
+
+    let stdin = eval_fields
+        .get("stdin")
+        .and_then(|opt| opt.clone())
+        .filter(|s| !s.is_empty() && s != "null");
+
+    let call_smid = machine.annotation();
+
+    if eval_fields.contains_key("args") {
+        // io-exec: cmd + args.
+        let cmd = eval_fields
+            .get("cmd")
+            .and_then(|opt| opt.clone())
+            .ok_or_else(|| {
+                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+                    call_smid,
+                    "io.exec: 'cmd' field is required in the action spec".to_string(),
+                )))
+            })?;
+        let args = eval_fields
+            .get("args")
+            .and_then(|opt| opt.clone())
+            .map(|s| {
+                if s.is_empty() {
+                    vec![]
+                } else {
+                    s.split('\x00').map(|x| x.to_string()).collect()
+                }
+            })
+            .unwrap_or_default();
+        Ok(ActionSpec::Exec {
+            cmd,
+            args,
+            stdin,
+            timeout_secs,
+        })
+    } else if eval_fields.contains_key("cmd") {
+        // io-shell: cmd, no args.
+        let cmd = eval_fields
+            .get("cmd")
+            .and_then(|opt| opt.clone())
+            .ok_or_else(|| {
+                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+                    call_smid,
+                    "io.shell: 'cmd' field is required in the action spec".to_string(),
+                )))
+            })?;
+        Ok(ActionSpec::Shell {
+            cmd,
+            stdin,
+            timeout_secs,
+        })
+    } else if eval_fields.contains_key("message") {
+        // io-fail: a message, no command.
+        let message = eval_fields
+            .get("message")
+            .and_then(|opt| opt.clone())
+            .unwrap_or_else(|| "io.fail".to_string());
+        Err(IoRunError::Fail(message))
+    } else {
+        Err(IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+            call_smid,
+            "unknown IO action spec (no cmd/args/message field)".to_string(),
+        ))))
+    }
+}
+
+// ─── IO monad interpret loop ──────────────────────────────────────────────────
+
+/// Interpret the IO monad until an `IoReturn` or `IoFail` is reached.
+///
+/// The machine must be in the io-yielded state when this is called. Returns the
+/// pure value from the final `IoReturn`. Mirrors `io_run::io_run`.
+pub fn io_run(machine: &mut BytecodeMachine<'_>, allow_io: bool) -> Result<BcValue, IoRunError> {
+    loop {
+        if !machine.io_yielded() {
+            return Err(panic(
+                machine,
+                "bytecode io_run called on a non-yielded machine",
+            ));
+        }
+
+        let tag = machine
+            .yielded_io_tag()
+            .ok_or_else(|| panic(machine, "bytecode io_run: machine yield has no IO tag"))?;
+        let args = machine.yielded_io_args().ok_or_else(|| {
+            panic(
+                machine,
+                "bytecode io_run: could not resolve IO constructor args",
+            )
+        })?;
+
+        match DataConstructor::try_from(tag) {
+            Ok(DataConstructor::IoReturn) => {
+                // IoReturn(world=0, value=1)
+                return args
+                    .into_iter()
+                    .nth(1)
+                    .ok_or_else(|| panic(machine, "IoReturn missing value argument"));
+            }
+
+            Ok(DataConstructor::IoFail) => {
+                let error_value = args
+                    .into_iter()
+                    .nth(1)
+                    .ok_or_else(|| panic(machine, "IoFail missing error argument"))?;
+                let msg = machine
+                    .evaluate_to_whnf_for_io(error_value)
+                    .ok()
+                    .and_then(|c| machine.whnf_scalar_string(&c))
+                    .unwrap_or_else(|| "IO monad failure".to_string());
+                return Err(IoRunError::Fail(msg));
+            }
+
+            Ok(DataConstructor::IoAction) => {
+                if !allow_io {
+                    return Err(IoRunError::IoNotAllowed(machine.annotation()));
+                }
+                let world = args[0].clone();
+                let spec_block = args[1].clone();
+
+                // Stash world so it survives GC across the spec evaluation and
+                // shell execution below.
+                machine.stash_push(world);
+
+                let spec = evaluate_spec_block(machine, spec_block)?;
+
+                // Capture the source annotation before the shell call so
+                // timeout / command errors carry a source location.
+                let ann = machine.annotation();
+                let result = run_spec(&spec, ann)?;
+
+                // Build the result block { stdout, stderr, exit-code }. World is
+                // still stashed as a GC root.
+                let result_c = machine
+                    .build_io_result_block(&result.stdout, &result.stderr, result.exit_code)
+                    .map_err(IoRunError::from)?;
+
+                // Wrap in IoReturn(world, result_block) and resume. Pop world
+                // (GC-updated) only now that all allocation is complete.
+                machine.stash_push(result_c);
+                let result_c = machine.stash_pop();
+                let world = machine.stash_pop();
+                let io_return = machine
+                    .build_io_return(world, result_c)
+                    .map_err(IoRunError::from)?;
+
+                machine.stash_push(io_return);
+                let io_return = machine.stash_peek(0);
+                machine.resume(io_return);
+                machine.run(None).map_err(IoRunError::from)?;
+                machine.stash_pop();
+                // Loop back to inspect the new yield.
+            }
+
+            Ok(DataConstructor::IoBind) => {
+                // IoBind(world=0, cont=1, action=2)
+                let world = args[0].clone();
+                let cont = args[1].clone();
+                let action = args[2].clone();
+
+                // Stash `cont` and `world` across the recursive machine runs.
+                machine.stash_push(cont);
+                machine.stash_push(world);
+
+                // Step 1: apply world to the action (a PAP waiting for world,
+                // e.g. io.return(42) = λworld.IoReturn(world, 42)).
+                let world_ref = machine.stash_peek(0);
+                let action_with_world = machine
+                    .build_apply1(action, world_ref)
+                    .map_err(IoRunError::from)?;
+
+                machine.stash_push(action_with_world);
+                let action_with_world = machine.stash_peek(0);
+                machine.resume(action_with_world);
+                machine.run(None).map_err(IoRunError::from)?;
+                machine.stash_pop(); // action_with_world
+
+                if !machine.io_yielded() {
+                    machine.stash_pop(); // world
+                    machine.stash_pop(); // cont
+                    return Err(panic(
+                        machine,
+                        "IoBind action did not yield an IO constructor",
+                    ));
+                }
+
+                // Step 2: recursively process the action result. `cont` and
+                // `world` remain stashed throughout.
+                let action_result = io_run(machine, allow_io)?;
+
+                // Step 3: apply the continuation to (result, world).
+                machine.stash_push(action_result);
+                let action_result = machine.stash_peek(0);
+                let world = machine.stash_peek(1);
+                let cont = machine.stash_peek(2);
+                let cont_call = machine
+                    .build_apply2(cont, action_result, world)
+                    .map_err(IoRunError::from)?;
+                machine.stash_pop(); // action_result
+                machine.stash_pop(); // world
+                machine.stash_pop(); // cont
+
+                machine.stash_push(cont_call);
+                let cont_call = machine.stash_peek(0);
+                machine.resume(cont_call);
+                machine.run(None).map_err(IoRunError::from)?;
+                machine.stash_pop();
+                // Loop back.
+            }
+
+            _ => {
+                return Err(panic(
+                    machine,
+                    &format!("unexpected IO constructor tag: {tag}"),
+                ));
+            }
+        }
+    }
+}
+
+/// Build a `RENDER_DOC(value)` application thunk (the render entry point).
+fn build_render_doc(machine: &BytecodeMachine<'_>, value: BcValue) -> Result<BcValue, IoRunError> {
+    let idx = intrinsics::index("RENDER_DOC")
+        .ok_or_else(|| panic(machine, "RENDER_DOC intrinsic not found in registry"))?;
+    let render_global = machine.global_value(idx).map_err(IoRunError::from)?;
+    machine
+        .build_apply1(render_global, value)
+        .map_err(IoRunError::from)
+}
+
+/// Apply the initial world token (unit) to an IO function and re-run so the
+/// first IO constructor is produced and the machine yields. Returns `false` if
+/// the closure is not a function (a plain document value) or if injection did
+/// not result in an IO yield. Mirrors `io_run::inject_world_and_run`.
+pub fn inject_world_and_run(machine: &mut BytecodeMachine<'_>) -> Result<bool, IoRunError> {
+    let io_fn = machine.current();
+
+    // Only inject world if the current value is a function (arity > 0). Plain
+    // data values are rendered directly without world injection.
+    let arity = match &io_fn {
+        BcValue::Closure(c) => c.arity(),
+        BcValue::Native(_) => 0,
+    };
+    if arity == 0 {
+        return Ok(false);
+    }
+
+    let unit = machine.build_unit().map_err(IoRunError::from)?;
+    let apply_c = machine
+        .build_apply1(io_fn, unit)
+        .map_err(IoRunError::from)?;
+    machine.resume(apply_c);
+    machine.run(None).map_err(IoRunError::from)?;
+
+    Ok(machine.io_yielded())
+}
+
+/// Render the result of a headless evaluation that did not yield an IO
+/// constructor: build `RENDER_DOC(value)` and re-run. Mirrors
+/// `io_run::render_headless_result`.
+pub fn render_headless_result(machine: &mut BytecodeMachine<'_>) -> Result<Option<u8>, IoRunError> {
+    let value = machine.current();
+    let render_c = build_render_doc(machine, value)?;
+    machine.resume(render_c);
+    machine.run(None).map_err(IoRunError::from)
+}
+
+/// Run the IO monad interpret loop and render the final pure value. The main
+/// integration point called from `eval.rs`. Mirrors `io_run::io_run_and_render`.
+pub fn io_run_and_render(
+    machine: &mut BytecodeMachine<'_>,
+    allow_io: bool,
+) -> Result<Option<u8>, IoRunError> {
+    let final_value = io_run(machine, allow_io)?;
+    let render_c = build_render_doc(machine, final_value)?;
+    machine.resume(render_c);
+    machine.run(None).map_err(IoRunError::from)
+}
+
+/// Construct a boxed `Panic` `IoRunError` carrying the machine's annotation.
+fn panic(machine: &BytecodeMachine<'_>, msg: &str) -> IoRunError {
+    IoRunError::MachineError(Box::new(ExecutionError::Panic(
+        machine.annotation(),
+        msg.to_string(),
+    )))
+}

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -7,7 +7,8 @@ use crate::{
     core::{expr::*, typecheck::error::TypeWarning},
     driver::{
         error::EucalyptError,
-        io_run::{inject_world_and_run, io_run_and_render, render_headless_result, IoRunError},
+        io_common::IoRunError,
+        io_run::{inject_world_and_run, io_run_and_render, render_headless_result},
         options::{ErrorFormat, EucalyptOptions},
         source::SourceLoader,
     },
@@ -399,19 +400,15 @@ impl<'a> Executor<'a> {
             } else if crate::eval::bytecode::bytecode_enabled() {
                 // Experimental parallel bytecode engine (EU_BYTECODE=1).
                 //
-                // Pure programs only: recompile with a self-contained
-                // RenderDoc wrapper (the bytecode engine has no runtime code
-                // synthesis for the headless-render path) and run the
-                // BytecodeMachine. IO / world-injection is not yet ported;
-                // intrinsics still on the HeapSyn-typed ABI will panic and
-                // surface which ones the corpus needs.
-                let bc_settings = StgSettings {
-                    render_type: RenderType::RenderDoc,
-                    ..stg_settings.clone()
-                };
-                let bc_syn = stg::compile(&bc_settings, self.evaluand.clone(), rt.as_ref())?;
+                // Compile headless (like the HeapSyn path — `syn` above is
+                // already the headless compile) so IO constructors yield to the
+                // bytecode io-run driver rather than being consumed by a
+                // RENDER_DOC wrapper. After the first run the result is handled
+                // in three cases exactly as the HeapSyn path below: a direct IO
+                // yield, a terminated IO function (inject world), or a plain
+                // document (RENDER_DOC in place).
                 let globals = rt.globals();
-                let (prog, root, gforms) = crate::eval::bytecode::encode(&bc_syn, &globals);
+                let (prog, root, gforms) = crate::eval::bytecode::encode(&syn, &globals);
                 emitter.stream_start();
                 let heap_mib = stg_settings.heap_limit_mib.unwrap_or(0);
                 let mut m = crate::eval::bytecode::BytecodeMachine::new(
@@ -428,8 +425,47 @@ impl<'a> Executor<'a> {
                 stats
                     .timings_mut()
                     .record("bytecode-eval", t_exec.elapsed());
+
+                use crate::driver::bytecode_io_run::{
+                    inject_world_and_run, io_run_and_render, render_headless_result,
+                };
+                let result = if ret.is_ok() {
+                    if m.io_yielded() {
+                        let t_io = Instant::now();
+                        let io_result = io_run_and_render(&mut m, opt.allow_io)
+                            .map_err(io_run_error_to_execution);
+                        stats.timings_mut().record("io-run", t_io.elapsed());
+                        io_result
+                    } else {
+                        // Terminated without yielding: try world injection to
+                        // handle IO functions, else render as a plain document.
+                        let io_yielded =
+                            inject_world_and_run(&mut m).map_err(io_run_error_to_execution);
+                        match io_yielded {
+                            Ok(true) => {
+                                let t_io = Instant::now();
+                                let io_result = io_run_and_render(&mut m, opt.allow_io)
+                                    .map_err(io_run_error_to_execution);
+                                stats.timings_mut().record("io-run", t_io.elapsed());
+                                io_result
+                            }
+                            Ok(false) => {
+                                let t_render = Instant::now();
+                                let render_result = render_headless_result(&mut m)
+                                    .map_err(io_run_error_to_execution);
+                                stats
+                                    .timings_mut()
+                                    .record("bytecode-render", t_render.elapsed());
+                                render_result
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                } else {
+                    ret.map(|_| None)
+                };
                 m.take_emitter().stream_end();
-                ret
+                result
             } else {
                 emitter.stream_start();
                 let mut machine = standard_machine(&stg_settings, syn, emitter, rt.as_ref())?;

--- a/src/driver/io_common.rs
+++ b/src/driver/io_common.rs
@@ -1,0 +1,222 @@
+//! Representation-agnostic IO action execution.
+//!
+//! The shell / exec side of the IO monad driver: the action spec extracted
+//! from an `IoAction` spec block, its execution (`sh -c` / direct binary with
+//! stdin + timeout), the command result, and the driver error type. These are
+//! shared verbatim by both the HeapSyn io-run driver (`driver::io_run`) and
+//! the bytecode io-run driver (`driver::bytecode_io_run`) — only the heap
+//! navigation that *builds* an `ActionSpec` and consumes a `CommandResult`
+//! differs between the two engines.
+
+use std::{
+    io::Write as IoWrite,
+    process::{Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use crate::common::sourcemap::Smid;
+use crate::eval::error::ExecutionError;
+
+// ─── Public error type ────────────────────────────────────────────────────────
+
+/// Error from running the IO monad interpret loop.
+#[derive(Debug, thiserror::Error)]
+pub enum IoRunError {
+    #[error("io.fail: {0}")]
+    Fail(String),
+    #[error("IO operations are not permitted; use the --allow-io (-I) flag to enable")]
+    IoNotAllowed(Smid),
+    #[error("io.shell-with: command timed out after {0} seconds")]
+    Timeout(Smid, u64),
+    #[error("io.shell-with: command execution error: {0}")]
+    CommandError(Smid, String),
+    /// Boxed to keep the error variant size small (ExecutionError is large).
+    #[error("STG machine error: {0}")]
+    MachineError(Box<ExecutionError>),
+}
+
+impl From<ExecutionError> for IoRunError {
+    fn from(e: ExecutionError) -> Self {
+        IoRunError::MachineError(Box::new(e))
+    }
+}
+
+// ─── Command result ───────────────────────────────────────────────────────────
+
+/// The outcome of a shell command execution.
+#[derive(Debug)]
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i64,
+}
+
+// ─── Action spec (extracted from an IoAction spec block) ─────────────────────
+
+/// A parsed IO action, ready to execute. Built by each engine's driver from
+/// the evaluated spec block, then run by [`run_spec`].
+#[derive(Debug)]
+pub enum ActionSpec {
+    Shell {
+        cmd: String,
+        stdin: Option<String>,
+        timeout_secs: u64,
+    },
+    Exec {
+        cmd: String,
+        args: Vec<String>,
+        stdin: Option<String>,
+        timeout_secs: u64,
+    },
+}
+
+// ─── Shell execution ──────────────────────────────────────────────────────────
+
+/// Execute a shell command via the platform shell.
+///
+/// On Unix, uses `sh -c`. On Windows, uses `pwsh -NoProfile -Command`
+/// (PowerShell Core). Shell command strings are inherently
+/// platform-specific.
+fn execute_shell(
+    cmd: &str,
+    stdin_data: Option<&str>,
+    timeout_secs: u64,
+    call_smid: Smid,
+) -> Result<CommandResult, IoRunError> {
+    let command = if cfg!(windows) {
+        let mut c = Command::new("pwsh");
+        c.args(["-NoProfile", "-Command", cmd]);
+        c
+    } else {
+        let mut c = Command::new("sh");
+        c.args(["-c", cmd]);
+        c
+    };
+    run_command(command, stdin_data, timeout_secs, call_smid)
+}
+
+/// Execute a binary directly.
+fn execute_exec(
+    cmd: &str,
+    args: &[String],
+    stdin_data: Option<&str>,
+    timeout_secs: u64,
+    call_smid: Smid,
+) -> Result<CommandResult, IoRunError> {
+    let mut command = Command::new(cmd);
+    command.args(args);
+    run_command(command, stdin_data, timeout_secs, call_smid)
+}
+
+/// Core helper: spawn the command, optionally write stdin, and wait with timeout.
+fn run_command(
+    mut command: Command,
+    stdin_data: Option<&str>,
+    timeout_secs: u64,
+    call_smid: Smid,
+) -> Result<CommandResult, IoRunError> {
+    command
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            // Spawn failure (e.g. binary not found) returns a result block
+            // rather than a hard error, matching shell conventions.
+            let exit_code = match e.kind() {
+                std::io::ErrorKind::NotFound => 127,
+                std::io::ErrorKind::PermissionDenied => 126,
+                _ => -1,
+            };
+            return Ok(CommandResult {
+                stdout: String::new(),
+                stderr: e.to_string(),
+                exit_code,
+            });
+        }
+    };
+
+    if let Some(input) = stdin_data {
+        if let Some(mut pipe) = child.stdin.take() {
+            pipe.write_all(input.as_bytes())
+                .map_err(|e| IoRunError::CommandError(call_smid, e.to_string()))?;
+            // Drop `pipe` to close stdin and signal EOF to the child
+        }
+    }
+
+    // Use a worker thread to implement timeout, since `wait_timeout` is not a
+    // project dependency.
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
+        Ok(Ok(output)) => {
+            let exit_code = output.status.code().unwrap_or(-1) as i64;
+            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            Ok(CommandResult {
+                stdout,
+                stderr,
+                exit_code,
+            })
+        }
+        Ok(Err(e)) => Err(IoRunError::CommandError(call_smid, e.to_string())),
+        Err(_timeout) => Err(IoRunError::Timeout(call_smid, timeout_secs)),
+    }
+}
+
+/// Whether IO tracing is enabled (cached from `EU_IO_TRACE` env var).
+static IO_TRACE: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| std::env::var("EU_IO_TRACE").is_ok());
+
+/// Dispatch an `ActionSpec` to the appropriate executor.
+pub fn run_spec(spec: &ActionSpec, call_smid: Smid) -> Result<CommandResult, IoRunError> {
+    if *IO_TRACE {
+        match spec {
+            ActionSpec::Shell { cmd, stdin, .. } => {
+                eprintln!(
+                    "IO TRACE: shell {cmd:?}{}",
+                    if stdin.is_some() { " (with stdin)" } else { "" }
+                );
+            }
+            ActionSpec::Exec {
+                cmd, args, stdin, ..
+            } => {
+                eprintln!(
+                    "IO TRACE: exec {cmd:?} {args:?}{}",
+                    if stdin.is_some() { " (with stdin)" } else { "" }
+                );
+            }
+        }
+    }
+    let result = match spec {
+        ActionSpec::Shell {
+            cmd,
+            stdin,
+            timeout_secs,
+        } => execute_shell(cmd, stdin.as_deref(), *timeout_secs, call_smid),
+        ActionSpec::Exec {
+            cmd,
+            args,
+            stdin,
+            timeout_secs,
+        } => execute_exec(cmd, args, stdin.as_deref(), *timeout_secs, call_smid),
+    };
+    if *IO_TRACE {
+        match &result {
+            Ok(r) => eprintln!("IO TRACE: → exit {}", r.exit_code),
+            Err(e) => eprintln!("IO TRACE: → error: {e}"),
+        }
+    }
+    result
+}

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -10,14 +10,7 @@
 //! `io_run_and_render` is called from `eval.rs` after `machine.run()` when
 //! `machine.io_yielded()` is true.
 
-use std::{
-    collections::HashMap,
-    io::Write as IoWrite,
-    process::{Command, Stdio},
-    sync::mpsc,
-    thread,
-    time::Duration,
-};
+use std::collections::HashMap;
 
 use crate::common::sourcemap::Smid;
 use crate::eval::machine::env::EnvFrame;
@@ -36,56 +29,10 @@ use crate::eval::{
     stg::{render_to_string::extract_scalar_string, tags::DataConstructor},
 };
 
-// ─── Public error type ────────────────────────────────────────────────────────
-
-/// Error from running the IO monad interpret loop
-#[derive(Debug, thiserror::Error)]
-pub enum IoRunError {
-    #[error("io.fail: {0}")]
-    Fail(String),
-    #[error("IO operations are not permitted; use the --allow-io (-I) flag to enable")]
-    IoNotAllowed(Smid),
-    #[error("io.shell-with: command timed out after {0} seconds")]
-    Timeout(Smid, u64),
-    #[error("io.shell-with: command execution error: {0}")]
-    CommandError(Smid, String),
-    /// Boxed to keep the error variant size small (ExecutionError is large).
-    #[error("STG machine error: {0}")]
-    MachineError(Box<ExecutionError>),
-}
-
-impl From<ExecutionError> for IoRunError {
-    fn from(e: ExecutionError) -> Self {
-        IoRunError::MachineError(Box::new(e))
-    }
-}
-
-// ─── Command result ───────────────────────────────────────────────────────────
-
-/// The outcome of a shell command execution
-#[derive(Debug)]
-struct CommandResult {
-    stdout: String,
-    stderr: String,
-    exit_code: i64,
-}
-
-// ─── Action spec (extracted from IoAction spec block) ────────────────────────
-
-#[derive(Debug)]
-enum ActionSpec {
-    Shell {
-        cmd: String,
-        stdin: Option<String>,
-        timeout_secs: u64,
-    },
-    Exec {
-        cmd: String,
-        args: Vec<String>,
-        stdin: Option<String>,
-        timeout_secs: u64,
-    },
-}
+// The shell / exec execution side (the action spec, its execution, the command
+// result, and the driver error type) is representation-agnostic and shared with
+// the bytecode io-run driver.
+use crate::driver::io_common::{run_spec, ActionSpec, IoRunError};
 
 // ─── Heap navigation helpers ──────────────────────────────────────────────────
 
@@ -1055,155 +1002,6 @@ impl Mutator for BuildRenderDoc {
             .as_ptr();
         Ok(SynClosure::new(app_syn, env))
     }
-}
-
-// ─── Shell execution ──────────────────────────────────────────────────────────
-
-/// Execute a shell command via the platform shell.
-///
-/// On Unix, uses `sh -c`. On Windows, uses `pwsh -NoProfile -Command`
-/// (PowerShell Core). Shell command strings are inherently
-/// platform-specific.
-fn execute_shell(
-    cmd: &str,
-    stdin_data: Option<&str>,
-    timeout_secs: u64,
-    call_smid: Smid,
-) -> Result<CommandResult, IoRunError> {
-    let command = if cfg!(windows) {
-        let mut c = Command::new("pwsh");
-        c.args(["-NoProfile", "-Command", cmd]);
-        c
-    } else {
-        let mut c = Command::new("sh");
-        c.args(["-c", cmd]);
-        c
-    };
-    run_command(command, stdin_data, timeout_secs, call_smid)
-}
-
-/// Execute a binary directly.
-fn execute_exec(
-    cmd: &str,
-    args: &[String],
-    stdin_data: Option<&str>,
-    timeout_secs: u64,
-    call_smid: Smid,
-) -> Result<CommandResult, IoRunError> {
-    let mut command = Command::new(cmd);
-    command.args(args);
-    run_command(command, stdin_data, timeout_secs, call_smid)
-}
-
-/// Core helper: spawn the command, optionally write stdin, and wait with timeout.
-fn run_command(
-    mut command: Command,
-    stdin_data: Option<&str>,
-    timeout_secs: u64,
-    call_smid: Smid,
-) -> Result<CommandResult, IoRunError> {
-    command
-        .stdin(if stdin_data.is_some() {
-            Stdio::piped()
-        } else {
-            Stdio::null()
-        })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(e) => {
-            // Spawn failure (e.g. binary not found) returns a result block
-            // rather than a hard error, matching shell conventions.
-            let exit_code = match e.kind() {
-                std::io::ErrorKind::NotFound => 127,
-                std::io::ErrorKind::PermissionDenied => 126,
-                _ => -1,
-            };
-            return Ok(CommandResult {
-                stdout: String::new(),
-                stderr: e.to_string(),
-                exit_code,
-            });
-        }
-    };
-
-    if let Some(input) = stdin_data {
-        if let Some(mut pipe) = child.stdin.take() {
-            pipe.write_all(input.as_bytes())
-                .map_err(|e| IoRunError::CommandError(call_smid, e.to_string()))?;
-            // Drop `pipe` to close stdin and signal EOF to the child
-        }
-    }
-
-    // Use a worker thread to implement timeout, since `wait_timeout` is not a
-    // project dependency.
-    let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
-
-    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
-        Ok(Ok(output)) => {
-            let exit_code = output.status.code().unwrap_or(-1) as i64;
-            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-            Ok(CommandResult {
-                stdout,
-                stderr,
-                exit_code,
-            })
-        }
-        Ok(Err(e)) => Err(IoRunError::CommandError(call_smid, e.to_string())),
-        Err(_timeout) => Err(IoRunError::Timeout(call_smid, timeout_secs)),
-    }
-}
-
-/// Whether IO tracing is enabled (cached from `EU_IO_TRACE` env var).
-static IO_TRACE: std::sync::LazyLock<bool> =
-    std::sync::LazyLock::new(|| std::env::var("EU_IO_TRACE").is_ok());
-
-/// Dispatch an `ActionSpec` to the appropriate executor.
-fn run_spec(spec: &ActionSpec, call_smid: Smid) -> Result<CommandResult, IoRunError> {
-    if *IO_TRACE {
-        match spec {
-            ActionSpec::Shell { cmd, stdin, .. } => {
-                eprintln!(
-                    "IO TRACE: shell {cmd:?}{}",
-                    if stdin.is_some() { " (with stdin)" } else { "" }
-                );
-            }
-            ActionSpec::Exec {
-                cmd, args, stdin, ..
-            } => {
-                eprintln!(
-                    "IO TRACE: exec {cmd:?} {args:?}{}",
-                    if stdin.is_some() { " (with stdin)" } else { "" }
-                );
-            }
-        }
-    }
-    let result = match spec {
-        ActionSpec::Shell {
-            cmd,
-            stdin,
-            timeout_secs,
-        } => execute_shell(cmd, stdin.as_deref(), *timeout_secs, call_smid),
-        ActionSpec::Exec {
-            cmd,
-            args,
-            stdin,
-            timeout_secs,
-        } => execute_exec(cmd, args, stdin.as_deref(), *timeout_secs, call_smid),
-    };
-    if *IO_TRACE {
-        match &result {
-            Ok(r) => eprintln!("IO TRACE: → exit {}", r.exit_code),
-            Err(e) => eprintln!("IO TRACE: → error: {e}"),
-        }
-    }
-    result
 }
 
 // ─── Error message extraction ─────────────────────────────────────────────────

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
+pub mod bytecode_io_run;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod check;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod doc;
@@ -8,6 +10,8 @@ pub mod eval;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod format;
 pub mod io;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod io_common;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod io_run;
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/eval/bytecode/encode.rs
+++ b/src/eval/bytecode/encode.rs
@@ -437,6 +437,8 @@ pub fn encode(
     // pre-encoded once here; runtime construction allocates only the GC-heap
     // env frame over the fixed code, so there is no per-call arena growth.
     //
+    // `apply1_template`: `App(L0, [L1])` — a lazy `f(a)` thunk (io-run driver).
+    let apply1_template = enc.encode_node(&dsl::app(dsl::lref(0), vec![dsl::lref(1)]));
     // `apply2_template`: `App(L0, [L1, L2])` — a lazy `f(a0, a1)` thunk.
     let apply2_template =
         enc.encode_node(&dsl::app(dsl::lref(0), vec![dsl::lref(1), dsl::lref(2)]));
@@ -471,6 +473,7 @@ pub fn encode(
         blackhole,
         meta_template,
         pap,
+        apply1_template,
         apply2_template,
         producer_tail_template,
     };

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -1788,6 +1788,685 @@ impl<'a> BytecodeMachine<'a> {
     }
 }
 
+// ── io-run driver support (spec §6; eu-lka7) ────────────────────────────────
+//
+// The public surface the bytecode io-run driver (`driver::bytecode_io_run`)
+// needs to drive the IO monad: yield inspection, GC-safe stashing, re-entry,
+// re-entrant WHNF sub-evaluation, and the data-synthesis / navigation helpers
+// that build IO result values and read IO action spec blocks. This mirrors the
+// HeapSyn `Machine` surface used by `driver::io_run` (`vm.rs`), one method per
+// analogue, kept in a single additive block to localise the addition.
+impl BytecodeMachine<'_> {
+    /// Whether the machine has yielded on an IO constructor at the top.
+    pub fn io_yielded(&self) -> bool {
+        self.state.yielded_io
+    }
+
+    /// The current source annotation (stamped onto IO errors).
+    pub fn annotation(&self) -> Smid {
+        self.state.annotation
+    }
+
+    /// The current machine value (a clone; GC roots stay in the state).
+    pub fn current(&self) -> BcValue {
+        self.state.current.clone()
+    }
+
+    /// The empty root environment frame.
+    pub fn root_env(&self) -> RefPtr<BcEnvFrame> {
+        self.state.root_env
+    }
+
+    /// Intern a symbol into the machine's pool, returning its id.
+    pub fn intern_symbol(&mut self, s: &str) -> SymbolId {
+        self.symbol_pool.intern(s)
+    }
+
+    /// Push a value onto the GC-visible stash (a root across `run`/WHNF calls).
+    pub fn stash_push(&mut self, value: BcValue) {
+        self.state.stash.push(value);
+    }
+
+    /// Pop the top stashed value.
+    pub fn stash_pop(&mut self) -> BcValue {
+        self.state
+            .stash
+            .pop()
+            .expect("bytecode io-run stash underflow")
+    }
+
+    /// Peek a stashed value `depth` slots from the top (0 = top).
+    pub fn stash_peek(&self, depth: usize) -> BcValue {
+        let len = self.state.stash.len();
+        self.state.stash[len - 1 - depth].clone()
+    }
+
+    /// Resume execution with a new value after an IO yield: clear the
+    /// terminated / yielded flags and re-seat `current` (mirrors `vm.rs`
+    /// `resume`). A subsequent `run` drives from the new value.
+    pub fn resume(&mut self, value: BcValue) {
+        self.state.terminated = false;
+        self.state.yielded_io = false;
+        self.state.current = value;
+    }
+
+    /// The IO constructor tag the machine yielded on, or `None` if it has not
+    /// yielded on an IO constructor.
+    pub fn yielded_io_tag(&self) -> Option<Tag> {
+        if !self.state.yielded_io {
+            return None;
+        }
+        let c = self.state.current.as_closure()?;
+        decode_cons(&self.program, c).map(|(tag, _)| tag)
+    }
+
+    /// Resolve the argument values of the IO constructor the machine yielded
+    /// on, in declaration order. `None` if it has not yielded on one.
+    pub fn yielded_io_args(&self) -> Option<Vec<BcValue>> {
+        if !self.state.yielded_io {
+            return None;
+        }
+        let view = MutatorHeapView::new(&self.heap);
+        let c = *self.state.current.as_closure()?;
+        let (_, offsets) = decode_cons(&self.program, &c)?;
+        let code = self.program.code.as_slice();
+        let mut out = Vec::with_capacity(offsets.len());
+        for off in offsets {
+            let dref = arg_ref(code, off).ok()?;
+            let v = resolve_ref(
+                view,
+                &self.state.constants,
+                c.env(),
+                self.state.globals,
+                dref,
+            )
+            .ok()?;
+            out.push(v);
+        }
+        Some(out)
+    }
+
+    /// Evaluate `value` to WHNF on a fresh continuation stack, then restore the
+    /// IO yield state so the driver sees a consistent post-yield machine
+    /// (mirrors `vm.rs` `evaluate_to_whnf_for_io`). Errors if the
+    /// sub-evaluation itself yields an IO constructor (spec fields are pure).
+    pub fn evaluate_to_whnf_for_io(&mut self, value: BcValue) -> Result<BcValue, ExecutionError> {
+        // Suspend the caller's (empty) stack and stash its current value so the
+        // collector traces both across the sub-run.
+        let saved_stack = std::mem::take(&mut self.state.stack);
+        self.state.suspended_stacks.push(saved_stack);
+        let saved_current = std::mem::replace(&mut self.state.current, value);
+        self.state.stash.push(saved_current);
+        self.state.terminated = false;
+        self.state.yielded_io = false;
+
+        let run_result = self.drive_whnf();
+
+        let saved_current = self
+            .state
+            .stash
+            .pop()
+            .expect("bytecode io whnf stash underflow");
+        let saved_stack = self
+            .state
+            .suspended_stacks
+            .pop()
+            .expect("bytecode io whnf suspended-stack underflow");
+
+        let sub_yielded = self.state.yielded_io;
+        let result = std::mem::replace(&mut self.state.current, saved_current);
+        // Restore the IO yield termination state unconditionally so the driver
+        // sees a consistent yield whether or not an error occurred.
+        self.state.terminated = true;
+        self.state.yielded_io = true;
+        self.state.stack = saved_stack;
+
+        run_result?;
+        if sub_yielded {
+            return Err(ExecutionError::Panic(
+                self.state.annotation,
+                "bytecode: IO spec field evaluation unexpectedly yielded an IO constructor"
+                    .to_string(),
+            ));
+        }
+        Ok(result)
+    }
+
+    /// The re-entrant dispatch loop for `evaluate_to_whnf_for_io`: drives
+    /// `dispatch` (which runs the deferred `Bif` tail + capture lifecycle)
+    /// until the sub-evaluation terminates. Mirrors `run`'s loop body.
+    fn drive_whnf(&mut self) -> Result<(), ExecutionError> {
+        self.clock.switch(ThreadOccupation::Mutator);
+        let gc_check_freq: u32 = 500;
+        let mut gc_countdown: u32 = gc_check_freq;
+        while !self.state.terminated {
+            gc_countdown -= 1;
+            if gc_countdown == 0 {
+                gc_countdown = gc_check_freq;
+                if interrupted() {
+                    return Err(ExecutionError::Interrupted);
+                }
+                if self.heap.policy_requires_collection() {
+                    gc_collect(
+                        &mut self.state,
+                        &mut self.heap,
+                        &mut self.clock,
+                        self.dump_heap,
+                    );
+                    self.clock.switch(ThreadOccupation::Mutator);
+                }
+            }
+            self.dispatch()?;
+        }
+        Ok(())
+    }
+
+    /// Statically peel an `IoAction` spec block, mirroring `io_run::peel_meta`.
+    ///
+    /// The spec block produced by `io.shell`/`io.exec`/`io.fail` is a
+    /// `let`-bound `Meta(tag, block-thunk)` value whose field refs are relative
+    /// to the **let frame** (the container), while the `Meta` closure's own env
+    /// is the enclosing scope. Forcing the `Meta` naively resolves its body ref
+    /// against the wrong (own) env — grabbing an enclosing binding rather than
+    /// the block — so we follow `OP_ATOM` indirections tracking the container
+    /// frame, and when we reach a `Meta` resolve its body ref against that
+    /// container, yielding the block-thunk closure (whose own env is correct
+    /// for its interior refs). For parameterised (App-thunk) spec blocks
+    /// (`io.shell-with`, `io.exec-with`) no static `Meta` is visible; the spec
+    /// is returned unchanged and forcing it evaluates the application to the
+    /// block directly (the machine strips the `Meta` as nothing consumes it).
+    pub fn peel_io_spec(&self, spec: BcValue) -> BcValue {
+        let view = MutatorHeapView::new(&self.heap);
+        let code = self.program.code.as_slice();
+        let mut current = spec;
+        let mut container: Option<RefPtr<BcEnvFrame>> = None;
+        for _ in 0..64 {
+            let c = match &current {
+                BcValue::Closure(c) => *c,
+                BcValue::Native(_) => break,
+            };
+            let mut pc = c.code() as usize;
+            match Op::from_u8(read_u8(code, &mut pc)) {
+                Some(Op::Atom) => {
+                    let Ok(dref) = read_ref(code, &mut pc) else {
+                        break;
+                    };
+                    match dref {
+                        DecodedRef::Local(i) => {
+                            let env = c.env();
+                            match view.scoped(env).get(&view, i as usize) {
+                                Some(inner) => {
+                                    container = Some(env);
+                                    current = inner;
+                                }
+                                None => break,
+                            }
+                        }
+                        DecodedRef::Global(i) => {
+                            match view.scoped(self.state.globals).get(&view, i as usize) {
+                                Some(inner) => current = inner,
+                                None => break,
+                            }
+                        }
+                        DecodedRef::Value(_) => break,
+                    }
+                }
+                Some(Op::Ann) => {
+                    // Source annotation: transparent to spec navigation.
+                    let _smid = read_u32(code, &mut pc);
+                    let body_off = read_u32(code, &mut pc);
+                    current = BcValue::Closure(BcClosure::new(body_off, c.env()));
+                }
+                Some(Op::Meta) => {
+                    let _meta_off = read_u32(code, &mut pc);
+                    let body_off = read_u32(code, &mut pc);
+                    let Ok(body_ref) = arg_ref(code, body_off) else {
+                        break;
+                    };
+                    // Resolve the body against the container frame (the let
+                    // frame that holds this Meta binding), falling back to the
+                    // Meta's own env when reached without an indirection.
+                    let env = container.unwrap_or_else(|| c.env());
+                    match resolve_ref(
+                        view,
+                        &self.state.constants,
+                        env,
+                        self.state.globals,
+                        body_ref,
+                    ) {
+                        Ok(body) => return body,
+                        Err(_) => break,
+                    }
+                }
+                _ => break,
+            }
+        }
+        current
+    }
+
+    // ── Data synthesis (pre-encoded templates; no per-call code alloc) ──────
+
+    /// Build a data-constructor value of `tag` over `fields` using the
+    /// pre-encoded constructor template (mirrors `BcBifContext::build_data`).
+    pub fn build_data(&self, tag: Tag, fields: &[BcValue]) -> Result<BcValue, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        let code = self
+            .program
+            .templates
+            .get(tag as usize)
+            .copied()
+            .ok_or_else(|| {
+                ExecutionError::Panic(
+                    self.state.annotation,
+                    format!("bytecode: no constructor template for tag {tag}"),
+                )
+            })?;
+        let env = if fields.is_empty() {
+            self.state.root_env
+        } else {
+            view.from_values(
+                fields.iter().cloned(),
+                fields.len(),
+                self.state.root_env,
+                self.state.annotation,
+            )?
+        };
+        Ok(BcValue::Closure(BcClosure::new(code, env)))
+    }
+
+    /// Build a lazy `f(arg)` application thunk via the `apply1` template.
+    pub fn build_apply1(&self, f: BcValue, arg: BcValue) -> Result<BcValue, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        let env = view.from_values(
+            [f, arg].into_iter(),
+            2,
+            self.state.root_env,
+            self.state.annotation,
+        )?;
+        Ok(BcValue::Closure(BcClosure::new(
+            self.program.apply1_template,
+            env,
+        )))
+    }
+
+    /// Build a lazy `f(a0, a1)` application thunk via the `apply2` template.
+    pub fn build_apply2(
+        &self,
+        f: BcValue,
+        a0: BcValue,
+        a1: BcValue,
+    ) -> Result<BcValue, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        let env = view.from_values(
+            [f, a0, a1].into_iter(),
+            3,
+            self.state.root_env,
+            self.state.annotation,
+        )?;
+        Ok(BcValue::Closure(BcClosure::new(
+            self.program.apply2_template,
+            env,
+        )))
+    }
+
+    /// The zero-field `Unit` constructor value (the initial world token).
+    pub fn build_unit(&self) -> Result<BcValue, ExecutionError> {
+        self.build_data(DataConstructor::Unit.tag(), &[])
+    }
+
+    /// Resolve a global slot to its runtime value (e.g. the `RENDER_DOC`
+    /// intrinsic wrapper closure) so it can be applied as an ordinary callable.
+    pub fn global_value(&self, index: usize) -> Result<BcValue, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        view.scoped(self.state.globals)
+            .get(&view, index)
+            .ok_or(ExecutionError::BadGlobalIndex(index))
+    }
+
+    /// Build the shell result block `{stdout: Str, stderr: Str, exit-code: Num}`
+    /// on the heap (mirrors `io_run::BuildResultBlock`). Strings are wrapped in
+    /// `BoxedString` and the exit code in `BoxedNumber` so eucalypt intrinsics
+    /// that case-match those tags receive them in the expected form.
+    pub fn build_io_result_block(
+        &mut self,
+        stdout: &str,
+        stderr: &str,
+        exit_code: i64,
+    ) -> Result<BcValue, ExecutionError> {
+        let stdout_sym = self.symbol_pool.intern("stdout");
+        let stderr_sym = self.symbol_pool.intern("stderr");
+        let exitcode_sym = self.symbol_pool.intern("exit-code");
+
+        let view = MutatorHeapView::new(&self.heap);
+        let stdout_ptr = view.alloc(HeapString::from_str(&view, stdout))?.as_ptr();
+        let stderr_ptr = view.alloc(HeapString::from_str(&view, stderr))?.as_ptr();
+
+        let stdout_box = self.build_data(
+            DataConstructor::BoxedString.tag(),
+            &[BcValue::Native(Native::Str(stdout_ptr))],
+        )?;
+        let stderr_box = self.build_data(
+            DataConstructor::BoxedString.tag(),
+            &[BcValue::Native(Native::Str(stderr_ptr))],
+        )?;
+        let exit_box = self.build_data(
+            DataConstructor::BoxedNumber.tag(),
+            &[BcValue::Native(Native::Num(Number::from(exit_code)))],
+        )?;
+
+        // Three BlockPair(key-sym, value) entries.
+        let pair0 = self.build_data(
+            DataConstructor::BlockPair.tag(),
+            &[BcValue::Native(Native::Sym(stdout_sym)), stdout_box],
+        )?;
+        let pair1 = self.build_data(
+            DataConstructor::BlockPair.tag(),
+            &[BcValue::Native(Native::Sym(stderr_sym)), stderr_box],
+        )?;
+        let pair2 = self.build_data(
+            DataConstructor::BlockPair.tag(),
+            &[BcValue::Native(Native::Sym(exitcode_sym)), exit_box],
+        )?;
+
+        // Cons list, tail-first: nil → [pair2] → [pair1] → [pair0].
+        let nil = self.build_data(DataConstructor::ListNil.tag(), &[])?;
+        let c2 = self.build_data(DataConstructor::ListCons.tag(), &[pair2, nil])?;
+        let c1 = self.build_data(DataConstructor::ListCons.tag(), &[pair1, c2])?;
+        let c0 = self.build_data(DataConstructor::ListCons.tag(), &[pair0, c1])?;
+
+        // Block { entry-list, no-index } — the index arg is ignored on lookup.
+        let no_index = BcValue::Native(Native::Num(Number::from(0)));
+        self.build_data(DataConstructor::Block.tag(), &[c0, no_index])
+    }
+
+    /// Build `IoReturn(world, value)` to resume the io-run loop.
+    pub fn build_io_return(
+        &self,
+        world: BcValue,
+        value: BcValue,
+    ) -> Result<BcValue, ExecutionError> {
+        self.build_data(DataConstructor::IoReturn.tag(), &[world, value])
+    }
+
+    // ── Navigation of forced IO values (read-only) ─────────────────────────
+
+    /// If `value` is a WHNF scalar (native, boxed scalar, unit, bool), extract
+    /// its string form (mirrors `render_to_string::extract_scalar_string` over
+    /// `BcValue`). `None` for complex values (blocks, lists) or non-scalars.
+    pub fn whnf_scalar_string(&self, value: &BcValue) -> Option<String> {
+        let view = MutatorHeapView::new(&self.heap);
+        self.scalar_string_inner(view, value)
+    }
+
+    fn scalar_string_inner(&self, view: MutatorHeapView<'_>, value: &BcValue) -> Option<String> {
+        match value {
+            BcValue::Native(n) => scalar_from_native(&self.symbol_pool, view, n),
+            BcValue::Closure(c) => {
+                let code = self.program.code.as_slice();
+                let mut pc = c.code() as usize;
+                match Op::from_u8(read_u8(code, &mut pc)) {
+                    Some(Op::Atom) => {
+                        let dref = read_ref(code, &mut pc).ok()?;
+                        let inner = resolve_ref(
+                            view,
+                            &self.state.constants,
+                            c.env(),
+                            self.state.globals,
+                            dref,
+                        )
+                        .ok()?;
+                        self.scalar_string_inner(view, &inner)
+                    }
+                    Some(Op::Cons) => {
+                        let tag = read_u8(code, &mut pc);
+                        let dc = DataConstructor::try_from(tag).ok()?;
+                        match dc {
+                            DataConstructor::Unit => Some(String::new()),
+                            DataConstructor::BoolTrue => Some("true".to_string()),
+                            DataConstructor::BoolFalse => Some("false".to_string()),
+                            DataConstructor::BoxedNumber
+                            | DataConstructor::BoxedString
+                            | DataConstructor::BoxedSymbol
+                            | DataConstructor::BoxedZdt => {
+                                let offsets = read_arg_offsets(code, &mut pc);
+                                let field_ref = arg_ref(code, *offsets.first()?).ok()?;
+                                let inner = resolve_ref(
+                                    view,
+                                    &self.state.constants,
+                                    c.env(),
+                                    self.state.globals,
+                                    field_ref,
+                                )
+                                .ok()?;
+                                self.scalar_string_inner(view, &inner)
+                            }
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Whether `value` is a list (`ListCons`/`ListNil`) constructor.
+    pub fn value_is_list(&self, value: &BcValue) -> bool {
+        let BcValue::Closure(c) = value else {
+            return false;
+        };
+        match decode_cons(&self.program, c) {
+            Some((tag, _)) => {
+                tag == DataConstructor::ListCons.tag() || tag == DataConstructor::ListNil.tag()
+            }
+            None => false,
+        }
+    }
+
+    /// Collect the raw (unevaluated) element values of a `ListCons` chain.
+    /// Mirrors `io_run::CollectListElements`.
+    pub fn list_element_values(&self, value: &BcValue) -> Result<Vec<BcValue>, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        let code = self.program.code.as_slice();
+        let mut out = Vec::new();
+        let mut current = value.clone();
+        while let BcValue::Closure(c) = current.clone() {
+            let Some((tag, offsets)) = decode_cons(&self.program, &c) else {
+                break;
+            };
+            if tag == DataConstructor::ListNil.tag() {
+                break;
+            }
+            if tag != DataConstructor::ListCons.tag() {
+                break;
+            }
+            let head_ref = arg_ref(
+                code,
+                *offsets.first().ok_or_else(|| {
+                    ExecutionError::Panic(self.state.annotation, "malformed list cons".to_string())
+                })?,
+            )?;
+            let head = resolve_ref(
+                view,
+                &self.state.constants,
+                c.env(),
+                self.state.globals,
+                head_ref,
+            )?;
+            out.push(head);
+            let tail_ref = arg_ref(
+                code,
+                *offsets.get(1).ok_or_else(|| {
+                    ExecutionError::Panic(self.state.annotation, "malformed list cons".to_string())
+                })?,
+            )?;
+            current = resolve_ref(
+                view,
+                &self.state.constants,
+                c.env(),
+                self.state.globals,
+                tail_ref,
+            )?;
+        }
+        Ok(out)
+    }
+
+    /// If `value` is a boxed scalar whose inner field is still an unevaluated
+    /// closure (e.g. `BoxedString` wrapping a format-expr thunk), return the
+    /// inner value so the driver can force it. `None` if already a native or
+    /// not a box. Mirrors `io_run::peel_box_inner`.
+    pub fn peel_box_inner(&self, value: &BcValue) -> Option<BcValue> {
+        let view = MutatorHeapView::new(&self.heap);
+        let BcValue::Closure(c) = value else {
+            return None;
+        };
+        let (tag, offsets) = decode_cons(&self.program, c)?;
+        let is_box = tag == DataConstructor::BoxedString.tag()
+            || tag == DataConstructor::BoxedNumber.tag()
+            || tag == DataConstructor::BoxedSymbol.tag()
+            || tag == DataConstructor::BoxedZdt.tag();
+        if !is_box {
+            return None;
+        }
+        let field_ref = arg_ref(self.program.code.as_slice(), *offsets.first()?).ok()?;
+        let inner = resolve_ref(
+            view,
+            &self.state.constants,
+            c.env(),
+            self.state.globals,
+            field_ref,
+        )
+        .ok()?;
+        // Only re-force closures; a native is already fully evaluated.
+        match inner {
+            BcValue::Closure(_) => Some(inner),
+            BcValue::Native(_) => None,
+        }
+    }
+
+    /// Read the raw (unevaluated) field values of an evaluated IO spec block,
+    /// keyed by symbol-key name. Mirrors `io_run::collect_raw_block_fields`;
+    /// keys that are not readable symbols are skipped.
+    pub fn block_field_values(
+        &self,
+        block: &BcValue,
+    ) -> Result<Vec<(String, BcValue)>, ExecutionError> {
+        let view = MutatorHeapView::new(&self.heap);
+        let code = self.program.code.as_slice();
+        let BcValue::Closure(bc) = block else {
+            return Err(ExecutionError::Panic(
+                self.state.annotation,
+                "bytecode: IO spec block is not a block value".to_string(),
+            ));
+        };
+        let (btag, boffs) = decode_cons(&self.program, bc).ok_or_else(|| {
+            ExecutionError::Panic(
+                self.state.annotation,
+                "bytecode: IO spec block did not evaluate to a Block constructor".to_string(),
+            )
+        })?;
+        if btag != DataConstructor::Block.tag() {
+            return Err(ExecutionError::Panic(
+                self.state.annotation,
+                "bytecode: IO spec block did not evaluate to a Block constructor".to_string(),
+            ));
+        }
+        let list_ref = arg_ref(
+            code,
+            *boffs.first().ok_or_else(|| {
+                ExecutionError::Panic(self.state.annotation, "malformed Block".to_string())
+            })?,
+        )?;
+        let mut current = resolve_ref(
+            view,
+            &self.state.constants,
+            bc.env(),
+            self.state.globals,
+            list_ref,
+        )?;
+
+        let mut fields = Vec::new();
+        while let BcValue::Closure(c) = current.clone() {
+            let Some((tag, offs)) = decode_cons(&self.program, &c) else {
+                break;
+            };
+            if tag == DataConstructor::ListNil.tag() {
+                break;
+            }
+            if tag != DataConstructor::ListCons.tag() {
+                break;
+            }
+            let head_ref = arg_ref(
+                code,
+                *offs.first().ok_or_else(|| {
+                    ExecutionError::Panic(self.state.annotation, "malformed list cons".to_string())
+                })?,
+            )?;
+            let head = resolve_ref(
+                view,
+                &self.state.constants,
+                c.env(),
+                self.state.globals,
+                head_ref,
+            )?;
+            if let BcValue::Closure(pc) = &head {
+                if let Some((ptag, poffs)) = decode_cons(&self.program, pc) {
+                    if ptag == DataConstructor::BlockPair.tag() && poffs.len() >= 2 {
+                        let key_ref = arg_ref(code, poffs[0])?;
+                        let key = resolve_ref(
+                            view,
+                            &self.state.constants,
+                            pc.env(),
+                            self.state.globals,
+                            key_ref,
+                        )?;
+                        if let Some(sym) = value_symbol(&self.program, &self.state, view, key) {
+                            let val_ref = arg_ref(code, poffs[1])?;
+                            let val = resolve_ref(
+                                view,
+                                &self.state.constants,
+                                pc.env(),
+                                self.state.globals,
+                                val_ref,
+                            )?;
+                            fields.push((self.symbol_pool.resolve(sym).to_string(), val));
+                        }
+                    }
+                }
+            }
+            let tail_ref = arg_ref(
+                code,
+                *offs.get(1).ok_or_else(|| {
+                    ExecutionError::Panic(self.state.annotation, "malformed list cons".to_string())
+                })?,
+            )?;
+            current = resolve_ref(
+                view,
+                &self.state.constants,
+                c.env(),
+                self.state.globals,
+                tail_ref,
+            )?;
+        }
+        Ok(fields)
+    }
+}
+
+/// Convert a native value to its string representation (bytecode analogue of
+/// `render_to_string::scalar_from_native`).
+fn scalar_from_native(
+    pool: &SymbolPool,
+    view: MutatorHeapView<'_>,
+    native: &Native,
+) -> Option<String> {
+    match native {
+        Native::Num(n) => Some(n.to_string()),
+        Native::Str(s) => Some((*view.scoped(*s)).as_str().to_string()),
+        Native::Sym(id) => Some(pool.resolve(*id).to_string()),
+        Native::Zdt(dt) => Some(dt.to_string()),
+        _ => None,
+    }
+}
+
 /// The `IntrinsicMachine` implementation for the bytecode engine (spec §5.5).
 ///
 /// It overrides the neutral, code-type-agnostic ABI methods to operate over

--- a/src/eval/bytecode/program.rs
+++ b/src/eval/bytecode/program.rs
@@ -50,10 +50,18 @@ pub struct BytecodeProgram {
     /// closure that resumes a partially-applied function (spec §6.1 / the
     /// `pap_syn` analogue). Use `pap_offset` to index.
     pub pap: Vec<CodeRef>,
+    /// Fixed-shape apply-one template: an `App(L0, [L1])` node. A runtime
+    /// `f(a)` application thunk is a `BcClosure(apply1_template, env{f, a})` —
+    /// used by the io-run driver to apply the world token to an IO action, the
+    /// unit token to an IO function, and the `RENDER_DOC` global to the final
+    /// value, all with no per-call arena growth (the env frame is GC-heap
+    /// allocated).
+    pub apply1_template: CodeRef,
     /// Fixed-shape apply-two template: an `App(L0, [L1, L2])` node. A runtime
     /// `f(a0, a1)` application thunk is a `BcClosure(apply2_template, env{f,
     /// a0, a1})` — used by `MERGEWITH` to combine colliding block values with
-    /// no per-call arena growth (the env frame is GC-heap allocated).
+    /// no per-call arena growth (the env frame is GC-heap allocated), and by
+    /// the io-run driver to apply an IO continuation to (result, world).
     pub apply2_template: CodeRef,
     /// Fixed-shape producer-tail template: an `AppBif(PRODUCER_NEXT, [L0])`
     /// node. The `PRODUCER_NEXT` tail thunk is an updatable

--- a/tests/bytecode_io_differential_test.rs
+++ b/tests/bytecode_io_differential_test.rs
@@ -1,0 +1,81 @@
+//! Differential tests for the bytecode IO driver (eu-lka7).
+//!
+//! Runs IO programs through the full driver twice — once on the default
+//! HeapSyn engine and once on the parallel bytecode engine (`EU_BYTECODE=1`) —
+//! and asserts the rendered output agrees. This exercises the ported io-run /
+//! world-injection loop end to end (io.return, io.shell, io.exec, io.bind
+//! sequencing, and the parameterised shell-with spec block).
+
+use std::path::Path;
+use std::process::Command;
+
+/// Path to the `eu` binary built by cargo for this test run.
+fn eu_binary() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_eu"))
+}
+
+/// Run `eu -I -e <expr>` on the given engine, returning `(stdout, exit_code)`.
+/// `bytecode` selects the parallel engine via `EU_BYTECODE=1`.
+fn run(expr: &str, bytecode: bool) -> (String, Option<i32>) {
+    let mut cmd = Command::new(eu_binary());
+    cmd.arg("-I")
+        .arg("--heap-limit-mib")
+        .arg("2048")
+        .arg("-e")
+        .arg(expr);
+    if bytecode {
+        cmd.env("EU_BYTECODE", "1");
+    } else {
+        cmd.env_remove("EU_BYTECODE");
+    }
+    let output = cmd.output().expect("failed to run eu binary");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        output.status.code(),
+    )
+}
+
+/// Assert the two engines render byte-identical stdout and share an exit code.
+fn assert_engines_agree(expr: &str) {
+    let (heap_out, heap_code) = run(expr, false);
+    let (bc_out, bc_code) = run(expr, true);
+    assert_eq!(
+        heap_out, bc_out,
+        "engines disagree on stdout for {expr:?}\n HeapSyn: {heap_out:?}\n bytecode: {bc_out:?}"
+    );
+    assert_eq!(
+        heap_code, bc_code,
+        "engines disagree on exit code for {expr:?}"
+    );
+}
+
+#[test]
+fn io_return_agrees() {
+    assert_engines_agree("io.return({ result: :ok, n: 42 })");
+}
+
+#[test]
+fn io_shell_agrees() {
+    assert_engines_agree("io.shell(\"echo hello\")");
+}
+
+#[test]
+fn io_exec_agrees() {
+    assert_engines_agree("io.exec([\"echo\", \"a\", \"b\"])");
+}
+
+#[test]
+fn io_bind_chain_agrees() {
+    // io.bind sequences two shell actions, threading the first result into the
+    // continuation that decides the final document.
+    assert_engines_agree(
+        "io.bind(io.shell(\"echo hello\"), \
+         check) where check(r): io.return({ matched: r.stdout str.matches?(\"hello.*\") })",
+    );
+}
+
+#[test]
+fn io_shell_with_stdin_agrees() {
+    // Parameterised (App-thunk) spec block with an options block (stdin).
+    assert_engines_agree("io.shell-with({ stdin: \"piped\\n\" }, \"cat\")");
+}


### PR DESCRIPTION
## Summary

Wires the **IO / world-injection loop into the bytecode driver** so IO programs run under `EU_BYTECODE=1` (bead **eu-lka7**, one of the eu-enyv blockers). A faithful mirror of the HeapSyn io-run driver over the bytecode machine's existing yield / re-enter / GC infrastructure.

## What was ported

- **`driver/io_common.rs`** — extracts the representation-agnostic shell/exec executor (`ActionSpec`, `CommandResult`, `IoRunError`, `run_spec`, `execute_shell`/`exec`/`run_command`) shared verbatim by both the HeapSyn (`io_run`) and bytecode (`bytecode_io_run`) drivers. No duplication.
- **`driver/bytecode_io_run.rs`** — new driver mirroring `io_run`'s `IoReturn` / `IoFail` / `IoAction` / `IoBind` loop, spec-block evaluation, world injection and `RENDER_DOC` render, over `BcValue` instead of HeapSyn `SynClosure`. Same control flow and GC-stash discipline.
- **`driver/eval.rs`** — the bytecode branch now compiles **headless** (drops the `RenderDoc` wrapper) like the HeapSyn path, then drives: direct IO yield → io-run loop; terminated IO function → inject world + re-run; plain document → `RENDER_DOC` in place.
- **`eval/bytecode/machine.rs`** — a single additive `impl BytecodeMachine` block exposing the io-run API: yield inspection (`io_yielded`/`yielded_io_tag`/`yielded_io_args`), GC stash, `resume`, `evaluate_to_whnf_for_io`, data synthesis via constructor templates (result block, `IoReturn`, unit), `apply1`/`apply2` builders, and read-only spec-block navigation (`peel_io_spec`, `block_field_values`, `whnf_scalar_string`, list/box helpers).
- **`eval/bytecode/{program,encode}.rs`** — one new fixed `apply1_template = App(L0,[L1])`, following the established `apply2_template`/`producer_tail_template` pattern.

## STEP-1 finding & the one wrinkle

As reported at checkpoint, this is a **faithful algorithmic mirror** — the bytecode machine already had the yield/re-enter/stash/suspended-stack GC infrastructure. The one thing deeper than the plan anticipated: the IO spec block is a **`let`-bound `Meta`** whose field refs are relative to the *let frame* (the container), not the `Meta` closure's own env. Forcing it naively grabs the wrong binding (the `cmd` string instead of the block). HeapSyn's `io_run` handles this with container-env tracking in `peel_meta`; `BytecodeMachine::peel_io_spec` mirrors that — resolving the block body against the container frame before forcing. The tag (`io-shell`/`io-exec`/`io-fail`) is inferred from the evaluated field set (disjoint signatures) since the `Meta` symbol is stripped during forcing; documented as a deliberate deviation.

## Results / gates

- **Bytecode harness: 32/477 → 18/477 failing.** The 14 fixed are the IO corpus (io_opts 104,105,106,116,117,118,119,121 + IO error 072,094,124,125,168). The **remaining 18 are all pre-existing `test_error_*` diagnostic tests** (bytecode error message/location differences), unrelated to IO.
- **No regressions:** `cargo test --lib` 1252 green; HeapSyn-default `harness_test` **477** green (HeapSyn behaviour untouched).
- **`EU_GC_VERIFY=2 EU_GC_STRESS=1`** clean on the IO paths (io_opts corpus + differential + direct io.shell/exec/bind programs).
- New **differential IO test** (`tests/bytecode_io_differential_test.rs`) asserts bytecode and HeapSyn agree on io.return / io.shell / io.exec / io.bind-chain / io.shell-with.
- `clippy --all-targets -D warnings` clean; `cargo fmt --all` clean.

Every `eu` invocation wrapped in `timeout` with a heap limit; verified on a clean release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee