### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Problem

The **Security Audit** CI gate is failing on every PR (including #970) because of a fresh advisory published 2026-07-06:

- **RUSTSEC-2026-0204** — invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared`. Affected `0.9.18`; fixed in `0.9.20`.

It reaches the tree only through a dev-dependency chain: `criterion → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`.

## Fix

One-line `Cargo.lock` bump `0.9.18 → 0.9.20` (`cargo update -p crossbeam-epoch`). No source changes.

## Verification

- `cargo audit` — no vulnerabilities; only the two pre-existing *allowed* warnings (`atomic-polyfill` unmaintained, `anyhow` unsound) remain.
- `cargo check --release` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk