### PR TITLE
docs: 0.12.1 delivery plan + roadmap Phase-4 deferral

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -356,8 +356,8 @@ reordered as the cadence dictates.
 |---|---|---|
 | **0.11** | Codegen wins, typing on, type-value foundation, bytecode spike | CG type-free tier; TY default-on; SV `s"…"` + `as-spec`; **optional record fields**; **BV0** gate |
 | **0.12** *(shipped scope)* | The bytecode core + the startup win | **BV1** (default engine, code out of the heap; Phase-4 collapse deferred) + **BV5 embedded prelude** (dual-form blob, deterministic; startup win on release binaries). *Unit cache spec'd + held (eu-lb0r)* |
-| **0.12.1** | Close the engine gap | **BV4** superinstructions / decode-cost fusion (eu-9mvh) + `ExecutionError` boxing (eu-adnu) → then the **Phase-4 collapse** (eu-oufc); bytecode block index (eu-4zhi) |
-| **0.13** | Frames, annotations, type-gated codegen, prefix-lists | **BV5-cache** whole-program unit cache (eu-lb0r); **BV2** side tables; **BV3** register frames + CG selective lifting; **CG** type-gated (unboxing); **prefix-list type** |
+| **0.12.1** | Close the engine gap | **BV4** superinstructions / decode-cost fusion (eu-9mvh) + `ExecutionError` boxing (eu-adnu); bytecode block index (eu-4zhi). *Gap-close only — the Phase-4 collapse it unlocks lands in 0.13.* |
+| **0.13** | Frames, annotations, type-gated codegen, prefix-lists | **Phase-4 collapse** — retire HeapSyn once at parity (eu-oufc); **BV5-cache** whole-program unit cache (eu-lb0r); **BV2** side tables; **BV3** register frames + CG selective lifting; **CG** type-gated (unboxing); **prefix-list type** |
 | **0.14** | Polish, parallelism, effects, contracts | **PP** `par-map`/`par-fold`; **EF2** native filesystem IO + **EF1** effect-composition combinators; **W16** contracts; presence inference |
 | **0.15+** | Value model, ecosystem, surface | **DS** persistent blocks + `vec`; **EF1** unified effect context; **W18** modules + **CU1** separate-unit compilation; **W19** watch/REPL + **CU2** per-unit incremental cache; **W17** hermetic; **W22** schema interop |
 | **1.0** *(milestone)* | Decide, prove, freeze | *No features.* Surface complete + **W5** conformance green → ratify and freeze the stable-surface tiers, turn on the version contract (§4.6) |
@@ -953,8 +953,8 @@ Recorded so they are not forgotten, able to swap in if priorities shift:
 
 **CG type-free tier + TY default-on + SV `s"…"` + optional fields (0.11) → BV0 gate →
 BV1 + BV5-prelude (0.12, the bytecode core; shipped) → BV4 decode-fusion +
-ExecutionError boxing → Phase-4 collapse (0.12.1, close the engine gap, retire
-HeapSyn) → BV2 + BV3 + CG type-gated (0.13) → SV
+ExecutionError boxing (0.12.1, close the engine gap) → Phase-4 collapse (retire
+HeapSyn, 0.13) → BV2 + BV3 + CG type-gated (0.13) → SV
 contracts + DS + modules (0.14–0.15) → W5 conformance green → the 1.0 milestone:
 ratify and freeze the surface (§4.6).** DS, PP and the post-1.0 candidates slot
 alongside or follow. The 1.0 freeze is gated on the surface and conformance, not on
@@ -966,7 +966,7 @@ land in point releases first.
 | ID | Item | Release |
 |---|---|:---:|
 | **BV0** | Bytecode encoding + dispatch-ceiling spike (gate) | 0.11 |
-| **BV1** | Threaded interpreter; code out of the GC heap *(shipped — default engine; Phase-4 collapse deferred to 0.12.1)* | 0.12 |
+| **BV1** | Threaded interpreter; code out of the GC heap *(shipped — default engine; Phase-4 collapse deferred to 0.13)* | 0.12 |
 | **BV5** | Embedded bytecode prelude *(shipped, dual-form)* | 0.12 |
 | **BV5-cache** | Content-hash whole-program unit cache (spec `#953`; dispatch-ready, unbuilt — eu-lb0r) | 0.13 |
 | **BV2** | Side tables for annotations | 0.13 |

--- a/docs/superpowers/plans/2026-07-09-0.12.1-close-the-engine-gap.md
+++ b/docs/superpowers/plans/2026-07-09-0.12.1-close-the-engine-gap.md
@@ -1,0 +1,319 @@
+# 0.12.1 — Close the engine gap — Implementation Plan
+
+> **For agentic workers:** This is a **team-delegated** plan. The coordinator does
+> not write code — each task below is an agent brief. Tasks use checkbox (`- [ ]`)
+> syntax for tracking. Where a task says "Owner: X", spawn that agent as a team
+> member (TeamCreate first) with the worktree + doc-reading preamble in §Global.
+
+**Goal:** Ship eucalypt 0.12.1, a perf-only patch closing the bytecode-vs-HeapSyn
+gap (alloc+call-dense programs trail 1.36–2.14× today) to within 1.25× on the
+regression set, gating the 0.13 Phase-4 HeapSyn retirement.
+
+**Architecture:** Three VM-level perf changes, spike-gated and staged so the two
+risky changes are measured cleanly. W0 profiling spike → W1 decode-cost fusion →
+W3 block index; W2 error-boxing runs independently in parallel. Direct-to-master,
+wicket-gated, numbers independently verified.
+
+**Tech Stack:** Rust; STG bytecode VM (`src/eval/machine/`, `src/eval/stg/`);
+GC/memory (`src/eval/memory/`); harness benches (`tests/harness/bench/`) + AoC
+corpus (`examples/aoc25/`).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md`
+
+## Global Constraints
+
+- **UK English** in all code, comments, docs (optimise, colour, behaviour).
+- **Never allow clippy warnings:** `cargo clippy --all-targets -- -D warnings`; no
+  `#[allow(...)]` without explicit owner permission.
+- **Pre-commit, in order:** `rustup update stable` (weekly), `cargo fmt --all`,
+  `cargo clippy --all-targets -- -D warnings`, `cargo test` (full suite, not
+  `--lib`), then commit/push.
+- **Every `eu` run wrapped in `timeout` with a heap limit.** Benchmarks:
+  `--heap-limit-mib 12288` under `timeout 600`.
+- **Benchmarks only on a clean release build:** `cargo clean && cargo build
+  --release`. Agent-reported numbers are **independently re-verified** before
+  acceptance — never taken at face value.
+- **Harness must stay byte-identical on both engines** (default bytecode and
+  `EU_HEAPSYN=1`) — this is the BV1 differential-testing invariant. `cargo test`
+  green on both is a hard gate for every VM-touching task.
+- **Panics are critical:** a user-reachable `panic!`/`expect()` must become an
+  `ExecutionError`/`CoreError`; every panic fix carries a regression test. Use
+  `eu dump <phase>` to inspect the pipeline — do NOT add `eprintln!`.
+- **Agent preamble (every agent, first steps):**
+  1. `pwd && git branch --show-current && git log --oneline -3`
+  2. Worktree setup: `git worktree add /tmp/eu-<task> -b <branch> origin/master
+     && cd /tmp/eu-<task>` — do ALL work there.
+  3. If touching `.eu`: read `docs/reference/agent-reference.md`,
+     `docs/appendices/syntax-gotchas.md`, `docs/appendices/cheat-sheet.md` first.
+- **Beads:** claim with `bd update <id> --claim`; close only after wicket review
+  or coordinator verification against the task's acceptance — never on "merged".
+
+## Benchmark protocol (referenced by W0/W1/W2/W3 acceptance)
+
+Canonical A/B command for one case (`<case>.eu` is a harness bench or an aoc25
+target file; use `-t test`/target as the case requires):
+
+```bash
+# clean build first
+cargo clean && cargo build --release
+BIN=./target/release/eu
+# bytecode (default) — median of 5
+for i in 1 2 3 4 5; do timeout 600 $BIN --heap-limit-mib 12288 <case> >/dev/null; done
+# HeapSyn baseline — median of 5
+for i in 1 2 3 4 5; do EU_HEAPSYN=1 timeout 600 $BIN --heap-limit-mib 12288 <case> >/dev/null; done
+```
+
+Regression set (target ≤1.25×, none >1.3×): `tests/harness/bench/001_naive_fib`,
+`005_drop_cons`, `007_short_lived`; aoc25 `day03 -t p2`, `day09 -t p1` (run aoc25
+from `examples/aoc25/` so imports resolve). Protected wins (must not regress):
+higher-order `count`, aoc25 `day07-p2`, `day11-p1`, `004_generations`. `day08-p1`
+is a profiling exemplar only (already ~52× ahead), never a ratio target.
+
+---
+
+## Phase 0 — Version bump (blocks the release)
+
+### Task 0: Bump version 0.12.0 → 0.12.1 — bead eu-cj1h.1 — Owner: quill (or any)
+
+**Files:**
+- Modify: `Cargo.toml:7` (`version = "0.12.0"` → `"0.12.1"`)
+- Modify: `Cargo.lock` (the `name = "eucalypt"` package entry, ~`:663`)
+- Modify: `CHANGELOG.md` (open a new section)
+
+- [ ] **Step 1:** Edit `Cargo.toml:7`: `version = "0.12.1"`.
+- [ ] **Step 2:** Regenerate the lock entry: `cargo build` (updates
+      `Cargo.lock` eucalypt version deterministically; do not hand-edit).
+- [ ] **Step 3:** In `CHANGELOG.md`, immediately below `## [Unreleased]`, add:
+
+```markdown
+## [0.12.1] - Unreleased
+
+### Changed
+
+- **Bytecode-vs-HeapSyn engine gap closed** — (entries added as W1/W2/W3 land)
+```
+
+- [ ] **Step 4:** Verify: `./target/release/eu --version` prints `0.12.1` (after
+      `cargo build --release`).
+- [ ] **Step 5:** `cargo fmt --all && cargo clippy --all-targets -- -D warnings`.
+- [ ] **Step 6:** Commit + PR direct to master:
+
+```bash
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "release: bump version to 0.12.1"
+```
+
+**Acceptance:** `eu --version` = 0.12.1; CHANGELOG has a `[0.12.1]` section; CI
+green; wicket-merged. This lands **before** W1/W2/W3 PRs so they target 0.12.1.
+
+---
+
+## Phase 1 — Spike + independent win (parallel)
+
+### Task 1 (W0): Profiling spike — bead eu-9mvh.1 — Owner: stopwatch
+
+**Deliverable:** `docs/superpowers/reports/2026-07-09-bytecode-decode-cost-spike.md`
+(a report — **no VM changes**). Gates W1.
+
+**Files:**
+- Create: `docs/superpowers/reports/2026-07-09-bytecode-decode-cost-spike.md`
+
+- [ ] **Step 1:** Clean release build; confirm baseline ratios on the regression
+      set with the §Benchmark protocol. Record today's bc/hs per case.
+- [ ] **Step 2:** CPU-profile the bytecode engine on `001_naive_fib`, `day03-p2`,
+      `day09-p1`, and `day08-p1` (extreme-allocation exemplar). Use a sampling
+      profiler (e.g. `cargo flamegraph`/`perf`/`samply` — whatever is available on
+      the platform). Capture the per-symbol breakdown: `read_ref`,
+      `read_arg_offsets`, `read_form_header`, `read_let`, `handle_op`,
+      `enter_local`, `drop ExecutionError`, malloc/free.
+- [ ] **Step 3:** Attribute the boxing-heavy hot sequences that dominate: identify
+      the top fusible opcode runs (candidates from eu-9mvh: force-then-case,
+      alloc-thunk-update, literal arithmetic). Quantify each candidate's share.
+- [ ] **Step 4:** For each of the three levers — (a) superinstruction fusion,
+      (b) denser operand encoding, (c) reduced per-reduction decode work — project
+      the plausible upside against the regression set and the 1.25× bar. State
+      which single lever (or ordered combination) to pursue first, with the
+      evidence.
+- [ ] **Step 5:** Write the report: baseline table, per-symbol profiles, fusible
+      sequences with shares, per-lever projection, **explicit recommendation**,
+      and any interaction risk with W3 (block-index lookup path) or W2.
+- [ ] **Step 6:** Commit + PR the report direct to master.
+
+**Acceptance:** report merged; **owner signs off on the chosen lever** before W1
+starts. No VM code changed. Numbers independently reproducible from the stated
+commands.
+
+### Task 2 (W2): Box the `ExecutionError` payload — bead eu-adnu — Owner: furnace
+
+Independent of W0/W1/W3 — start immediately in parallel with Task 1.
+
+**Files:**
+- Modify: `src/eval/error.rs` (the `ExecutionError` enum / its `Result` alias)
+- Modify: call sites in `src/eval/machine/vm.rs` and `src/eval/stg/` that
+  construct/match `ExecutionError` (compiler will list them)
+- Test: existing harness (byte-identical invariant) is the correctness test
+
+- [ ] **Step 1:** Confirm the cost is real: profile `day08-p1` (or `001_naive_fib`)
+      and locate `drop_in_place<ExecutionError>` at ~2.4–3.5% (baseline evidence
+      for the PR).
+- [ ] **Step 2:** Make the hot-path `Result` pointer-sized. Options, pick the
+      least invasive that compiles clean: box the large variant(s) of
+      `ExecutionError` (e.g. `Box<...>` around the heavy payload) so
+      `size_of::<ExecutionError>()` drops and the per-instruction drop is a pointer
+      free on the error (cold) path only. Verify `size_of` before/after.
+- [ ] **Step 3:** Fix all construction/match sites the compiler flags (deref/box
+      as needed). Keep error messages and `to_diagnostic()` output **identical** —
+      no user-visible change.
+- [ ] **Step 4:** `cargo test` green on **both** engines (default and
+      `EU_HEAPSYN=1`). Error harness (`tests/harness/errors/`) unchanged.
+- [ ] **Step 5:** Clean release build; re-profile: confirm the `drop_in_place`
+      line is gone/shrunk; confirm no regression on the regression set or protected
+      wins (§Benchmark protocol).
+- [ ] **Step 6:** `cargo fmt --all && cargo clippy --all-targets -- -D warnings`.
+- [ ] **Step 7:** Add a CHANGELOG `[0.12.1]` entry. Commit + PR direct to master.
+
+**Acceptance:** harness byte-identical both engines; `size_of::<ExecutionError>()`
+reduced; profile confirms drop cost retired; no perf regression; error diagnostics
+unchanged; wicket-reviewed with independently-verified before/after.
+
+---
+
+## Phase 2 — Decode-cost fusion (gated on W0)
+
+### Task 3 (W1): Implement the recommended lever — bead eu-9mvh — Owner: per W0
+
+Owner assigned when Task 1 lands: superinstruction fusion → stopwatch or furnace;
+denser encoding / decode-work reduction → furnace. **Do not start until the owner
+has signed off on the W0 recommendation.**
+
+**Files (indicative — the W0-recommended design pins these):**
+- Modify: `src/eval/stg/syntax.rs` (new fused `StgSyn` node(s) if superinstructions)
+- Modify: `src/eval/stg/compiler.rs` (emit the fused form for matched sequences)
+- Modify: `src/eval/machine/vm.rs` (decode + `handle_instruction` for new opcodes)
+- Modify: `src/eval/stg/blob.rs` if the arena/serialised encoding changes (blob +
+  source-prelude parity is mandatory)
+- Test: `tests/harness/` (byte-identical invariant); add targeted regression bench
+  if a new pattern is introduced
+
+- [ ] **Step 1:** Write the W1 design section into the W0 report (or a short design
+      note): exact fused opcodes / encoding, the STG sequences they replace, the
+      decode/dispatch/Result-drop cost each removes, and blob/source-prelude parity
+      strategy.
+- [ ] **Step 2:** TDD where it maps: add/confirm a harness case that exercises the
+      targeted sequence; run it on **both** engines and capture identical output as
+      the correctness oracle before changing codegen.
+- [ ] **Step 3:** Implement the fused node(s)/encoding in `syntax.rs` + emit in
+      `compiler.rs`. Keep the 192-intrinsic path and continuation model intact
+      unless the design explicitly justifies otherwise.
+- [ ] **Step 4:** Implement decode + dispatch in `vm.rs`. If the operand encoding
+      changed, update `blob.rs` and **regenerate the prelude blob**: `cargo xtask
+      prelude-compile`; verify blob-mode and `--source-prelude` give identical
+      results.
+- [ ] **Step 5:** `cargo test` green on **both** engines — byte-identical harness
+      is the hard gate. `EU_GC_VERIFY=2` + `EU_GC_POISON=1` on the harness if the
+      change touches allocation/thunk-update sequences.
+- [ ] **Step 6:** Clean release build; run the full §Benchmark protocol.
+      **Gate:** regression set each ≤1.25× (none >1.3×); protected wins not
+      regressed; report AoC geomean shift. If short of the bar, stack the next
+      lever from W0 before proposing a bar change (bar changes are an owner
+      decision).
+- [ ] **Step 7:** `cargo fmt --all && cargo clippy --all-targets -- -D warnings`.
+- [ ] **Step 8:** CHANGELOG `[0.12.1]` entry. Commit + PR direct to master.
+
+**Acceptance:** harness byte-identical both engines; blob + source-prelude parity;
+regression set within bar on a clean build; no protected-win regression; GC-safe
+if allocation paths touched; wicket-reviewed with independently-verified numbers.
+
+---
+
+## Phase 3 — Block index (last; riskiest)
+
+### Task 4 (W3): Reinstate the bytecode block index — bead eu-4zhi — Owner: furnace
+
+**Do not start until Task 3 (W1) has landed and been benchmarked clean** — so W3's
+risk never confounds W1's measurement. This is a **large SynClosure-ABI migration**
+with a GC-safety hazard, not a slot update.
+
+**Files (indicative):**
+- Modify: `src/eval/stg/block.rs` (the `LOOKUP` wrapper / `LookupOr` / `SafeLookup`
+  path — where the index is gated off on bytecode)
+- Modify: `src/eval/memory/` block representation if literals need a mutable index
+  slot; or a new GC-safe side-table module
+- Modify: `src/eval/stg/compiler.rs::compile_lookup` if static-literal index
+  baking changes
+- Test: `tests/harness/bench/006_block_lookup` + a new large-block lookup bench;
+  GC stress harness
+
+- [ ] **Step 1:** Design decision — pick and justify ONE (per spec §4 W3, the
+      pointer-keyed side-table is **unsafe across GC evacuation** and is
+      forbidden): (a) port the index build/store/lookup off the panicking
+      SynClosure ABI (`nav`/`set_closure`/`root_env` panic on `BcBifContext`);
+      (b) give static literals a per-instance mutable index slot; (c) a **GC-safe
+      identity-keyed** side-table (not pointer-keyed); or (d) cache dynamic blocks
+      only. Write the decision + why into a short design note. Owner sign-off.
+- [ ] **Step 2:** TDD: add a large-block (≥40-key) lookup bench and a correctness
+      harness case covering dynamic `build_data` blocks AND static block literals.
+      Confirm current O(n) behaviour, capture both engines' identical output.
+- [ ] **Step 3:** Implement the chosen approach. If a mutable slot on literals: the
+      static template lives in the immutable code arena — the index must attach to
+      the per-instance closure, not the arena template.
+- [ ] **Step 4:** GC-safety gate — run the harness under `EU_GC_VERIFY=2` and
+      `EU_GC_POISON=1`; if the index survives evacuation it must be rebuilt or
+      updated correctly (this is the crux — a stale/dangling index after evacuation
+      is heap corruption). No unmarked-reachable, no poison in mark.
+- [ ] **Step 5:** `cargo test` green on **both** engines; byte-identical harness.
+- [ ] **Step 6:** Clean release build; benchmark: block lookups O(1) on the large
+      block (was ~4% tax); confirm no regression elsewhere and no GC-safety
+      regression on the stress harness.
+- [ ] **Step 7:** `cargo fmt --all && cargo clippy --all-targets -- -D warnings`.
+- [ ] **Step 8:** CHANGELOG `[0.12.1]` entry. Commit + PR direct to master.
+
+**Acceptance:** O(1) lookups on dynamic + static blocks (or a justified subset);
+**no GC-safety regression** (`EU_GC_VERIFY=2` + `EU_GC_POISON=1` clean); harness
+byte-identical; no perf regression; wicket-reviewed. If GC-safety cannot be
+guaranteed in time, W3 aborts without blocking release (it is last by design).
+
+---
+
+## Phase 4 — Cut the release
+
+### Task 5: Release 0.12.1 — bead eu-cj1h (epic close) — Owner: coordinator + release skill
+
+- [ ] **Step 1:** Confirm W1 + W2 landed (W3 landed OR explicitly deferred with a
+      bead) and CI green on master incl. aarch64.
+- [ ] **Step 2:** Full clean-build §Benchmark protocol across the regression set +
+      protected wins + AoC geomean. **Independently verify** the bar is met.
+      Produce a final before/after table.
+- [ ] **Step 3:** Reconcile beads: close eu-adnu, eu-9mvh (+ eu-9mvh.1), eu-4zhi
+      (or defer with reason), and the epic eu-cj1h — each close reason cites the
+      acceptance met, not just a PR number. Close eu-1tkk.1 as superseded.
+- [ ] **Step 4:** Finalise `CHANGELOG.md`: replace `[0.12.1] - Unreleased` with the
+      release date; ensure W1/W2/W3 entries read cleanly.
+- [ ] **Step 5:** Run the `release` skill (tag, release notes). Do not tag until
+      the bar is verified on a clean build.
+
+**Acceptance:** 0.12.1 tagged; CHANGELOG dated; bar met and documented; epic
+closed with verified numbers.
+
+---
+
+## Dependency summary (beads)
+
+```
+eu-cj1h.1 (version bump)     READY  → land first
+eu-9mvh.1 (W0 spike)         READY  ─┐ blocks
+eu-adnu   (W2 error-boxing)  READY   │  (independent, parallel)
+eu-9mvh   (W1 fusion)        blocked ◄┘ by eu-9mvh.1 ; blocks ↓
+eu-4zhi   (W3 block index)   blocked ◄── by eu-9mvh
+eu-1tkk.1 (BV4 @0.14)        superseded by eu-9mvh
+```
+
+## Self-review notes
+
+- **Spec coverage:** §2 bar → Task 5 Step 2 + per-task acceptance; §3 W1/W2/W3 →
+  Tasks 3/2/4; §4 W0 → Task 1; §5 sequencing → Phase order + dependency summary;
+  §6 direct-to-master + version bump → Task 0 + per-task PR steps; §7 beads →
+  dependency summary + Task 5 Step 3; §8 guardrails → Global Constraints + agent
+  preamble; §9 risks → Task 3 Step 6 (bar shortfall), Task 4 Steps 1/4 (GC safety).
+- **day08-p1** is consistently a profiling exemplar (Tasks 1), never a ratio target.
+- **Byte-identical-both-engines** gate repeated on every VM-touching task (2/3/4).

--- a/docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md
@@ -24,19 +24,42 @@ in 0.12.1; 0.12.1 only unlocks it.)
 
 ## 2. Acceptance bar (definition of "gap closed")
 
-Measured against HeapSyn (`EU_HEAPSYN=1`) on the four regression cases that trail
-today — **fib, day03-p2, day08-p1, day09-p1** — on a clean release build
-(`cargo clean && cargo build --release`):
+Measured against HeapSyn (`EU_HEAPSYN=1`) on a clean release build
+(`cargo clean && cargo build --release`), external wall median of ≥5 runs at the
+production heap (`--heap-limit-mib 12288`, under `timeout`), per the
+2026-07-03 A/B report methodology.
 
-- **Every case within 1.25×** of HeapSyn, and **no case above 1.3×**.
-- **No regression** on workloads already at or beyond parity — in particular
-  higher-order `count` (0.66×) and `foldl` (0.89×) must not get worse.
+**Regression set** — the genuinely alloc+call-dense cases where bytecode trails
+today (bc/hs ratios from the 2026-07-03 A/B sweep):
+
+| Case | today bc/hs |
+|------|--:|
+| `tests/harness/bench/001_naive_fib` | 2.14× |
+| `tests/harness/bench/005_drop_cons` | 2.13× |
+| `tests/harness/bench/007_short_lived` | 1.87× |
+| aoc25 `day03-p2` | 1.67× |
+| aoc25 `day09-p1` | 1.36× |
+
+- **Every case in the regression set within 1.25×** of HeapSyn, and **no case
+  above 1.3×**.
+- **No regression** on the genuine bytecode wins: higher-order `count` (0.66×),
+  `day07-p2` (0.94×), `day11-p1` (0.97×), `004_generations` (0.94×) must not get
+  worse. (`foldl` is **not** a protected win — it is O(n²) on *both* engines,
+  0.92× at N=5k but 2.28× at N=10k with high variance; engine-independent, out of
+  scope.)
 - The AoC-2025 corpus geomean must move meaningfully toward parity from today's
   position (reported, not gated to a fixed number).
 
+**Note on `day08-p1`:** the eu-9mvh bead and roadmap list it among the
+"alloc+call-dense" cases, but it is **already a ~52× bytecode win** — HeapSyn is
+GC-bound there and does not finish in 500 s. It is a **profiling target** for the
+W0 spike (extreme allocation exposes `handle_op`/decode/`drop ExecutionError`
+cost cleanly), **not** a ratio target. Do not treat it as a case to "bring within
+1.25×".
+
 Rationale: full parity is likely unreachable because decode is structural to any
 bytecode VM; 1.1× was judged too tight for the most alloc-dense case. 1.25×/1.3×
-is a meaningful improvement from 2.05× worst-case and, combined with BV1's
+is a meaningful improvement from the 2.14× worst-case (fib) and, combined with BV1's
 off-heap-code and startup wins, makes Phase-4 arguable on aggregate.
 
 **Every perf claim is independently verified** on a clean release build before
@@ -64,9 +87,11 @@ acceptance — agent-reported numbers are never taken at face value (CLAUDE.md).
 
 ### W0 — Profiling spike (eu-9mvh, part 1) — *gates W1*
 
-Profile the four regression cases and produce a per-opcode / per-hot-sequence CPU
-breakdown (`read_ref`, `read_arg_offsets`, `read_form_header`, `read_let`, plus the
-boxing-heavy sequences: force-then-case, alloc-thunk-update, literal arithmetic).
+Profile the regression set (§2) plus `day08-p1` as the extreme-allocation
+hot-path exemplar, and produce a per-opcode / per-hot-sequence CPU breakdown
+(`read_ref`, `read_arg_offsets`, `read_form_header`, `read_let`, `handle_op`,
+`enter_local`, plus the boxing-heavy sequences: force-then-case,
+alloc-thunk-update, literal arithmetic).
 **Deliverable:** a report under `docs/superpowers/reports/` recommending the
 primary lever — fused superinstructions, denser operand encoding, or decode-work
 reduction — with the projected upside of each against the 1.25× bar. **No VM

--- a/docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md
@@ -1,0 +1,188 @@
+# 0.12.1 — Close the engine gap — Delivery design
+
+- **Status:** Approved plan of record
+- **Date:** 2026-07-09
+- **Baseline:** eucalypt 0.12.0 (bytecode VM is the default engine)
+- **Roadmap anchor:** ROADMAP.md §8 line 359, §9 (BV4 promoted to 0.12.1)
+
+---
+
+## 1. Purpose and the one-line goal
+
+0.12.0 made the bytecode VM (BV1) the default engine. It shipped with one known,
+documented trade-off (CHANGELOG 0.12.0): on allocation- and call-dense programs
+bytecode runs **1.2–2.05× slower than the legacy HeapSyn tree-walk engine**,
+because a bytecode VM pays instruction-stream *decode* cost that HeapSyn — which
+walks a materialised pointer graph — does not. Pure-dispatch and higher-order /
+env-walk workloads are already at parity or faster (higher-order `count` 0.66×,
+`foldl` 0.89×).
+
+**0.12.1 closes that gap.** It is a perf-only patch release. It ships no new
+language surface. Its second purpose is to be the *gate* that makes the Phase-4
+collapse — retiring HeapSyn — defensible in 0.13. (The collapse itself is **not**
+in 0.12.1; 0.12.1 only unlocks it.)
+
+## 2. Acceptance bar (definition of "gap closed")
+
+Measured against HeapSyn (`EU_HEAPSYN=1`) on the four regression cases that trail
+today — **fib, day03-p2, day08-p1, day09-p1** — on a clean release build
+(`cargo clean && cargo build --release`):
+
+- **Every case within 1.25×** of HeapSyn, and **no case above 1.3×**.
+- **No regression** on workloads already at or beyond parity — in particular
+  higher-order `count` (0.66×) and `foldl` (0.89×) must not get worse.
+- The AoC-2025 corpus geomean must move meaningfully toward parity from today's
+  position (reported, not gated to a fixed number).
+
+Rationale: full parity is likely unreachable because decode is structural to any
+bytecode VM; 1.1× was judged too tight for the most alloc-dense case. 1.25×/1.3×
+is a meaningful improvement from 2.05× worst-case and, combined with BV1's
+off-heap-code and startup wins, makes Phase-4 arguable on aggregate.
+
+**Every perf claim is independently verified** on a clean release build before
+acceptance — agent-reported numbers are never taken at face value (CLAUDE.md).
+
+## 3. Scope
+
+### In scope (all three roadmap items)
+
+| Item | Bead | What | Expected win |
+|------|------|------|--------------|
+| **W1** | eu-9mvh | BV4 decode-cost fusion — superinstructions / denser encoding / reduced per-reduction decode work. *Lever chosen by the W0 spike.* | The bulk of the gap-close (~40% of fib CPU is decode) |
+| **W2** | eu-adnu | Box the `ExecutionError` payload so the hot-path `Result` is a pointer, retiring the per-instruction `drop_in_place` | 2.4–3.5% CPU |
+| **W3** | eu-4zhi | Reinstate the bytecode-compatible block index (SymbolId→position), an O(n)→O(1) lookup fix via a SynClosure-ABI migration | ~4% on lookup-heavy blocks |
+
+### Explicitly out of scope
+
+- **eu-famg** (residual stream O(N²)) — owner-marked post-0.12; needs the deferred
+  lazy-streams rework and/or BV3 register frames, engine-independent, not a gap.
+- **Phase-4 collapse / HeapSyn retirement** (eu-oufc) — deferred to 0.13. 0.12.1
+  only unlocks it.
+- Any new language surface, prelude, or IO capability.
+
+## 4. Work items in detail
+
+### W0 — Profiling spike (eu-9mvh, part 1) — *gates W1*
+
+Profile the four regression cases and produce a per-opcode / per-hot-sequence CPU
+breakdown (`read_ref`, `read_arg_offsets`, `read_form_header`, `read_let`, plus the
+boxing-heavy sequences: force-then-case, alloc-thunk-update, literal arithmetic).
+**Deliverable:** a report under `docs/superpowers/reports/` recommending the
+primary lever — fused superinstructions, denser operand encoding, or decode-work
+reduction — with the projected upside of each against the 1.25× bar. **No VM
+changes.** W1's design is written against this recommendation.
+
+- Owner: **stopwatch**. Acceptance: report merged; owner signs off on the chosen lever.
+
+### W1 — Decode-cost fusion (eu-9mvh, part 2) — *the prize*
+
+Implement the lever W0 recommends. Most likely superinstructions fusing the
+profiled hot sequences into single opcodes (attacking decode + dispatch + Result
+drop together), possibly with denser operand encoding. Source-prelude and
+blob-prelude parity is mandatory. The full harness must stay **byte-identical on
+both engines** (the BV1 differential-testing invariant).
+
+- Owner: **stopwatch or furnace** — decided by the W0 lever (encoding/decode-work →
+  furnace VM work; fusion → either).
+- Acceptance: harness byte-identical both engines; clean-build benchmarks meet §2
+  on all four cases with no winning-workload regression; wicket-reviewed with
+  independently-verified numbers.
+
+### W2 — Box the `ExecutionError` payload (eu-adnu)
+
+Box the error payload so the hot-loop `Result<_, ExecutionError>` is pointer-sized,
+retiring the per-instruction `drop_in_place`. Small, mechanical, independent of
+W1/W3.
+
+- Owner: **furnace**. Acceptance: harness byte-identical; profile confirms the
+  `drop_in_place` line is gone; no regression elsewhere; wicket-reviewed.
+
+### W3 — Bytecode block index (eu-4zhi) — *the risky one, done last*
+
+Reinstate the SymbolId→position index on the bytecode lookup path. This is a
+**large SynClosure-ABI migration**, not a slot update: the index build/store/lookup
+subsystem is written against the HeapSyn ABI (`nav`/`set_closure`/`root_env` panic
+on `BcBifContext`); static block literals bake their template into the *immutable*
+code arena with no per-instance mutable slot; **a pointer-keyed side-table is unsafe
+across GC evacuation.** The design must pick and justify one of: port the index
+machinery off the panicking SynClosure ABI; give literals a mutable index slot;
+a GC-safe (identity-keyed, not pointer-keyed) side-table; or cache dynamic blocks
+only. Sequenced **after W1 lands and is benchmarked clean**, so its risk never
+confounds W1's measurement.
+
+- Owner: **furnace**. Acceptance: block lookups O(1) on dynamic *and* static blocks
+  (or a justified subset); **no GC-safety regression** — passes `EU_GC_VERIFY=2`
+  and `EU_GC_POISON=1` on the harness; harness byte-identical; wicket-reviewed.
+
+## 5. Sequencing (Approach B — spike-gated, staged)
+
+```
+Phase 0  ── Version bump to 0.12.1 (blocks everything)
+              │
+              ├────────────────────────┐
+Phase 1  ── W0 spike (stopwatch)     W2 error-boxing (furnace)   ← parallel
+              │                         │
+              ▼                         ▼
+Phase 2  ── W1 fusion (owner picks)   [W2 lands → master]
+              │
+              ▼  (W1 lands + benchmarked clean against §2)
+Phase 3  ── W3 block index (furnace)
+              │
+              ▼  (all three land, §2 met on clean build)
+Phase 4  ── Cut 0.12.1: finalise CHANGELOG, tag, release
+```
+
+Why B: honours the profile-driven gate (W0→W1); banks the cheap independent win
+(W2) immediately in parallel; and isolates the two risky VM changes (W1 then W3)
+so each is measured against the bar without the other confounding it. Rejected:
+Approach A (max parallelism) ran W1+W3 concurrently → merge-conflict and
+confounded-measurement risk in shared VM hot paths; Approach C (strictly serial)
+wasted W2's independence.
+
+## 6. Release mechanics — direct to master
+
+Each item is a PR **straight to master**, wicket-reviewed, once its acceptance
+criteria are met. No integration branch (0.12.0 used one; 0.12.1 is smaller and
+each item is independently shippable). CI must be green (incl. aarch64) before any
+merge. When all three have landed and §2 is met on a clean build, cut the 0.12.1
+tag via the release process.
+
+**Phase 0 version bump touches:** `Cargo.toml:7` (`0.12.0`→`0.12.1`),
+`Cargo.lock:663`, and `CHANGELOG.md` (open a `[0.12.1] - Unreleased` section;
+`build-meta.yaml` derives from Cargo and needs no manual edit).
+
+## 7. Beads structure
+
+- **Create epic `0.12.1 — Close the engine gap`** and file W1/W2/W3 under it:
+  eu-9mvh, eu-adnu, eu-4zhi. Add a spike child of eu-9mvh for W0 (eu-9mvh.1).
+- Encode the dependencies: W0 blocks W1; W1 blocks W3; W2 independent.
+- **Reconcile eu-1tkk.1** ("BV4: Superinstructions ← 0.14") — stale: BV4 was
+  promoted to 0.12.1 and is now eu-9mvh. Mark eu-1tkk.1 superseded/closed with a
+  pointer to eu-9mvh so the 0.14 epic doesn't double-count it.
+- Beads are closed only after wicket review or coordinator verification against
+  these acceptance criteria — never batch-closed on "merged".
+
+## 8. Team and guardrails
+
+- **Coordinator** plans, sequences, structures beads, and verifies — it does **not**
+  write code or docs; every change (including the version bump) is delegated.
+- Agents spawned as **team members** (TeamCreate first), each with mandatory
+  worktree setup in-prompt, branch verification, and the doc-reading preamble if
+  they touch `.eu`.
+- All `eu` runs wrapped in `timeout` with a heap limit. Benchmarks on clean
+  release builds; **numbers independently re-verified** before any acceptance.
+- **wicket** gatekeeps: CI green (incl. aarch64) before merge; perf PRs rejected
+  without independently-verified before/after numbers; no merge while the line is
+  stopped.
+
+## 9. Risks
+
+- **W1 under-delivers against the bar.** Mitigation: W0 spike projects the upside
+  *before* committing; if the top lever falls short, stack a second lever (fusion
+  + denser encoding) before loosening the bar — bar changes are an owner decision.
+- **W3 GC-safety regression.** The pointer-keyed side-table is explicitly unsafe
+  across evacuation. Mitigation: design must be GC-safe by construction; acceptance
+  gates on `EU_GC_VERIFY=2` + `EU_GC_POISON=1`; W3 is last so a late abort doesn't
+  block the rest of the release.
+- **Decode is structurally irreducible past some floor.** Accepted: the 1.25×/1.3×
+  bar already prices this in; parity is not required.


### PR DESCRIPTION
Lands the **0.12.1 "close the engine gap"** planning artefacts on master, plus the roadmap edit deferring the Phase-4 HeapSyn retirement to 0.13.

## What's here

- **Spec** — `docs/superpowers/specs/2026-07-09-0.12.1-delivery-design.md`: 0.12.1 is a perf-only patch closing the bytecode-vs-HeapSyn gap (alloc+call-dense programs trail 1.36–2.14× today). Scope: eu-9mvh (BV4 decode-cost fusion, spike-gated), eu-adnu (ExecutionError boxing), eu-4zhi (block index). Acceptance bar: regression set within 1.25× (none >1.3×) on a clean release build; protected wins not regressed.
- **Plan** — `docs/superpowers/plans/2026-07-09-0.12.1-close-the-engine-gap.md`: team-delegated execution playbook — Phase 0 version bump → W0 spike ∥ W2 error-boxing → W1 fusion (gated) → W3 block index (last) → cut release. Per-task agent briefs with exact benchmark protocol and GC-safety gates.
- **Roadmap** — Phase-4 collapse deferred to 0.13; 0.12.1 only *unlocks* it.

## Key correction (see spec commit 893933a1)

The 2026-07-03 A/B report shows **day08-p1 is a ~52× bytecode WIN** (HeapSyn GC-bound, >500 s TO), not a trailing case — it is a W0 profiling target, not a ratio target. The acceptance bar uses the genuine trailing set: `naive_fib` 2.14×, `drop_cons` 2.13×, `short_lived` 1.87×, `day03-p2` 1.67×, `day09-p1` 1.36×.

## Beads

Epic `eu-cj1h` (0.12.1 — Close the engine gap) over `eu-cj1h.1` (version bump), `eu-9mvh`/`eu-9mvh.1` (W1+spike), `eu-adnu` (W2), `eu-4zhi` (W3); `eu-1tkk.1` marked superseded. All six reference this spec + plan.

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk