### PR TITLE
docs(bv5): unit cache design spec (eu-lb0r)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-bv5-unit-cache.md
+++ b/docs/superpowers/plans/2026-07-03-bv5-unit-cache.md
@@ -1,0 +1,264 @@
+# BV5 Whole-Program Unit Cache — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a backend feature in an existing codebase you know — where a task says "hook in at `eval.rs:NNN`", read that seam and match its conventions. Every task ends `cargo fmt --all` + `cargo clippy --all-targets -- -D warnings` clean and its tests green; wrap every `eu` run in `timeout 90 --heap-limit-mib 12288`.
+
+**Goal:** A default-on, content-hash, whole-program cache of the compiled merged program, so a repeat run with unchanged inputs skips parse→…→STG-compile and loads a serialised artifact instead — correct by construction (a hit is byte-identical to a fresh compile, or it is not a hit).
+
+**Architecture:** Generalises the prelude-blob mechanism (`src/eval/stg/blob.rs`) to arbitrary merged user programs. At the post-STG seam (`src/driver/eval.rs:391`), compute a cache key `K` over (all input contents + compile-affecting options + a memoised binary-self-hash compiler identity); on hit, load the engine-keyed compiled artifact from `~/.cache/eucalypt/units/<K>.euc` and skip compilation; on miss, compile and write it atomically. A fail-closed envelope (`format_version` + identity + key re-checked on load) makes the cache faster-or-equal, never wrong.
+
+**Tech Stack:** Rust, `postcard` (already a dep, used by the blob), `sha2` (already a build-dep), `serde`. New code lives under `src/driver/unit_cache/`. Reuses `ArenaStgSyn`/`BytecodeProgram` serialisation from eu-amp9 (`blob.rs`, `program.rs`).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-07-03-bv5-unit-cache-design.md` — the authority; this plan implements it. Re-read §6–§12 before Task 5.
+- **Default-on**, so correctness is non-negotiable: never a stale hit. Every "is this in the key?" decision fails safe (include it, or recompile).
+- **Fail-closed:** any header/key/identity mismatch, decode failure, or I/O error → treat as a miss and compile normally. The cache path must never panic on a bad/short/foreign file.
+- **Engine-keyed:** the engine selector is part of `K`. Do NOT assume the bytecode and HeapSyn artifacts are byte-identical (the bytecode path recompiles STG with `RenderDoc`) — see Task 5; default to caching each engine's own artifact.
+- **Never change HeapSyn or compiled output.** The cache is a pure short-circuit: `--no-cache` output must be byte-identical to cached-hit output on both engines. This is the differential test net (Task 10).
+- Base branch: `docs/bv5-unit-cache-spec` (has the spec) off post-#952 `integration/0.12.0`. Work on a feature branch; PR to `integration/0.12.0`.
+- Blob stays gitignored; this feature adds no committed binary artifacts.
+- UK English in comments/docs; no `#[allow]`s.
+
+---
+
+## File Structure
+
+**New — `src/driver/unit_cache/` (one responsibility each):**
+- `mod.rs` — public surface: `UnitCache` façade (`lookup`/`store`), `CacheOutcome`, wiring types. Re-exports.
+- `identity.rs` — `compiler_identity() -> [u8;32]`: memoised binary self-hash (`(exe-path,mtime,size)`-keyed sidecar) combined with build-meta version/commit + prelude `source_hash`.
+- `key.rs` — `CacheKey` = `[u8;32]`; `compute_key(inputs, compile_config, identity) -> CacheKey`.
+- `config.rs` — `compile_affecting_fingerprint(&EucalyptOptions, &StgSettings) -> Vec<u8>` (structural extraction, Task 3) + the completeness guard.
+- `envelope.rs` — `Header { format_version:u32, identity:[u8;32], key:[u8;32] }`; `write_entry`/`read_entry` (fail-closed).
+- `store.rs` — path resolution (`cache_dir()`), `read(K)`, `write_atomic(K, bytes)`, `evict_if_needed()`.
+- `artifact.rs` — the serialisable cached-artifact bundle (Task 5) wrapping the engine's compiled form + what the loader needs to inject it.
+
+**Modified:**
+- `src/driver/options.rs` — add `--no-cache` flag + `EU_NO_CACHE` env; add the `eu cache` subcommand (Task 11); expose the compile-affecting fields the fingerprint reads.
+- `src/driver/eval.rs` — the seam: lookup before `stg::compile` (`:391`); store after; skip-to-eval on hit (Task 9).
+- `Cargo.toml` — add `sha2` to `[dependencies]` if only a build-dep today; add a `dirs`-style cache-dir helper (or hand-roll XDG — see Task 7, prefer no new dep if `std` + `EU_*`/`XDG_CACHE_HOME`/`HOME` suffice).
+- Docs: `CLAUDE.md` debug-env table (`EU_NO_CACHE`), `ROADMAP.md` (mark BV5 unit-cache landed), `eu --help`.
+
+**Tests:** unit tests inline per module; one integration test `tests/unit_cache_differential_test.rs` (Task 10).
+
+---
+
+### Task 1: Cache directory + config plumbing (`--no-cache` / `EU_NO_CACHE`)
+
+**Files:**
+- Create: `src/driver/unit_cache/mod.rs`, `src/driver/unit_cache/store.rs`
+- Modify: `src/driver/options.rs` (flag + env), `src/driver/mod.rs` (add `pub mod unit_cache;`)
+
+**Interfaces:**
+- Produces: `unit_cache::cache_enabled(&EucalyptOptions) -> bool` (false if `--no-cache` or `EU_NO_CACHE=1`); `unit_cache::store::cache_dir() -> Option<PathBuf>` (respects `EU_CACHE_DIR` → `XDG_CACHE_HOME/eucalypt` → `HOME/.cache/eucalypt`; `None` if none resolvable → caching disabled, fail-safe); the sub-dir for entries is `<cache_dir>/units/`.
+
+- [ ] **Step 1: Failing test** — in `store.rs`, `#[cfg(test)]`: `cache_dir_honours_env` sets `EU_CACHE_DIR` to a temp path and asserts `cache_dir()` returns `<temp>` and `units_dir()` returns `<temp>/units`. Assert `None` when `EU_CACHE_DIR`/`XDG_CACHE_HOME`/`HOME` are all unset.
+- [ ] **Step 2: Run — expect FAIL** (`cargo test --lib unit_cache::store::` — undefined fn).
+- [ ] **Step 3: Implement** `cache_dir()`/`units_dir()` with the precedence above (std env only; no new dep). Add `--no-cache` to `options.rs` (mirror an existing bool flag like `--no-dce` at `options.rs:220`) and read `EU_NO_CACHE` (mirror the `EU_SOURCE_PRELUDE` env read at `options.rs:439`). Implement `cache_enabled`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): cache dir resolution + --no-cache/EU_NO_CACHE`.
+
+---
+
+### Task 2: Compiler identity — memoised binary self-hash
+
+**Files:**
+- Create: `src/driver/unit_cache/identity.rs`
+- Modify: `Cargo.toml` (ensure `sha2` is a normal dependency)
+
+**Interfaces:**
+- Produces: `identity::compiler_identity() -> [u8;32]` — deterministic within a build, changes on any recompile. Internally: `sha256( self_hash ‖ build_meta_version ‖ build_meta_commit ‖ prelude_source_hash )`.
+- Consumes: `Resources::get("build-meta")` (build-meta.yaml string, `resources.rs:51`); the prelude `source_hash` — via `PreludeBlob::source_hash` when a blob is present (`blob.rs:53`), else a fixed sentinel (source-prelude runs have no blob hash but the `--source-prelude` option is already in the key, Task 3).
+
+**Design (spec §7):** `self_hash` = SHA-256 of the compiler binary, **memoised** in `<cache_dir>/self-hash.json` keyed by `(exe_path, mtime, size)`. First run after a rebuild hashes once (~15 ms); subsequent runs `stat` + reuse. `std::env::current_exe()` for the path; on any failure (no exe, unreadable) return a random-free sentinel that **disables caching for the run** (caller treats identity-uncertain as no-cache — see Task 9), never a fixed value that could alias two different binaries.
+
+- [ ] **Step 1: Failing test** `self_hash_memo_reuses_on_stat_match`: write a temp "binary" file, compute+store its self-hash via the memo, mutate its bytes but reset mtime+size to the stored pair (simulate the impossible-in-practice case) → memo returns the OLD hash (documents the (mtime,size) trust boundary); then change mtime → memo re-hashes and returns the NEW hash. Also `compiler_identity_changes_with_build_meta`: two different build-meta strings ⇒ different identity.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** the memo (serde_json or postcard sidecar; postcard preferred, no new dep) + `compiler_identity()`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): memoised binary-self-hash compiler identity`.
+
+---
+
+### Task 3: Compile-affecting option fingerprint + completeness guard
+
+**Files:**
+- Create: `src/driver/unit_cache/config.rs`
+- Modify: `src/driver/options.rs` / `src/eval/stg/mod.rs` only if a compile-affecting field lacks an accessor.
+
+**Interfaces:**
+- Produces: `config::compile_affecting_fingerprint(opts: &EucalyptOptions, stg: &StgSettings) -> Vec<u8>` — a stable byte-encoding of exactly the compile-affecting inputs (spec §6.2): `no_dce`, `source_prelude`, `no_prelude`, `target`, `evaluand text`, `collect_as`+`name_inputs`, `suppress_demand_analysis`, engine selector (`EU_BYTECODE`/`EU_HEAPSYN` resolved to a single `Engine` enum), and the `StgSettings` compile flags (`prelude_globals` presence, `suppress_inlining`, `suppress_updates`, `suppress_optimiser`, `suppress_demand_analysis`). Rendering/output/IO options are excluded.
+
+**Structural completeness (spec §8):** build the fingerprint by matching on the *canonical* config structs field-by-field so a new field forces a compile error / conscious decision. Add a guard test that will fail when a field is added without classification.
+
+- [ ] **Step 1: Failing test** `fingerprint_sensitive_to_each_compile_option`: construct a baseline `(opts, stg)`; for each compile-affecting field, flip it and assert the fingerprint bytes change; for two rendering-only options (`json`, `output`), flip and assert the fingerprint is **unchanged**.
+- [ ] **Step 2: Failing test** `compile_config_fields_all_classified`: a test that enumerates the compile-config fields (via an explicit `const CLASSIFIED: &[&str]` list the implementer maintains next to the match, or a small proc/derive) and asserts it equals the current struct's field set — failing CI when a field is added un-classified. (Choose the lightest mechanism; a hand-list + `debug_assert`-style equality against `stringify!`-enumerated fields is acceptable and zero-dep.)
+- [ ] **Step 3: Run — expect FAIL.**
+- [ ] **Step 4: Implement** `compile_affecting_fingerprint` with the field-by-field match + the classification list.
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Commit** `feat(unit-cache): structural compile-affecting-option fingerprint + guard`.
+
+---
+
+### Task 4: Cache key
+
+**Files:** Create `src/driver/unit_cache/key.rs`.
+
+**Interfaces:**
+- Produces: `key::CacheKey([u8;32])`; `key::compute_key(inputs: &[ResolvedInput], fingerprint: &[u8], identity: &[u8;32]) -> CacheKey`, where `ResolvedInput { locator_id: String, content: Vec<u8> }` is the ordered list of all merged inputs (Task 9 gathers them). Encoding: a domain-separation constant + `format_version`, then length-prefixed `(locator_id, sha256(content))` per input in order, then the fingerprint, then the identity → one SHA-256.
+- Consumes: nothing runtime; `ResolvedInput` is defined here.
+
+- [ ] **Step 1: Failing test** `key_order_and_content_sensitive`: same inputs in a different order ⇒ different key; changing one input's content ⇒ different key; changing a locator id ⇒ different key; identical everything ⇒ identical key; changing fingerprint or identity ⇒ different key.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** `compute_key` (hash content per input so large data files aren't re-hashed into one giant buffer; length-prefix everything to avoid concatenation ambiguity).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): content-hash cache key`.
+
+---
+
+### Task 5: Cached artifact bundle (engine-keyed) + serialisation
+
+**Files:** Create `src/driver/unit_cache/artifact.rs`.
+
+**Interfaces:**
+- Produces: `artifact::CachedArtifact` (postcard `Serialize/Deserialize`) carrying exactly what `eval.rs` needs to resume post-STG for the active engine, plus `to_bytes`/`from_bytes` (mirror `PreludeBlob::to_bytes`/`from_bytes`, `blob.rs:113-120`).
+
+**Determination (spec §4 — do this first):** empirically check whether the post-STG artifact differs between engines. In a scratch test, compile a small program through `stg::compile` on the HeapSyn config and on the bytecode config (the `RenderDoc` recompile at `eval.rs:412`) and compare. **Record the finding in a comment.**
+  - If identical → cache one engine-agnostic `ArenaStgSyn` bundle; the bytecode engine re-encodes on load (<15 µs) exactly as eu-amp9's loader does.
+  - If different → `CachedArtifact` holds the **engine's own** compiled form (reuse `ArenaStgSyn` serialisation for HeapSyn; reuse `BytecodeProgram` serialisation from eu-amp9/`program.rs` for bytecode). The engine is already in `K`, so a given `<K>.euc` is unambiguous.
+
+Reuse the arena serialisation the blob already round-trips (`src/eval/stg/arena/`, `blob.rs`). Do NOT invent a new format.
+
+- [ ] **Step 1: Determination test** `post_stg_artifact_engine_parity` — asserts + documents which branch holds (this is a real test that pins the assumption; if it ever flips, this fails loudly).
+- [ ] **Step 2: Failing test** `cached_artifact_round_trips`: build a `CachedArtifact` from a compiled small program, `to_bytes` → `from_bytes`, assert structural equality (and that reconstructing + evaluating yields the same render as compiling fresh — can be deferred to Task 10 if heavy here).
+- [ ] **Step 3: Run — expect FAIL.**
+- [ ] **Step 4: Implement** `CachedArtifact` + serde, per the determination.
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Commit** `feat(unit-cache): engine-keyed cached-artifact bundle + serialisation`.
+
+---
+
+### Task 6: Fail-closed envelope
+
+**Files:** Create `src/driver/unit_cache/envelope.rs`.
+
+**Interfaces:**
+- Produces: `envelope::FORMAT_VERSION: u32`; `envelope::write_entry(w, identity:&[u8;32], key:&CacheKey, artifact:&CachedArtifact) -> io::Result<()>`; `envelope::read_entry(bytes:&[u8], expected_identity:&[u8;32], expected_key:&CacheKey) -> Option<CachedArtifact>` returning `None` on ANY mismatch/short/decode-error (never `Err`, never panic).
+
+- [ ] **Step 1: Failing tests** in `envelope.rs`: `roundtrip_ok` (write then read with matching identity+key ⇒ `Some`); `rejects_wrong_version` (hand-craft a header with a bumped version ⇒ `None`); `rejects_wrong_identity`; `rejects_wrong_key`; `rejects_truncated` (feed 3 bytes ⇒ `None`, no panic); `rejects_garbage` (random bytes ⇒ `None`).
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** header write/read with length checks before every slice; postcard decode wrapped so errors map to `None`.
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): fail-closed cache envelope`.
+
+---
+
+### Task 7: On-disk store — atomic write + read
+
+**Files:** Modify `src/driver/unit_cache/store.rs`.
+
+**Interfaces:**
+- Produces: `store::read(dir:&Path, key:&CacheKey) -> Option<Vec<u8>>` (bump the file's mtime on hit, for LRU); `store::write_atomic(dir:&Path, key:&CacheKey, bytes:&[u8]) -> io::Result<()>` (write to `<dir>/units/.tmp-<rand-free-unique>` then `rename` into `<dir>/units/<hex(K)>.euc`; create dirs as needed). Uniqueness for the temp name without `rand`: use `std::process::id()` + an atomic counter (no `Math.random`/time deps).
+
+- [ ] **Step 1: Failing test** `write_then_read_roundtrips` (temp dir): `write_atomic` then `read` returns the bytes; `read` of an absent key ⇒ `None`; a partial temp file left behind is ignored by `read` (only `.euc` files are read).
+- [ ] **Step 2: Failing test** `concurrent_writers_leave_valid_file`: spawn N threads writing the same key with identical bytes; after join, exactly one `.euc` exists and reads back intact (atomic rename guarantees no torn file).
+- [ ] **Step 3: Run — expect FAIL.**
+- [ ] **Step 4: Implement** write-to-temp + atomic rename + read (with mtime bump).
+- [ ] **Step 5: Run — expect PASS.**
+- [ ] **Step 6: Commit** `feat(unit-cache): atomic-rename store with LRU mtime bump`.
+
+---
+
+### Task 8: Eviction — LRU by mtime + size cap
+
+**Files:** Modify `src/driver/unit_cache/store.rs`; cap config in `config.rs`.
+
+**Interfaces:**
+- Produces: `store::evict_if_needed(dir:&Path, cap_bytes:u64)` — if `units/` total size > cap, delete oldest-mtime `.euc` files until under cap. Default cap `512 MiB` (`config::DEFAULT_CACHE_CAP_BYTES`), overridable via `EU_CACHE_CAP_MIB`.
+
+**When to run:** cheaply and probabilistically on write — e.g. run eviction only when `hex(K)` starts with a fixed nibble (≈1/16 of writes), so it's amortised and needs no timestamp/RNG. Also runnable via `eu cache gc` (Task 11).
+
+- [ ] **Step 1: Failing test** `evicts_oldest_until_under_cap`: create entries with ascending mtimes totalling > a tiny cap; run `evict_if_needed(cap)`; assert the newest survive, oldest are gone, total ≤ cap.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** eviction (list `.euc`, sort by mtime asc, delete until under cap; ignore I/O errors on individual deletes — best-effort).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): LRU size-cap eviction`.
+
+---
+
+### Task 9: Driver integration at the seam (the load-bearing task)
+
+**Files:** Modify `src/driver/eval.rs` (around `:361-414`), `src/driver/unit_cache/mod.rs`.
+
+**Interfaces:**
+- Produces: `UnitCache::lookup(...) -> Option<CachedArtifact>` and `UnitCache::store(key, artifact)`; and a `CacheOutcome` the eval path branches on.
+- Consumes: everything above; the resolved input list + `EucalyptOptions` + `StgSettings` available at the seam; the `ArenaStgSyn`/`BytecodeProgram` produced at `stg::compile` (`eval.rs:391`) / bytecode encode (`eval.rs:412`).
+
+**Behaviour (spec §5):**
+1. Early in the compile path (after inputs are resolved — the parse phase already knows the full input set, `prepare.rs:57-109`), gather `Vec<ResolvedInput>` from the merged input list (each input's locator identity + content bytes; include the `__args`/`__io`/`__build` pseudo-inputs since they affect the merged program).
+2. If `cache_enabled` and identity is certain: `identity = compiler_identity()`; `fp = compile_affecting_fingerprint(opts, stg)`; `K = compute_key(inputs, &fp, &identity)`; `read(dir,K)` → `read_entry(bytes,&identity,&K)`.
+   - **Hit:** reconstruct the engine's runnable form from `CachedArtifact` and jump straight to eval — skipping parse→…→STG-compile. Match exactly how the blob path injects a precompiled artifact (`Executor::try_execute`, `eval.rs:275-324`, `set_prelude_bindings`) — the user program is the analogue of the prelude here.
+   - **Miss:** compile normally; on success build `CachedArtifact` from the just-produced compiled form and `store` it (`write_atomic` + probabilistic `evict_if_needed`).
+3. Identity-uncertain (no exe / unreadable) ⇒ behave as `--no-cache` (compile, do not read or write).
+
+**Guard:** the hit path must produce byte-identical output to the miss path (Task 10 proves it). If reconstructing from the artifact is non-trivial for the bytecode+blob interplay (the artifact references prelude `Ref::G` slots — valid because the prelude `source_hash` is in the identity), verify the prelude image loaded for this run matches the one the artifact was compiled against; the identity already enforces this, but assert it.
+
+- [ ] **Step 1: Failing integration test** (put in `tests/unit_cache_differential_test.rs`, expand in Task 10) `second_run_hits_cache`: run a small program twice with a shared `EU_CACHE_DIR` temp; assert run 2 produces identical stdout AND that a `.euc` file exists after run 1. (Use the `eu` binary via `assert_cmd`-style or the existing harness/tester plumbing — match how `tests/` invokes `eu`.)
+- [ ] **Step 2: Run — expect FAIL** (no caching yet / no hit).
+- [ ] **Step 3: Implement** the seam wiring in `eval.rs` per the behaviour above.
+- [ ] **Step 4: Run — expect PASS** (run 2 hits; output identical; entry written).
+- [ ] **Step 5: Gate** — full harness both engines unchanged with cache **on** (default): `cargo test --test harness_test` and `EU_HEAPSYN=1 cargo test --test harness_test` both green; `cargo test --lib` green.
+- [ ] **Step 6: Commit** `feat(unit-cache): wire whole-program cache into the compile seam (default-on)`.
+
+---
+
+### Task 10: Differential correctness net (non-negotiable)
+
+**Files:** Modify `tests/unit_cache_differential_test.rs`.
+
+**Behaviour (spec §12):** the safety net that justifies default-on.
+
+- [ ] **Step 1: `hit_equals_no_cache_matrix`** — for a representative set of programs (arithmetic, block/list, `map`/`filter` recursion, a multi-file `import`, a data-file-as-unit, a `-t target`, a `-e` evaluand) × a few compile-affecting options, run each **twice with cache on** (second = hit) and once with `--no-cache`; assert all three stdouts are byte-identical. Run the whole matrix on the default engine AND under `EU_HEAPSYN=1`.
+- [ ] **Step 2: `key_sensitivity`** — for each program, flipping any compile-affecting option or editing any input file yields a **miss** (fresh compile), never a stale hit: assert output tracks the change (e.g. edit an imported constant → output changes on the very next run despite a warm cache).
+- [ ] **Step 3: `envelope_robustness_e2e`** — corrupt a `.euc` file on disk (truncate / flip the version byte / random bytes) then run; assert the program still produces correct output (miss + recompile) and no panic/hang.
+- [ ] **Step 4: `identity_change_invalidates`** — simulate a compiler-identity change (point `EU_CACHE_DIR` at a warm cache but force a different identity via the test seam, or stale the self-hash sidecar) → miss, correct output.
+- [ ] **Step 5: Run — all PASS.** Also run under `EU_GC_VERIFY=2 EU_GC_STRESS=1` for the map/filter cases (the hit path reconstructs heap artifacts — GC-sensitive).
+- [ ] **Step 6: Commit** `test(unit-cache): differential + key-sensitivity + envelope correctness net`.
+
+---
+
+### Task 11: `eu cache` subcommand
+
+**Files:** Modify `src/driver/options.rs` (subcommand parse) + a small handler (near where other non-eval subcommands like `eu test`/`eu dump` dispatch).
+
+**Interfaces:**
+- Produces: `eu cache clear` (delete `units/` + `self-hash.json`), `eu cache path` (print `cache_dir()`), `eu cache info` (entry count + total size + cap), `eu cache gc` (run `evict_if_needed`).
+
+- [ ] **Step 1: Failing test** `cache_clear_empties_dir`: warm the cache (run a program), `eu cache info` shows ≥1 entry, `eu cache clear`, `eu cache info` shows 0.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** the subcommand + handlers (match the existing subcommand dispatch style — find how `eu test`/`eu dump` are routed in `options.rs`/`driver`).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit** `feat(unit-cache): eu cache clear/path/info/gc`.
+
+---
+
+### Task 12: Docs
+
+**Files:** `CLAUDE.md` (debug-env table: add `EU_NO_CACHE`, `EU_CACHE_DIR`, `EU_CACHE_CAP_MIB`), `ROADMAP.md` (§6.4/§9 mark BV5 unit-cache landed; note per-unit incremental remains the deferred "separate unit compilation" route), `eu --help` text.
+
+- [ ] **Step 1:** Update the three docs (real content, not placeholders).
+- [ ] **Step 2:** `eu build.eu -t build-meta` NOT needed; just confirm `eu --help` renders the new flag.
+- [ ] **Step 3: Commit** `docs(unit-cache): env vars, roadmap, help`.
+
+---
+
+## PR & acceptance
+
+- PR to `integration/0.12.0`. Title: `feat(bytecode): BV5 — whole-program content-hash unit cache, default-on (eu-lb0r)`.
+- Acceptance: full harness 477/477 on **both** engines with cache default-on; the Task 10 differential net green; `cargo test --lib` green; `EU_GC_VERIFY=2 EU_GC_STRESS=1` clean on the hit path; clippy `--all-targets` + fmt clean; CI green (incl the new `test-bytecode-blob` job once #954 lands). Gatekeeper (wicket) reviews — the key scrutiny is Task 3 (option completeness), Task 6/9 (fail-closed, never a stale hit), and Task 10 (hit == no-cache on both engines).
+- Do NOT merge your own PR; do NOT close eu-lb0r — report back.
+
+## Self-review notes (author)
+
+- Spec coverage: §3 whole-program→Task 9; §4 artifact→Task 5; §6 key→Tasks 3+4; §7 identity→Task 2; §8 completeness→Task 3; §9 envelope→Task 6; §10 rollout/escape→Tasks 1+11; §11 location/eviction/concurrency→Tasks 1+7+8; §12 tests→Task 10. All sections mapped.
+- Sequence: Tasks 1–8 are independent, testable units; Task 9 integrates them; Task 10 proves correctness; 11–12 finish the surface. Task 5's determination gates whether the artifact is shared or engine-keyed — do it first within Task 5.
+- Open determinations flagged inline (Task 5 engine-parity; Task 3 completeness-guard mechanism) — resolve against the code, don't guess.

--- a/docs/superpowers/specs/2026-07-03-bv5-unit-cache-design.md
+++ b/docs/superpowers/specs/2026-07-03-bv5-unit-cache-design.md
@@ -1,0 +1,239 @@
+# BV5 Whole-Program Unit Cache — Design
+
+> Status: **DRAFT for owner review** · Date: 2026-07-03 · Bead: **eu-lb0r**
+> Parent: BV5 (eu-xfxc) · Depends on: eu-amp9 (dual-form blob, merged #952)
+> Related memory: `bv5-serialisation-format-three-consumers`
+
+## 1. Context & framing
+
+Per ROADMAP §7 Pillar BV **decision 5 ("one serialisation format, three consumers")**, BV5's
+postcard/arena serialisation machinery serves three consumers:
+
+1. **Embedded prelude bytecode** — shipped in eu-amp9 (`PreludeBlob` now carries a
+   `BytecodeProgram` alongside `ArenaStgSyn`).
+2. **Content-hash unit cache** — *this document*.
+3. **PP IPC wire payload** (Pillar PP, ~0.14) — serialised eucalypt **values**.
+
+Settled scope fork (owner, 2026-07-03): build the serialisation **machinery + versioning
+discipline** payload-agnostic, but implement the **code payload only** in 0.12 (prelude +
+unit cache). The **value payload** (PP wire) is a documented extension point deferred to 0.14.
+This spec covers consumer #2, code payload only.
+
+The unit cache is, concretely, **the prelude-blob mechanism generalised to arbitrary merged
+user programs**: the blob already caches one well-known "unit" (the whole prelude) as
+serialised `ArenaStgSyn`, swapped in before STG-compile. This cache does the same for the
+merged user program.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Skip recompilation on a repeat run whose inputs are unchanged: on a hit, load a serialised
+  compiled artifact instead of running parse → desugar → merge → cook → … → STG-compile.
+- **Default-on** (owner decision), so it must be **correct by construction**: a hit is
+  byte-identical to a fresh compile, or it is not a hit.
+- Serves both engines (bytecode default, HeapSyn via `EU_HEAPSYN=1`). The engine is part of
+  the key (§6), so each engine caches the artifact it actually consumes; whether the two can
+  share one entry is an implementation determination (§4).
+- Reuse the existing postcard/arena serialisation (`src/eval/stg/blob.rs`,
+  `src/eval/stg/arena/`).
+
+**Non-goals (0.12)**
+- **Per-unit / incremental caching** ("edit one file → fast recompile"). The pipeline merges
+  units *early* (§4), so this needs the compiler restructured to defer merge — deferred to the
+  roadmap (bead filed: "separate unit compilation (defer merge)").
+- **Value serialisation / PP wire.** Machinery built payload-agnostic; value payload lands in
+  0.14.
+- Caching data-file parsing independently of the program.
+
+## 3. Scope decision — whole-program
+
+**The pipeline merges units early.** From the pipeline map (`src/driver/prepare.rs`):
+per-input desugar (`prepare.rs:154-166`) → **merge into one `TranslationUnit`**
+(`prepare.rs:169-188`) → then cook / split-letrecs / hoist / DCE / inline / fuse / verify /
+demand-analysis / STG-compile all run **once on the single merged program**
+(`prepare.rs:234` onward, `eval.rs:361-414`). Desugar itself carries cross-unit state forward
+via `UnitInterface` (monad/operator/type registries, `source.rs:564-570`).
+
+Consequence: a per-unit cache is **not natural** — the expensive work is inherently
+whole-program, and per-unit desugar has sequential cross-unit dependence. So 0.12 caches the
+**whole merged program**. Its reach: a hit occurs only when the **entire input set** is
+byte-identical across runs (same `.eu` files, same data-loaded-as-units, same
+compile-affecting options, same compiler). This covers CI re-runs, repeated identical
+invocations, and run-on-save-without-edits; it does **not** cover changing input data between
+runs or incremental multi-file edits (that is the deferred per-unit work).
+
+## 4. What is cached — the artifact
+
+Cache the **compiled artifact the active engine consumes**, at the post-STG-compile seam the
+prelude blob uses. The **engine is part of the key** (§6), so correctness never depends on the
+two engines producing identical bytes. HeapSyn consumes the `ArenaStgSyn` form directly; the
+bytecode engine consumes a `BytecodeProgram` (the bytecode path recompiles STG with
+`render_type: RenderDoc` before encoding — the reason eu-amp9's blob is **dual-form**).
+**Implementation determination:** confirm whether the post-STG `ArenaStgSyn` is genuinely
+identical across engines — if so, one shared entry suffices with the bytecode engine
+re-encoding in <15 µs on load (measured); if the `RenderDoc` recompile makes them differ,
+cache each engine's artifact under its engine-keyed `K`. Default to the safe, engine-keyed
+form; treat the single-shared-entry version as an optimisation to prove, not assume.
+
+Rationale for the stage: startup/compile cost is dominated by the front end (parse 7.8 /
+desugar 7.0 / cook 5.6 / merge 2.9 / hoist 2.2 ms; STG-compile 33 µs; bytecode encode <15 µs
+— measured on the prelude). Caching the post-STG artifact captures essentially the entire
+compilation cost, and it matches exactly how the prelude blob already works.
+
+**Insertion point** (from the map): the artifact produced by `stg::compile` (`eval.rs:391`,
+via `src/eval/stg/mod.rs:333`). On a hit, skip everything from parse through STG-compile and
+inject the cached `ArenaStgSyn` at the same seam the blob uses; on a miss, compile normally
+and write the artifact. Cross-reference note: a compiled user program resolves prelude
+free-vars to `Ref::G` global slots via the blob's `name_to_slot`, so the artifact references
+prelude global slots — hence the prelude `source_hash` is part of the cache key (§6).
+
+## 5. Cache lifecycle
+
+```
+run start
+  → resolve inputs + options  (unchanged; parse phase still discovers the import graph)
+  → compute cache key K        (§6)
+  → look up  <cache-dir>/<K>.euc
+       hit  → validate header (§7); load ArenaStgSyn; skip to demand-analysis/eval
+       miss → compile normally; write <K>.euc atomically (§9)
+```
+
+Note: computing K requires reading the input file contents and resolving the import graph,
+which the driver already does in the parse phase (`prepare.rs:57-109`) *before* the expensive
+passes. So the key is available at the right point with no extra I/O beyond hashing bytes we
+already read.
+
+## 6. The cache key (correctness core)
+
+`K = SHA-256( domain-sep ‖ inputs ‖ options ‖ compiler-identity )`, where a hit **guarantees**
+the artifact equals a fresh compile. Components:
+
+1. **Inputs.** For the ordered list of resolved input `Input`s (the full transitive set,
+   including data-loaded-as-units and the `__args`/`__io`/`__build` pseudo-inputs that affect
+   the merged program): each contributes `(locator-identity, content-bytes)`. Locator identity
+   distinguishes `a.eu` from `lib/a.eu`. Order matters (merge order affects the program).
+2. **Compile-affecting options.** Derived **programmatically from the canonical compile
+   configuration**, not a hand-maintained list — see §8. The known set (from the map):
+   `--no-dce`, `--source-prelude`/`EU_SOURCE_PRELUDE`, `--no-prelude`, `-t/--target`,
+   `-e/--eval` (evaluand text), `-c/--collect-as` + `-N/--name-inputs`,
+   `--suppress-demand-analysis`, the engine selector (`EU_BYTECODE`/`EU_HEAPSYN`), and the
+   effective `StgSettings` compile flags (`prelude_globals`, `suppress_inlining`,
+   `suppress_updates`, `suppress_optimiser`, `suppress_demand_analysis`). Rendering/output
+   options (`-x`, `-j`, `-o`, `--error-format`, `-S`, `-d`, `--allow-io`, `--seed`*) are
+   **excluded**. (*`--seed` feeds `__io` content, which is captured via the `__io`
+   pseudo-input in component 1, not as an option.)
+3. **Compiler identity.** §7.
+
+Domain-separation prefix + a `format-version` constant guard against cross-version /
+cross-consumer collisions.
+
+## 7. Compiler identity — default-on strength
+
+Default-on means any identity gap silently corrupts every user's output, so the identity must
+change on **any** compiler change. The reliable ground-truth signal is the compiler **binary
+itself** (a `.rs` edit re-links it; `build.rs`-embedded constants do **not** reliably change,
+because the existing `build.rs` emits `rerun-if-changed` directives that disable the
+full-package rescan). A full binary hash every run (~10–25 ms for a 20–50 MB binary) would
+eat the startup win, so:
+
+**Memoised binary self-hash.** Identity = SHA-256 of the compiler binary, **memoised** via a
+sidecar `<cache-dir>/self-hash.json` keyed by `(exe-path, mtime, size)`:
+- First run after a rebuild: `stat` misses the sidecar key → hash the binary once (~15 ms,
+  one-time) → store `{path,mtime,size} → sha`.
+- Subsequent runs: `stat` matches → reuse the stored sha (near-zero cost).
+
+Combine with `build-meta.yaml` `version` + `commit` and the prelude `source_hash`
+(`blob.rs:53`). The only theoretical hole — a byte-different binary with identical `mtime`
+*and* `size` — cannot arise from a normal `cargo build` (it always re-links, bumping mtime).
+
+`std::env::current_exe()` provides the path; fall back to "no cache" (compile normally,
+don't write) if the exe path can't be resolved or hashed, so identity uncertainty never
+produces a hit.
+
+## 8. Completeness, made structural
+
+A forgotten compile-affecting option is the other corruption path. Mitigations:
+- The key's option-component is computed by a single function over the **resolved
+  compile-configuration struct(s)** (`EucalyptOptions` compile-affecting fields +
+  `StgSettings`), so a newly-added compile flag is included by construction rather than by
+  remembering to update a list.
+- A **guard test** enumerates the compile-configuration fields and asserts each is either in
+  the key or on an explicit `#[cache_irrelevant]`-style allowlist — failing CI when a new
+  field is added without a decision. (Mechanism: a derive/macro or a reflection-style test
+  over the struct; exact form an implementation detail.)
+
+## 9. Safety envelope (fail-closed)
+
+Every cache file `<K>.euc` is:
+```
+Header { format_version: u32, compiler_identity: [u8;32], key: [u8;32] }
+Payload: postcard(ArenaStgSyn-bundle)
+```
+On load: if `format_version` ≠ current, or `compiler_identity` ≠ current, or `key` ≠ the K we
+computed, or postcard deserialisation fails, or any I/O error → **treat as a miss and compile
+normally.** The cache is therefore *faster-or-equal, never wrong* given a complete key. This
+is the prelude blob's `source_hash` reject-not-misdecode discipline, generalised.
+
+## 10. Rollout & escape hatches
+
+- **Default-on** from 0.12 (owner decision).
+- `--no-cache` / `EU_NO_CACHE=1` — bypass entirely (no read, no write).
+- `eu cache clear` — wipe the cache dir. `eu cache path` / `eu cache info` — introspection.
+- On a `compiler_identity` change, stale entries are simply never hit (fail-closed); eviction
+  (§11) reclaims them lazily.
+
+## 11. Operational
+
+- **Location.** `$XDG_CACHE_HOME/eucalypt/units/` → `~/.cache/eucalypt/units/` (respect
+  `XDG_CACHE_HOME`; platform-appropriate on macOS/Windows via a small dirs helper). One file
+  per key: `<K>.euc`. The `self-hash.json` sidecar lives at `~/.cache/eucalypt/self-hash.json`.
+- **Eviction.** Size cap (default e.g. 512 MiB or N entries, configurable) with **LRU by file
+  mtime** (bump mtime on read-hit). Prune opportunistically: cheap probabilistic check on
+  write, plus `eu cache clear`/gc. No background daemon.
+- **Concurrency.** Writes are **write-to-temp + atomic rename** into place, so a reader never
+  sees a partial file; concurrent writers of the same K race harmlessly (last rename wins;
+  content is identical by construction). Readers tolerate missing/half-written (rename makes
+  the latter impossible) and always fall back to compile-on-any-error.
+
+## 12. Correctness test plan (non-negotiable for default-on)
+
+- **Differential matrix:** for a representative set of programs × compile-affecting options,
+  assert **cache-hit output is byte-identical to a fresh (`--no-cache`) compile** — on both
+  engines (default bytecode and `EU_HEAPSYN=1`).
+- **Key-sensitivity:** assert K **changes** when any hashed input changes — flip each
+  compile-affecting option, edit each input file, and vary the compiler identity; assert a
+  miss (and no stale hit) in each case.
+- **Envelope:** corrupt/short/wrong-version/wrong-identity files → miss, never a panic or
+  wrong output.
+- **Completeness guard test** (§8).
+- **Concurrency:** parallel processes over the same K produce identical results and a valid
+  cache file.
+
+## 13. Risks & residual concerns
+
+- **Identity `mtime`/`size` collision** — negligible in practice (see §7); fail-closed envelope
+  bounds blast radius to "unexpected miss," never "wrong hit," *unless* the collision produces
+  a matching self-hash sidecar entry for a different binary. Accepted.
+- **Option-completeness drift** — mitigated structurally (§8) but is the highest-consequence
+  failure; the guard test is the safety net.
+- **Reach is narrow** (whole-program identical-inputs only). Documented; the per-unit story is
+  the deferred roadmap item.
+- **Cache-dir portability** across OSes — handled by a dirs helper; verify Windows path
+  behaviour.
+
+## 14. Future (out of scope here)
+
+- **Per-unit incremental cache** — blocked on "separate unit compilation (defer merge)"
+  (roadmap bead). Once units compile independently, cache each unit's compiled form keyed on
+  its transitive-source hash + replayed `UnitInterface` state; this cache's format/envelope
+  carries over.
+- **Value payload / PP IPC wire** (0.14) — the same postcard/arena machinery + versioning
+  envelope, carrying serialised eucalypt values instead of compiled code.
+
+## 15. Open questions for the owner
+
+1. Default eviction cap (512 MiB? entry count?) and whether it's user-configurable in 0.12.
+2. `eu cache` subcommand surface — `clear` + `path`/`info` in 0.12, or just `clear`?
+3. Is the `--no-cache`/`EU_NO_CACHE` naming right, or prefer `--cache=off` style?
+4. Should a run with `--source-prelude` (no blob) still use the unit cache? (It can — the key
+   already encodes `--source-prelude`; confirm we want it.)


### PR DESCRIPTION
Design spec for the BV5 whole-program content-hash unit cache (eu-lb0r), consumer #2 of the one-format-three-consumers serialisation (ROADMAP §7 BV decision 5).

Settled decisions captured: whole-program cache (early-merge forces it; per-unit deferred to roadmap), **default-on**, cache the engine-keyed post-STG artifact, **memoised-binary-self-hash** compiler identity, fail-closed envelope, structural option-completeness guard, and a differential correctness test net.

Open questions for the owner are listed in §15. This PR is the design doc only — implementation follows in a separate plan/PR once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)