### PR TITLE
perf(bytecode): box ExecutionError payload (eu-adnu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to eucalypt are documented here.
 ### Changed
 
 - **Bytecode-vs-HeapSyn engine gap closed** — entries added as the gap-close work (superinstructions/decode fusion, ExecutionError boxing, block index) lands.
+- **Bytecode hot-path error payload boxed** — `ExecutionError`'s heavy variants (`Traced`, `LookupFailure`, `TypeMismatch`, `BadDateTimeComponents`, `BadRegex`, `ParseError`, `VersionRequirementFailed`, `AssertionFailed`, `FormatError`) now carry their string/vector/tuple payloads behind a single `Box`, shrinking `size_of::<ExecutionError>()` from 128 to 40 bytes (68.75%). This retires the oversized `Result<_, ExecutionError>` the bytecode VM's per-instruction dispatch loop was moving and dropping on every step. Layout-only change: error messages, diagnostics, and harness output are byte-identical on both engines (eu-adnu).
 
 ## [0.12.0] - 2026-07-04
 

--- a/src/eval/bytecode/differential.rs
+++ b/src/eval/bytecode/differential.rs
@@ -149,19 +149,16 @@ fn assert_engines_lookup_fail_agree(syntax: Rc<StgSyn>, bifs: Vec<Box<dyn StgInt
     // the underlying diagnostic on equal terms with the bytecode engine.
     fn unwrap_traced(e: &ExecutionError) -> &ExecutionError {
         match e {
-            ExecutionError::Traced(inner, _, _) => unwrap_traced(inner),
+            ExecutionError::Traced(inner, _) => unwrap_traced(inner),
             other => other,
         }
     }
 
     match (unwrap_traced(&heap_err), unwrap_traced(&bc_err)) {
-        (
-            ExecutionError::LookupFailure(_, hk, hs, ha),
-            ExecutionError::LookupFailure(_, bk, bs, ba),
-        ) => {
-            assert_eq!(hk, bk, "engines disagree on the failing key");
-            assert_eq!(hs, bs, "engines disagree on the suggestions");
-            assert_eq!(ha, ba, "engines disagree on the available keys");
+        (ExecutionError::LookupFailure(_, hd), ExecutionError::LookupFailure(_, bd)) => {
+            assert_eq!(hd.0, bd.0, "engines disagree on the failing key");
+            assert_eq!(hd.1, bd.1, "engines disagree on the suggestions");
+            assert_eq!(hd.2, bd.2, "engines disagree on the available keys");
         }
         _ => {
             panic!("expected LookupFailure from both engines, got heap={heap_err:?} bc={bc_err:?}")
@@ -221,7 +218,7 @@ fn assert_engines_not_value_agree(
 
     fn unwrap_traced(e: &ExecutionError) -> &ExecutionError {
         match e {
-            ExecutionError::Traced(inner, _, _) => unwrap_traced(inner),
+            ExecutionError::Traced(inner, _) => unwrap_traced(inner),
             other => other,
         }
     }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -368,7 +368,7 @@ fn attach_trace(
 ) -> ExecutionError {
     let env_trace = state.env_trace(view);
     let stack_trace = state.stack_trace(view);
-    ExecutionError::Traced(Box::new(e), env_trace, stack_trace)
+    ExecutionError::Traced(Box::new(e), Box::new((env_trace, stack_trace)))
 }
 
 /// Mark the heap pointers embedded in a prepared constant (`Ref::V(native)`).

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -588,9 +588,11 @@ fn display_expected_tags(tags: &[u8]) -> String {
 
 #[derive(Debug, Error)]
 pub enum ExecutionError {
-    /// wrapped, env trace and stack trace
+    /// wrapped, env trace and stack trace (traces boxed together to keep
+    /// this variant — constructed on every VM error-propagation step —
+    /// pointer-sized rather than carrying two inline `Vec`s)
     #[error("{0}")]
-    Traced(Box<ExecutionError>, Vec<Smid>, Vec<Smid>),
+    Traced(Box<ExecutionError>, Box<(Vec<Smid>, Vec<Smid>)>),
     #[error("allocation error")]
     AllocationError,
     #[error("expected {1} received {2}")]
@@ -609,20 +611,23 @@ pub enum ExecutionError {
     FreeVar(Smid, String),
     #[error("code not valid for execution")]
     InvalidCode(Smid),
-    #[error("{}", format_lookup_failure(.1, .2, .3))]
-    LookupFailure(Smid, String, Vec<String>, Vec<String>),
-    #[error("{}", format_type_mismatch(.1, .2, .3))]
-    TypeMismatch(Smid, Box<IntrinsicType>, Box<IntrinsicType>, Option<String>),
+    #[error("{}", format_lookup_failure(&.1.0, &.1.1, &.1.2))]
+    LookupFailure(Smid, Box<(String, Vec<String>, Vec<String>)>),
+    #[error("{}", format_type_mismatch(&.1.0, &.1.1, &.1.2))]
+    TypeMismatch(Smid, Box<(IntrinsicType, IntrinsicType, Option<String>)>),
     #[error("unknown intrinsic {1}")]
     UnknownIntrinsic(Smid, String),
     #[error("{}", format_not_callable(.1))]
     NotCallable(Smid, String),
     #[error("{}", format_not_value(.1))]
     NotValue(Smid, String),
-    #[error("bad regex: {2}\n  help: the pattern '{1}' is not a valid regular expression")]
-    BadRegex(Smid, String, String),
-    #[error("{}", format_bad_datetime_components(.1, .2, .3, .4, .5, .6, .7))]
-    BadDateTimeComponents(Smid, Number, Number, Number, Number, Number, Number, String),
+    #[error("bad regex: {}\n  help: the pattern '{}' is not a valid regular expression", .1.1, .1.0)]
+    BadRegex(Smid, Box<(String, String)>),
+    #[error("{}", format_bad_datetime_components(&.1.0, &.1.1, &.1.2, &.1.3, &.1.4, &.1.5, &.1.6))]
+    BadDateTimeComponents(
+        Smid,
+        Box<(Number, Number, Number, Number, Number, Number, String)>,
+    ),
     #[error("{}", format_bad_timezone(.1))]
     BadTimeZone(Smid, String),
     #[error("bad timestamp ({1})")]
@@ -639,8 +644,8 @@ pub enum ExecutionError {
     BadNumericTypeForFormat(Smid),
     #[error("bad number format: {1}")]
     BadNumberFormat(Smid, String),
-    #[error("could not format {2} with {1}")]
-    FormatError(Smid, String, Number),
+    #[error("could not format {} with {}", .1.1, .1.0)]
+    FormatError(Smid, Box<(String, Number)>),
     #[error("expected scalar value")]
     NotScalar(Smid),
     #[error("{}", format_unknown_format(.0))]
@@ -673,10 +678,10 @@ pub enum ExecutionError {
     /// call to `panic()` reflected in the error message.
     #[error("panic: {1}")]
     UserPanic(Smid, String),
-    #[error("parse-as({1}): {2}")]
-    ParseError(Smid, String, String),
-    #[error("version requirement not satisfied: eucalypt {1} does not satisfy '{2}'")]
-    VersionRequirementFailed(Smid, String, String),
+    #[error("parse-as({}): {}", .1.0, .1.1)]
+    ParseError(Smid, Box<(String, String)>),
+    #[error("version requirement not satisfied: eucalypt {} does not satisfy '{}'", .1.0, .1.1)]
+    VersionRequirementFailed(Smid, Box<(String, String)>),
     #[error("IO operations are not permitted; use the --allow-io (-I) flag to enable")]
     IoNotAllowed(Smid),
     #[error("io.fail: {1}")]
@@ -689,8 +694,8 @@ pub enum ExecutionError {
     InvalidBase64(Smid, String),
     #[error("str.base64-decode: decoded bytes are not valid UTF-8: {1}")]
     InvalidBase64Utf8(Smid, String),
-    #[error("assertion failed: expected {2}, got {1}")]
-    AssertionFailed(Smid, String, String),
+    #[error("assertion failed: expected {}, got {}", .1.1, .1.0)]
+    AssertionFailed(Smid, Box<(String, String)>),
     #[error("shift amount {1} is out of range: must be between 0 and 63 for 64-bit integers")]
     BitshiftRangeError(Smid, i64),
     #[error("unknown render format '{1}'\n  help: supported formats for render-as are: :yaml, :json, :toml, :text, :edn, :html")]
@@ -766,13 +771,13 @@ impl From<super::memory::heap::HeapError> for ExecutionError {
 impl HasSmid for ExecutionError {
     fn smid(&self) -> Smid {
         match self {
-            ExecutionError::Traced(e, _, _) => e.smid(),
+            ExecutionError::Traced(e, _) => e.smid(),
             ExecutionError::ArityMismatch(s, _, _) => *s,
             ExecutionError::NotFound(s) => *s,
             ExecutionError::FreeVar(s, _) => *s,
             ExecutionError::InvalidCode(s) => *s,
-            ExecutionError::LookupFailure(s, _, _, _) => *s,
-            ExecutionError::TypeMismatch(s, _, _, _) => *s,
+            ExecutionError::LookupFailure(s, _) => *s,
+            ExecutionError::TypeMismatch(s, _) => *s,
             ExecutionError::UnknownIntrinsic(s, _) => *s,
             ExecutionError::NotCallable(s, _) => *s,
             ExecutionError::NotValue(s, _) => *s,
@@ -783,11 +788,11 @@ impl HasSmid for ExecutionError {
             ExecutionError::BlackHole(s) => *s,
             ExecutionError::Panic(s, _) => *s,
             ExecutionError::UserPanic(s, _) => *s,
-            ExecutionError::ParseError(s, _, _) => *s,
-            ExecutionError::VersionRequirementFailed(s, _, _) => *s,
+            ExecutionError::ParseError(s, _) => *s,
+            ExecutionError::VersionRequirementFailed(s, _) => *s,
             ExecutionError::InvalidBase64(s, _) => *s,
             ExecutionError::InvalidBase64Utf8(s, _) => *s,
-            ExecutionError::AssertionFailed(s, _, _) => *s,
+            ExecutionError::AssertionFailed(s, _) => *s,
             ExecutionError::BitshiftRangeError(s, _) => *s,
             ExecutionError::UnknownRenderFormat(s, _) => *s,
             ExecutionError::ComparisonTypeMismatch(s, _) => *s,
@@ -805,19 +810,19 @@ impl HasSmid for ExecutionError {
             ExecutionError::HeadOfEmptyList(s) => *s,
             ExecutionError::TailOfEmptyList(s) => *s,
             ExecutionError::BadDateTimeString(s, _) => *s,
-            ExecutionError::BadRegex(s, _, _) => *s,
+            ExecutionError::BadRegex(s, _) => *s,
             ExecutionError::BadFormatString(s, _) => *s,
             ExecutionError::BadTimeZone(s, _) => *s,
             ExecutionError::BadTimestamp(s, _) => *s,
             ExecutionError::FormatFailure(s) => *s,
             ExecutionError::BadNumericTypeForFormat(s) => *s,
             ExecutionError::BadNumberFormat(s, _) => *s,
-            ExecutionError::FormatError(s, _, _) => *s,
+            ExecutionError::FormatError(s, _) => *s,
             ExecutionError::NumericDomainError(s, _, _) => *s,
             ExecutionError::ComplexResult(s, _, _) => *s,
             ExecutionError::NumericRangeError(s, _, _) => *s,
             ExecutionError::DivisionByZero(s, _) => *s,
-            ExecutionError::BadDateTimeComponents(s, _, _, _, _, _, _, _) => *s,
+            ExecutionError::BadDateTimeComponents(s, _) => *s,
             ExecutionError::BitwiseIntegerRequired(s, _) => *s,
             _ => Smid::default(),
         }
@@ -835,7 +840,9 @@ impl ExecutionError {
         let mut diag = source_map.diagnostic(self);
         // Unwrap Traced to get at the inner error for note generation
         let (inner, env_trace, stack_trace) = match self {
-            ExecutionError::Traced(e, env, stack) => (e.as_ref(), env.as_slice(), stack.as_slice()),
+            ExecutionError::Traced(e, trace) => {
+                (e.as_ref(), trace.0.as_slice(), trace.1.as_slice())
+            }
             other => (other, [].as_slice(), [].as_slice()),
         };
 
@@ -1021,9 +1028,7 @@ impl ExecutionError {
         }
 
         let notes = match inner {
-            ExecutionError::TypeMismatch(_, expected, actual, _) => {
-                type_mismatch_notes(expected, actual)
-            }
+            ExecutionError::TypeMismatch(_, detail) => type_mismatch_notes(&detail.0, &detail.1),
             ExecutionError::NoBranchForDataTag(_, actual, expected) => {
                 data_tag_mismatch_notes(*actual, expected)
             }
@@ -1081,9 +1086,7 @@ impl ExecutionError {
                 ]
             }
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
-            ExecutionError::LookupFailure(_, key, suggestions, _) => {
-                lookup_failure_notes(key, suggestions)
-            }
+            ExecutionError::LookupFailure(_, detail) => lookup_failure_notes(&detail.0, &detail.1),
             ExecutionError::CannotReturnFunToCase(_, expected_tags) => {
                 let expects_bool = expected_tags.contains(&DataConstructor::BoolTrue.tag())
                     || expected_tags.contains(&DataConstructor::BoolFalse.tag());
@@ -1141,7 +1144,7 @@ impl ExecutionError {
                 }
                 notes
             }
-            ExecutionError::BadDateTimeComponents(_, _, _, _, _, _, _, _) => {
+            ExecutionError::BadDateTimeComponents(_, _) => {
                 vec![
                     "valid ranges: year (any integer), month (1–12), day (1–28/29/30/31 \
                      depending on month), hour (0–23), minute (0–59), second (0–59)"
@@ -1204,15 +1207,15 @@ impl ExecutionError {
     pub fn is_interrupted(&self) -> bool {
         match self {
             ExecutionError::Interrupted => true,
-            ExecutionError::Traced(inner, _, _) => inner.is_interrupted(),
+            ExecutionError::Traced(inner, _) => inner.is_interrupted(),
             _ => false,
         }
     }
 
     /// Access environment trace if present
     pub fn env_trace(&self) -> Option<&[Smid]> {
-        if let ExecutionError::Traced(_, trace, _) = self {
-            Some(trace)
+        if let ExecutionError::Traced(_, trace) = self {
+            Some(&trace.0)
         } else {
             None
         }
@@ -1220,8 +1223,8 @@ impl ExecutionError {
 
     /// Access stack trace if present
     pub fn stack_trace(&self) -> Option<&[Smid]> {
-        if let ExecutionError::Traced(_, _, trace) = self {
-            Some(trace)
+        if let ExecutionError::Traced(_, trace) = self {
+            Some(&trace.1)
         } else {
             None
         }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1648,8 +1648,7 @@ fn evaluate_to_whnf_impl(
             .map_err(|e| {
                 ExecutionError::Traced(
                     Box::new(e),
-                    state.nav(view).env_trace(),
-                    state.stack_trace(&view),
+                    Box::new((state.nav(view).env_trace(), state.stack_trace(&view))),
                 )
             });
         if let Err(e) = step_result {
@@ -2006,8 +2005,7 @@ impl<'a> Machine<'a> {
             .map_err(|e| {
                 ExecutionError::Traced(
                     Box::new(e),
-                    state.nav(view).env_trace(),
-                    state.stack_trace(&view),
+                    Box::new((state.nav(view).env_trace(), state.stack_trace(&view))),
                 )
             })?;
 
@@ -2057,11 +2055,13 @@ impl<'a> Machine<'a> {
             bif_result.map_err(|e| {
                 ExecutionError::Traced(
                     Box::new(e),
-                    self.state
-                        .nav(MutatorHeapView::new(&self.core.heap))
-                        .env_trace(),
-                    self.state
-                        .stack_trace(&MutatorHeapView::new(&self.core.heap)),
+                    Box::new((
+                        self.state
+                            .nav(MutatorHeapView::new(&self.core.heap))
+                            .env_trace(),
+                        self.state
+                            .stack_trace(&MutatorHeapView::new(&self.core.heap)),
+                    )),
                 )
             })?;
         }

--- a/src/eval/stg/assert.rs
+++ b/src/eval/stg/assert.rs
@@ -152,8 +152,7 @@ impl StgIntrinsic for AssertFail {
         let expected_str = format_ref(machine, view, &args[1]);
         Err(ExecutionError::AssertionFailed(
             machine.annotation(),
-            actual_str,
-            expected_str,
+            Box::new((actual_str, expected_str)),
         ))
     }
 }

--- a/src/eval/stg/block.rs
+++ b/src/eval/stg/block.rs
@@ -1315,9 +1315,7 @@ impl StgIntrinsic for LookupFail {
 
         Err(ExecutionError::LookupFailure(
             machine.annotation(),
-            key_name,
-            suggestions,
-            available_keys,
+            Box::new((key_name, suggestions, available_keys)),
         ))
     }
 }

--- a/src/eval/stg/expect.rs
+++ b/src/eval/stg/expect.rs
@@ -91,8 +91,7 @@ impl StgIntrinsic for Expect {
                 // Normal mode: panic with assertion failure
                 Err(ExecutionError::AssertionFailed(
                     machine.annotation(),
-                    actual_repr,
-                    expected_repr,
+                    Box::new((actual_repr, expected_repr)),
                 ))
             }
         }

--- a/src/eval/stg/parse_string.rs
+++ b/src/eval/stg/parse_string.rs
@@ -68,8 +68,7 @@ impl StgIntrinsic for ParseString {
                 .map_err(|e| {
                     ExecutionError::ParseError(
                         machine.annotation(),
-                        format_name.clone(),
-                        e.to_string(),
+                        Box::new((format_name.clone(), e.to_string())),
                     )
                 })?;
 

--- a/src/eval/stg/stream_prng.rs
+++ b/src/eval/stg/stream_prng.rs
@@ -44,9 +44,11 @@ fn prng_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(crate::eval::types::IntrinsicType::Unknown),
-            Box::new(crate::eval::types::IntrinsicType::Unknown),
-            None,
+            Box::new((
+                crate::eval::types::IntrinsicType::Unknown,
+                crate::eval::types::IntrinsicType::Unknown,
+                None,
+            )),
         ))
     }
 }

--- a/src/eval/stg/string.rs
+++ b/src/eval/stg/string.rs
@@ -45,8 +45,9 @@ fn cached_regex<T: AsRef<str>>(
     let rcache = machine.rcache();
 
     if !rcache.contains(&text_owned) {
-        let re = Regex::new(&text_owned)
-            .map_err(|e| ExecutionError::BadRegex(smid, text_owned.clone(), e.to_string()))?;
+        let re = Regex::new(&text_owned).map_err(|e| {
+            ExecutionError::BadRegex(smid, Box::new((text_owned.clone(), e.to_string())))
+        })?;
         rcache.put(text_owned.clone(), re);
     }
 

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -98,9 +98,11 @@ pub fn num_arg(
         Ok(Native::Num(n)) => Ok(n),
         Ok(native) => Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::Number),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                IntrinsicType::Number,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         )),
         Err(_) => {
             // resolve_native failed — likely a Cons (block/list). Inspect the
@@ -127,9 +129,11 @@ pub fn str_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::String),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                IntrinsicType::String,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         ))
     }
 }
@@ -184,9 +188,11 @@ pub fn str_arg_ref(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::String),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                IntrinsicType::String,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         ))
     }
 }
@@ -203,9 +209,11 @@ pub fn sym_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::Symbol),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                IntrinsicType::Symbol,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         ))
     }
 }
@@ -222,9 +230,11 @@ pub fn zdt_arg(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::ZonedDateTime),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                IntrinsicType::ZonedDateTime,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         ))
     }
 }
@@ -291,9 +301,7 @@ pub fn str_list_arg(
                     other => {
                         return Err(ExecutionError::TypeMismatch(
                             smid,
-                            Box::new(IntrinsicType::String),
-                            Box::new(native_type(&other)),
-                            None,
+                            Box::new((IntrinsicType::String, native_type(&other), None)),
                         ))
                     }
                 }
@@ -454,9 +462,11 @@ pub fn native_to_set_primitive(
         Native::Sym(id) => Ok(SetPrim::Sym(*id)),
         _ => Err(ExecutionError::TypeMismatch(
             smid,
-            Box::new(crate::eval::types::IntrinsicType::Set),
-            Box::new(native_type(native)),
-            None,
+            Box::new((
+                crate::eval::types::IntrinsicType::Set,
+                native_type(native),
+                None,
+            )),
         )),
     }
 }
@@ -494,9 +504,11 @@ pub fn set_arg<'guard>(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(crate::eval::types::IntrinsicType::Set),
-            Box::new(native_type(&native)),
-            describe_native(&native, machine, view),
+            Box::new((
+                crate::eval::types::IntrinsicType::Set,
+                native_type(&native),
+                describe_native(&native, machine, view),
+            )),
         ))
     }
 }
@@ -523,9 +535,7 @@ pub fn ndarray_arg<'guard>(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::Array),
-            Box::new(native_type(&native)),
-            None,
+            Box::new((IntrinsicType::Array, native_type(&native), None)),
         ))
     }
 }
@@ -552,9 +562,7 @@ pub fn vec_arg<'guard>(
     } else {
         Err(ExecutionError::TypeMismatch(
             machine.annotation(),
-            Box::new(IntrinsicType::Vec),
-            Box::new(native_type(&native)),
-            None,
+            Box::new((IntrinsicType::Vec, native_type(&native), None)),
         ))
     }
 }

--- a/src/eval/stg/time.rs
+++ b/src/eval/stg/time.rs
@@ -104,13 +104,15 @@ impl StgIntrinsic for Zdt {
         let err = || {
             ExecutionError::BadDateTimeComponents(
                 smid,
-                y.clone(),
-                m.clone(),
-                d.clone(),
-                hour.clone(),
-                min.clone(),
-                sec.clone(),
-                tz.clone(),
+                Box::new((
+                    y.clone(),
+                    m.clone(),
+                    d.clone(),
+                    hour.clone(),
+                    min.clone(),
+                    sec.clone(),
+                    tz.clone(),
+                )),
             )
         };
 

--- a/src/eval/stg/version.rs
+++ b/src/eval/stg/version.rs
@@ -48,8 +48,7 @@ impl StgIntrinsic for Requires {
         } else {
             Err(ExecutionError::VersionRequirementFailed(
                 machine.annotation(),
-                version.to_string(),
-                constraint_str,
+                Box::new((version.to_string(), constraint_str)),
             ))
         }
     }


### PR DESCRIPTION
## Summary

W2 of the 0.12.1 "close the engine gap" plan (independent of W0/W1/W3).
Boxes the heavy variant payloads of `ExecutionError` (`Traced`,
`LookupFailure`, `TypeMismatch`, `BadDateTimeComponents`, `BadRegex`,
`ParseError`, `VersionRequirementFailed`, `AssertionFailed`,
`FormatError`) behind a single `Box` each, so `size_of::<ExecutionError>()`
drops from **128 to 40 bytes (68.75%)**. This retires the oversized
`Result<_, ExecutionError>` that the bytecode VM's per-instruction
dispatch loop was moving/dropping on every step
(`drop_in_place<ExecutionError>` measured at 2.4-3.5% CPU in the eu-mhjz
A/B).

- Layout-only change — no behaviour change. Error messages,
  `to_diagnostic()` output, and every `.expect` sidecar in
  `tests/harness/errors/` are byte-identical.
- All construction/match sites across `src/eval/stg/*.rs`,
  `src/eval/machine/vm.rs`, `src/eval/bytecode/{machine,differential}.rs`
  updated to box/deref through the new tuple payloads.

## Test plan

- [x] `cargo build --all-targets` clean
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` clean
- [x] `cargo test` — full suite green (default bytecode engine): 479/479 harness tests, 1268/1268 lib tests
- [x] `EU_HEAPSYN=1 cargo test` — full suite green (HeapSyn engine): 479/479 harness tests identical
- [x] `EU_GC_VERIFY=2 EU_GC_STRESS=1 cargo test --test harness_test` — green
- [x] `size_of::<ExecutionError>()`: 128 → 40 bytes, confirmed via a throwaway probe test
- [x] Clean release build A/B on `tests/harness/bench/001_naive_fib.eu` (call-dense case) against `origin/master`: no wall-clock/CPU-time regression (differences within run-to-run noise on this shared machine — the effect is at the few-percent level the original profile predicted, and this is a structural/mechanical size win either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk