### PR TITLE
fix(stg): ABI migration + GC-safe block-key walk + nth laziness (eu-mr5e, eu-f3ss, eu-xk49)

### DIFF
--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -10,10 +10,10 @@ use std::convert::TryInto;
 use crate::eval::{
     emit::Emitter,
     error::ExecutionError,
-    machine::intrinsic::{CallGlobal2, IntrinsicMachine, StgIntrinsic},
+    machine::intrinsic::{AbiClosure, CallGlobal2, IntrinsicMachine, StgIntrinsic},
     memory::{
         mutator::MutatorHeapView,
-        syntax::{HeapSyn, Native, Ref},
+        syntax::{Native, Ref},
     },
 };
 
@@ -21,58 +21,50 @@ use super::tags::DataConstructor;
 
 /// Format a value ref as a human-readable string for assertion messages.
 ///
-/// Resolves the closure at `r` to WHNF and formats it:
+/// Resolves the closure at `r` and formats it:
 /// - Boxed scalars (number, string, symbol, zdt) — their literal form
 /// - Booleans and null — their literal form
 /// - Lists and blocks — a type label such as `[list]` or `{block}`
 /// - Unevaluated / unknown — `<unevaluated>`
+///
+/// Classification goes through the engine-neutral ABI (`resolve_closure`/
+/// `data_tag`/`value_native`), so it runs on both the HeapSyn and bytecode
+/// engines. The HeapSyn-only `nav` navigator panics on the bytecode engine
+/// (eu-mr5e). The value is already at WHNF — the `//=>` operator forced both
+/// sides via the equality check — so no forcing is needed here.
 fn format_ref(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref) -> String {
-    // Resolve to a closure, following Atom indirections.
-    // The closure should already be at WHNF since the //=> operator
-    // forced both sides via the equality check.
-    let closure = match machine.nav(view).resolve(r) {
+    let closure = match machine.resolve_closure(view, r) {
         Ok(c) => c,
         Err(_) => return "<unknown>".to_string(),
     };
 
-    let code = view.scoped(closure.code());
-    let env = view.scoped(closure.env());
-
-    match &*code {
-        HeapSyn::Cons { tag, args } => {
-            let dc: Result<DataConstructor, _> = (*tag).try_into();
+    match machine.data_tag(view, &closure) {
+        Some(tag) => {
+            let dc: Result<DataConstructor, _> = tag.try_into();
             match dc {
                 Ok(DataConstructor::BoolTrue) => "true".to_string(),
                 Ok(DataConstructor::BoolFalse) => "false".to_string(),
                 Ok(DataConstructor::Unit) => "null".to_string(),
                 Ok(DataConstructor::ListNil) => "[]".to_string(),
                 Ok(DataConstructor::ListCons) => "[list]".to_string(),
-                Ok(DataConstructor::Block) => "{block}".to_string(),
-                Ok(DataConstructor::BlockPair) | Ok(DataConstructor::BlockKvList) => {
-                    "{block}".to_string()
-                }
+                Ok(DataConstructor::Block)
+                | Ok(DataConstructor::BlockPair)
+                | Ok(DataConstructor::BlockKvList) => "{block}".to_string(),
                 Ok(DataConstructor::BoxedNumber) => {
-                    // The inner ref is args[0]: try to get it as a native num
-                    args.get(0)
-                        .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
-                        .unwrap_or_else(|| "<number>".to_string())
+                    boxed_scalar(machine, view, &closure, "<number>")
                 }
-                Ok(DataConstructor::BoxedString) => args
-                    .get(0)
-                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<string>".to_string()),
-                Ok(DataConstructor::BoxedSymbol) => args
-                    .get(0)
-                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<symbol>".to_string()),
-                Ok(DataConstructor::BoxedZdt) => args
-                    .get(0)
-                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<datetime>".to_string()),
-                Ok(DataConstructor::BoxedTypeData) => args
-                    .get(0)
-                    .and_then(|inner| format_inner_ref(machine, view, &env, &inner))
-                    .unwrap_or_else(|| "<type-data>".to_string()),
+                Ok(DataConstructor::BoxedString) => {
+                    boxed_scalar(machine, view, &closure, "<string>")
+                }
+                Ok(DataConstructor::BoxedSymbol) => {
+                    boxed_scalar(machine, view, &closure, "<symbol>")
+                }
+                Ok(DataConstructor::BoxedZdt) => {
+                    boxed_scalar(machine, view, &closure, "<datetime>")
+                }
+                Ok(DataConstructor::BoxedTypeData) => {
+                    boxed_scalar(machine, view, &closure, "<type-data>")
+                }
                 Ok(DataConstructor::IoReturn) => "<io-return>".to_string(),
                 Ok(DataConstructor::IoBind) => "<io-bind>".to_string(),
                 Ok(DataConstructor::IoAction) => "<io-action>".to_string(),
@@ -81,38 +73,29 @@ fn format_ref(machine: &dyn IntrinsicMachine, view: MutatorHeapView<'_>, r: &Ref
                 Err(_) => "<value>".to_string(),
             }
         }
-        HeapSyn::Atom {
-            evaluand: Ref::V(n),
-        } => format_native(n, view, machine),
-        _ => "<unevaluated>".to_string(),
+        None => {
+            // Not a data constructor: a bare native atom renders as its
+            // literal; anything else is still unevaluated.
+            match machine.value_native(view, &closure) {
+                Some(n) => format_native(&n, view, machine),
+                None => "<unevaluated>".to_string(),
+            }
+        }
     }
 }
 
-/// Format an inner ref (arg of a boxed constructor) as a string.
-///
-/// Handles `Ref::V` directly and resolves `Ref::L` through the given
-/// env frame.
-fn format_inner_ref(
+/// Render a boxed scalar's inner native (field 0) as a string, falling back to
+/// `placeholder` when the inner value is not (yet) available as a native.
+fn boxed_scalar(
     machine: &dyn IntrinsicMachine,
     view: MutatorHeapView<'_>,
-    env: &crate::eval::machine::env::EnvFrame,
-    r: &Ref,
-) -> Option<String> {
-    let native = match r {
-        Ref::V(n) => n.clone(),
-        Ref::L(idx) => {
-            let closure = env.get(&view, *idx)?;
-            let code = view.scoped(closure.code());
-            match &*code {
-                HeapSyn::Atom {
-                    evaluand: Ref::V(n),
-                } => n.clone(),
-                _ => return None,
-            }
-        }
-        _ => return None,
-    };
-    Some(format_native(&native, view, machine))
+    closure: &AbiClosure,
+    placeholder: &str,
+) -> String {
+    match machine.value_native(view, closure) {
+        Some(n) => format_native(&n, view, machine),
+        None => placeholder.to_string(),
+    }
 }
 
 /// Render a `Native` value as a human-readable string.

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1345,39 +1345,61 @@ fn collect_block_keys(
 ) -> Vec<String> {
     let mut keys = Vec::new();
 
-    // Resolve and force the block to WHNF; it should be a `Block` cell whose
-    // field 0 is the kv-pair list.
-    let block = match machine.resolve_closure(view, block_ref) {
-        Ok(c) => c,
-        Err(_) => return keys,
-    };
-    let block = match machine.force(block) {
-        Ok(c) => c,
-        Err(_) => return keys,
-    };
-    if machine.data_tag(view, &block) != Some(DataConstructor::Block.tag()) {
-        return keys;
-    }
-    let mut current = match machine.data_field(view, &block, 0) {
-        Some(c) => c,
-        None => return keys,
-    };
-
-    // Walk the list spine, reading each pair's key (field 0).
-    while let Ok(cell) = machine.force(current) {
-        if machine.data_tag(view, &cell) != Some(DataConstructor::ListCons.tag()) {
-            break; // ListNil or an unexpected shape
-        }
-        if let Some(key) = pair_key_name(machine, view, &cell) {
-            keys.push(key);
-        }
-        match machine.data_field(view, &cell, 1) {
-            Some(tail) => current = tail,
+    // Walk the kv-pair spine one cell at a time, re-deriving each cell from
+    // the rooted `block_ref` (a GC-stable `Ref` into the machine env) rather
+    // than carrying a spine handle across the `force` that reads each pair's
+    // key. A forced sub-evaluation can evacuate the heap, so any `AbiClosure`
+    // held across it would dangle (eu-f3ss); re-resolving from the root after
+    // every force keeps every handle fresh. This mirrors `get_list_element_at`
+    // in debug.rs. It is the error path (a lookup has already failed), so the
+    // extra spine walks are cheap.
+    for index in 0.. {
+        match nth_block_pair_cell(machine, view, block_ref, index) {
+            Some(cell) => {
+                if let Some(key) = pair_key_name(machine, view, &cell) {
+                    keys.push(key);
+                }
+            }
             None => break,
         }
     }
 
     keys
+}
+
+/// Re-derive the `index`-th `ListCons` cell of a block's kv-pair spine from the
+/// rooted `block_ref`, forcing the spine as far as needed. Returns `None` once
+/// the spine ends (nil), on any error, or on any non-list shape.
+///
+/// Deriving from the GC-stable `Ref` on each call — rather than caching a spine
+/// handle across the per-pair `force` in `collect_block_keys` — keeps the walk
+/// safe against heap evacuation during those forces (eu-f3ss). The walk itself
+/// holds no handle across an allocation: each `force` consumes the handle it is
+/// given, and the intervening `data_field` reads do not allocate.
+fn nth_block_pair_cell(
+    machine: &mut dyn IntrinsicMachine,
+    view: MutatorHeapView<'_>,
+    block_ref: &Ref,
+    index: usize,
+) -> Option<AbiClosure> {
+    let block = machine.resolve_closure(view, block_ref).ok()?;
+    let block = machine.force(block).ok()?;
+    if machine.data_tag(view, &block) != Some(DataConstructor::Block.tag()) {
+        return None;
+    }
+    let mut current = machine.data_field(view, &block, 0)?;
+    for _ in 0..index {
+        let cell = machine.force(current).ok()?;
+        if machine.data_tag(view, &cell) != Some(DataConstructor::ListCons.tag()) {
+            return None;
+        }
+        current = machine.data_field(view, &cell, 1)?;
+    }
+    let cell = machine.force(current).ok()?;
+    if machine.data_tag(view, &cell) != Some(DataConstructor::ListCons.tag()) {
+        return None;
+    }
+    Some(cell)
 }
 
 /// Best-effort read of a kv-list cell's head `BlockPair` key as a string,

--- a/src/eval/stg/list.rs
+++ b/src/eval/stg/list.rs
@@ -16,17 +16,13 @@ use crate::{
 
 use super::{
     force::SeqNumList,
-    support::{
-        collect_num_list, data_list_arg, machine_return_bool, machine_return_num_list, num_arg,
-    },
+    support::{collect_num_list, machine_return_bool, machine_return_num_list, num_arg},
     syntax::{
         dsl::{app_bif, case, data, f, force, lambda, local, lref, t, value},
         LambdaForm,
     },
     tags::DataConstructor,
 };
-
-use crate::eval::memory::syntax::HeapSyn;
 
 /// A constant for CONS
 pub struct Cons;
@@ -446,9 +442,10 @@ impl CallGlobal1 for SortNumList {}
 
 /// LIST.NTH(list, n) — return the nth element (0-indexed) of a list.
 ///
-/// Both arguments are forced (strict: [0, 1]). The list must be a
-/// fully-evaluated cons structure. Panics if the list has fewer than
-/// n+1 elements.
+/// Walks exactly n+1 cons cells, forcing only as far as needed, and returns
+/// the n-th element unforced. The list head is already forced (strict:
+/// [0, 1]); successive tails are forced as the walk advances. Raises
+/// `ListIndexOutOfBounds` if the list has fewer than n+1 elements.
 pub struct ListNth;
 
 impl StgIntrinsic for ListNth {
@@ -467,12 +464,49 @@ impl StgIntrinsic for ListNth {
             let num = num_arg(machine, view, &args[1])?;
             num.as_u64().unwrap_or(0) as usize
         };
-        let items = data_list_arg(machine, view, args[0].clone())?;
-        match items.into_iter().nth(n) {
-            Some(closure) => machine.set_result(closure),
-            None => Err(ExecutionError::ListIndexOutOfBounds(
-                machine.annotation(),
-                n,
+        let smid = machine.annotation();
+
+        // Bounded traversal via the engine-neutral data_tag/data_field ABI
+        // (works on both engines; the HeapSyn-only navigator is not used).
+        // Forcing only the n+1 cells we visit restores the lazy invariant: a
+        // list well-formed up to index n succeeds even when its tail beyond n
+        // would error if forced (eu-xk49). No handle is held across a force —
+        // each `force` consumes the handle it is given — so it is GC-safe.
+        let mut current = machine.resolve_closure(view, &args[0])?;
+        for _ in 0..n {
+            let cell = machine.force(current)?;
+            match machine.data_tag(view, &cell) {
+                Some(tag) if tag == DataConstructor::ListCons.tag() => {
+                    current = machine.data_field(view, &cell, 1).ok_or_else(|| {
+                        ExecutionError::Panic(smid, "malformed cons cell".to_string())
+                    })?;
+                }
+                Some(tag) if tag == DataConstructor::ListNil.tag() => {
+                    return Err(ExecutionError::ListIndexOutOfBounds(smid, n));
+                }
+                _ => {
+                    return Err(ExecutionError::NotValue(
+                        smid,
+                        "expected list data".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let cell = machine.force(current)?;
+        match machine.data_tag(view, &cell) {
+            Some(tag) if tag == DataConstructor::ListCons.tag() => {
+                let head = machine.data_field(view, &cell, 0).ok_or_else(|| {
+                    ExecutionError::Panic(smid, "malformed cons cell".to_string())
+                })?;
+                machine.set_result(head)
+            }
+            Some(tag) if tag == DataConstructor::ListNil.tag() => {
+                Err(ExecutionError::ListIndexOutOfBounds(smid, n))
+            }
+            _ => Err(ExecutionError::NotValue(
+                smid,
+                "expected list data".to_string(),
             )),
         }
     }
@@ -503,37 +537,24 @@ impl StgIntrinsic for ListDrop {
             let num = num_arg(machine, view, &args[0])?;
             num.as_u64().unwrap_or(0) as usize
         };
-
         let smid = machine.annotation();
-        // Navigate through the cons structure, skipping n elements.
-        // We traverse the tail links directly so we can return the
-        // remaining cons cell (rather than reconstructing the list).
-        let mut closure = machine.nav(view).resolve(&args[1])?;
+
+        // Walk the cons spine, skipping n elements, then return the remaining
+        // cell. Uses the engine-neutral data_tag/data_field ABI (the strict
+        // wrapper has forced the spine), so it runs on both engines rather
+        // than the HeapSyn-only navigator, which panics on the bytecode engine
+        // (eu-mr5e). No handle is held across an allocation, so it is GC-safe.
+        let mut current = machine.resolve_closure(view, &args[1])?;
         for _ in 0..n {
-            let code = view.scoped(closure.code());
-            match &*code {
-                HeapSyn::Cons {
-                    tag,
-                    args: cons_args,
-                } => {
-                    match (*tag).try_into() {
-                        Ok(DataConstructor::ListCons) => {
-                            let tail_ref = cons_args.get(1).ok_or_else(|| {
-                                ExecutionError::Panic(smid, "malformed cons cell".to_string())
-                            })?;
-                            closure = closure.navigate_local(&view, tail_ref);
-                        }
-                        Ok(DataConstructor::ListNil) => {
-                            // Ran out of elements — return the nil (empty list)
-                            return machine.set_closure(closure);
-                        }
-                        _ => {
-                            return Err(ExecutionError::NotValue(
-                                smid,
-                                "drop: expected a list".to_string(),
-                            ));
-                        }
-                    }
+            match machine.data_tag(view, &current) {
+                Some(tag) if tag == DataConstructor::ListCons.tag() => {
+                    current = machine.data_field(view, &current, 1).ok_or_else(|| {
+                        ExecutionError::Panic(smid, "malformed cons cell".to_string())
+                    })?;
+                }
+                Some(tag) if tag == DataConstructor::ListNil.tag() => {
+                    // Ran out of elements — return the nil (empty list).
+                    return machine.set_result(current);
                 }
                 _ => {
                     return Err(ExecutionError::NotValue(
@@ -543,7 +564,7 @@ impl StgIntrinsic for ListDrop {
                 }
             }
         }
-        machine.set_closure(closure)
+        machine.set_result(current)
     }
 }
 

--- a/tests/harness/092_destructure_list.eu
+++ b/tests/harness/092_destructure_list.eu
@@ -43,6 +43,14 @@ tests: {
     b: (f-rest([10, 20, 30, 40]) = [30, 40]) //= true
   }
 
+  ` "Lazy tail — LIST.NTH/LIST.DROP must not force the spine beyond the destructured indices (eu-xk49, eu-mr5e)"
+  lazy-tail: {
+    ` "extracting a, b does not force the erroring tail beyond index 1"
+    a: f-multi-head(cons(10, cons(20, panic("tail must not be forced")))) //= 30
+    ` "the head/tail rest is returned lazily; only its own head is forced"
+    b: (f-rest(cons(1, cons(2, cons(3, panic("tail must not be forced"))))) head) //= 3
+  }
+
 }
 
 RESULT: tests values map(values) map(all-true?) all-true? then(:PASS, :FAIL)

--- a/tests/harness/errors/179_assert_fail_scalar.eu
+++ b/tests/harness/errors/179_assert_fail_scalar.eu
@@ -1,0 +1,4 @@
+# Error test (eu-mr5e): a failing numeric assertion must render the actual and
+# expected values through the engine-neutral ABI on the default engine, not
+# panic in the HeapSyn-only navigator.
+x: 1 //=> 2

--- a/tests/harness/errors/179_assert_fail_scalar.eu.expect
+++ b/tests/harness/errors/179_assert_fail_scalar.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "assertion failed: expected 2, got 1"

--- a/tests/harness/errors/180_lookup_fail_large_block.eu
+++ b/tests/harness/errors/180_lookup_fail_large_block.eu
@@ -1,0 +1,46 @@
+# Error test (eu-f3ss): a key-not-found lookup on a large block walks the
+# whole kv-pair spine to build the 'did you mean?' hint. The walk must stay
+# GC-safe (re-resolving from the rooted block ref across each force).
+b: {
+  k00: 0
+  k01: 1
+  k02: 2
+  k03: 3
+  k04: 4
+  k05: 5
+  k06: 6
+  k07: 7
+  k08: 8
+  k09: 9
+  k10: 10
+  k11: 11
+  k12: 12
+  k13: 13
+  k14: 14
+  k15: 15
+  k16: 16
+  k17: 17
+  k18: 18
+  k19: 19
+  k20: 20
+  k21: 21
+  k22: 22
+  k23: 23
+  k24: 24
+  k25: 25
+  k26: 26
+  k27: 27
+  k28: 28
+  k29: 29
+  k30: 30
+  k31: 31
+  k32: 32
+  k33: 33
+  k34: 34
+  k35: 35
+  k36: 36
+  k37: 37
+  k38: 38
+  k39: 39
+}
+miss: b.k99

--- a/tests/harness/errors/180_lookup_fail_large_block.eu.expect
+++ b/tests/harness/errors/180_lookup_fail_large_block.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "key 'k99' not found in block"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2516,6 +2516,21 @@ pub fn test_error_172() {
 }
 
 #[test]
+/// A failing numeric assertion must render actual/expected through the
+/// engine-neutral ABI and raise `AssertionFailed`, not panic in the
+/// HeapSyn-only navigator on the default (bytecode) engine (eu-mr5e).
+pub fn test_error_179() {
+    run_error_test(&error_opts("179_assert_fail_scalar.eu"));
+}
+
+#[test]
+/// A key-not-found lookup on a large block walks the whole kv-pair spine to
+/// build the "did you mean?" hint; the walk must stay GC-safe (eu-f3ss).
+pub fn test_error_180() {
+    run_error_test(&error_opts("180_lookup_fail_large_block.eu"));
+}
+
+#[test]
 /// W4p2 integration: valid declarations structurally equivalent to those
 /// that would survive error recovery evaluate correctly end-to-end.
 /// Paired with test_error_164/165 to prove the full recovery story:


### PR DESCRIPTION
Fixes three confirmed release-gate bugs in the `src/eval/stg/` intrinsic layer (0.12 bytecode review).

## eu-mr5e (P1, user-reachable panic) — ASSERT_FAIL + LIST.DROP on the HeapSyn ABI
`__ASSERT_FAIL` (`format_ref`) and `LIST.DROP` still used the HeapSyn-only `nav`/`set_closure` navigator, which panics on the bytecode engine (`BcBifContext::nav`, machine.rs:2974). On the **default** engine, `eu -e '__ASSERT_FAIL(1, 2)'` aborted (exit 101) instead of raising the proper `assertion failed: expected 2, got 1` diagnostic; the same panic hit any failing assertion (`//=>`) and any `[x : xs]` / `[a, b : rest]` list-tail destructuring (LIST.DROP).

Both are migrated to the neutral ABI (`resolve_closure`/`data_tag`/`data_field`/`value_native`/`set_result`), matching the merged eu-9p9g/eu-ter9 pattern. `format_ref` now classifies via `data_tag` + `value_native` (boxed scalars read field 0 natively); `LIST.DROP` walks the spine structurally (no force, GC-safe, behaviour-preserving).

**ABI audit — no stragglers.** Every remaining `nav`/`set_closure`/`root_env` caller under `src/eval/stg/`:
- `LookupOr::execute` / `SafeLookup::execute` (block-index optimisation, block.rs) and their helpers (`walk_list_to_position`, `extract_value_from_pair`, `count_list`, `build_index`, `store_index_in_block`, `BlockListIterator`, `pair_key_symbol_id`) — **gated behind `block_index_enabled()`**, which returns `false` on bytecode (early-returns `return_closure_list(vec![])` before any HeapSyn-ABI call). Unreachable on the bytecode path.
- `lookup_lit_in_block` + `walk_list_to_position_from_closure` / `extract_value_from_pair_closure` / `linear_scan_for_key` / `resolve_ref_in_closure` — take a `&HeapNavigator` and are called **only from the HeapSyn VM** (vm.rs:708, vm.rs:1181, via the `LookupLit` IR node). The bytecode engine has its own translation (bytecode/machine.rs:705). Not reached via a bytecode BIF.

## eu-f3ss (P1, GC) — un-rooted closure across force in `collect_block_keys`
The lookup-failure "did you mean?" walk held an `AbiClosure` spine cell across the nested `force` that reads each pair's key. A forced sub-evaluation can evacuate the heap, leaving that handle dangling → garbage suggestions or SIGSEGV while reporting the error. Introduced by #947 (the pre-#947 code navigated without forcing).

Fix: re-derive each cell from the rooted `block_ref` (a GC-stable `Ref`) after every force, holding no handle across an allocation — the established pattern from `get_list_element_at`/`TraceEntry` in debug.rs. Cost is O(n²) on the error path only (a lookup has already failed). Checked the same walk-force pattern elsewhere in block.rs: the MERGE/deconstruct spine walks operate on already-forced pairs and hold nothing across a force; no other instance of the hazard.

## eu-xk49 (P2, semantic regression) — LIST.NTH lost laziness
`LIST.NTH` had been rewritten to collect the whole spine eagerly (`data_list_arg`): indexing a list well-formed to index n but with an unforced/erroring tail beyond n failed with `NotValue`, and it was O(len) not O(n). Restored to a bounded n+1-cell walk via the neutral ABI, forcing only what is needed and returning the element unforced.

## Regression guards (revert-proof)
- **092_destructure_list.eu** — new `lazy-tail` cases: `f-multi-head`/`f-rest` on `cons(..., panic(...))` lists must not force the tail beyond the destructured indices (guards eu-xk49 NTH + eu-mr5e DROP laziness on both engines; eager NTH errors on the panic tail).
- **errors/179_assert_fail_scalar.eu** — `1 //=> 2` on the default engine yields `assertion failed: expected 2, got 1` (exit 1), not a panic (guards eu-mr5e boxed-number `value_native` path).
- **errors/180_lookup_fail_large_block.eu** — a 40-key block key-not-found (guards the `collect_block_keys` spine walk; under the GC-stress CI run this exercises eu-f3ss).

## Validation
- Full harness **479/479 on both engines** (default bytecode and `EU_HEAPSYN=1`), byte-identical.
- `cargo test --lib` 1262 passed.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all` clean.
- Clean under `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1`: full harness (479), GC property tests (11), and a 1500-key lookup failure under a 4 MiB heap on both engines. (Three `src/eval/memory/` GC *strategy* unit tests assert a non-evacuating strategy and so fail under `EU_GC_STRESS=1` by design — pre-existing, no memory/ files touched.)

Refs eu-mr5e, eu-f3ss, eu-xk49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee