### PR TITLE
fix(bytecode): force global thunk callees in DirectApp — fixes bytecode+blob hang on recursive prelude globals (eu-0iba)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -103,6 +103,30 @@ jobs:
           EU_GC_STRESS: "1"
           EU_GC_POISON: "1"
 
+  test-bytecode-blob:
+    name: Bytecode + blob harness
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # Generate the prelude blob so the *release-shaped* bytecode + blob path
+      # is exercised (bytecode is the default engine post eu-enyv). Without
+      # this step the binary falls back to the source prelude and the blob
+      # path — the one released binaries embed — goes completely untested.
+      # That gap let eu-0iba (a `DirectApp` to an unforced global thunk hung
+      # every recursive prelude function, e.g. `map`/`filter`) reach
+      # release-candidate builds uncaught while every CI job stayed green.
+      - name: Generate prelude blob
+        run: cargo run --package xtask -- prelude-compile
+      - name: Build release binary
+        run: cargo build --release
+      - name: Run harness on the bytecode + blob path
+        run: ./target/release/eu test --allow-io tests/harness
+
   test-source-prelude:
     name: Source-prelude harness (x86-64)
     runs-on: ubuntu-latest

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -1449,21 +1449,30 @@ pub fn handle_op(
                 ));
             };
 
-            // Thunk callee (only reachable for a local): blackhole + Update.
+            // Thunk callee: force it before applying the args. This is
+            // reachable for a *global* callee too — every pre-compiled prelude
+            // binding is stored as an arity-0 updatable thunk (see the xtask
+            // `LambdaForm::thunk` wrapping), so e.g. `cons`/`if`/`nil?` are
+            // thunks that yield their lambda when forced. A local thunk is
+            // memoised (blackhole + `Update`); a global thunk is entered
+            // without memoisation, mirroring `Op::App` (the globals frame is
+            // shared, so we do not blackhole/overwrite it here). Previously
+            // only the local case was handled, and a `DirectApp` to an unforced
+            // global thunk left `state.current` unchanged, spinning forever.
             if c.update() {
+                state.stack.push(BcContinuation::ApplyTo {
+                    args,
+                    annotation: state.annotation,
+                });
                 if let DecodedRef::Local(i) = callable {
                     let hole = BcValue::Closure(BcClosure::new(state.blackhole, callee_env));
                     view.scoped(callee_env).update(&view, i as usize, hole)?;
-                    state.stack.push(BcContinuation::ApplyTo {
-                        args,
-                        annotation: state.annotation,
-                    });
                     state.stack.push(BcContinuation::Update {
                         environment: callee_env,
                         index: i as usize,
                     });
-                    state.current = callee;
                 }
+                state.current = callee;
             } else if c.arity() as usize == args.len() {
                 // Fast path: exact arity → saturate, skip the ApplyTo push.
                 state.current = BcValue::Closure(view.saturate_with_array(&c, args)?);
@@ -3740,5 +3749,46 @@ mod tests {
             BytecodeMachine::new(prog, root, &[], intrinsics, Box::new(NullEmitter), 0, false)
                 .unwrap();
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn direct_app_forces_global_thunk() {
+        // Regression (eu-0iba): every pre-compiled prelude global is stored as
+        // an arity-0 updatable thunk (see the xtask `LambdaForm::thunk`
+        // wrapping), so `cons`/`map`/`if`/… are thunks that yield their lambda
+        // when forced. A `DirectApp` to such a global with args must FORCE the
+        // thunk before applying. The previous handler only forced *local*
+        // thunks; a `DirectApp` to an unforced *global* thunk left
+        // `state.current` unchanged and spun forever (the whole bytecode+blob
+        // path hung on any recursive prelude function). With a tick limit this
+        // now surfaces as a clean failure rather than a hang.
+        use crate::common::sourcemap::{Smid, SourceMap};
+        use crate::eval::intrinsics;
+        use crate::eval::stg::{make_standard_runtime, runtime::Runtime};
+
+        let mut source_map = SourceMap::new();
+        let runtime = make_standard_runtime(&mut source_map);
+        let intrinsics = runtime.intrinsics();
+        let add = intrinsics::index_u8("ADD");
+
+        // Global 0: a thunk that, when forced, yields a 1-arg lambda `\x → x+1`.
+        let inc = dsl::lambda(1, dsl::app_bif(add, vec![dsl::lref(0), dsl::num(1)]));
+        let g_thunk = dsl::thunk(dsl::let_(vec![inc], dsl::local(0)));
+        let globals = vec![g_thunk];
+
+        // Root: `DirectApp G0(5)` — invoke the unforced global thunk with an arg.
+        let root = dsl::direct_app(Smid::default(), dsl::gref(0), vec![dsl::num(5)]);
+        let (prog, root_off, gforms) = encode(&root, &globals);
+        let mut m = BytecodeMachine::new(
+            prog,
+            root_off,
+            &gforms,
+            intrinsics,
+            Box::new(NullEmitter),
+            0,
+            false,
+        )
+        .unwrap();
+        assert_eq!(m.run(Some(100_000)).unwrap(), Some(6));
     }
 }


### PR DESCRIPTION
## Root cause

Every pre-compiled prelude binding is stored in the blob as an **arity-0 updatable thunk** (the xtask `LambdaForm::thunk` wrapping), so `cons`, `if`, `nil?`, `map`, … are thunks that yield their lambda when first forced.

`Op::DirectApp`'s thunk-callee branch only handled a **local** thunk:

```rust
if c.update() {
    if let DecodedRef::Local(i) = callable {
        // blackhole + Update + ApplyTo + current = callee
    }
    // Global thunk: NOTHING ran → state.current unchanged
}
```

When the callee was a **global** thunk (the common case on the blob path), the inner `if let DecodedRef::Local` failed and **no branch executed** — `state.current` was left pointing at the same `DirectApp` node, which re-dispatched forever. An infinite, unbounded-allocation loop (`~12 GB` before the heap cap, GC thrashing).

Any recursive/non-inlined prelude global reached via `DirectApp` hung: `map`, `filter`, `count`, `reverse`, `foldl`, `zip`, … A `sample(1)` of the hung process showed `DirectApp cons` (global slot 269, `update=true`, `arity=0`, `args=2`) repeating with **constant stack depth and env pointer** — the tell-tale of `state.current` never advancing.

## Fix

In `DirectApp`, force a thunk callee regardless of Local/Global. A local thunk is still memoised (blackhole + `Update`); a global thunk is entered **without** memoisation, mirroring `Op::App` (the globals frame is shared, so it is not blackholed/overwritten here). `state.current` is now always advanced to the callee, so the thunk is forced to its lambda and the pending `ApplyTo` saturates it.

## Not macOS-specific — and why it shipped uncaught

The bug is a platform-independent logic error. It only ever surfaces on the **bytecode + blob** path, and **no CI job exercised that path**: the bytecode harness jobs (`test`, `test-gc-verified`, `test-aarch64-sequential`) run `cargo build --release` **without** `cargo run -p xtask -- prelude-compile`, so the binary falls back to the **source** prelude (which compiles prelude functions as root-letrec locals — `Ref::L`, handled correctly). It appeared "macOS-only" purely because that path was first generated locally during BV5 work. **Released binaries do embed the blob**, so this was release-blocking for 0.12.0 on every platform.

## Prevention

- **Regression test** `direct_app_forces_global_thunk`: a global arity-0 thunk that yields a lambda, invoked via `DirectApp` with an arg. Runs in `cargo test --lib` on every platform (no blob needed); **fails** (`DidntTerminate` under a tick limit) without the fix, **passes** with it. Verified both directions.
- **CI**: new `test-bytecode-blob` job (ubuntu-latest, macos-latest, ubuntu-24.04-arm) that generates the blob and runs the harness on the default bytecode engine — closing the coverage gap.

## Verification (macOS aarch64)

| Check | Result |
|---|---|
| Full bytecode+blob harness (`eu test`, default engine) | **176/176, exit 0** (was hanging) |
| `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1` bytecode+blob harness | **176/176, clean** (earlier POISON hole-warning gone) |
| `cargo test --lib` | **1259 passed, 0 failed** (incl. new regression test) |
| clippy `--all-targets -D warnings` / `cargo fmt` | clean |
| `map`/`filter`/`reverse`/`foldl`/`zip` on bytecode+blob | correct output |

Branched from the pristine `integration/0.12.0` baseline (the fix is in the VM engine, independent of the BV5 blob work in #952).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee