### PR TITLE
fix(io): cross-engine IO action parity + dedup (eu-xqab); document XML attribute normalisation (eu-cgys)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to eucalypt are documented here.
 
+## [0.12.0] - Unreleased
+
+### Changed
+
+- **XML attribute values are now whitespace-normalised (BEHAVIOUR CHANGE)** — following the `quick-xml` 0.25→0.41 security bump, XML import now applies XML 1.0 §3.3.3 attribute-value normalisation, as required of a conforming processor. Each **literal** whitespace character (tab, carriage return, line feed) inside an attribute value is replaced by a single space. Raw newlines/tabs in attribute values therefore no longer survive import verbatim as they did in every previous release (which was non-conformant). To carry literal whitespace in an attribute value, use character references: `&#10;` for a newline, `&#9;` for a tab — these are resolved before normalisation and survive intact. **Element text content is unaffected.** (eu-cgys)
+
 ## [0.11.1] - Unreleased
 
 ### Changed

--- a/src/driver/bytecode_io_run.rs
+++ b/src/driver/bytecode_io_run.rs
@@ -44,6 +44,16 @@ fn evaluate_spec_block(
     machine: &mut BytecodeMachine<'_>,
     spec_block: BcValue,
 ) -> Result<ActionSpec, IoRunError> {
+    // Recover the spec block's meta tag (`io-shell` / `io-exec` / `io-fail`)
+    // statically, BEFORE forcing strips the `Meta` wrapper. This lets the
+    // bytecode engine dispatch on the actual tag exactly as the HeapSyn driver
+    // does, so a spec whose field set disagrees with its tag (e.g.
+    // `{:io-shell cmd: ..., args: []}`) runs the SAME action on both engines
+    // (eu-xqab). `None` for App-thunk specs (`io.shell-with` / `io.exec-with`)
+    // whose `Meta` is not statically visible — the shared policy then falls
+    // back to field inference, matching HeapSyn's `peel_meta` behaviour.
+    let tag = machine.peel_io_spec_tag(spec_block.clone());
+
     // Statically peel the `Meta` wrapper (see `BytecodeMachine::peel_io_spec`):
     // an inline spec block is a `let`-bound `Meta` whose body ref is relative
     // to the let frame, so it cannot be forced naively — we resolve the block
@@ -103,7 +113,11 @@ fn evaluate_spec_block(
         eval_fields.insert(key.clone(), value_str);
     }
 
-    build_action_spec(machine, eval_fields)
+    // Hand the recovered tag and evaluated fields to the shared, representation-
+    // agnostic policy so both engines apply identical tag dispatch, timeout /
+    // stdin handling, NUL-split args, required-cmd errors, and io-fail wording.
+    let call_smid = machine.annotation();
+    crate::driver::io_common::action_spec_from_fields(tag.as_deref(), &eval_fields, call_smid)
 }
 
 /// Force a spec-block field to WHNF, peeling a boxed scalar whose inner field
@@ -119,84 +133,6 @@ fn force_field(machine: &mut BytecodeMachine<'_>, value: BcValue) -> Result<BcVa
             .map_err(IoRunError::from)
     } else {
         Ok(whnf)
-    }
-}
-
-/// Turn the evaluated spec fields into an [`ActionSpec`], inferring the action
-/// tag from the field set (see module docs).
-fn build_action_spec(
-    machine: &BytecodeMachine<'_>,
-    eval_fields: HashMap<String, Option<String>>,
-) -> Result<ActionSpec, IoRunError> {
-    let timeout_secs = eval_fields
-        .get("timeout")
-        .and_then(|opt| opt.as_deref())
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(30);
-
-    let stdin = eval_fields
-        .get("stdin")
-        .and_then(|opt| opt.clone())
-        .filter(|s| !s.is_empty() && s != "null");
-
-    let call_smid = machine.annotation();
-
-    if eval_fields.contains_key("args") {
-        // io-exec: cmd + args.
-        let cmd = eval_fields
-            .get("cmd")
-            .and_then(|opt| opt.clone())
-            .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-                    call_smid,
-                    "io.exec: 'cmd' field is required in the action spec".to_string(),
-                )))
-            })?;
-        let args = eval_fields
-            .get("args")
-            .and_then(|opt| opt.clone())
-            .map(|s| {
-                if s.is_empty() {
-                    vec![]
-                } else {
-                    s.split('\x00').map(|x| x.to_string()).collect()
-                }
-            })
-            .unwrap_or_default();
-        Ok(ActionSpec::Exec {
-            cmd,
-            args,
-            stdin,
-            timeout_secs,
-        })
-    } else if eval_fields.contains_key("cmd") {
-        // io-shell: cmd, no args.
-        let cmd = eval_fields
-            .get("cmd")
-            .and_then(|opt| opt.clone())
-            .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-                    call_smid,
-                    "io.shell: 'cmd' field is required in the action spec".to_string(),
-                )))
-            })?;
-        Ok(ActionSpec::Shell {
-            cmd,
-            stdin,
-            timeout_secs,
-        })
-    } else if eval_fields.contains_key("message") {
-        // io-fail: a message, no command.
-        let message = eval_fields
-            .get("message")
-            .and_then(|opt| opt.clone())
-            .unwrap_or_else(|| "io.fail".to_string());
-        Err(IoRunError::Fail(message))
-    } else {
-        Err(IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-            call_smid,
-            "unknown IO action spec (no cmd/args/message field)".to_string(),
-        ))))
     }
 }
 

--- a/src/driver/io_common.rs
+++ b/src/driver/io_common.rs
@@ -9,6 +9,7 @@
 //! differs between the two engines.
 
 use std::{
+    collections::HashMap,
     io::Write as IoWrite,
     process::{Command, Stdio},
     sync::mpsc,
@@ -70,6 +71,131 @@ pub enum ActionSpec {
         stdin: Option<String>,
         timeout_secs: u64,
     },
+}
+
+// ─── Action-spec policy (shared by both engine drivers) ──────────────────────
+
+/// Resolve an [`ActionSpec`] (or an io-fail) from the statically-recovered meta
+/// tag and the evaluated spec-block field set.
+///
+/// This is the single, representation-agnostic IO-action policy shared by the
+/// HeapSyn ([`crate::driver::io_run`]) and bytecode
+/// ([`crate::driver::bytecode_io_run`]) drivers. Each driver navigates its own
+/// heap representation to (a) recover the spec block's meta tag — `io-shell` /
+/// `io-exec` / `io-fail` — when it is statically visible, and (b) evaluate each
+/// field to a rendered string; it then hands both to this function, which owns
+/// all the actual *policy*:
+///
+/// - `timeout` defaults to 30 seconds when absent or unparseable;
+/// - `stdin` is dropped when empty or the literal `"null"`;
+/// - the action is chosen by the meta **tag** when present, falling back to
+///   field inference only when the tag is genuinely unavailable (App-thunk spec
+///   blocks — `io.shell-with` / `io.exec-with` — whose `Meta` wrapper is
+///   stripped during forcing). Both engines therefore dispatch identically;
+/// - `args` is split on NUL (the element separator used by both drivers);
+/// - a missing `cmd` is a hard error; an `io-fail` becomes `IoRunError::Fail`.
+///
+/// Keeping this here guarantees the two engines cannot drift (they previously
+/// hand-rolled subtly different copies of this logic).
+pub fn action_spec_from_fields(
+    tag: Option<&str>,
+    fields: &HashMap<String, Option<String>>,
+    call_smid: Smid,
+) -> Result<ActionSpec, IoRunError> {
+    let timeout_secs = fields
+        .get("timeout")
+        .and_then(|opt| opt.as_deref())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(30);
+
+    let stdin = fields
+        .get("stdin")
+        .and_then(|opt| opt.clone())
+        .filter(|s| !s.is_empty() && s != "null");
+
+    // Prefer the meta tag; fall back to field inference only when unavailable.
+    let resolved = tag.map(str::to_string).or_else(|| infer_action_tag(fields));
+
+    match resolved.as_deref() {
+        Some("io-exec") => {
+            let cmd = require_cmd(fields, "io.exec", call_smid)?;
+            let args = fields
+                .get("args")
+                .and_then(|opt| opt.clone())
+                .map(split_nul_args)
+                .unwrap_or_default();
+            Ok(ActionSpec::Exec {
+                cmd,
+                args,
+                stdin,
+                timeout_secs,
+            })
+        }
+        Some("io-shell") => {
+            let cmd = require_cmd(fields, "io.shell", call_smid)?;
+            Ok(ActionSpec::Shell {
+                cmd,
+                stdin,
+                timeout_secs,
+            })
+        }
+        Some("io-fail") => {
+            let message = fields
+                .get("message")
+                .and_then(|opt| opt.clone())
+                .unwrap_or_else(|| "io.fail".to_string());
+            Err(IoRunError::Fail(message))
+        }
+        _ => Err(IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+            call_smid,
+            "unknown IO action spec: no io-shell/io-exec/io-fail tag and no \
+             cmd/args/message field"
+                .to_string(),
+        )))),
+    }
+}
+
+/// Field-based action inference — the shared fallback for App-thunk spec blocks
+/// whose meta tag was stripped during forcing: `args` ⇒ exec, `cmd` ⇒ shell,
+/// `message` ⇒ fail.
+fn infer_action_tag(fields: &HashMap<String, Option<String>>) -> Option<String> {
+    if fields.contains_key("args") {
+        Some("io-exec".to_string())
+    } else if fields.contains_key("cmd") {
+        Some("io-shell".to_string())
+    } else if fields.contains_key("message") {
+        Some("io-fail".to_string())
+    } else {
+        None
+    }
+}
+
+/// Read the required `cmd` field, erroring with an action-qualified message.
+fn require_cmd(
+    fields: &HashMap<String, Option<String>>,
+    action: &str,
+    call_smid: Smid,
+) -> Result<String, IoRunError> {
+    fields
+        .get("cmd")
+        .and_then(|opt| opt.clone())
+        .ok_or_else(|| {
+            IoRunError::MachineError(Box::new(ExecutionError::IoFail(
+                call_smid,
+                format!("{action}: 'cmd' field is required in the action spec"),
+            )))
+        })
+}
+
+/// Split a rendered list field into its elements. Both drivers join list
+/// elements with NUL (`\x00`) before handing the field to this policy, so the
+/// inverse split lives here too.
+fn split_nul_args(s: String) -> Vec<String> {
+    if s.is_empty() {
+        vec![]
+    } else {
+        s.split('\x00').map(|x| x.to_string()).collect()
+    }
 }
 
 // ─── Shell execution ──────────────────────────────────────────────────────────

--- a/src/driver/io_run.rs
+++ b/src/driver/io_run.rs
@@ -692,91 +692,19 @@ fn evaluate_spec_block(
         eval_fields.insert(key, value_str);
     }
 
-    // ── Determine tag ─────────────────────────────────────────────────────────
+    // ── Build the ActionSpec via the shared policy ────────────────────────────
     //
-    // For inline blocks the tag was captured statically above.
-    // For App-thunk blocks the Meta was stripped by evaluation; infer from fields.
-    let tag_name = static_tag.unwrap_or_else(|| {
-        if eval_fields.contains_key("args") {
-            "io-exec".to_string()
-        } else {
-            "io-shell".to_string()
-        }
-    });
-
-    // Step 4: build ActionSpec from evaluated fields.
-    let timeout_secs = eval_fields
-        .get("timeout")
-        .and_then(|opt| opt.as_deref())
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(30);
-
-    let stdin = eval_fields
-        .get("stdin")
-        .and_then(|opt| opt.clone())
-        .filter(|s| !s.is_empty() && s != "null");
-
-    let is_shell = tag_name == "io-shell";
-    let is_exec = tag_name == "io-exec";
-
-    // Capture the call-site annotation before the branching so closures below
-    // can reference it without re-borrowing `machine`.
+    // For inline blocks the tag was captured statically above; for App-thunk
+    // blocks (shell-with / exec-with) the Meta was stripped during evaluation
+    // so `static_tag` is None and the shared policy infers from the field set.
+    // Both engines call the same `io_common::action_spec_from_fields`, so their
+    // tag dispatch, timeout / stdin handling, and error wording cannot drift.
     let call_smid = machine.annotation();
-
-    if is_shell {
-        let cmd = eval_fields
-            .get("cmd")
-            .and_then(|opt| opt.clone())
-            .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-                    call_smid,
-                    "io.shell: 'cmd' field is required in the action spec".to_string(),
-                )))
-            })?;
-        Ok(ActionSpec::Shell {
-            cmd,
-            stdin,
-            timeout_secs,
-        })
-    } else if is_exec {
-        let cmd = eval_fields
-            .get("cmd")
-            .and_then(|opt| opt.clone())
-            .ok_or_else(|| {
-                IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-                    call_smid,
-                    "io.exec: 'cmd' field is required in the action spec".to_string(),
-                )))
-            })?;
-        let args = eval_fields
-            .get("args")
-            .and_then(|opt| opt.clone())
-            .map(|s| {
-                if s.is_empty() {
-                    vec![]
-                } else {
-                    s.split('\x00').map(|x| x.to_string()).collect()
-                }
-            })
-            .unwrap_or_default();
-        Ok(ActionSpec::Exec {
-            cmd,
-            args,
-            stdin,
-            timeout_secs,
-        })
-    } else if tag_name == "io-fail" {
-        let message = eval_fields
-            .get("message")
-            .and_then(|opt| opt.clone())
-            .unwrap_or_else(|| "io.fail".to_string());
-        Err(IoRunError::Fail(message))
-    } else {
-        Err(IoRunError::MachineError(Box::new(ExecutionError::IoFail(
-            call_smid,
-            format!("unknown IO action tag '{tag_name}'"),
-        ))))
-    }
+    crate::driver::io_common::action_spec_from_fields(
+        static_tag.as_deref(),
+        &eval_fields,
+        call_smid,
+    )
 }
 
 // ─── Mutator: build result block {stdout, stderr, exit-code} ─────────────────

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2258,6 +2258,84 @@ impl BytecodeMachine<'_> {
         current
     }
 
+    /// Recover the static meta tag symbol (`io-shell` / `io-exec` / `io-fail`)
+    /// of an `IoAction` spec block, if it is an inline `Meta`-tagged block.
+    ///
+    /// This mirrors the navigation of [`Self::peel_io_spec`] but resolves the
+    /// `Meta` node's *meta* ref (rather than its body) to a symbol name. It is
+    /// a purely additive, read-only accessor introduced for the cross-engine IO
+    /// action dispatch parity fix (eu-xqab): forcing the spec block strips the
+    /// `Meta` wrapper, so the tag must be read statically here — before forcing
+    /// — for the bytecode driver to dispatch on the tag exactly as the HeapSyn
+    /// driver's `peel_meta` does.
+    ///
+    /// Returns `None` for parameterised (App-thunk) spec blocks
+    /// (`io.shell-with` / `io.exec-with`) whose `Meta` is not statically
+    /// visible; the caller then falls back to field-based inference.
+    pub fn peel_io_spec_tag(&self, spec: BcValue) -> Option<String> {
+        let view = MutatorHeapView::new(&self.heap);
+        let code = self.program.code.as_slice();
+        let mut current = spec;
+        let mut container: Option<RefPtr<BcEnvFrame>> = None;
+        for _ in 0..64 {
+            let c = match &current {
+                BcValue::Closure(c) => *c,
+                BcValue::Native(_) => return None,
+            };
+            let mut pc = c.code() as usize;
+            match Op::from_u8(read_u8(code, &mut pc)) {
+                Some(Op::Atom) => {
+                    let dref = read_ref(code, &mut pc).ok()?;
+                    match dref {
+                        DecodedRef::Local(i) => {
+                            let env = c.env();
+                            match view.scoped(env).get(&view, i as usize) {
+                                Some(inner) => {
+                                    container = Some(env);
+                                    current = inner;
+                                }
+                                None => return None,
+                            }
+                        }
+                        DecodedRef::Global(i) => {
+                            match view.scoped(self.state.globals).get(&view, i as usize) {
+                                Some(inner) => current = inner,
+                                None => return None,
+                            }
+                        }
+                        DecodedRef::Value(_) => return None,
+                    }
+                }
+                Some(Op::Ann) => {
+                    let _smid = read_u32(code, &mut pc);
+                    let body_off = read_u32(code, &mut pc);
+                    current = BcValue::Closure(BcClosure::new(body_off, c.env()));
+                }
+                Some(Op::Meta) => {
+                    let meta_off = read_u32(code, &mut pc);
+                    let _body_off = read_u32(code, &mut pc);
+                    let meta_ref = arg_ref(code, meta_off).ok()?;
+                    // Resolve the meta ref against the container frame (the let
+                    // frame that holds this Meta binding), falling back to the
+                    // Meta's own env when reached without an indirection.
+                    let env = container.unwrap_or_else(|| c.env());
+                    let meta_v = resolve_ref(
+                        view,
+                        &self.state.constants,
+                        env,
+                        self.state.globals,
+                        meta_ref,
+                    )
+                    .ok()?;
+                    return value_symbol(&self.program, &self.state, view, meta_v)
+                        .map(|id| self.symbol_pool.resolve(id).to_string());
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
     // ── Data synthesis (pre-encoded templates; no per-call code alloc) ──────
 
     /// Build a data-constructor value of `tag` over `fields` using the

--- a/src/import/xml.rs
+++ b/src/import/xml.rs
@@ -148,25 +148,21 @@ impl<'src> XmlImporter<'src> {
         for a in e.attributes() {
             let attr = a.map_err(|e| self.to_source_error(e))?;
             let k = self.to_str(attr.key.local_name().as_ref())?;
-            // Restore the pre-0.12 VERBATIM attribute-value behaviour (eu-cgys):
-            // decode the raw bytes, then unescape entities WITHOUT applying XML
-            // attribute-value whitespace normalisation. quick-xml 0.41's
-            // `decoded_and_normalized_value` family all normalise per the XML
-            // spec — literal tabs/newlines in an attribute value collapse to
-            // spaces — which silently altered imported data vs every previous
-            // release. 0.41 has no non-normalising decode+unescape method, so we
-            // compose one from `Decoder::decode` + `escape::unescape` (predefined
-            // entities only, matching the old `decode_and_unescape_value`).
-            // GUARANTEE: embedded newlines/tabs in attribute values survive
-            // verbatim through import.
-            let decoded = self
-                .reader
-                .decoder()
-                .decode(attr.value.as_ref())
-                .map_err(|e| self.to_source_error(e))?;
-            let unescaped = quick_xml::escape::unescape(decoded.as_ref())
-                .map_err(|e| self.to_source_error(e))?;
-            let v = acore::str(unescaped.as_ref());
+            // DELIBERATE (eu-cgys, post-review owner decision): apply XML 1.0
+            // §3.3.3 attribute-value normalisation. Literal whitespace (tab, CR,
+            // LF) in an attribute value becomes a space, as required of a
+            // conforming processor; character references such as `&#10;` / `&#9;`
+            // are resolved *before* normalisation and so still yield real
+            // newlines/tabs. This is a behaviour change from pre-0.12 eucalypt
+            // (which was non-conformant) — see CHANGELOG 0.12.0. Element *text*
+            // content is unaffected (it is unescaped without normalisation).
+            let v = acore::str(
+                attr.decoded_and_normalized_value(
+                    quick_xml::XmlVersion::Implicit1_0,
+                    self.reader.decoder(),
+                )
+                .map_err(|e| self.to_source_error(e))?,
+            );
             attrs.push((k, v));
         }
 
@@ -185,19 +181,11 @@ mod tests {
     use super::*;
     use crate::common::sourcemap::SourceMap;
 
-    /// eu-cgys regression: attribute values must be imported VERBATIM. Literal
-    /// newlines and tabs inside an attribute value must survive unchanged — the
-    /// XML-spec attribute-value whitespace normalisation (which collapses them
-    /// to spaces) is deliberately NOT applied, matching every release before the
-    /// quick-xml 0.25→0.41 bump.
-    #[test]
-    fn attribute_whitespace_is_preserved_verbatim() {
+    /// Extract the `a` attribute string of the (single) root element from the
+    /// hiccup import `[:root {a: "..."} ...]`.
+    fn import_attr_a(xml: &str) -> String {
         let mut sm = SourceMap::new();
-        // Real newline + tab embedded in the `a` attribute value.
-        let xml = "<root a=\"x\nY\tZ\"/>";
         let expr = read_xml(&mut sm, 0, xml).expect("xml import should succeed");
-
-        // Hiccup shape: [:root {a: "..."}] — the attrs block is element 1.
         let attrs = match &*expr.inner {
             Expr::List(_, xs) => xs.get(1).cloned().expect("attrs block present"),
             other => panic!("expected a hiccup list, got {other:?}"),
@@ -207,11 +195,39 @@ mod tests {
             other => panic!("expected an attrs block, got {other:?}"),
         };
         match &*value.inner {
-            Expr::Literal(_, Primitive::Str(s)) => assert_eq!(
-                s, "x\nY\tZ",
-                "attribute whitespace must survive import verbatim (no normalisation)"
-            ),
+            Expr::Literal(_, Primitive::Str(s)) => s.clone(),
             other => panic!("expected a string literal, got {other:?}"),
         }
+    }
+
+    /// eu-cgys: DELIBERATE spec-conformant behaviour. XML 1.0 §3.3.3 requires a
+    /// conforming processor to normalise attribute values — each literal
+    /// whitespace character (tab, CR, LF) in an attribute value is replaced by a
+    /// single space. Post quick-xml 0.25→0.41 bump, eucalypt now conforms (it
+    /// previously did not). This test pins that behaviour so a future change
+    /// away from it is caught.
+    #[test]
+    fn literal_attribute_whitespace_is_normalised_to_space() {
+        // Real newline + tab embedded in the `a` attribute value.
+        assert_eq!(
+            import_attr_a("<root a=\"x\nY\tZ\"/>"),
+            "x Y Z",
+            "literal newline/tab in an attribute value must normalise to a \
+             single space each (XML 1.0 §3.3.3)"
+        );
+    }
+
+    /// eu-cgys: the escape hatch. Per XML 1.0 §3.3.3, *character references* to
+    /// whitespace are resolved before normalisation, so `&#10;` (LF) and `&#9;`
+    /// (tab) yield real control characters that survive verbatim — this is how a
+    /// document author requests literal whitespace in an attribute value.
+    #[test]
+    fn attribute_whitespace_character_references_survive() {
+        assert_eq!(
+            import_attr_a("<root a=\"x&#10;Y&#9;Z\"/>"),
+            "x\nY\tZ",
+            "character references to whitespace must survive normalisation \
+             (XML 1.0 §3.3.3)"
+        );
     }
 }

--- a/src/import/xml.rs
+++ b/src/import/xml.rs
@@ -148,13 +148,25 @@ impl<'src> XmlImporter<'src> {
         for a in e.attributes() {
             let attr = a.map_err(|e| self.to_source_error(e))?;
             let k = self.to_str(attr.key.local_name().as_ref())?;
-            let v = acore::str(
-                attr.decoded_and_normalized_value(
-                    quick_xml::XmlVersion::Implicit1_0,
-                    self.reader.decoder(),
-                )
-                .map_err(|e| self.to_source_error(e))?,
-            );
+            // Restore the pre-0.12 VERBATIM attribute-value behaviour (eu-cgys):
+            // decode the raw bytes, then unescape entities WITHOUT applying XML
+            // attribute-value whitespace normalisation. quick-xml 0.41's
+            // `decoded_and_normalized_value` family all normalise per the XML
+            // spec — literal tabs/newlines in an attribute value collapse to
+            // spaces — which silently altered imported data vs every previous
+            // release. 0.41 has no non-normalising decode+unescape method, so we
+            // compose one from `Decoder::decode` + `escape::unescape` (predefined
+            // entities only, matching the old `decode_and_unescape_value`).
+            // GUARANTEE: embedded newlines/tabs in attribute values survive
+            // verbatim through import.
+            let decoded = self
+                .reader
+                .decoder()
+                .decode(attr.value.as_ref())
+                .map_err(|e| self.to_source_error(e))?;
+            let unescaped = quick_xml::escape::unescape(decoded.as_ref())
+                .map_err(|e| self.to_source_error(e))?;
+            let v = acore::str(unescaped.as_ref());
             attrs.push((k, v));
         }
 
@@ -165,5 +177,41 @@ impl<'src> XmlImporter<'src> {
     /// `SourceError` by its display text.
     fn to_source_error<E: std::fmt::Display>(&self, e: E) -> SourceError {
         SourceError::InvalidXml(e.to_string(), self.file_id, self.span())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::sourcemap::SourceMap;
+
+    /// eu-cgys regression: attribute values must be imported VERBATIM. Literal
+    /// newlines and tabs inside an attribute value must survive unchanged — the
+    /// XML-spec attribute-value whitespace normalisation (which collapses them
+    /// to spaces) is deliberately NOT applied, matching every release before the
+    /// quick-xml 0.25→0.41 bump.
+    #[test]
+    fn attribute_whitespace_is_preserved_verbatim() {
+        let mut sm = SourceMap::new();
+        // Real newline + tab embedded in the `a` attribute value.
+        let xml = "<root a=\"x\nY\tZ\"/>";
+        let expr = read_xml(&mut sm, 0, xml).expect("xml import should succeed");
+
+        // Hiccup shape: [:root {a: "..."}] — the attrs block is element 1.
+        let attrs = match &*expr.inner {
+            Expr::List(_, xs) => xs.get(1).cloned().expect("attrs block present"),
+            other => panic!("expected a hiccup list, got {other:?}"),
+        };
+        let value = match &*attrs.inner {
+            Expr::Block(_, bm) => bm.get("a").cloned().expect("attribute `a` present"),
+            other => panic!("expected an attrs block, got {other:?}"),
+        };
+        match &*value.inner {
+            Expr::Literal(_, Primitive::Str(s)) => assert_eq!(
+                s, "x\nY\tZ",
+                "attribute whitespace must survive import verbatim (no normalisation)"
+            ),
+            other => panic!("expected a string literal, got {other:?}"),
+        }
     }
 }

--- a/tests/bytecode_io_differential_test.rs
+++ b/tests/bytecode_io_differential_test.rs
@@ -83,3 +83,26 @@ fn io_shell_with_stdin_agrees() {
     // Parameterised (App-thunk) spec block with an options block (stdin).
     assert_engines_agree("io.shell-with({ stdin: \"piped\\n\" }, \"cat\")");
 }
+
+#[test]
+fn io_tag_field_mismatch_dispatches_on_tag_agrees() {
+    // eu-xqab: a spec whose FIELD set disagrees with its meta TAG. The block is
+    // tagged `:io-shell` but also carries an `args` field. The HeapSyn driver
+    // dispatches on the meta tag (→ shell, so the pipe is interpreted by the
+    // shell); the bytecode driver historically inferred the action from the
+    // field set (`args` ⇒ exec), running the whole command string as a single
+    // binary name — a divergent result. Both engines must now dispatch on the
+    // tag and agree.
+    assert_engines_agree(
+        "__IO_ACTION({:io-shell cmd: \"echo hi | tr a-z A-Z\", args: []}) io.map(_.stdout)",
+    );
+}
+
+#[test]
+fn io_exec_tag_with_shellish_cmd_agrees() {
+    // The mirror case: an `:io-exec`-tagged spec must run as exec on both
+    // engines (direct binary, no shell interpretation of the argument).
+    assert_engines_agree(
+        "__IO_ACTION({:io-exec cmd: \"echo\", args: [\"a\", \"b\"]}) io.map(_.stdout)",
+    );
+}


### PR DESCRIPTION
Fixes two CONFIRMED 0.12.0 release-gate bugs from the code review.

## eu-xqab (P2) — cross-engine IO action divergence + duplicated policy
The bytecode io-run driver inferred the IO action from the evaluated **field set** (`args`⇒exec, `cmd`⇒shell, `message`⇒fail), whereas the HeapSyn driver dispatches on the spec block's meta **tag**. A spec whose fields disagree with its tag — e.g. `__IO_ACTION({:io-shell cmd: \"echo hi | tr a-z A-Z\", args: []})` — ran as **shell** on HeapSyn (→ `HI`) but as **exec** on bytecode (→ the whole string treated as a binary name, exit 127).

**Fix:** surface the meta tag from the bytecode machine via a new *additive, read-only* accessor `BytecodeMachine::peel_io_spec_tag` and dispatch on it. Both engines now dispatch on the tag when present and fall back to the **same** field inference only when the tag is genuinely unavailable (App-thunk `shell-with`/`exec-with` specs).

**Dedup (same bead):** the ActionSpec construction policy (timeout default 30, stdin empty/`null` filter, required-`cmd` errors, NUL-split `args`, io-fail message) was hand-duplicated across `bytecode_io_run.rs` and `io_run.rs` and had **drifted** (different unknown-action wording). It now lives once in `io_common.rs` as `action_spec_from_fields`; both drivers call it, so tag dispatch, timeout/stdin handling and error wording cannot diverge.

## eu-cgys (P1) — XML attribute whitespace normalisation (ACCEPTED + documented)
The quick-xml 0.25→0.41 bump introduced XML 1.0 §3.3.3 attribute-value normalisation: literal newlines/tabs in attribute values become spaces. **Post-review owner decision: ACCEPT this** — it is what a conforming XML processor must do (pre-0.12 eucalypt was non-conformant); blast radius is raw whitespace in attribute *values* only (element text untouched), and character references (`&#10;` / `&#9;`) still yield real whitespace.

This PR therefore does **not** change XML behaviour; it documents and locks it:
- one-line comment at the `decoded_and_normalized_value` call noting the deliberate post-review decision;
- two regression tests — a literal newline/tab attribute normalises to spaces; a `&#10;`/`&#9;` character-reference attribute keeps the real newline/tab (both commented with §3.3.3);
- a loud CHANGELOG 0.12.0 behaviour-change entry (with the `&#10;`/`&#9;` guidance).

> Note: CHANGELOG top was `[0.11.1] - Unreleased`; I added a new `[0.12.0] - Unreleased` section per the owner's instruction. Reconcile with the version bump at release time.

## machine.rs surface (additive — please review as machine.rs)
Adds ONE new method `pub fn peel_io_spec_tag(&self, spec: BcValue) -> Option<String>` immediately after `peel_io_spec`. **No existing code modified.** The traversal is a deliberate *exact mirror* of `peel_io_spec`: identical 64-iteration bound, identical `Atom` Local/Global/Value handling, identical `Ann`-transparency, identical container-env tracking, same `container.unwrap_or_else(|| c.env())` frame for the `Meta` node — it simply resolves the Meta *meta* ref (→ symbol name) instead of the *body* ref, so the tag corresponds to the exact same `Meta` `peel_io_spec` resolves the body from. Read-only.

## Verification
- Full harness **477/477** (bytecode+source, heapsyn+source, bytecode+blob, heapsyn+blob).
- `cargo test` green (harness 477, lib incl. new xml + differential tests); differential 7/7 (2 new IO mismatch tests); 2 new xml unit tests.
- IO tag/field-mismatch and XML literal-vs-charref verified byte-identical on both engines end-to-end.
- `EU_GC_VERIFY=2 EU_GC_STRESS=1` clean on all IO action paths + XML import, both engines.
- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --all --check` clean. Every `eu` wrapped in `timeout 90 --heap-limit-mib 12288`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee