### PR TITLE
fix(clippy): resolve Rust 1.97.0 lint errors

### DIFF
--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -888,10 +888,9 @@ impl Checker {
 
         let (type_str, is_hint): (String, bool) = if let Some(e) = block.get("type") {
             (extract_string_literal(e)?, false)
-        } else if let Some(e) = block.get("__type_hint") {
-            (extract_string_literal(e)?, true)
         } else {
-            return None;
+            let e = block.get("__type_hint")?;
+            (extract_string_literal(e)?, true)
         };
 
         // A leading `!` marks the annotation as asserted (body not verified)

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -1123,7 +1123,7 @@ pub mod tests {
         for f in eu_paths() {
             if let Err(e) = loader.load_eucalypt(&Locator::Fs(f.clone())) {
                 let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                panic!("Failed to parse {:?}.\n{}", &f, diag);
+                panic!("Failed to parse {:?}.\n{}", f, diag);
             }
         }
     }
@@ -1137,12 +1137,12 @@ pub mod tests {
 
             if let Err(e) = loader.load_tree(&Input::from(loc.clone())) {
                 let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                panic!("Failed to parse {:?}.\n{}", &f, diag);
+                panic!("Failed to parse {:?}.\n{}", f, diag);
             }
 
             if let Err(e) = loader.translate(&Input::from(loc.clone())) {
                 let diag = loader.diagnose_to_string(&e.to_diagnostic(loader.source_map()));
-                panic!("Failed to desugar {:?}.\n{}", &f, diag);
+                panic!("Failed to desugar {:?}.\n{}", f, diag);
             };
         }
     }

--- a/src/driver/tester.rs
+++ b/src/driver/tester.rs
@@ -345,19 +345,19 @@ impl InProcessTester {
             // embedded for testing expectations against
             let output = Input::new(
                 Locator::Literal(result.stdout.clone()),
-                Some(format!("{}-{}-result", &target_name, &format)),
+                Some(format!("{}-{}-result", target_name, format)),
                 format.clone(),
             );
             // Literal stdout
             let stdout = Input::new(
                 Locator::Literal(result.stdout.clone()),
-                Some(format!("{}-{}-stdout-text", &target_name, &format)),
+                Some(format!("{}-{}-stdout-text", target_name, format)),
                 "text",
             );
             // Literal stderr
             let stderr = Input::new(
                 Locator::Literal(result.stderr),
-                Some(format!("{}-{}-stderr-text", &target_name, &format)),
+                Some(format!("{}-{}-stderr-text", target_name, format)),
                 "text",
             );
 
@@ -398,8 +398,8 @@ impl InProcessTester {
     expectations: [{}]
     stats: {}{benchmark_field}
   }}"#,
-                &target_name,
-                &format,
+                target_name,
+                format,
                 result.exit_code.unwrap_or(1),
                 stdout.name().as_ref().expect("stdout temp file has a name"),
                 stderr.name().as_ref().expect("stderr temp file has a name"),

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2426,19 +2426,12 @@ impl BytecodeMachine<'_> {
                     match dref {
                         DecodedRef::Local(i) => {
                             let env = c.env();
-                            match view.scoped(env).get(&view, i as usize) {
-                                Some(inner) => {
-                                    container = Some(env);
-                                    current = inner;
-                                }
-                                None => return None,
-                            }
+                            let inner = view.scoped(env).get(&view, i as usize)?;
+                            container = Some(env);
+                            current = inner;
                         }
                         DecodedRef::Global(i) => {
-                            match view.scoped(self.state.globals).get(&view, i as usize) {
-                                Some(inner) => current = inner,
-                                None => return None,
-                            }
+                            current = view.scoped(self.state.globals).get(&view, i as usize)?;
                         }
                         DecodedRef::Value(_) => return None,
                     }

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -420,7 +420,7 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
     }
 
     if dump_heap {
-        eprintln!("Heap after mark:\n\n{:?}", &heap_view.heap)
+        eprintln!("Heap after mark:\n\n{:?}", heap_view.heap)
     }
 
     // Post-mark verification (level 2 already verified inline during mark)
@@ -440,7 +440,7 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
     }
 
     if dump_heap {
-        eprintln!("Heap after defer_sweep:\n\n{:?}", &heap_view.heap)
+        eprintln!("Heap after defer_sweep:\n\n{:?}", heap_view.heap)
     }
 
     // Record collection count and update peak blocks
@@ -511,7 +511,7 @@ pub fn collect_with_evacuation(
         }
 
         if dump_heap {
-            eprintln!("Heap after mark:\n\n{:?}", &heap_view.heap)
+            eprintln!("Heap after mark:\n\n{:?}", heap_view.heap)
         }
     }
 
@@ -795,7 +795,7 @@ pub mod tests {
 
         heap.flush_unswept();
         let stats_c = heap.stats();
-        eprintln!("Final stats: {:?}", &stats_c);
+        eprintln!("Final stats: {:?}", stats_c);
 
         // Original test logic: removing let_ptr root should cause more blocks to be recycled
         assert!(stats_a.recycled < stats_b.recycled,
@@ -1242,7 +1242,7 @@ pub mod tests {
 
         heap.flush_unswept();
         let stats_c = heap.stats();
-        eprintln!("Final stats: {:?}", &stats_c);
+        eprintln!("Final stats: {:?}", stats_c);
 
         // Original test logic: removing let_ptr root should cause more blocks to be recycled
         assert!(stats_a.recycled < stats_b.recycled,

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1012,15 +1012,8 @@ fn linear_scan_for_key(
                         }
                     }
                 }
-                if let Some(tail_ref) = args.get(1) {
-                    if let Some(next) = resolve_ref_in_closure(nav, &current, tail_ref.clone()) {
-                        current = next;
-                    } else {
-                        return None;
-                    }
-                } else {
-                    return None;
-                }
+                let tail_ref = args.get(1)?;
+                current = resolve_ref_in_closure(nav, &current, tail_ref.clone())?;
             }
             _ => return None,
         }

--- a/src/eval/stg/embed.rs
+++ b/src/eval/stg/embed.rs
@@ -163,12 +163,7 @@ fn embed_stg(syn: &StgSyn) -> Option<rowan_ast::Soup> {
             }
             b.finish()
         }
-        StgSyn::DirectApp {
-            callable,
-            args,
-            smid: _,
-            ..
-        } => {
+        StgSyn::DirectApp { callable, args, .. } => {
             let mut b = StgEmbedBuilder::new("s-direct-app");
             b.token(&embed_ref(callable));
             for arg in args {


### PR DESCRIPTION
New Rust stable 1.97.0 tightened clippy, which now flags pre-existing patterns repo-wide and breaks the Lint and WASM Compilation Check CI jobs on master and every open PR (CI pulls `dtolnay/rust-toolchain@stable`, i.e. latest stable).

## Fixes (mechanical, no behaviour change)

- **`question_mark`** — if-let/match blocks rewritable with `?`:
  - `src/eval/bytecode/machine.rs` — `peel_io_spec_tag`
  - `src/eval/stg/block.rs` — `linear_scan_for_key`
  - `src/core/typecheck/check.rs` — `extract_annotation`
- **`useless_borrows_in_formatting`** — redundant `&` in `format!`/`eprintln!`/`panic!` args:
  - `src/driver/tester.rs`, `src/driver/source.rs`, `src/eval/memory/collect.rs`
- **`unneeded_wildcard_pattern`** — redundant `smid: _` alongside `..`:
  - `src/eval/stg/embed.rs`

No `#[allow(...)]` suppressions used, per CLAUDE.md.

## Verification

- `cargo clippy --all-targets -- -D warnings` — exit 0, clean
- `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` — exit 0, clean
- `cargo fmt --all` — no additional diff beyond the fixes above
- `cargo test` (full suite) — 1268 + 479 + 111 + others all passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk