### PR TITLE
fix(blob): make prelude blob generation deterministic (eu-c2ue)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -127,6 +127,35 @@ jobs:
       - name: Run harness on the bytecode + blob path
         run: ./target/release/eu test --allow-io tests/harness
 
+  blob-determinism:
+    name: Prelude blob determinism
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # The released binary embeds `lib/prelude.blob`, so its generation must
+      # be byte-for-byte reproducible: otherwise builds are non-reproducible
+      # and blob-path perf is unstable (eu-c2ue). Regenerate the blob twice
+      # and assert the two outputs are identical.
+      - name: Generate prelude blob (run 1)
+        run: |
+          cargo run --package xtask -- prelude-compile
+          cp lib/prelude.blob /tmp/prelude-run1.blob
+      - name: Generate prelude blob (run 2)
+        run: |
+          cargo run --package xtask -- prelude-compile
+          cp lib/prelude.blob /tmp/prelude-run2.blob
+      - name: Assert blobs are byte-identical
+        run: |
+          if ! cmp -s /tmp/prelude-run1.blob /tmp/prelude-run2.blob; then
+            echo "::error::prelude.blob generation is non-deterministic (eu-c2ue regression)"
+            sha256sum /tmp/prelude-run1.blob /tmp/prelude-run2.blob
+            cmp /tmp/prelude-run1.blob /tmp/prelude-run2.blob || true
+            exit 1
+          fi
+          echo "prelude.blob is byte-identical across two runs"
+          sha256sum /tmp/prelude-run1.blob
+
   test-source-prelude:
     name: Source-prelude harness (x86-64)
     runs-on: ubuntu-latest

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod environment;
 pub mod prettify;
+pub mod serde_sorted;
 pub mod sourcemap;
 pub mod truncate;

--- a/src/common/serde_sorted.rs
+++ b/src/common/serde_sorted.rs
@@ -1,0 +1,82 @@
+//! Deterministic serialisation for `HashMap` fields.
+//!
+//! `HashMap` iterates in an arbitrary, run-to-run order, so serialising one
+//! directly (e.g. with postcard into the prelude blob) produces different
+//! bytes on every run even when the logical contents are identical.  This
+//! breaks reproducible builds and confounds blob-path benchmarking (eu-c2ue).
+//!
+//! Apply `#[serde(with = "crate::common::serde_sorted")]` to a
+//! `HashMap<K, V>` field where `K: Ord` to serialise its entries in sorted
+//! key order.  The wire format is identical to a plain map (postcard encodes
+//! both `HashMap` and `BTreeMap` as a length-prefixed sequence of entries),
+//! so deserialisation reads straight back into a `HashMap` and nothing else
+//! in the codebase needs to change.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Serialise a `HashMap` with its entries in sorted key order.
+pub fn serialize<S, K, V>(map: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    K: Serialize + Ord,
+    V: Serialize,
+{
+    // Collect into a BTreeMap so the entries are emitted in a stable, sorted
+    // order regardless of the source HashMap's iteration order.
+    let sorted: BTreeMap<&K, &V> = map.iter().collect();
+    sorted.serialize(serializer)
+}
+
+/// Deserialise a `HashMap` (order is irrelevant on the way in).
+pub fn deserialize<'de, D, K, V>(deserializer: D) -> Result<HashMap<K, V>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
+{
+    HashMap::deserialize(deserializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Holder {
+        #[serde(with = "super")]
+        map: HashMap<String, u32>,
+    }
+
+    #[test]
+    fn sorted_serialisation_is_order_independent() {
+        // Two logically-equal maps built with different insertion orders must
+        // serialise to identical bytes.
+        let mut a = HashMap::new();
+        a.insert("zebra".to_string(), 1u32);
+        a.insert("apple".to_string(), 2u32);
+        a.insert("mango".to_string(), 3u32);
+
+        let mut b = HashMap::new();
+        b.insert("mango".to_string(), 3u32);
+        b.insert("zebra".to_string(), 1u32);
+        b.insert("apple".to_string(), 2u32);
+
+        let ba = postcard::to_allocvec(&Holder { map: a }).unwrap();
+        let bb = postcard::to_allocvec(&Holder { map: b }).unwrap();
+        assert_eq!(ba, bb, "sorted serialisation must be order-independent");
+    }
+
+    #[test]
+    fn round_trips() {
+        let mut map = HashMap::new();
+        map.insert("one".to_string(), 1u32);
+        map.insert("two".to_string(), 2u32);
+        let holder = Holder { map };
+        let bytes = postcard::to_allocvec(&holder).unwrap();
+        let restored: Holder = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(holder, restored);
+    }
+}

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -201,10 +201,12 @@ pub struct PreludeSummary {
     ///
     /// Polymorphic schemes are preserved so that every use-site freshens
     /// the type variables independently.
+    #[serde(with = "crate::common::serde_sorted")]
     pub bindings: HashMap<String, TypeScheme>,
 
     /// Type aliases the prelude registers (from `type-def:` / `types:`
     /// metadata).  User-file annotations can reference these alias names.
+    #[serde(with = "crate::common::serde_sorted")]
     pub aliases: AliasMap,
 
     /// BranchShape classification for recognised brancher combinators,
@@ -213,6 +215,7 @@ pub struct PreludeSummary {
     /// With prelude caching, prelude functions appear as `Var::Free` in user
     /// code.  `recognise_brancher` consults this map when the head is a
     /// free variable so that `if`, `then`, `and`, etc. are still recognised.
+    #[serde(with = "crate::common::serde_sorted")]
     pub branch_shapes: HashMap<String, BranchShape>,
 
     /// Pre-cook operator type overloads for constraint discharge (§B2).
@@ -222,6 +225,7 @@ pub struct PreludeSummary {
     /// the type checker.  This map captures the annotations before cook and
     /// allows `discharge_constraint` to verify operator constraints even when
     /// the scope-stack entry for the operator is `Any`.
+    #[serde(with = "crate::common::serde_sorted")]
     pub operator_overloads: HashMap<String, TypeScheme>,
 }
 

--- a/src/driver/io.rs
+++ b/src/driver/io.rs
@@ -88,6 +88,33 @@ pub fn create_io_pseudoblock(seed: Option<i64>) -> RcExpr {
     ])
 }
 
+/// Construct a deterministic `__io` pseudoblock for blob generation.
+///
+/// The blob's `__io` slot is always overridden at runtime with a freshly
+/// constructed pseudoblock reflecting the real invocation (see
+/// `Executor::execute`), so the values baked into the blob at generation
+/// time are never observed by a running program.  Building it from live
+/// `SystemTime::now()`, `env::vars()` and the current timezone would bake
+/// invocation-specific data (an epoch timestamp, a nanosecond random seed,
+/// the whole environment) into the blob, making `cargo xtask
+/// prelude-compile` non-reproducible.  Using fixed placeholders (epoch 0,
+/// empty env, seed 0, UTC) keeps the generated blob byte-for-byte identical
+/// across runs without affecting runtime behaviour.
+pub fn create_io_pseudoblock_deterministic() -> RcExpr {
+    acore::block(vec![
+        (
+            "ENV".to_string(),
+            acore::block(std::iter::empty::<(String, RcExpr)>()),
+        ),
+        ("EPOCHTIME".to_string(), acore::num(0i64)),
+        (
+            "TZ".to_string(),
+            acore::block(vec![("offset".to_string(), acore::str("+00:00"))]),
+        ),
+        ("RANDOM_SEED".to_string(), acore::num(0i64)),
+    ])
+}
+
 /// Construct a core list containing command-line arguments passed
 /// after the -- separator.
 pub fn create_args_pseudoblock(args: &[String]) -> RcExpr {

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -51,7 +51,9 @@ use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
 use std::{fs, iter};
 
-use super::io::{create_args_pseudoblock, create_io_pseudoblock};
+use super::io::{
+    create_args_pseudoblock, create_io_pseudoblock, create_io_pseudoblock_deterministic,
+};
 use super::unit_interface::UnitInterface;
 
 /// A loader for source code that stores the bytes for error reporting
@@ -83,6 +85,12 @@ pub struct SourceLoader {
     args: Vec<String>,
     /// Seed for random number generation
     seed: Option<i64>,
+    /// When set, the `__io` pseudoblock is built with deterministic
+    /// placeholder values (epoch 0, empty env, seed 0, UTC) rather than live
+    /// invocation data.  Used by `cargo xtask prelude-compile` so the
+    /// generated blob is byte-for-byte reproducible; the runtime always
+    /// overrides the `__io` slot with real values anyway.
+    deterministic_io: bool,
     /// Prelude override: set when a loaded unit specifies `prelude:` metadata.
     /// The `Input` replaces the default `Resource("prelude")` in the inputs list.
     prelude_override: Option<Input>,
@@ -130,6 +138,7 @@ impl Default for SourceLoader {
             lib_path: Vec::new(),
             args: Vec::new(),
             seed: None,
+            deterministic_io: false,
             prelude_override: None,
             unit_interface: UnitInterface::default(),
             pending_parse_errors: Vec::new(),
@@ -156,6 +165,7 @@ impl SourceLoader {
             lib_path,
             args: Vec::new(),
             seed: None,
+            deterministic_io: false,
             prelude_override: None,
             unit_interface: UnitInterface::default(),
             #[cfg(not(target_arch = "wasm32"))]
@@ -174,6 +184,17 @@ impl SourceLoader {
     /// Set the random seed for the __io pseudoblock
     pub fn with_seed(mut self, seed: Option<i64>) -> Self {
         self.seed = seed;
+        self
+    }
+
+    /// Build the `__io` pseudoblock deterministically (for blob generation).
+    ///
+    /// When enabled, the `__io` pseudoblock uses fixed placeholder values
+    /// instead of live invocation data, so `cargo xtask prelude-compile`
+    /// produces a byte-for-byte reproducible blob.  The runtime always
+    /// overrides the `__io` slot with real values, so behaviour is unchanged.
+    pub fn with_deterministic_io(mut self, deterministic: bool) -> Self {
+        self.deterministic_io = deterministic;
         self
     }
 
@@ -459,6 +480,7 @@ impl SourceLoader {
         // Dispatch based on pseudo name
         let core = match input.locator() {
             Locator::Pseudo(name) if name == "args" => create_args_pseudoblock(&self.args),
+            _ if self.deterministic_io => create_io_pseudoblock_deterministic(),
             _ => create_io_pseudoblock(self.seed),
         };
 

--- a/src/eval/stg/blob.rs
+++ b/src/eval/stg/blob.rs
@@ -96,9 +96,11 @@ pub struct PreludeBlob {
     pub binding_entries: Vec<FormIdx>,
 
     /// Binding name → index into `binding_entries` (= global slot − `INTRINSIC_COUNT`).
+    #[serde(with = "crate::common::serde_sorted")]
     pub name_to_slot: HashMap<String, usize>,
 
     /// Operator metadata for seeding cook's `Distributor`.
+    #[serde(with = "crate::common::serde_sorted")]
     pub operators: HashMap<String, OperatorInfo>,
 
     /// Type schemes, aliases, branch shapes for seeding the type checker.
@@ -108,11 +110,11 @@ pub struct PreludeBlob {
     ///
     /// Extracted from prelude source during translate/desugar.  Seeded into
     /// the desugarer so that `{ :for ... }` blocks are recognised as monadic.
-    #[serde(default)]
+    #[serde(default, with = "crate::common::serde_sorted")]
     pub monad_specs: HashMap<String, crate::core::desugar::desugarer::MonadSpec>,
 
     /// Monad wrapper type hints for LSP display (e.g. `"io"` → `"IO(a)"`).
-    #[serde(default)]
+    #[serde(default, with = "crate::common::serde_sorted")]
     pub monad_type_hints: HashMap<String, String>,
 
     /// Core expressions for inlinable prelude bindings.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,7 +108,11 @@ fn cmd_prelude_compile() -> Result<()> {
         prelude_input.clone(),
     ];
 
-    let mut loader = SourceLoader::new(vec![]);
+    // Build the `__io` pseudoblock deterministically: the blob must not embed
+    // the current epoch time / random seed / environment (all overridden at
+    // runtime anyway), or two prelude-compile runs would produce differing
+    // blobs (see eu-c2ue).
+    let mut loader = SourceLoader::new(vec![]).with_deterministic_io(true);
     for inp in &all_inputs {
         loader.load(inp).with_context(|| format!("load {inp}"))?;
     }


### PR DESCRIPTION
## Summary

`cargo run -p xtask -- prelude-compile` was **non-deterministic** — every run produced a different `lib/prelude.blob`. This breaks reproducible builds and confounds every blob-path benchmark (eu-c2ue, a 0.12 release gate).

## Root cause — bytes-only, NOT slot/layout (case a, not case b)

Structural diff of two divergent blobs showed the executable prelude image was **already deterministic**: STG node order, bytecode `code`/`templates`/`global_forms`/`global_entries`, and `name_to_slot` slot **values** were all byte-identical. Only two things differed:

1. **Build timestamps.** Loading the `__io` pseudoblock during generation baked live `SystemTime::now()` (`EPOCHTIME`) and a nanosecond `RANDOM_SEED` into the compiled prelude (via `io.epoch-time`, `cal.now`, `io.RANDOM_SEED`). Exactly **2 arena nodes / 2 bytecode constants** differed between runs — both timestamps. These slots are always overridden at runtime with real invocation values, so the baked constants are dead data.
2. **HashMap serialisation order.** `PreludeBlob`'s `name_to_slot`, `operators`, `monad_specs`, `monad_type_hints` and `PreludeSummary`'s `bindings`, `aliases`, `branch_shapes`, `operator_overloads` are HashMaps; postcard emits them in arbitrary iteration order.

Because the executable image was identical, **the ~2x wall swing furnace-w2oy attributed to "which blob variant" was not a slot-assignment effect.** Serialised map order has zero runtime effect (a HashMap re-hashes on load) and two constant *values* cannot cause a 2x swing. The swing was a binary-layout/measurement artifact of the shifting embedded blob bytes; making the bytes identical removes the confound entirely.

## Fix

- **Deterministic `__io` for generation.** New `SourceLoader::with_deterministic_io(true)` selects a fixed `__io` pseudoblock (epoch 0, empty env, seed 0, UTC); xtask uses it. Runtime behaviour unchanged (the slot is overridden per-invocation regardless).
- **Sorted serialisation.** New `common::serde_sorted` serde adapter serialises a HashMap in sorted key order (values are map-free, so sorting outer keys is sufficient). Applied via `#[serde(with = ...)]` to the 8 map fields above. Runtime types stay `HashMap`; only the wire byte order changes, and deserialisation reads straight back into a `HashMap`.

## Verification

- **Byte-identical:** two `prelude-compile` runs (with a 1s gap) → identical sha256. Core acceptance met.
- **Perf variance gone by construction:** two regenerated blobs are now byte-identical, so binaries built from them are identical. day03 part-2 stable at ~1.65s median over 5 runs (~7% noise), no 2x swing.
- **Harness 477/477** via `cargo test`; release-binary harness 176/176 files on **blob (bytecode)**, **source-prelude** and **HeapSyn** paths.
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1` harness clean (176/0).
- `cargo test --lib` (1264) green; clippy `--all-targets -D warnings` + fmt clean.
- **CI guard:** new `blob-determinism` job regenerates the blob twice and asserts `cmp` equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee