### PR TITLE
feat(bytecode): BV1 — make bytecode the default engine, HeapSyn behind EU_HEAPSYN (eu-enyv)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ The project includes a sophisticated garbage collector:
 | `EU_STACK_DIAG=1` | Log continuation stack composition to stderr whenever a new max stack depth is reached. |
 | `EU_ERROR_TRACE_DUMP=1` | Dump full env trace and stack trace Smid details as diagnostic notes on every execution error. Useful for debugging which source locations are available at error time. |
 | `EU_IO_TRACE=1` | Trace all `io.shell` and `io.exec` commands to stderr before execution. Shows the command string and whether stdin is piped. |
+| `EU_HEAPSYN=1` | Select the legacy HeapSyn tree-walk engine instead of the default bytecode engine (BV1). Retained as the performance baseline and differential-testing engine; Phase 4 collapse is deferred pending an A/B perf study. |
+| `EU_BYTECODE=1` | Now redundant — the bytecode engine is the default. Still accepted as an explicit opt-in; `EU_HEAPSYN=1` takes precedence over it. |
 
 The crash signal handler (SIGSEGV/SIGBUS diagnostics) is always active and has no environment variable — it installs unconditionally in `main()`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -229,7 +229,11 @@ that the cost lives in code materialisation, dispatch and env-walk. Therefore:
   tables (annotation dispatch), superinstructions (hot patterns), and
   serialisability (the startup win). Estimated 3–10× on dispatch-bound code and a
   large drop in GC load, keeping the Immix GC, all intrinsics, the emitter, the
-  error machinery and the `EU_*` tooling.
+  error machinery and the `EU_*` tooling. **Status (BV1, eu-enyv):** the bytecode
+  engine is now the **default**; the legacy HeapSyn tree-walk machine is retained
+  behind `EU_HEAPSYN=1` as the perf baseline and differential-testing engine. The
+  Phase 4 collapse (deleting HeapSyn + retiring `GcScannable`) is deferred pending
+  an A/B perf study.
 - **Demand- and type-directed compilation rides on it** (Pillar CG): the bytecode is
   the substrate the smarter codegen emits into.
 - **The speculative generational-GC rebuild is shelved** (§10), to be revisited only

--- a/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
+++ b/docs/superpowers/plans/2026-07-01-bv1-bytecode-vm.md
@@ -2,7 +2,16 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a deep translation of intricate existing code, not greenfield — where a step says "translate `vm.rs:NNN-MMM`", read that arm and port its semantics; the differential harness (Phase 2) is the exact correctness gate for every such translation.
 
-> ## ▶ RESUME HERE (cold-start header — read this first) · updated 2026-07-02 (post-#941)
+> ## ▶ RESUME HERE (cold-start header — read this first) · updated 2026-07-03 (post-#948, eu-enyv flip)
+>
+> **eu-enyv (BV1 default flip):** the bytecode engine is now the **default**.
+> `bytecode_enabled()` (`src/eval/bytecode/mod.rs`) returns `true` unless
+> `EU_HEAPSYN=1` selects the legacy HeapSyn machine. `EU_BYTECODE=1` is now a
+> redundant no-op opt-in (kept working; `EU_HEAPSYN=1` wins). HeapSyn is **not**
+> deleted — the Phase 4 collapse (eu-oufc) stays deferred pending an A/B perf
+> study; HeapSyn remains the perf baseline + differential-testing engine. Full
+> harness green both ways: `cargo test --test harness_test` (bytecode default) =
+> 477/477; `EU_HEAPSYN=1 cargo test --test harness_test` = 477/477.
 >
 > **Where:** worktree `/Users/greg/dev/curvelogic/eucalypt-worktrees/integration-0.12.0`,
 > integration branch `integration/0.12.0`. **Toolchain:** prepend

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -398,7 +398,8 @@ impl<'a> Executor<'a> {
                 println!("{}", prettify::prettify(&*syn));
                 Ok(None)
             } else if crate::eval::bytecode::bytecode_enabled() {
-                // Experimental parallel bytecode engine (EU_BYTECODE=1).
+                // Default bytecode engine (BV1). HeapSyn is selected instead
+                // via the EU_HEAPSYN=1 opt-out — see `bytecode_enabled`.
                 //
                 // Compile headless (like the HeapSyn path — `syn` above is
                 // already the headless compile) so IO constructors yield to the

--- a/src/eval/bytecode/mod.rs
+++ b/src/eval/bytecode/mod.rs
@@ -30,8 +30,22 @@ pub use machine::*;
 #[cfg(test)]
 mod differential;
 
-/// Whether the experimental bytecode engine is selected for this run
-/// (`EU_BYTECODE=1`). Wired into `driver/eval.rs` for pure programs.
+/// Whether the bytecode engine is selected for this run. Wired into
+/// `driver/eval.rs` for pure programs.
+///
+/// As of BV1 (eu-enyv) the bytecode engine is the **default**. Set
+/// `EU_HEAPSYN=1` to opt out and select the legacy HeapSyn machine, which is
+/// retained as the performance baseline and differential-testing engine
+/// (Phase 4 collapse is deferred pending an A/B perf study).
+///
+/// `EU_BYTECODE=1` is still accepted as a now-redundant explicit opt-in so
+/// existing invocations keep working; `EU_HEAPSYN=1` takes precedence over it.
 pub fn bytecode_enabled() -> bool {
-    std::env::var("EU_BYTECODE").as_deref() == Ok("1")
+    !heapsyn_enabled()
+}
+
+/// Whether the legacy HeapSyn engine has been explicitly requested via the
+/// `EU_HEAPSYN=1` opt-out.
+pub fn heapsyn_enabled() -> bool {
+    std::env::var("EU_HEAPSYN").as_deref() == Ok("1")
 }

--- a/tests/bytecode_io_differential_test.rs
+++ b/tests/bytecode_io_differential_test.rs
@@ -1,7 +1,7 @@
 //! Differential tests for the bytecode IO driver (eu-lka7).
 //!
-//! Runs IO programs through the full driver twice — once on the default
-//! HeapSyn engine and once on the parallel bytecode engine (`EU_BYTECODE=1`) —
+//! Runs IO programs through the full driver twice — once on the legacy
+//! HeapSyn engine (`EU_HEAPSYN=1`) and once on the default bytecode engine —
 //! and asserts the rendered output agrees. This exercises the ported io-run /
 //! world-injection loop end to end (io.return, io.shell, io.exec, io.bind
 //! sequencing, and the parameterised shell-with spec block).
@@ -15,7 +15,8 @@ fn eu_binary() -> &'static Path {
 }
 
 /// Run `eu -I -e <expr>` on the given engine, returning `(stdout, exit_code)`.
-/// `bytecode` selects the parallel engine via `EU_BYTECODE=1`.
+/// `bytecode` selects the default bytecode engine; otherwise the legacy
+/// HeapSyn engine is selected via `EU_HEAPSYN=1`.
 fn run(expr: &str, bytecode: bool) -> (String, Option<i32>) {
     let mut cmd = Command::new(eu_binary());
     cmd.arg("-I")
@@ -23,10 +24,13 @@ fn run(expr: &str, bytecode: bool) -> (String, Option<i32>) {
         .arg("2048")
         .arg("-e")
         .arg(expr);
+    // Select engines explicitly and defensively: clear the other engine's
+    // selector so an inherited env var cannot bleed across the two runs.
+    cmd.env_remove("EU_BYTECODE");
     if bytecode {
-        cmd.env("EU_BYTECODE", "1");
+        cmd.env_remove("EU_HEAPSYN");
     } else {
-        cmd.env_remove("EU_BYTECODE");
+        cmd.env("EU_HEAPSYN", "1");
     }
     let output = cmd.output().expect("failed to run eu binary");
     (


### PR DESCRIPTION
## Summary

Final step of BV1 (**eu-enyv**, on top of **eu-vi3a** and the #949 diagnostic-parity work): flip the default execution engine to the native bytecode machine. HeapSyn is **retained** and fully reachable via the `EU_HEAPSYN=1` opt-out as the performance baseline and differential-testing engine.

**Scope guard:** HeapSyn is NOT deleted. The Phase 4 collapse (eu-oufc — remove HeapSyn + retire `GcScannable`) stays deferred pending an A/B perf study. This PR only changes engine *selection*, not either engine.

## What changed

- `src/eval/bytecode/mod.rs`: `bytecode_enabled()` now returns `true` unless `EU_HEAPSYN=1` selects HeapSyn (new `heapsyn_enabled()` helper). `EU_BYTECODE=1` is kept as a now-redundant no-op opt-in; `EU_HEAPSYN=1` takes precedence over it, so existing invocations keep working.
- `src/driver/eval.rs`: updated the engine-dispatch comment.
- `tests/bytecode_io_differential_test.rs`: the reference direction now selects HeapSyn via `EU_HEAPSYN=1` (previously relied on the *absence* of `EU_BYTECODE`, which would now silently run bytecode on both sides). Both engines are still exercised.
- Docs: CLAUDE.md debug-env-vars table (added `EU_HEAPSYN=1`, noted `EU_BYTECODE` is now redundant), ROADMAP BV-pillar status, and the BV1 plan ledger (eu-enyv entry).

## How to select HeapSyn

`EU_HEAPSYN=1 eu <file>` runs the legacy tree-walk engine; plain `eu <file>` now runs bytecode.

## Verification (post-rebase onto #949, `4bfb18ea`)

Both-direction harness — the key gate:

- `cargo test --test harness_test` (no env, **bytecode default**): **477 passed, 0 failed**
- `EU_HEAPSYN=1 cargo test --test harness_test` (**HeapSyn**): **477 passed, 0 failed**

Other gates:

- `cargo test --lib`: **1255 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Byte-identical spot-check (default vs `EU_HEAPSYN=1`, real non-empty output hashes): 6/6 files agree (006_lists, 008_folds, 010_prelude, 015_block_fns, 018_metadata, 021_calls_and_lookups).
- `EU_GC_VERIFY=2 EU_GC_STRESS=1` sweep with **bytecode default** over 168 harness `.eu` files (`--heap-limit-mib 12288`, each wrapped in `timeout 90`): **0 GC diagnostics, 0 crashes**.

Refs eu-vi3a, eu-enyv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee