### PR TITLE
feat(bytecode): BV5 — embed pre-encoded BytecodeProgram in the prelude blob alongside ArenaStgSyn (eu-amp9)

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -408,8 +408,36 @@ impl<'a> Executor<'a> {
                 // in three cases exactly as the HeapSyn path below: a direct IO
                 // yield, a terminated IO function (inject world), or a plain
                 // document (RENDER_DOC in place).
-                let globals = rt.globals();
-                let (prog, root, gforms) = crate::eval::bytecode::encode(&syn, &globals);
+                // BV5 (eu-amp9): when the blob carries a pre-encoded prelude
+                // BytecodeProgram, run straight off it — append only the user
+                // program root and the per-invocation __args/__io override
+                // globals — instead of re-encoding every prelude and intrinsic
+                // global on this run. When absent (source-prelude fallback or a
+                // pre-BV5 blob), encode the whole program from STG as before.
+                #[cfg(not(target_arch = "wasm32"))]
+                let embedded = self.prelude_blob.as_ref().and_then(|b| b.bytecode.as_ref());
+                #[cfg(target_arch = "wasm32")]
+                let embedded: Option<
+                    &crate::eval::stg::blob::PreludeBytecodeImage,
+                > = None;
+
+                let (prog, root, gforms) = match embedded {
+                    Some(image) => {
+                        let mut gforms = image.global_forms.clone();
+                        let overrides = rt.prelude_global_overrides();
+                        let (prog, root) = crate::eval::bytecode::encode_overrides_and_root(
+                            &image.program,
+                            &overrides,
+                            &mut gforms,
+                            &syn,
+                        );
+                        (prog, root, gforms)
+                    }
+                    None => {
+                        let globals = rt.globals();
+                        crate::eval::bytecode::encode(&syn, &globals)
+                    }
+                };
                 emitter.stream_start();
                 let heap_mib = stg_settings.heap_limit_mib.unwrap_or(0);
                 let mut m = crate::eval::bytecode::BytecodeMachine::new(

--- a/src/eval/bytecode/encode.rs
+++ b/src/eval/bytecode/encode.rs
@@ -21,6 +21,8 @@
 
 use std::rc::Rc;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     common::sourcemap::Smid,
     eval::stg::{
@@ -33,7 +35,10 @@ use super::{opcode::*, program::BytecodeProgram, CodeRef};
 
 /// Encoded global form header: everything the machine needs to build a
 /// global closure — its kind, arity, source annotation and entry offset.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Derives `Serialize`/`Deserialize` so the prelude's global forms can be
+/// embedded in the blob alongside the pre-encoded `BytecodeProgram` (BV5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GlobalForm {
     pub kind: u8,
     pub arity: u8,
@@ -411,18 +416,25 @@ fn classify_lambda_form(lf: &LambdaForm) -> (u8, u8, Smid) {
     }
 }
 
-/// Encode a program root and its global lambda forms into one
-/// `BytecodeProgram`.
-///
-/// Returns `(program, root_offset, global_forms)`; `program.global_entries`
-/// is populated with each global's entry offset (spec §5). Globals are
-/// encoded before the root so their offsets are stable.
-pub fn encode(
-    root: &Rc<StgSyn>,
-    globals: &[LambdaForm],
-) -> (BytecodeProgram, CodeRef, Vec<GlobalForm>) {
-    let mut enc = Encoder::new();
+/// The fixed-shape templates and global entry table shared by every
+/// program built from a given set of globals. Emitted before any program
+/// root so their offsets are stable (spec §4.2 / §5.5).
+struct Fixtures {
+    templates: Vec<CodeRef>,
+    blackhole: CodeRef,
+    meta_template: CodeRef,
+    pap: Vec<CodeRef>,
+    apply1_template: CodeRef,
+    apply2_template: CodeRef,
+    producer_tail_template: CodeRef,
+    global_forms: Vec<GlobalForm>,
+}
 
+/// Emit the constructor/PAP/thunk templates and every global lambda-form
+/// body into `enc`, returning the resulting `Fixtures`. Shared by `encode`
+/// (which then appends a program root) and `encode_prelude` (which stops
+/// here, leaving a reusable pre-encoded prelude image).
+fn emit_fixtures_and_globals(enc: &mut Encoder, globals: &[LambdaForm]) -> Fixtures {
     // Constructor templates first, so their offsets sit at the low end of
     // the arena and are stable regardless of program size.
     let templates = enc.encode_templates();
@@ -463,12 +475,7 @@ pub fn encode(
         })
         .collect();
 
-    let root_off = enc.encode_node(root);
-
-    let program = BytecodeProgram {
-        code: enc.code,
-        constants: enc.constants,
-        global_entries: global_forms.iter().map(|f| f.entry).collect(),
+    Fixtures {
         templates,
         blackhole,
         meta_template,
@@ -476,8 +483,140 @@ pub fn encode(
         apply1_template,
         apply2_template,
         producer_tail_template,
+        global_forms,
+    }
+}
+
+/// Assemble a `BytecodeProgram` from an encoder's accumulated `code`/
+/// `constants` and the shared `Fixtures`.
+fn build_program(enc: Encoder, f: &Fixtures) -> BytecodeProgram {
+    BytecodeProgram {
+        code: enc.code,
+        constants: enc.constants,
+        global_entries: f.global_forms.iter().map(|g| g.entry).collect(),
+        templates: f.templates.clone(),
+        blackhole: f.blackhole,
+        meta_template: f.meta_template,
+        pap: f.pap.clone(),
+        apply1_template: f.apply1_template,
+        apply2_template: f.apply2_template,
+        producer_tail_template: f.producer_tail_template,
+    }
+}
+
+/// Encode a program root and its global lambda forms into one
+/// `BytecodeProgram`.
+///
+/// Returns `(program, root_offset, global_forms)`; `program.global_entries`
+/// is populated with each global's entry offset (spec §5). Globals are
+/// encoded before the root so their offsets are stable.
+pub fn encode(
+    root: &Rc<StgSyn>,
+    globals: &[LambdaForm],
+) -> (BytecodeProgram, CodeRef, Vec<GlobalForm>) {
+    let mut enc = Encoder::new();
+    let fixtures = emit_fixtures_and_globals(&mut enc, globals);
+    let root_off = enc.encode_node(root);
+    let program = build_program(enc, &fixtures);
+    (program, root_off, fixtures.global_forms)
+}
+
+/// Encode only the fixed templates and prelude global bodies — no program
+/// root — producing a reusable pre-encoded prelude image (BV5, eu-amp9).
+///
+/// The returned program's `code` ends immediately after the last global
+/// body, so a subsequent [`encode_root_onto`] appends the program root at
+/// exactly the offset `encode` would have used, yielding byte-identical
+/// output. Embedded in the prelude blob so the loader can run straight off
+/// serialised bytecode instead of re-encoding hundreds of prelude globals
+/// on every invocation.
+pub fn encode_prelude(globals: &[LambdaForm]) -> (BytecodeProgram, Vec<GlobalForm>) {
+    let mut enc = Encoder::new();
+    let fixtures = emit_fixtures_and_globals(&mut enc, globals);
+    let program = build_program(enc, &fixtures);
+    (program, fixtures.global_forms)
+}
+
+/// Append a program root to a pre-encoded prelude `base`, reusing its
+/// `code`/`constants` prefix unchanged, and return the extended program and
+/// the root's entry offset (BV5, eu-amp9).
+///
+/// Because every cross-reference is by global slot (`Ref::G`, resolved via
+/// the global entry table) or constant-pool index — never a raw byte offset
+/// into another global — appending the root leaves every existing offset
+/// valid and produces exactly what a full `encode(root, globals)` would.
+pub fn encode_root_onto(base: &BytecodeProgram, root: &Rc<StgSyn>) -> (BytecodeProgram, CodeRef) {
+    let mut enc = Encoder {
+        code: base.code.clone(),
+        constants: base.constants.clone(),
     };
-    (program, root_off, global_forms)
+    let root_off = enc.encode_node(root);
+    let program = BytecodeProgram {
+        code: enc.code,
+        constants: enc.constants,
+        global_entries: base.global_entries.clone(),
+        templates: base.templates.clone(),
+        blackhole: base.blackhole,
+        meta_template: base.meta_template,
+        pap: base.pap.clone(),
+        apply1_template: base.apply1_template,
+        apply2_template: base.apply2_template,
+        producer_tail_template: base.producer_tail_template,
+    };
+    (program, root_off)
+}
+
+/// Re-encode a set of override global forms and a program root onto a
+/// pre-encoded prelude `base` (BV5, eu-amp9).
+///
+/// The prelude blob bakes stale bodies for the `__args` / `__io` globals
+/// (their real values depend on the invocation). This mirrors the STG blob
+/// path's `set_prelude_slot_override`: each `(slot, form)` body is encoded
+/// afresh and its `global_entries[slot]` / `global_forms[slot]` patched to
+/// point at the new bytecode. The old (dead) bytecode remains in the buffer
+/// but is never referenced. Only these few globals plus the root are
+/// re-encoded — the hundreds of ordinary prelude/intrinsic globals are used
+/// straight from `base`.
+pub fn encode_overrides_and_root(
+    base: &BytecodeProgram,
+    overrides: &[(usize, LambdaForm)],
+    global_forms: &mut [GlobalForm],
+    root: &Rc<StgSyn>,
+) -> (BytecodeProgram, CodeRef) {
+    let mut enc = Encoder {
+        code: base.code.clone(),
+        constants: base.constants.clone(),
+    };
+    let mut global_entries = base.global_entries.clone();
+    for (slot, lf) in overrides {
+        let entry = enc.encode_node(lf.body());
+        let (kind, arity, smid) = classify_lambda_form(lf);
+        if let Some(e) = global_entries.get_mut(*slot) {
+            *e = entry;
+        }
+        if let Some(g) = global_forms.get_mut(*slot) {
+            *g = GlobalForm {
+                kind,
+                arity,
+                smid,
+                entry,
+            };
+        }
+    }
+    let root_off = enc.encode_node(root);
+    let program = BytecodeProgram {
+        code: enc.code,
+        constants: enc.constants,
+        global_entries,
+        templates: base.templates.clone(),
+        blackhole: base.blackhole,
+        meta_template: base.meta_template,
+        pap: base.pap.clone(),
+        apply1_template: base.apply1_template,
+        apply2_template: base.apply2_template,
+        producer_tail_template: base.producer_tail_template,
+    };
+    (program, root_off)
 }
 
 #[cfg(test)]

--- a/src/eval/bytecode/program.rs
+++ b/src/eval/bytecode/program.rs
@@ -6,6 +6,8 @@
 //! literals (strings, symbols) cannot live in the byte stream, so they are
 //! hoisted once into the constant pool and rooted for the run (spec §4.4).
 
+use serde::{Deserialize, Serialize};
+
 use crate::eval::{
     memory::{
         alloc::ScopedAllocator,
@@ -21,7 +23,13 @@ use super::CodeRef;
 
 /// A compiled bytecode program: a flat opcode stream plus the constant
 /// pool and per-global entry offsets it refers to.
-#[derive(Debug, Default)]
+///
+/// Derives `Serialize`/`Deserialize` (postcard) so the pre-encoded prelude
+/// program can be embedded in the prelude blob (BV5, eu-amp9). Every field
+/// is a plain `Vec<u8>`, `Vec<u32>`, `u32`, or `Vec<StgNative>` (whose
+/// `Number`s serialise via their decimal-string form), so no field needs
+/// special handling.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct BytecodeProgram {
     /// Flat opcode + inline-operand stream (non-GC).
     pub code: Vec<u8>,

--- a/src/eval/stg/blob.rs
+++ b/src/eval/stg/blob.rs
@@ -35,8 +35,30 @@ use serde::{Deserialize, Serialize};
 use crate::{
     core::{expr::RcExpr, typecheck::check::PreludeSummary},
     driver::unit_interface::OperatorInfo,
-    eval::stg::arena::{ArenaLambdaForm, ArenaStgSyn, FormIdx},
+    eval::{
+        bytecode::{BytecodeProgram, GlobalForm},
+        stg::arena::{ArenaLambdaForm, ArenaStgSyn, FormIdx},
+    },
 };
+
+// ── PreludeBytecodeImage ──────────────────────────────────────────────────────
+
+/// The pre-encoded prelude bytecode embedded in the blob (BV5, eu-amp9).
+///
+/// Holds the flat `BytecodeProgram` for the prelude (fixed templates plus
+/// every intrinsic-wrapper and prelude-binding global body — no program
+/// root) together with the parallel `global_forms` the machine needs to
+/// build the globals frame. The loader appends the user program root (and
+/// re-encodes the per-invocation `__args` / `__io` overrides) onto this
+/// image rather than re-encoding the whole prelude on every run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreludeBytecodeImage {
+    /// Pre-encoded prelude program: templates + all global bodies, no root.
+    pub program: BytecodeProgram,
+    /// Global forms (kind/arity/smid/entry) for every global slot, in slot
+    /// order (intrinsic wrappers `0..INTRINSIC_COUNT`, then prelude bindings).
+    pub global_forms: Vec<GlobalForm>,
+}
 
 // ── PreludeBlob ───────────────────────────────────────────────────────────────
 
@@ -106,6 +128,17 @@ pub struct PreludeBlob {
     /// `Var::Free` references resolve at compile time via `Ref::G`.
     #[serde(default)]
     pub inline_cores: Vec<(String, RcExpr)>,
+
+    /// Pre-encoded prelude BytecodeProgram + global forms (BV5, eu-amp9).
+    ///
+    /// Present alongside the STG arena form (`nodes` / `forms_pool`): the
+    /// HeapSyn engine loads the STG form, while the bytecode engine loads
+    /// this pre-encoded program directly instead of re-encoding the prelude
+    /// on every run. `Option` + `#[serde(default)]` so a blob generated
+    /// before BV5 (or one deliberately omitting it) deserialises to `None`
+    /// and the loader degrades gracefully to encode-from-STG.
+    #[serde(default)]
+    pub bytecode: Option<PreludeBytecodeImage>,
 }
 
 impl PreludeBlob {
@@ -138,6 +171,7 @@ mod tests {
             monad_specs: HashMap::new(),
             monad_type_hints: HashMap::new(),
             inline_cores: vec![],
+            bytecode: None,
         }
     }
 
@@ -238,6 +272,66 @@ mod tests {
         assert!(restored.monad_specs.is_empty());
         assert!(restored.monad_type_hints.is_empty());
         assert!(restored.inline_cores.is_empty());
+        // A blob generated before BV5 has no bytecode image; the loader must
+        // see `None` and degrade to encode-from-STG.
+        assert!(restored.bytecode.is_none());
+    }
+
+    #[test]
+    fn bytecode_image_round_trip() {
+        use crate::common::sourcemap::Smid;
+        use crate::eval::bytecode::GlobalForm;
+        use crate::eval::stg::syntax::Native;
+
+        let mut blob = minimal_blob();
+        // A small hand-built program with one constant and one global form.
+        let mut program = BytecodeProgram {
+            code: vec![1, 2, 3, 4, 5],
+            constants: vec![Native::Num(7.into()), Native::Sym("k".to_string())],
+            global_entries: vec![0, 3],
+            templates: vec![10, 11, 12],
+            blackhole: 4,
+            meta_template: 2,
+            ..Default::default()
+        };
+        program.pap = vec![13, 14];
+        program.apply1_template = 1;
+        program.apply2_template = 2;
+        program.producer_tail_template = 3;
+
+        blob.bytecode = Some(PreludeBytecodeImage {
+            program,
+            global_forms: vec![
+                GlobalForm {
+                    kind: 1,
+                    arity: 0,
+                    smid: Smid::default(),
+                    entry: 0,
+                },
+                GlobalForm {
+                    kind: 3,
+                    arity: 2,
+                    smid: Smid::default(),
+                    entry: 3,
+                },
+            ],
+        });
+
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+        let img = restored.bytecode.expect("bytecode image must round-trip");
+
+        assert_eq!(img.program.code, vec![1, 2, 3, 4, 5]);
+        assert_eq!(img.program.constants.len(), 2);
+        assert_eq!(img.program.constants[0], Native::Num(7.into()));
+        assert_eq!(img.program.global_entries, vec![0, 3]);
+        assert_eq!(img.program.templates, vec![10, 11, 12]);
+        assert_eq!(img.program.blackhole, 4);
+        assert_eq!(img.program.pap, vec![13, 14]);
+        assert_eq!(img.program.producer_tail_template, 3);
+        assert_eq!(img.global_forms.len(), 2);
+        assert_eq!(img.global_forms[1].arity, 2);
+        assert_eq!(img.global_forms[1].entry, 3);
     }
 
     #[test]
@@ -347,6 +441,88 @@ mod tests {
         assert!(
             result.is_err(),
             "corrupted bytes should produce a deserialisation error"
+        );
+    }
+
+    #[test]
+    #[cfg(prelude_blob_ok)]
+    fn embedded_bytecode_matches_fresh_encode() {
+        use crate::common::sourcemap::SourceMap;
+        use crate::eval::bytecode::encode;
+        use crate::eval::stg::runtime::Runtime;
+        use crate::eval::stg::{make_standard_runtime, syntax::dsl};
+
+        let bytes = crate::driver::resources::PRELUDE_BLOB_BYTES;
+        let blob = PreludeBlob::from_bytes(bytes).expect("embedded blob should deserialise");
+        let image = blob
+            .bytecode
+            .as_ref()
+            .expect("embedded blob must carry pre-encoded bytecode (BV5)");
+
+        // Rebuild the runtime globals exactly as the loader does, then encode
+        // a trivial root. The prelude image must be a byte-identical prefix.
+        let mut sm = SourceMap::new();
+        let mut rt = make_standard_runtime(&mut sm);
+        let mut names = vec![String::new(); blob.binding_entries.len()];
+        for (name, &slot) in &blob.name_to_slot {
+            if slot < names.len() {
+                names[slot] = name.clone();
+            }
+        }
+        rt.set_prelude_bindings(
+            blob.nodes.clone(),
+            blob.forms_pool.clone(),
+            blob.binding_entries.clone(),
+            names,
+        );
+        let globals = rt.globals();
+        let (fresh, _root, fresh_forms) = encode(&dsl::atom(dsl::num(0)), &globals);
+
+        assert_eq!(
+            image.global_forms, fresh_forms,
+            "embedded global_forms must match a fresh encode"
+        );
+        assert_eq!(
+            image.program.templates, fresh.templates,
+            "templates must survive the postcard round-trip"
+        );
+        assert_eq!(image.program.blackhole, fresh.blackhole, "blackhole");
+        assert_eq!(image.program.meta_template, fresh.meta_template, "meta");
+        assert_eq!(image.program.pap, fresh.pap, "pap templates");
+        assert_eq!(
+            image.program.apply1_template, fresh.apply1_template,
+            "apply1"
+        );
+        assert_eq!(
+            image.program.apply2_template, fresh.apply2_template,
+            "apply2"
+        );
+        assert_eq!(
+            image.program.producer_tail_template, fresh.producer_tail_template,
+            "producer tail"
+        );
+        assert_eq!(
+            image.program.global_entries,
+            fresh.global_entries[..image.program.global_entries.len()],
+            "global entry table prefix"
+        );
+        assert!(
+            image.program.constants.len() <= fresh.constants.len(),
+            "prelude image constants must be a prefix (no root)"
+        );
+        assert_eq!(
+            image.program.constants,
+            fresh.constants[..image.program.constants.len()],
+            "embedded prelude constants must be a byte-identical prefix"
+        );
+        assert!(
+            image.program.code.len() <= fresh.code.len(),
+            "prelude image code must be a prefix (no root)"
+        );
+        assert_eq!(
+            image.program.code,
+            fresh.code[..image.program.code.len()],
+            "embedded prelude code must be a byte-identical prefix of a fresh encode"
         );
     }
 

--- a/src/eval/stg/runtime.rs
+++ b/src/eval/stg/runtime.rs
@@ -162,6 +162,31 @@ impl StandardRuntime {
         self.prelude_slot_overrides
             .push((slot, arena.nodes, arena.forms, entry_idx));
     }
+
+    /// Reconstruct the per-invocation override globals as `(full global
+    /// slot, LambdaForm)` pairs, for the bytecode blob loader.
+    ///
+    /// The pre-encoded prelude bytecode in the blob bakes stale `__args` /
+    /// `__io` bodies; the loader re-encodes these fresh forms onto the
+    /// embedded program (mirroring how `globals()` substitutes them into the
+    /// STG path). The returned slot is the full `Ref::G` index
+    /// (`INTRINSIC_COUNT + prelude slot`), matching the `global_forms` order.
+    pub fn prelude_global_overrides(&self) -> Vec<(usize, LambdaForm)> {
+        let intrinsic_count = self.impls.len();
+        self.prelude_slot_overrides
+            .iter()
+            .filter_map(|(slot, nodes, forms, entry)| {
+                let arena = StgArena {
+                    nodes: nodes.clone(),
+                    forms: forms.clone(),
+                };
+                arena
+                    .reconstruct_form(*entry)
+                    .ok()
+                    .map(|form| (intrinsic_count + slot, form))
+            })
+            .collect()
+    }
 }
 
 impl ToPretty for StandardRuntime {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,7 +37,7 @@ use eucalypt::{
     driver::source::SourceLoader,
     eval::stg::{
         arena::{ArenaLambdaForm, ArenaStgSyn, StgArena},
-        blob::PreludeBlob,
+        blob::{PreludeBlob, PreludeBytecodeImage},
         make_standard_runtime,
         syntax::LambdaForm,
     },
@@ -342,6 +342,47 @@ fn cmd_prelude_compile() -> Result<()> {
         binding_entries.len()
     );
 
+    // ── 8b. Pre-encode the prelude BytecodeProgram (BV5, eu-amp9) ─────────────
+    // Encode the fixed templates plus every global body (intrinsic wrappers
+    // followed by the prelude bindings, in the same slot order the runtime
+    // uses) with no program root. The bytecode engine loads this image
+    // directly and appends only the user root (and the per-invocation
+    // __args/__io overrides) at run time, instead of re-encoding the prelude.
+    //
+    // `runtime.globals()` here returns just the intrinsic wrappers (this
+    // runtime has no prelude bindings set); `forms` are the prelude bindings.
+    let bytecode = {
+        use eucalypt::eval::stg::runtime::Runtime;
+        // Encode the prelude bindings from the SAME arena-reconstructed forms
+        // the runtime uses in `globals()`, so the baked bytecode is identical
+        // to what a fresh `encode(&syn, &rt.globals())` would produce.
+        let arena = StgArena {
+            nodes: nodes.clone(),
+            forms: forms_pool.clone(),
+        };
+        let prelude_forms: Vec<LambdaForm> = binding_entries
+            .iter()
+            .map(|&e| {
+                arena
+                    .reconstruct_form(e)
+                    .expect("reconstruct prelude form for bytecode encode")
+            })
+            .collect();
+        let mut all_globals = runtime.globals();
+        all_globals.extend(prelude_forms);
+        let (program, global_forms) = eucalypt::eval::bytecode::encode_prelude(&all_globals);
+        println!(
+            "  bytecode: {} bytes, {} constants, {} global forms",
+            program.code.len(),
+            program.constants.len(),
+            global_forms.len(),
+        );
+        Some(PreludeBytecodeImage {
+            program,
+            global_forms,
+        })
+    };
+
     // ── 9. Serialise and write ────────────────────────────────────────────────
     let blob = PreludeBlob {
         source_hash,
@@ -354,6 +395,7 @@ fn cmd_prelude_compile() -> Result<()> {
         monad_specs,
         monad_type_hints,
         inline_cores,
+        bytecode,
     };
 
     let bytes = blob.to_bytes().context("serialise PreludeBlob")?;


### PR DESCRIPTION
## Summary

BV5 (eu-amp9, child of eu-xfxc). Puts the pre-encoded prelude **BytecodeProgram** into the prelude blob, **alongside** the existing `ArenaStgSyn` (`nodes`/`forms_pool`). The bytecode engine now runs straight off the embedded program instead of re-encoding hundreds of prelude/intrinsic globals on every invocation. HeapSyn continues to load the STG form unchanged — both forms coexist while HeapSyn is retained (Phase 4/eu-oufc deletes HeapSyn later, not here).

This is architectural (owner directive), not a startup-latency change (the STG blob already delivers that).

## Design — dual-form blob

- **program.rs**: derive `Serialize`/`Deserialize`/`Clone` on `BytecodeProgram`. Every field is `Vec<u8>` / `Vec<u32>` / `u32` / `Vec<StgNative>` (Numbers serialise via their decimal-string form), so no field needed special handling — **no serialisation snags**.
- **encode.rs**: derive `Serialize`/`Deserialize` on `GlobalForm`. Factor `encode` into a shared `emit_fixtures_and_globals` + `build_program` (behaviour-preserving), and add:
  - `encode_prelude` — templates + every global body, **no root** (the reusable image).
  - `encode_root_onto` — append a program root to a pre-encoded base, reusing its `code`/`constants` prefix unchanged.
  - `encode_overrides_and_root` — re-encode the per-invocation `__args`/`__io` override globals and the root onto the base, patching their `global_entries`/`global_forms`.
  - Cross-references are by global **slot** (`Ref::G`) or **constant index**, never a raw byte offset into another global, so appending leaves every existing offset valid and reproduces exactly what a full `encode` would emit.
- **blob.rs**: add `PreludeBytecodeImage { program, global_forms }` and an `Option<PreludeBytecodeImage>` `bytecode` field with `#[serde(default)]` so a blob generated before BV5 deserialises to `None` and the loader degrades gracefully to encode-from-STG.
- **runtime.rs**: add `prelude_global_overrides()` returning the reconstructed `__args`/`__io` override forms as `(full global slot, LambdaForm)` for the loader.
- **xtask** `prelude-compile`: after building the STG form, encode the prelude to a `BytecodeProgram` (from the **same** arena-reconstructed forms the runtime uses) and store it in the blob. One `prelude.eu` → both forms, same `source_hash`. Blob stays **out of git** (gitignored; release CI builds it).
- **driver/eval.rs**: when the bytecode engine is active **and** the blob carries a `BytecodeProgram`, load/use it directly (append only overrides + root); otherwise (source-prelude fallback or a pre-BV5 blob) encode from STG as before.

## How the embedded program is proven to be used

- `embedded_bytecode_matches_fresh_encode` (unit test, `cfg(prelude_blob_ok)`): the **deserialised** embedded program is a **byte-identical prefix** of a fresh `encode` of the same globals — `code`, `constants`, `templates`, `blackhole`, `meta_template`, `pap`, `apply1/2`, `producer_tail`, `global_entries`, and `global_forms` all match.
- On the live blob+bytecode path the loader takes the `Some(image)` branch and calls `encode_overrides_and_root(&image.program, …)`. Verified end-to-end locally: `io.args -- alpha beta` → `[alpha, beta]` (proves the `__args` override re-encode), `2+3` → `5`, `[9,8] head` → `9` (non-recursive globals executed from the embedded program).

## Validation

| Config | Result |
|---|---|
| `cargo test --lib` (release) | **1259 passed, 0 failed** (incl. new round-trip + byte-identical tests) |
| HeapSyn + blob harness (`eu test`) | **176/176, exit 0** |
| Bytecode + source-prelude harness | **176/176, exit 0** |
| GC verify+stress (`EU_GC_VERIFY=2 EU_GC_STRESS=1`, bytecode+source) | **176/176, exit 0, no corruption** |
| clippy `--all-targets -D warnings` | clean |
| `cargo fmt --all` | clean |

### Known local limitation (pre-existing, not BV5)

On **macOS aarch64**, the full **bytecode + blob** harness hangs on recursive/non-inlined prelude globals (`map`, `filter`, `count`, `reverse`). This reproduces at the **pristine baseline** (this change stashed; blob regenerated without the bytecode field; clean debug **and** release builds) — the pre-existing None-branch (`encode(&syn, &rt.globals())`) hangs identically, so it is **not introduced by BV5**. Bytecode+source and HeapSyn+blob both work locally. This exact path is green on Linux CI (`GC-verified harness (x86-64)` and `Sequential harness (aarch64 release)` both pass on integration/0.12.0), so CI validates the full bytecode+blob harness for this PR.

## Notes

- Blob is **not** committed (gitignored). Reviewers/CI must run `cargo run -p xtask -- prelude-compile` before building to exercise the blob path.
- No HeapSyn behaviour change; unit-cache untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee