### PR TITLE
fix(bytecode): BV1 — Traced env/stack traces + discriminated resolve_native + SeqBind annotation preservation (eu-v6c4, eu-0lvf)

### DIFF
--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -169,6 +169,73 @@ fn assert_engines_lookup_fail_agree(syntax: Rc<StgSyn>, bifs: Vec<Box<dyn StgInt
     }
 }
 
+/// Run `syntax` — which must raise a `NotValue` — through both engines and
+/// assert they agree on both the source `Smid` and the "found" context string.
+/// Regression guard for the bytecode diagnostic parity work (eu-v6c4 / eu-0lvf):
+/// RC2 gave the bytecode `resolve_native` the same closure classification as
+/// HeapSyn (a boolean, a block, …) instead of a garbled default, and the
+/// annotation must flow to the raised error identically on both engines.
+fn assert_engines_not_value_agree(
+    syntax: Rc<StgSyn>,
+    bifs: Vec<Box<dyn StgIntrinsic>>,
+    expected_context: &str,
+) {
+    use crate::eval::error::ExecutionError;
+
+    let mut rt = StandardRuntime::default();
+    for b in bifs {
+        rt.add(b);
+    }
+    rt.prepare(&mut SourceMap::default());
+    let settings = StgSettings::default();
+
+    let heap_err = {
+        let mut m = standard_machine(&settings, syntax.clone(), Box::new(NullEmitter), &rt)
+            .expect("build HeapSyn machine");
+        m.run(Some(1_000_000))
+            .expect_err("HeapSyn should raise NotValue")
+    };
+
+    // The bytecode error must be `Traced` (RC1 wraps raised errors with the
+    // env/stack annotation traces, as HeapSyn does) before we unwrap it.
+    let bc_err = {
+        let globals = rt.globals();
+        let (prog, root, gforms) = encode(&syntax, &globals);
+        let mut m = BytecodeMachine::new(
+            prog,
+            root,
+            &gforms,
+            rt.intrinsics(),
+            Box::new(NullEmitter),
+            0,
+            false,
+        )
+        .expect("build bytecode machine");
+        m.run(Some(1_000_000))
+            .expect_err("bytecode should raise NotValue")
+    };
+    assert!(
+        matches!(bc_err, ExecutionError::Traced(..)),
+        "bytecode error should be Traced (RC1), got {bc_err:?}"
+    );
+
+    fn unwrap_traced(e: &ExecutionError) -> &ExecutionError {
+        match e {
+            ExecutionError::Traced(inner, _, _) => unwrap_traced(inner),
+            other => other,
+        }
+    }
+
+    match (unwrap_traced(&heap_err), unwrap_traced(&bc_err)) {
+        (ExecutionError::NotValue(hs, hc), ExecutionError::NotValue(bs, bc)) => {
+            assert_eq!(hs, bs, "engines disagree on the NotValue source Smid");
+            assert_eq!(hc, bc, "engines disagree on the NotValue context string");
+            assert_eq!(bc, expected_context, "unexpected NotValue context");
+        }
+        _ => panic!("expected NotValue from both engines, got heap={heap_err:?} bc={bc_err:?}"),
+    }
+}
+
 mod tests {
     use super::*;
     use crate::eval::stg::arith::{Add, Lt};
@@ -235,6 +302,45 @@ mod tests {
         // let x = 5 in x -> 5
         let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
         assert_eq!(assert_engines_agree(syn, vec![]), Some(5));
+    }
+
+    #[test]
+    fn agree_on_not_value_boolean() {
+        // Ann(S, __STR(true)) — passing a boolean to an intrinsic that resolves
+        // its argument to a native. Both engines must classify the boolean
+        // identically ("a boolean (true)", not the pre-fix garbled "expected a
+        // native value") and carry the enclosing annotation `S` on the raised
+        // NotValue. Regresses eu-v6c4 RC2 (resolve_native classification).
+        use crate::common::sourcemap::Smid;
+        use crate::eval::stg::string::Str;
+        let str_idx = crate::eval::intrinsics::index_u8("STR");
+        let smid = Smid::from(4242);
+        let syn = dsl::letrec_(
+            vec![dsl::value(dsl::data(
+                DataConstructor::BoolTrue.tag(),
+                vec![],
+            ))],
+            dsl::ann(smid, dsl::app_bif(str_idx, vec![dsl::lref(0)])),
+        );
+        assert_engines_not_value_agree(syn, vec![Box::new(Str)], "a boolean (true)");
+    }
+
+    #[test]
+    fn agree_on_not_value_block() {
+        // Ann(S, __STR({})) — passing a block where a native is expected. Both
+        // engines classify it as "a block" and agree on the annotation `S`.
+        use crate::common::sourcemap::Smid;
+        use crate::eval::stg::string::Str;
+        let str_idx = crate::eval::intrinsics::index_u8("STR");
+        let smid = Smid::from(99);
+        let syn = dsl::letrec_(
+            vec![
+                dsl::value(dsl::nil()),               // 0: empty entry list
+                dsl::value(dsl::block(dsl::lref(0))), // 1: {} block
+            ],
+            dsl::ann(smid, dsl::app_bif(str_idx, vec![dsl::lref(1)])),
+        );
+        assert_engines_not_value_agree(syn, vec![Box::new(Str)], "a block");
     }
 
     #[test]

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -824,7 +824,16 @@ pub fn return_data(
             annotation,
         } => {
             state.current = BcValue::Closure(BcClosure::new(body, environment));
-            state.annotation = annotation;
+            // Only restore a meaningful annotation. A `force`/`Seq` in an outer
+            // context (e.g. the render loop) captures `Smid::default()` and must
+            // not wipe the live call-site annotation established by an inner
+            // `Ann` before a deferred arg-check BIF runs — mirrors the same
+            // invalid-annotation guard `handle_op` applies on closure entry.
+            // (HeapSyn avoids this by evaluation ordering, raising before the
+            // outer SeqBind is restored.)
+            if annotation.is_valid() {
+                state.annotation = annotation;
+            }
         }
         BcContinuation::LookupLitForce {
             key,
@@ -921,7 +930,16 @@ pub fn return_native(
         } => {
             // Force-and-discard: enter the body without binding the result.
             state.current = BcValue::Closure(BcClosure::new(body, environment));
-            state.annotation = annotation;
+            // Only restore a meaningful annotation. A `force`/`Seq` in an outer
+            // context (e.g. the render loop) captures `Smid::default()` and must
+            // not wipe the live call-site annotation established by an inner
+            // `Ann` before a deferred arg-check BIF runs — mirrors the same
+            // invalid-annotation guard `handle_op` applies on closure entry.
+            // (HeapSyn avoids this by evaluation ordering, raising before the
+            // outer SeqBind is restored.)
+            if annotation.is_valid() {
+                state.annotation = annotation;
+            }
         }
         BcContinuation::LookupLitForce { smid, .. } => {
             // A native is not a block — type error.
@@ -1026,7 +1044,16 @@ pub fn return_fun(
             annotation,
         } => {
             state.current = BcValue::Closure(BcClosure::new(body, environment));
-            state.annotation = annotation;
+            // Only restore a meaningful annotation. A `force`/`Seq` in an outer
+            // context (e.g. the render loop) captures `Smid::default()` and must
+            // not wipe the live call-site annotation established by an inner
+            // `Ann` before a deferred arg-check BIF runs — mirrors the same
+            // invalid-annotation guard `handle_op` applies on closure entry.
+            // (HeapSyn avoids this by evaluation ordering, raising before the
+            // outer SeqBind is restored.)
+            if annotation.is_valid() {
+                state.annotation = annotation;
+            }
         }
         BcContinuation::LookupLitForce { smid, .. } => {
             let ann = if smid.is_valid() {

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -104,22 +104,33 @@ pub fn resolve_ref(
     }
 }
 
-/// Resolve a native value directly (arg extractors), erroring if the ref
-/// does not resolve to a `Native`. Locals/globals that hold a native slot
-/// yield it; a `Value` const yields its native.
-pub fn resolve_native(
-    view: MutatorHeapView<'_>,
-    constants: &[Ref],
-    env: RefPtr<BcEnvFrame>,
-    globals: RefPtr<BcEnvFrame>,
-    dref: DecodedRef,
-) -> Result<Native, ExecutionError> {
-    match resolve_ref(view, constants, env, globals, dref)? {
-        BcValue::Native(n) => Ok(n),
-        BcValue::Closure(_) => Err(ExecutionError::NotValue(
-            Default::default(),
-            "expected a native value".to_string(),
-        )),
+/// Describe a non-native closure for a "not a value" error, mirroring the
+/// HeapSyn `HeapNavigator::resolve_native` discrimination (vm.rs): the head
+/// opcode names the shape, and a `Cons` opcode's tag distinguishes the data
+/// constructors (a boolean, a list, a block, …). `pc` must sit just past the
+/// opcode byte; for a `Cons` the tag byte that follows is read here. The
+/// returned string is the `context` passed to `format_not_value` (error.rs).
+fn not_value_description(op: Option<Op>, code: &[u8], pc: &mut usize) -> &'static str {
+    match op {
+        Some(Op::Cons) => match DataConstructor::try_from(read_u8(code, pc)) {
+            Ok(DataConstructor::BoolTrue) => "a boolean (true)",
+            Ok(DataConstructor::BoolFalse) => "a boolean (false)",
+            Ok(DataConstructor::ListCons) | Ok(DataConstructor::ListNil) => "a list",
+            Ok(DataConstructor::Block) => "a block",
+            _ => "a data constructor",
+        },
+        Some(Op::App) | Some(Op::DirectApp) => "a function application",
+        Some(Op::Bif) => "an intrinsic function call",
+        Some(Op::Case) => "a case expression",
+        Some(Op::Let) | Some(Op::LetRec) => "a let binding",
+        Some(Op::Meta) | Some(Op::DeMeta) => "a metadata expression",
+        Some(Op::Seq) => "a strict evaluation",
+        Some(Op::LookupLit) => "a lookup expression",
+        Some(Op::BlackHole) => "an uninitialised value (possible cycle)",
+        Some(Op::Ann) => "an annotated expression",
+        // `Atom` is followed transparently by the caller, so it should not
+        // reach here; treat any residual/unknown opcode as a bare atom.
+        Some(Op::Atom) | None => "an atom",
     }
 }
 
@@ -249,6 +260,67 @@ impl BcMachineState {
             suspended_stacks: Vec::new(),
         }
     }
+
+    /// Collect the annotation trace of the environment chain currently in
+    /// scope, for error diagnostics. Mirrors `MachineState::env_trace`
+    /// (vm.rs), which walks the environment of the closure being evaluated.
+    /// The current value is that closure while an op or BIF is executing; a
+    /// native `current` has no environment and yields an empty trace.
+    pub fn env_trace(&self, view: MutatorHeapView<'_>) -> Vec<Smid> {
+        match self.current.as_closure() {
+            Some(c) => view.scoped(c.env()).annotation_trace(&view),
+            None => Vec::new(),
+        }
+    }
+
+    /// Collect the annotation trace of the continuation stack (innermost
+    /// first, de-duplicating adjacent repeats), for error diagnostics.
+    /// Mirrors `MachineState::stack_trace` / `stack_trace_iter` (vm.rs) over
+    /// the `BcContinuation` variants: the case/apply/seq/lookup continuations
+    /// carry a source annotation directly; update/de-meta continuations
+    /// borrow their captured environment's annotation.
+    pub fn stack_trace(&self, view: MutatorHeapView<'_>) -> Vec<Smid> {
+        let capacity = self.stack.len().min(64);
+        let mut trace = Vec::with_capacity(capacity);
+        let mut prev = Smid::default();
+        for cont in self.stack.iter().rev() {
+            let smid = match cont {
+                BcContinuation::Branch { annotation, .. }
+                | BcContinuation::ApplyTo { annotation, .. }
+                | BcContinuation::SeqBind { annotation, .. } => *annotation,
+                BcContinuation::LookupLitForce { smid, .. } => *smid,
+                BcContinuation::Update { environment, .. }
+                | BcContinuation::DeMeta { environment, .. } => {
+                    view.scoped(*environment).annotation()
+                }
+                BcContinuation::CaptureEnd => Smid::default(),
+            };
+            if smid != Smid::default() && smid != prev {
+                prev = smid;
+                trace.push(smid);
+            }
+        }
+        trace
+    }
+}
+
+/// Wrap a raised machine error with the environment and continuation-stack
+/// annotation traces captured from the current state. Mirrors the HeapSyn
+/// `handle_instruction` / BIF `map_err` sites (vm.rs): building the traces
+/// here — before the Rust stack unwinds — captures the environment and
+/// continuation stack live at the raise point, so `to_diagnostic` can walk
+/// them to recover the user call site when the error's own Smid is synthetic
+/// or points into the prelude. As on the HeapSyn side, the wrap is
+/// unconditional (a nested sub-evaluation error may be wrapped twice; the
+/// outer traces then win in `to_diagnostic`, matching HeapSyn).
+fn attach_trace(
+    state: &BcMachineState,
+    view: MutatorHeapView<'_>,
+    e: ExecutionError,
+) -> ExecutionError {
+    let env_trace = state.env_trace(view);
+    let stack_trace = state.stack_trace(view);
+    ExecutionError::Traced(Box::new(e), env_trace, stack_trace)
 }
 
 /// Mark the heap pointers embedded in a prepared constant (`Ref::V(native)`).
@@ -1672,7 +1744,11 @@ impl<'a> BytecodeMachine<'a> {
         self.metrics.tick();
         {
             let view = MutatorHeapView::new(&self.heap);
-            step(&mut self.state, view, &self.program)?;
+            // Mirror the HeapSyn `handle_instruction` map_err (vm.rs): attach
+            // the env/stack traces at the raise point before unwinding.
+            if let Err(e) = step(&mut self.state, view, &self.program) {
+                return Err(attach_trace(&self.state, view, e));
+            }
         }
 
         if let Some(idx) = self.state.pending_bif.take() {
@@ -1701,25 +1777,35 @@ impl<'a> BytecodeMachine<'a> {
             // nested `evaluate_to_whnf`. This mirrors the HeapSyn `bif_view`
             // aliasing in `vm.rs`.
             let view = unsafe { MutatorHeapView::from_raw_heap(&self.heap as *const Heap) };
-            let mut ctx = BcBifContext {
-                state: &mut self.state,
-                program: &self.program,
-                symbol_pool: &mut self.symbol_pool,
-                rcache: &mut self.rcache,
-                test_mode: self.test_mode,
-                env,
-                heap: &mut self.heap,
-                intrinsics: &self.intrinsics,
-                metrics: &mut self.metrics,
-                clock: &mut self.clock,
-                dump_heap: self.dump_heap,
+            // Scope `ctx`/`emitter` so their `&mut self` borrows are released
+            // before we build the error trace (which reborrows `self.state`).
+            let bif_result = {
+                let mut ctx = BcBifContext {
+                    state: &mut self.state,
+                    program: &self.program,
+                    symbol_pool: &mut self.symbol_pool,
+                    rcache: &mut self.rcache,
+                    test_mode: self.test_mode,
+                    env,
+                    heap: &mut self.heap,
+                    intrinsics: &self.intrinsics,
+                    metrics: &mut self.metrics,
+                    clock: &mut self.clock,
+                    dump_heap: self.dump_heap,
+                };
+                // Emit BIFs route to the active capture emitter, else the main one.
+                let emitter: &mut dyn Emitter = match self.capture_emitters.last_mut() {
+                    Some(capture) => capture,
+                    None => self.emitter.as_mut(),
+                };
+                bif.execute(&mut ctx, view, emitter, &args)
             };
-            // Emit BIFs route to the active capture emitter, else the main one.
-            let emitter: &mut dyn Emitter = match self.capture_emitters.last_mut() {
-                Some(capture) => capture,
-                None => self.emitter.as_mut(),
-            };
-            bif.execute(&mut ctx, view, emitter, &args)?;
+            // Mirror the HeapSyn BIF-result map_err (vm.rs): the Bif closure is
+            // still `current`, so its env yields the trace at the raise point.
+            if let Err(e) = bif_result {
+                let view = MutatorHeapView::new(&self.heap);
+                return Err(attach_trace(&self.state, view, e));
+            }
         }
 
         // Capture lifecycle (mirrors `Machine::step`, vm.rs). A `render-as`
@@ -2506,7 +2592,8 @@ impl BcBifContext<'_, '_> {
             BcValue::Closure(c) => {
                 let code = self.program.code.as_slice();
                 let mut pc = c.code() as usize;
-                if Op::from_u8(read_u8(code, &mut pc)) == Some(Op::Atom) {
+                let op = Op::from_u8(read_u8(code, &mut pc));
+                if op == Some(Op::Atom) {
                     let dref = read_ref(code, &mut pc)?;
                     let inner = resolve_ref(
                         view,
@@ -2517,9 +2604,16 @@ impl BcBifContext<'_, '_> {
                     )?;
                     self.native_from_value(view, inner)
                 } else {
+                    // Classify the non-native closure so the diagnostic names
+                    // what was found (a boolean, a list, a block, …). Mirrors
+                    // the HeapSyn `HeapNavigator::resolve_native` discrimination
+                    // (vm.rs): decode the head opcode, reading a `Cons` tag to
+                    // distinguish the data constructors. `pc` already sits just
+                    // past the opcode byte.
+                    let description = not_value_description(op, code, &mut pc);
                     Err(ExecutionError::NotValue(
                         self.state.annotation,
-                        "expected a native value".to_string(),
+                        description.to_string(),
                     ))
                 }
             }
@@ -2664,7 +2758,14 @@ impl BcBifContext<'_, '_> {
                 // dropped before any `&mut self.heap` use; this mirrors the
                 // HeapSyn `bif_view` aliasing (`vm.rs`).
                 let view = unsafe { MutatorHeapView::from_raw_heap(self.heap as *const Heap) };
-                step(self.state, view, self.program)?;
+                // Mirror the sub-evaluation step map_err (vm.rs
+                // `evaluate_to_whnf_impl`): wrap the step error with traces
+                // here. The nested BIF error (below) is left raw, matching the
+                // HeapSyn sub-evaluation loop — it is wrapped once at the outer
+                // BIF site when it unwinds.
+                if let Err(e) = step(self.state, view, self.program) {
+                    return Err(attach_trace(self.state, view, e));
+                }
             }
             if let Some(idx) = self.state.pending_bif.take() {
                 self.dispatch_pending_bif(idx, &mut null)?;


### PR DESCRIPTION
## Summary

Brings the bytecode engine's error-path diagnostics to parity with HeapSyn across the harness error tests. **`EU_BYTECODE=1 cargo test --test harness_test` is now 477/477** (was 470/477 — the 7 failing diagnostic tests error_105/108/131/132/134/149/150 are all fixed). Closes the last BV1 diagnostic blocker before the default-engine flip.

Three independent root causes, all in the bytecode engine (furnace domain). HeapSyn is untouched — the fixes mirror it.

### RC1 — Traced propagation (eu-v6c4)
The bytecode `run`/`drive_to_whnf` loops propagated raised errors without attaching env/stack annotation traces, so `to_diagnostic` could not recover a user call site when the error's own Smid was synthetic or pointed into the prelude. Added `BcMachineState::env_trace`/`stack_trace` (mirroring `MachineState`) and an `attach_trace` helper, wrapping the step + BIF sites in `dispatch` and the step site in `drive_to_whnf` (the nested-BIF site stays raw, mirroring HeapSyn's sub-evaluation loop). Fixes 105/108/131/132/150 + the location of 149.

### RC2 — resolve_native discrimination (eu-v6c4)
`native_from_value` raised `NotValue(default, "expected a native value")`, which `format_not_value` double-wrapped into the garbled "found expected a native value". Now classifies the non-native closure by its head opcode / `Cons` tag (a boolean, a list, a block, …), mirroring `HeapNavigator::resolve_native` (vm.rs), and carries `state.annotation`. Removed the dead free `resolve_native` superseded by the ABI method. Fixes 134's message and 149's message.

### eu-0lvf — SeqBind annotation preservation
The last gap (149, direct-intrinsic aliases like `str.of = __STR`): the error carried no source location. Pinned by runtime tracing — a `force`/`Seq` in an outer context (the render loop) captures `Smid::default()` in its `SeqBind`; when it completes, the unconditional `SeqBind` annotation restore wiped the live call-site annotation established by an inner `Ann`, moments before the deferred arg-check BIF raised. HeapSyn avoids this only by evaluation ordering (it raises before the outer SeqBind restores). Fix: guard the three `SeqBind` annotation restores with `is_valid()`, mirroring the same invalid-annotation guard `handle_op` already applies on closure entry in both engines. This also restored the source location for ~10 other error tests (021/041/080/083/084/089/090/115/141/142/143) that were silently losing it to the same clobber.

## Before / after (EU_BYTECODE=1)

| Test | Before | After |
|---|---|---|
| 105 base64 | no source span | span restored |
| 108 secondary-labels | prelude-only | user site + secondary labels + stack trace |
| 131 / 132 map/foldl | prelude-only | user call site |
| 134 bool>5 | garbled "found expected a native value" | "found a boolean" |
| 149 str.of(f) | garbled msg + no span | msg + span byte-identical to HeapSyn |
| 150 bad-timezone | no source span | span restored |

For 149 the primary diagnostic (message, help, location, span) is now byte-identical to HeapSyn; the trailing stack-trace frame differs in framing, as bytecode traces already do for the RC1-era fixes (an inherent continuation-model difference, not asserted by the harness).

## Tests / gates
- **Bytecode harness `EU_BYTECODE=1 cargo test --test harness_test`: 477/477**
- HeapSyn harness: 477/477 (engine untouched)
- lib: 1255 passed (+2 new differential tests: `agree_on_not_value_boolean`, `agree_on_not_value_block` — assert both engines agree on the `NotValue` Smid + context and that the bytecode error is `Traced`)
- `clippy --all-targets -D warnings` clean; `cargo fmt` clean
- `EU_GC_VERIFY=2 EU_GC_STRESS=1` on the fixed cases: no GC issues (trace vectors allocate at error time — verified)

Beads: eu-v6c4 (RC1+RC2), eu-0lvf (SeqBind). Owner review please — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee