### PR TITLE
ci(bv1): run full harness on HeapSyn baseline via EU_HEAPSYN=1 (eu-jr74)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -116,6 +116,23 @@ jobs:
         env:
           EU_SOURCE_PRELUDE: "1"
 
+  test-heapsyn-baseline:
+    name: HeapSyn harness (baseline)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build release binary
+        run: cargo build --release
+      # Bytecode is the default engine post-flip (eu-enyv); the standard
+      # `test` job exercises it. HeapSyn is retained as the A/B perf baseline
+      # and differential engine, so run the full harness on it too (behind
+      # EU_HEAPSYN=1) to keep the baseline from silently rotting.
+      - name: Run harness on HeapSyn baseline engine
+        run: ./target/release/eu test --allow-io tests/harness
+        env:
+          EU_HEAPSYN: "1"
+
   test-aarch64-sequential:
     name: Sequential harness (aarch64 release)
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
## Why

After **eu-enyv** (#950) flipped the default engine to **bytecode**, `cargo test` and every existing harness job now exercise the bytecode engine. HeapSyn is *retained* as the A/B performance baseline and differential-testing engine (Phase 4 collapse deferred), but **no CI job ran the full 477-file harness on it any more** — so a HeapSyn regression would go silently uncaught.

Flagged by wicket in the #950 review. Part of the eu-vi3a fidelity work.

## What

Adds one job, `test-heapsyn-baseline` ("HeapSyn harness (baseline)"), mirroring the existing `test-source-prelude` harness job. It differs only by setting `EU_HEAPSYN=1` (the legacy-engine opt-out) instead of `EU_SOURCE_PRELUDE=1`:

```yaml
  test-heapsyn-baseline:
    name: HeapSyn harness (baseline)
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: dtolnay/rust-toolchain@stable
      - name: Build release binary
        run: cargo build --release
      - name: Run harness on HeapSyn baseline engine
        run: ./target/release/eu test --allow-io tests/harness
        env:
          EU_HEAPSYN: "1"
```

No engine or source code changes — CI config only. Result: the full harness now runs on **both** engines (bytecode by default in the standard jobs, HeapSyn in this new one).

## Local verification (aarch64)

- `EU_HEAPSYN=1 cargo test --test harness_test` → **477 passed; 0 failed**
- `EU_HEAPSYN=1 ./target/release/eu test --allow-io tests/harness` → exit 0, 0 FAIL
- `cargo test --lib` → 1255 passed; 0 failed
- `cargo fmt --all --check` → clean (no Rust changes)
- YAML parses; the new job appears in the jobs list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee