### PR TITLE
fix(driver): sanitise __io for eu dump to stop env secrets leak (eu-9uhq)

### DIFF
--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -121,7 +121,13 @@ fn run() -> i32 {
     // Anything else is going to involve reading the inputs
     let mut loader = SourceLoader::new(opt.lib_path().to_vec())
         .with_args(opt.args().to_vec())
-        .with_seed(opt.seed());
+        .with_seed(opt.seed())
+        // Inspection-only invocations (`eu dump <phase>`) embed the compiled
+        // unit — including the `__io` pseudoblock — into their output.  Build
+        // a sanitised `__io` (empty env) so the real process environment, and
+        // any secrets held in env vars, are never printed.  Eval/run keeps the
+        // real environment.
+        .with_deterministic_io(opt.inspects_ir());
 
     // Load the pre-compiled prelude blob once and store it in the loader.
     // cook() will seed the Distributor with blob.operators; after prepare(),

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -317,7 +317,16 @@ impl<'a> Executor<'a> {
             }
 
             if let Some(&io_slot) = b.name_to_slot.get("__io") {
-                let io_expr = crate::driver::io::create_io_pseudoblock(self.seed);
+                // Inspection-only invocations (`eu dump runtime`/`stg`) print
+                // the runtime globals, which include this overridden `__io`
+                // slot.  Use a sanitised (empty-env) pseudoblock so the real
+                // process environment is never embedded in dump output; eval
+                // (`opt.run()`) still substitutes the live environment.
+                let io_expr = if opt.inspects_ir() {
+                    crate::driver::io::create_io_pseudoblock_deterministic()
+                } else {
+                    crate::driver::io::create_io_pseudoblock(self.seed)
+                };
                 if let Ok(stg_syn) = stg::compile(&override_settings, io_expr, rt.as_ref()) {
                     rt.set_prelude_slot_override(io_slot, stg::syntax::LambdaForm::thunk(stg_syn));
                 }

--- a/src/driver/options.rs
+++ b/src/driver/options.rs
@@ -1019,6 +1019,31 @@ impl EucalyptOptions {
             && !self.doc_mode
     }
 
+    /// True when the invocation merely inspects/prints a compiled unit's
+    /// intermediate representation (any `eu dump <phase>` command) rather
+    /// than evaluating it.
+    ///
+    /// Such inspection embeds the whole compiled unit — including the `__io`
+    /// pseudoblock — into its output.  Capturing the real process environment
+    /// there would leak any secrets held in env vars (e.g. `ANTHROPIC_API_KEY`)
+    /// into dump output that is routinely pasted into bug reports, CI logs and
+    /// chat transcripts.  When this is set the loader (and the runtime-globals
+    /// override for the blob path) build a sanitised, deterministic `__io`
+    /// (empty env, epoch 0, seed 0, UTC).  Env/time/seed capture only matters
+    /// for eval/run, which is unaffected.
+    pub fn inspects_ir(&self) -> bool {
+        self.parse
+            || self.dump_desugared
+            || self.dump_cooked
+            || self.dump_split
+            || self.dump_inlined
+            || self.dump_pruned
+            || self.dump_demands
+            || self.dump_reflatten
+            || self.dump_stg
+            || self.dump_runtime
+    }
+
     pub fn target(&self) -> Option<&str> {
         self.target.as_deref()
     }

--- a/tests/io_args_test.rs
+++ b/tests/io_args_test.rs
@@ -145,3 +145,80 @@ fn test_io_random_seed_values_differ_per_seed() {
         "different --seed flags must produce different io.RANDOM_SEED values"
     );
 }
+
+/// Marker written into the process environment for the dump-leak regression
+/// tests below.  If it turns up in `eu dump` output the compiled unit is
+/// embedding the real process environment — a secrets-leak (see eu-9uhq).
+const SECRET_MARKER: &str = "eu-9uhq-secret-should-not-leak";
+
+/// Run `eu dump <phase> <extra_args> <file>` with a planted secret env var and
+/// return combined stdout+stderr.  Unlike `eu_eval`, this does not assert
+/// success — dump phases exit 0 but we care about output content.
+fn eu_dump_with_secret(phase: &str, extra_args: &[&str]) -> String {
+    // A trivial source file that still triggers the full compile pipeline
+    // (and, for `stg`/`runtime`, the blob runtime-globals override).
+    let mut file = std::env::temp_dir();
+    file.push(format!("eu_9uhq_dump_{phase}.eu"));
+    std::fs::write(&file, "h: 1\n").expect("failed to write temp source");
+
+    let mut args = vec!["dump", phase];
+    args.extend_from_slice(extra_args);
+    let file_str = file.to_string_lossy().to_string();
+    args.push(&file_str);
+
+    let output = std::process::Command::new(eu_binary())
+        .args(&args)
+        // Plant fake secrets in the child's environment.
+        .env("ANTHROPIC_API_KEY", SECRET_MARKER)
+        .env("OPENAI_API_KEY", SECRET_MARKER)
+        .output()
+        .expect("failed to run eu dump");
+
+    let _ = std::fs::remove_file(&file);
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+/// Regression for eu-9uhq: no `eu dump <phase>` variant may embed the real
+/// process environment (and therefore secrets held in env vars) into its
+/// output.  Covers every dump phase in both plain and `--embed` forms.
+#[test]
+fn test_dump_does_not_leak_process_env() {
+    for phase in [
+        "ast",
+        "desugared",
+        "cooked",
+        "inlined",
+        "pruned",
+        "stg",
+        "runtime",
+    ] {
+        for extra in [&[][..], &["--embed"][..]] {
+            let out = eu_dump_with_secret(phase, extra);
+            assert!(
+                !out.contains(SECRET_MARKER),
+                "eu dump {phase} {extra:?} leaked the planted secret into its output"
+            );
+        }
+    }
+}
+
+/// The inspection sanitisation must not touch eval/run: `io.env` reads the
+/// real environment at evaluation time (the correctness boundary).
+#[test]
+fn test_eval_still_reads_real_env() {
+    let output = std::process::Command::new(eu_binary())
+        .arg("-e")
+        .arg("io.env lookup(:EU_9UHQ_REAL_ENV_MARKER)")
+        .env("EU_9UHQ_REAL_ENV_MARKER", SECRET_MARKER)
+        .output()
+        .expect("failed to run eu binary");
+    assert!(output.status.success(), "eu eval failed");
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        out.contains(SECRET_MARKER),
+        "eval must observe the real environment, got: {out}"
+    );
+}


### PR DESCRIPTION
## Summary

`eu dump <phase> <file>` embeds the full compiled unit — including the `__io` pseudoblock whose `ENV` slot captures the **real process environment** — into its output. With secrets held in env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …), a plain `eu dump cooked --embed file.eu` prints them in plaintext, leaking them into anything the output lands in (bug reports, CI logs, chat/pairing transcripts). This is bead **eu-9uhq** (P1, a 0.12 gate); discovered live.

## Fix

Reuses the shared-root sanitisation from #958 (`SourceLoader::with_deterministic_io(true)`: empty env, epoch 0, seed 0, UTC), exactly as the owner directed ("deal with it similarly to the blob system-time issue").

- **New predicate** `EucalyptOptions::inspects_ir()` — true for every `eu dump <phase>` (ast/desugared/cooked/split/inlined/pruned/demands/reflatten/stg/runtime), i.e. invocations that *print/embed* a compiled unit rather than *evaluating* it.
- **Loader** (`src/bin/eu.rs`): `.with_deterministic_io(opt.inspects_ir())` — the unit's `__io.ENV` is empty for dumps.
- **Runtime-globals override** (`src/driver/eval.rs`): `dump runtime`/`dump stg`/`dump reflatten` go through `eval::run`, and the blob path overrides the `__io` slot *after* which `dump runtime` prints the runtime globals. That override now uses the deterministic pseudoblock when `inspects_ir()`, so the printed slot cannot carry real env either.

## Eval/run is unchanged (the correctness boundary)

Env/time/seed capture only matters for eval/run. Those paths keep `with_deterministic_io(false)` and the real runtime override — `io.env`, `io.epoch-time`, `--seed`/`random:` all still reflect the live invocation. `test` is deliberately **not** in `inspects_ir()` (it evaluates).

## Verification

- **Secret-absent proof:** with `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` set to `sk-secret-test*`, every dump phase (plain, `--embed`, `--debug-format`) output greps **clean** — no secret.
- **Eval unaffected:** `io.env lookup(:VAR)` returns the real value; `io.epoch-time` returns a real non-zero timestamp.
- **Regression tests** added to `tests/io_args_test.rs`: `test_dump_does_not_leak_process_env` (all phases × plain/--embed with planted secret) and `test_eval_still_reads_real_env`.
- Harness **477/477** under `EU_GC_VERIFY=2 EU_GC_STRESS=1`; `cargo test --lib` (1264) green; conform + bytecode-differential (both engines) green; clippy `--all-targets -D warnings` + `cargo fmt --all` clean.

Bead: eu-9uhq. Do not merge / do not close — gatekeeper review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee