### PR TITLE
release: bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to eucalypt are documented here.
 
 ## [Unreleased]
 
+## [0.12.1] - Unreleased
+
+### Changed
+
+- **Bytecode-vs-HeapSyn engine gap closed** — entries added as the gap-close work (superinstructions/decode fusion, ExecutionError boxing, block index) lands.
+
 ## [0.12.0] - 2026-07-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "eucalypt"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 
 [package]
 name = "eucalypt"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 


### PR DESCRIPTION
Phase 0 of the 0.12.1 delivery (eu-cj1h.1). Bumps version 0.12.0 → 0.12.1 and opens the CHANGELOG [0.12.1] section. Gap-close entries land as the work merges. 🤖 Generated with [Claude Code](https://claude.com/claude-code)