### PR TITLE
fix(bytecode): exclude io-run subprocess wait from VM mutator clock (eu-yhih)

### DIFF
--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2268,7 +2268,20 @@ impl BytecodeMachine<'_> {
 
     /// The re-entrant dispatch loop for `evaluate_to_whnf_for_io`: drives
     /// `dispatch` (which runs the deferred `Bif` tail + capture lifecycle)
-    /// until the sub-evaluation terminates. Mirrors `run`'s loop body.
+    /// until the sub-evaluation terminates. Mirrors `run` — both the loop body
+    /// and, crucially, its tail: the clock is **stopped** on return so the
+    /// mutator segment does not keep ticking after the sub-run ends.
+    ///
+    /// `evaluate_to_whnf_for_io` is invoked directly by the io-run driver
+    /// (`bytecode_io_run`), which then blocks on a subprocess wait (`run_spec`)
+    /// before re-entering the machine. If the clock were left running in the
+    /// mutator segment (as it was before eu-yhih), that blocking wait would be
+    /// committed to VM-Mutator on the next `switch`, so an IO-dominated
+    /// program's whole subprocess wait would be mis-attributed to the mutator —
+    /// contradicting the `-S` top bar's "IO ~100%" and diverging from HeapSyn,
+    /// whose `evaluate_to_whnf_for_io` delegates to `run` and so stops its clock
+    /// on return. Mirroring `run`'s tail here keeps `-S` clock semantics
+    /// identical across the two engines.
     fn drive_whnf(&mut self) -> Result<(), ExecutionError> {
         self.clock.switch(ThreadOccupation::Mutator);
         let gc_check_freq: u32 = 500;
@@ -2286,6 +2299,16 @@ impl BytecodeMachine<'_> {
             }
             self.dispatch()?;
         }
+
+        if self.heap.policy_requires_collection() {
+            gc_collect(
+                &mut self.state,
+                &mut self.heap,
+                &mut self.clock,
+                self.dump_heap,
+            );
+        }
+        self.clock.stop();
         Ok(())
     }
 
@@ -3997,6 +4020,51 @@ mod tests {
         assert!(
             total_gc > std::time::Duration::ZERO,
             "GC mark/sweep time should have been recorded"
+        );
+    }
+
+    #[test]
+    fn drive_whnf_stops_clock_so_io_wait_is_excluded_from_mutator() {
+        // eu-yhih: the io-run driver (`bytecode_io_run`) forces IO spec fields
+        // via `evaluate_to_whnf_for_io` (→ `drive_whnf`), then blocks on a
+        // subprocess wait (`run_spec`) OUTSIDE the machine before re-entering.
+        // If `drive_whnf` left the clock running in the mutator segment (the
+        // regression), that blocking wait would be committed to VM-Mutator on
+        // the next `switch`, so an IO-dominated program's whole subprocess wait
+        // would be mis-attributed to the mutator — contradicting the `-S` top
+        // bar's "IO ~100%" and diverging from HeapSyn, whose
+        // `evaluate_to_whnf_for_io` delegates to `run` (which stops its clock).
+        // This test asserts the invariant the bug violated: a blocking wait
+        // that happens between two io-run sub-evaluations is NOT absorbed by
+        // the mutator segment.
+        let syn = dsl::let_(vec![dsl::value(dsl::atom(dsl::num(5)))], dsl::local(0));
+        let (prog, root, gforms) = encode(&syn, &[]);
+        let mut m = bare_machine(prog, root, &gforms);
+
+        // Force to WHNF via the io-run entry point (drives `drive_whnf`).
+        let v1 = m.current();
+        m.evaluate_to_whnf_for_io(v1).unwrap();
+        let mutator_after_subrun = m.clock().duration(ThreadOccupation::Mutator);
+
+        // Simulate the blocking subprocess wait the driver performs between
+        // `evaluate_to_whnf_for_io` and re-entering the machine.
+        let wait = std::time::Duration::from_millis(200);
+        std::thread::sleep(wait);
+
+        // Re-enter the machine (as the driver does after `run_spec`). Its first
+        // act is `clock.switch(Mutator)`, which commits whatever segment was
+        // current: if `drive_whnf` stopped the clock the wait is excluded; if it
+        // left the mutator segment running, the wait is absorbed here.
+        let v2 = m.current();
+        m.evaluate_to_whnf_for_io(v2).unwrap();
+        let mutator_after_wait = m.clock().duration(ThreadOccupation::Mutator);
+
+        let absorbed = mutator_after_wait - mutator_after_subrun;
+        assert!(
+            absorbed < wait / 2,
+            "the mutator clock absorbed {absorbed:?} of the {wait:?} blocking \
+             wait — drive_whnf must stop the clock so io-run subprocess waits \
+             stay out of VM-Mutator (eu-yhih)"
         );
     }
 


### PR DESCRIPTION
Fixes **eu-yhih** (P2, 0.12.0 release gate).

## Problem

The bytecode `-S` VM **Mutator** segment absorbed the entire io-run
subprocess wait, contradicting its own top bar ("IO ~100%") and diverging
from HeapSyn. On a `sleep 0.5` shell program the bytecode VM Mutator read
~0.511s (the whole wait); HeapSyn read ~0.0002s.

## Root cause (what HeapSyn does that bytecode didn't)

The io-run driver (`bytecode_io_run`) forces IO spec fields via
`evaluate_to_whnf_for_io` → `drive_whnf`, then blocks on the subprocess
wait (`run_spec`) **outside** the machine before re-entering.

- HeapSyn's `evaluate_to_whnf_for_io` delegates to `Machine::run`, and
  `run` calls `clock.stop()` on return (`vm.rs`). So when it hands control
  back to the driver, the clock is **stopped**; the subprocess wait falls
  in the unattributed gap between machine runs and lands only in the
  io-run pipeline row.
- The bytecode `drive_whnf` switched the clock to the Mutator segment on
  entry but, unlike `run`, **never stopped it** on return. With the clock
  still ticking in Mutator, the blocking wait was committed to VM-Mutator
  on the next `switch`.

## Fix

Mirror `run`'s tail in `drive_whnf` — a guarded final collection plus
`clock.stop()` — so `-S` clock semantics are identical across the two
engines and the subprocess wait stays out of the mutator segment. One
call site, ~10 lines; no behavioural change to pure programs.

## Regression test

`drive_whnf_stops_clock_so_io_wait_is_excluded_from_mutator` reproduces
the io-run pattern (force to WHNF → blocking wait → re-enter) and asserts
the mutator segment does not absorb the wait. Without the fix it fails,
absorbing ~205ms of a 200ms wait; with the fix the mutator absorbs only
the trivial sub-run time. The #961 stats tests
(`bytecode_reports_machine_heap_gc_stats`,
`summary_bar_excludes_vm_from_total`) still pass.

## Cross-engine validation (single-run captures)

### 1. Pure compute — `day03.eu -t part-2` (self-consistent, unchanged)

| | Bytecode | HeapSyn |
|---|---|---|
| Top bar | `bytecode-eval 96%` | `stg-eval 54% … ` |
| Pipeline eval row | 0.683619s | 0.433040s |
| VM Mutator | 0.683626s | 0.433051s |

VM total == the eval pipeline row within each run (µs-level rounding).
Engine speed differs (bytecode slower here) — that is the known engine
delta, not a stats bug.

### 2. IO-dominated — `{ :io r: io.shell-with({timeout:120}, "sleep 0.5; echo done") }.(r.stdout)`, `-I`

| | Bytecode (before) | Bytecode (after) | HeapSyn |
|---|---|---|---|
| Top bar | IO 94% | **IO 94%** | IO 95% |
| io-run row | 0.5117s | **0.511074s** | 0.511438s |
| VM Mutator | **0.5118s ✗** | **0.000223s ✓** | 0.000156s |

After the fix the bytecode VM Mutator is ms-scale and ~equal to HeapSyn's;
the io-run row holds the wait; the top bar "IO ~94%" is consistent with
the sections on both engines.

### 3. Parse-heavy — import a 2.2 MB / 20 000-record JSON, trivial eval (`items first lookup(:id)`)

| | Bytecode | HeapSyn |
|---|---|---|
| Top bar | `type-check 78%` | `type-check 79%` |
| Top-bar Total | 7.211s | 7.008s |
| Pipeline Total | 7.211s | 7.008s |
| VM Mutator | 0.000479s | 0.000126s |
| Ticks / Allocs | 144 / 40,066 | 144 / 40,066 |

Bar composition matches the pipeline rows and the top-bar Total equals the
pipeline Total on both engines; the two engines byte-match on ticks and
allocs. (For a data-import program the JSON parse itself is cheap ~0.16s;
the dominant non-eval cost is type-check of the large literal, and VM is
correctly near-zero.)

## Gates

- Full harness **479/479** on both engines (default bytecode + `EU_HEAPSYN=1`) × both prelude paths (source + precompiled blob).
- `cargo test --lib` — 1268 passed.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QphBzunfXuSs4Mv8PMBsee
