### PR TITLE
perf(bytecode): unify -S statistics across engines (eu-s2oz); investigate block index (eu-4zhi)

### DIFF
--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -104,6 +104,44 @@ fn collect_machine_stats(machine: &crate::eval::machine::vm::Machine<'_>, stats:
     stats.set_total_sweep_time(machine.clock().duration(ThreadOccupation::CollectorSweep));
 }
 
+/// Collect machine, GC, and heap statistics from the bytecode machine after
+/// all execution phases (eval, render, IO) have completed.
+///
+/// The bytecode engine keeps the same `Metrics`/`Clock`/`HeapStats` records
+/// as the HeapSyn machine, so `-S` reports a comparable, single-counted set on
+/// both engines. Allocation counts come from the shared machine state (see
+/// `BytecodeMachine::allocs`) rather than `Metrics`, because they are recorded
+/// inside the free `handle_op` dispatch.
+fn collect_bytecode_stats(
+    machine: &crate::eval::bytecode::BytecodeMachine<'_>,
+    stats: &mut Statistics,
+) {
+    use crate::eval::machine::metrics::ThreadOccupation;
+
+    // GC phase timings
+    for (k, v) in machine.clock().report() {
+        stats.timings_mut().record(k, v);
+    }
+
+    // Machine counters
+    stats.set_ticks(machine.metrics().ticks());
+    stats.set_allocs(machine.allocs());
+    stats.set_max_stack(machine.metrics().max_stack());
+
+    // Heap stats
+    let heap_stats = machine.heap_stats();
+    stats.set_blocks_allocated(heap_stats.blocks_allocated);
+    stats.set_lobs_allocated(heap_stats.lobs_allocated);
+    stats.set_blocks_used(heap_stats.used);
+    stats.set_blocks_recycled(heap_stats.recycled);
+    stats.set_collections_count(heap_stats.collections_count);
+    stats.set_peak_heap_blocks(heap_stats.peak_heap_blocks);
+
+    // Aggregate GC timings
+    stats.set_total_mark_time(machine.clock().duration(ThreadOccupation::CollectorMark));
+    stats.set_total_sweep_time(machine.clock().duration(ThreadOccupation::CollectorSweep));
+}
+
 /// Run the prepared core expression and output to selected emitter
 /// Run result: statistics and an optional process exit code override.
 ///
@@ -494,6 +532,13 @@ impl<'a> Executor<'a> {
                     ret.map(|_| None)
                 };
                 m.take_emitter().stream_end();
+
+                // Collect machine/GC statistics from all execution phases so
+                // that -S reports bytecode Machine/Heap/GC stats comparable to
+                // the HeapSyn path (collected even on error, mirroring the
+                // HeapSyn branch below).
+                collect_bytecode_stats(&m, stats);
+
                 result
             } else {
                 emitter.stream_start();

--- a/src/driver/statistics.rs
+++ b/src/driver/statistics.rs
@@ -213,7 +213,7 @@ impl Display for Statistics {
         let parts = self.timings.partition();
 
         // Summary bar
-        let summary = render_summary_bar(&parts.pipeline, &parts.io, &parts.vm);
+        let summary = render_summary_bar(&parts.pipeline, &parts.io);
         if !summary.is_empty() {
             writeln!(f, "{summary}")?;
             writeln!(f)?;
@@ -352,11 +352,18 @@ fn render_bar(value: f64, max_value: f64) -> String {
 }
 
 /// Render a top-level summary bar showing where total time was spent.
-fn render_summary_bar(
-    pipeline: &[(String, Duration)],
-    io: &[(String, Duration)],
-    vm: &[(String, Duration)],
-) -> String {
+///
+/// The `Total` is the end-to-end wall clock: the sum of the sequential
+/// pipeline phases (parse, desugar, cook, compile, eval, render) plus IO.
+///
+/// The VM occupation timings (mutator vs GC) are deliberately excluded from
+/// this sum: they partition the *same* eval/render/IO span a second way, so
+/// adding them would double-count evaluation (the bug found in eu-mhjz where
+/// HeapSyn's `Total` was ~2× the real wall clock while the bytecode engine —
+/// which reported no VM timings — counted once). Excluding VM here makes the
+/// `Total` single-counted and directly comparable across both engines. The
+/// mutator/GC breakdown remains visible in the dedicated VM and GC sections.
+fn render_summary_bar(pipeline: &[(String, Duration)], io: &[(String, Duration)]) -> String {
     let mut fractions: Vec<(String, f64)> = Vec::new();
 
     for (name, dur) in pipeline {
@@ -367,16 +374,6 @@ fn render_summary_bar(
     let io_total: f64 = io.iter().map(|(_, v)| v.as_secs_f64()).sum();
     if io_total > 0.0 {
         fractions.push(("IO".to_string(), io_total));
-    }
-
-    // Add VM as a single entry (exclude the VM-Total synthetic key)
-    let vm_total: f64 = vm
-        .iter()
-        .filter(|(k, _)| k != "VM-Total")
-        .map(|(_, v)| v.as_secs_f64())
-        .sum();
-    if vm_total > 0.0 {
-        fractions.push(("VM".to_string(), vm_total));
     }
 
     let total: f64 = fractions.iter().map(|(_, s)| s).sum();
@@ -573,23 +570,34 @@ mod tests {
     #[test]
     fn summary_bar_single_entry() {
         let pipeline = vec![("parse".to_string(), Duration::from_millis(100))];
-        let bar = render_summary_bar(&pipeline, &[], &[]);
+        let bar = render_summary_bar(&pipeline, &[]);
         assert!(bar.contains("Total: 0.100s"));
         assert!(bar.contains("parse 100%"));
     }
 
     #[test]
     fn summary_bar_empty() {
-        assert_eq!(render_summary_bar(&[], &[], &[]), "Total: 0.000s");
+        assert_eq!(render_summary_bar(&[], &[]), "Total: 0.000s");
     }
 
     #[test]
-    fn summary_bar_with_vm() {
+    fn summary_bar_with_io() {
         let pipeline = vec![("parse".to_string(), Duration::from_millis(80))];
-        let vm = vec![("VM-Mutator".to_string(), Duration::from_millis(20))];
-        let bar = render_summary_bar(&pipeline, &[], &vm);
+        let io = vec![("io-run".to_string(), Duration::from_millis(20))];
+        let bar = render_summary_bar(&pipeline, &io);
         assert!(bar.contains("parse 80%"));
-        assert!(bar.contains("VM 20%"));
+        assert!(bar.contains("IO 20%"));
+    }
+
+    #[test]
+    fn summary_bar_excludes_vm_from_total() {
+        // VM occupation timings must NOT contribute to the summary Total —
+        // they are a second view of the eval span, not additive time.
+        // The Total should reflect only the pipeline wall clock.
+        let pipeline = vec![("stg-eval".to_string(), Duration::from_millis(100))];
+        let bar = render_summary_bar(&pipeline, &[]);
+        assert!(bar.contains("Total: 0.100s"));
+        assert!(!bar.contains("VM"));
     }
 
     #[test]

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -28,7 +28,7 @@ use crate::eval::memory::array::Array;
 use crate::eval::memory::collect::{
     collect as gc_collect, CollectorHeapView, CollectorScope, GcScannable, ScanPtr,
 };
-use crate::eval::memory::heap::Heap;
+use crate::eval::memory::heap::{Heap, HeapStats};
 use crate::eval::memory::infotable::{InfoTable, InfoTagged};
 use crate::eval::memory::mutator::MutatorHeapView;
 use crate::eval::memory::string::HeapString;
@@ -249,6 +249,12 @@ pub struct BcMachineState {
     /// their heap pointers must stay live for the sub-evaluation (mirrors
     /// `MachineState::suspended_stacks`).
     pub suspended_stacks: Vec<Vec<BcContinuation>>,
+    /// Closures allocated by `let`/`letrec` bindings, accumulated across every
+    /// execution phase (main run, io-run drives, nested `evaluate_to_whnf`).
+    /// Counted the same way as the HeapSyn machine's `Metrics::allocs`
+    /// (`vm.rs` — one per `let`/`letrec` binding) so `-S` allocation counts
+    /// are cross-engine comparable.
+    pub allocs: u64,
 }
 
 impl BcMachineState {
@@ -276,6 +282,7 @@ impl BcMachineState {
             blackhole: 0,
             stash: Vec::new(),
             suspended_stacks: Vec::new(),
+            allocs: 0,
         }
     }
 
@@ -1431,6 +1438,7 @@ pub fn handle_op(
         Op::Let => {
             let (headers, body_off) = read_let(code, &mut pc);
             // Non-recursive: bindings close over the enclosing env.
+            state.allocs += headers.len() as u64;
             let mut array = Array::with_capacity(&view, headers.len());
             for h in &headers {
                 array.push(&view, BcValue::Closure(BcClosure::close(&bc_info(h), env)));
@@ -1443,6 +1451,7 @@ pub fn handle_op(
         Op::LetRec => {
             let (headers, body_off) = read_let(code, &mut pc);
             // Recursive: bindings close over the new frame itself.
+            state.allocs += headers.len() as u64;
             let mut array = Array::with_capacity(&view, headers.len());
             for _ in &headers {
                 array.push(
@@ -1829,11 +1838,38 @@ impl<'a> BytecodeMachine<'a> {
         Ok(self.exit_code())
     }
 
+    /// Machine metrics (ticks, max stack) accumulated across every phase.
+    /// Note: allocation counts live on the shared machine state (see
+    /// [`Self::allocs`]) because they are recorded inside the free `handle_op`
+    /// dispatch, which has no access to the metrics record.
+    pub fn metrics(&self) -> &Metrics {
+        &self.metrics
+    }
+
+    /// Closures allocated by `let`/`letrec` across every execution phase,
+    /// counted equivalently to the HeapSyn `Metrics::allocs` so `-S`
+    /// allocation figures are comparable across engines.
+    pub fn allocs(&self) -> u64 {
+        self.state.allocs
+    }
+
+    /// GC / occupation timings (mirrors `Machine::clock`).
+    pub fn clock(&self) -> &Clock {
+        &self.clock
+    }
+
+    /// Heap statistics (blocks, LOBs, collection counts) — the same
+    /// `HeapStats` the HeapSyn machine reports.
+    pub fn heap_stats(&self) -> HeapStats {
+        self.heap.stats()
+    }
+
     /// One dispatch step over the shared machine state (the free `step`),
     /// followed by the deferred `Bif` dispatch tail (spec §6.3): when the
     /// `Bif` arm captured an intrinsic, run it through a [`BcBifContext`].
     fn dispatch(&mut self) -> Result<(), ExecutionError> {
         self.metrics.tick();
+        self.metrics.stack(self.state.stack.len());
         {
             let view = MutatorHeapView::new(&self.heap);
             // Mirror the HeapSyn `handle_instruction` map_err (vm.rs): attach
@@ -2845,6 +2881,7 @@ impl BcBifContext<'_, '_> {
                 }
             }
             self.metrics.tick();
+            self.metrics.stack(self.state.stack.len());
             {
                 // SAFETY: the view borrows the heap for this scope only and is
                 // dropped before any `&mut self.heap` use; this mirrors the
@@ -3713,6 +3750,48 @@ mod tests {
         m.dispatch().unwrap(); // execute the Let (allocates the env frame)
         m.gc_now(); // roots must survive
         assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
+    }
+
+    #[test]
+    fn bytecode_reports_machine_heap_gc_stats() {
+        // The bytecode engine must expose the same Machine/Heap/GC statistics
+        // the driver reports under `-S` (eu-s2oz): ticks and allocations
+        // (Machine), heap blocks (Heap), and collection counts / timings (GC).
+        // `let x = 5 in x` performs one heap allocation; a forced collection
+        // advances the GC counters, exactly as a real run's periodic GC would.
+        let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
+        let (prog, root, gforms) = encode(&syn, &[]);
+        let mut m = bare_machine(prog, root, &gforms);
+
+        m.dispatch().unwrap(); // execute the Let (allocates the env frame)
+        m.gc_now(); // exercise the GC counters
+        assert_eq!(m.run(Some(10_000)).unwrap(), Some(5));
+
+        // Machine counters — non-zero and sensible.
+        assert!(m.metrics().ticks() > 0, "ticks should be non-zero");
+        assert!(
+            m.allocs() > 0,
+            "allocs should be non-zero (the `let` binding)"
+        );
+
+        // Heap counters.
+        let heap_stats = m.heap_stats();
+        assert!(
+            heap_stats.blocks_allocated > 0,
+            "heap blocks should have been allocated"
+        );
+
+        // GC counters — a collection ran, so counts and timings advance.
+        assert!(
+            heap_stats.collections_count > 0,
+            "a collection should have been recorded"
+        );
+        let total_gc = m.clock().duration(ThreadOccupation::CollectorMark)
+            + m.clock().duration(ThreadOccupation::CollectorSweep);
+        assert!(
+            total_gc > std::time::Duration::ZERO,
+            "GC mark/sweep time should have been recorded"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements **eu-s2oz** (unify `-S`/`--statistics` across engines) and reports the **eu-4zhi** (bytecode block index) investigation — deferred, see below.

## eu-s2oz — implemented

The A/B study (eu-mhjz) found `-S` was **not** cross-engine comparable and nearly inverted its own conclusions:
1. The bytecode engine reported **ZERO** Machine/Heap/GC stats (ticks/allocs/GC were HeapSyn-only).
2. The summary **Total** double-counted evaluation on HeapSyn (pipeline `stg-eval` + VM occupation ≈ 2×) while bytecode counted once.

### Bytecode Machine/Heap/GC stats
The bytecode machine already carried a `Metrics`, `Clock` and `Heap` — they were just never surfaced. This PR:
- records `let`/`letrec` allocations on the shared machine state, counted **identically** to HeapSyn's `Metrics::allocs`;
- records max stack depth alongside the existing tick in both dispatch loops;
- exposes `metrics()`/`allocs()`/`clock()`/`heap_stats()` accessors on `BytecodeMachine`;
- collects them into `Statistics` via a new `collect_bytecode_stats`, mirroring HeapSyn's `collect_machine_stats` (collected even on error).

For an identical program, both engines now report **byte-identical** ticks, allocs and max-stack (verified: `[1..10] map(_*2) sum` → 1,948 ticks / 246 allocs / 37 max-stack on both). Heap-block counts differ, reflecting genuinely different heap layouts.

### Single-counted, comparable Total
`render_summary_bar` no longer folds VM occupation timings (mutator vs GC) into the summary `Total`: they are a second *view* of the eval/render/IO span, not additive time. The `Total` is now the end-to-end pipeline+IO wall clock — single-counted and directly comparable across engines. The mutator/GC breakdown remains in the dedicated **VM** and **GC** sections.

### Tests
- `bytecode_reports_machine_heap_gc_stats` — a bytecode run reports non-zero ticks, allocs, heap blocks and (under a forced collection) GC counts and mark/sweep timings.
- `summary_bar_excludes_vm_from_total` / `summary_bar_with_io` — pin the single-counted Total.

## eu-4zhi — investigated, **deferred** (recommend owner decision)

**Finding: this is the large SynClosure-ABI migration, not a contained change.** Recommend deferring given the ~4% measured impact (day11-p1 lookup-heavy is already at parity).

The index optimisation lives entirely in `LookupOr::execute` / `SafeLookup::execute`, written against the **HeapSyn ABI**: `nav`/`resolve_native`, `SynClosure`, `HeapSyn::Cons`, `set_closure`, `root_env`, plus `build_index`/`walk_list_to_position`/`store_index_in_block`/`BlockListIterator`. On the bytecode `BcBifContext`, `nav`/`set_closure`/`root_env` **panic** — so `block_index_enabled()` returns `false` and lookups fall through to the STG find-loop (correct, just O(n)).

Reinstating on bytecode requires **all** of:
1. Porting the entire index build/store/lookup subsystem to the neutral bytecode ABI (`BcValue`/`BcClosure`/`BcEnvFrame` + bytecode navigator).
2. A per-instance **mutable index slot**. `store_index_in_block` mutates a `HeapSyn::Cons` arg slot in place. Static block literals bake their data template into the **immutable shared code arena** — there is no per-instance mutable slot there; the slot would have to move to a heap-resident node, and block instances would need to be shared across lookups (thunk memoisation) for the cache to pay off.
3. GC work: a new `Native::Index` root inside a heap block must be scanned/updated across evacuation.

None of the "contained" options survive scrutiny: a side-table keyed by block **pointer** is unsafe across GC (pointers move on evacuation); "cache only dynamic blocks" still requires the full ABI port to get off the panicking `nav`/`set_closure` path. So there is no small, low-risk win here — it is the large migration, for ~4%.

## Verification
- Full harness **477/477 on both engines** (bytecode default + `EU_HEAPSYN=1`).
- `cargo test --lib` — 1262 passed.
- `EU_GC_VERIFY=2 EU_GC_STRESS=1` — full harness 477/477 clean.
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee