### PR TITLE
[experiment/measurement] Option A: suppress inlining for fusible primops

### DIFF
--- a/src/eval/bytecode/encode.rs
+++ b/src/eval/bytecode/encode.rs
@@ -438,6 +438,18 @@ static FUSIBLE_PRIMOPS: std::sync::LazyLock<[(&'static str, usize); 8]> =
         })
     });
 
+/// Whether an intrinsic (identified by its global index) is in the fusible-
+/// primop whitelist that the encoder intercepts as a single `Op::FusedPrimop`.
+///
+/// Shared with the STG compiler's inline guard (`compiler.rs`) so that
+/// "Option A" — suppressing wrapper inlining at direct call sites so direct
+/// arithmetic routes through the fused global form — stays in lockstep with
+/// exactly the set the encoder actually fuses. Sharing the single source of
+/// truth (`FUSIBLE_PRIMOPS`) keeps the two sites from drifting apart.
+pub fn is_fusible_primop_index(index: usize) -> bool {
+    FUSIBLE_PRIMOPS.iter().any(|(_, idx)| *idx == index)
+}
+
 /// Structural shape guard (design §9.4): confirms a whitelisted intrinsic's
 /// `LambdaForm` has `binary_wrapper`'s known shape (`lambda(2,
 /// case(local(0), ...))`) before the encoder substitutes the fused body.

--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1182,7 +1182,18 @@ impl ProtoSyntax for ProtoAppGroup {
             Some(bif)
                 if !compiler.suppress_inlining
                     && bif.inlinable()
-                    && bif.info().arity() == arg_indexes.len() =>
+                    && bif.info().arity() == arg_indexes.len()
+                    // Option A (experiment, eu-9mvh): for the whitelisted
+                    // fusible primops, do NOT inline the wrapper body at the
+                    // direct call site. Instead fall through to normal
+                    // App/global-form dispatch so the call routes through the
+                    // global lambda-form — which the bytecode encoder emits as
+                    // a single `Op::FusedPrimop` (PR #980). The whitelist is
+                    // shared verbatim with the encoder to keep the two sites
+                    // consistent.
+                    && !intrinsic_index
+                        .map(crate::eval::bytecode::is_fusible_primop_index)
+                        .unwrap_or(false) =>
             {
                 let inline_body = bif.wrapper(Smid::default()).body().clone();
                 local_binder.set_body(Box::new(ProtoInline::new(arg_indexes, inline_body)))?;


### PR DESCRIPTION
## Summary

**This is a MEASUREMENT EXPERIMENT for eu-9mvh (0.12.1), not a ship candidate.** Do not merge, do not undraft.

`Op::FusedPrimop` (PR #980, merged) is a bytecode superinstruction that force-and-binds a strict binary primop's operands and defers to the `Op::Bif` tail. It fires only on **first-class** operator uses (`foldl(+, ...)`), not on **direct** arithmetic (`n <= 1`, `a + b`), because the STG compiler inlines the intrinsic wrapper body at direct call sites (`compiler.rs:1187`).

**Option A**: suppress that inlining for the whitelisted fusible primops (`ADD/SUB/MUL/DIV/GT/GTE/LT/LTE`), so direct arithmetic falls through to normal App/global-form dispatch — which the encoder emits as a single `Op::FusedPrimop`. The whitelist is shared verbatim with the encoder via `bytecode::is_fusible_primop_index` (no drift between the two sites).

This is one of two levers being compared: **Option C** (a shared `StgSyn::FusedPrimop` node inlined directly, avoiding the App+enter overhead) is next.

## Diff

- `src/eval/bytecode/encode.rs`: expose `is_fusible_primop_index(index)` — the encoder's existing `FUSIBLE_PRIMOPS` whitelist, as a public predicate.
- `src/eval/stg/compiler.rs`: the wrapper-inline guard now also requires the intrinsic is *not* in the fusible whitelist; whitelisted primops fall through to normal App dispatch, routing through the global (fused) form.

## Proof A is active

`eu dump stg` of `{x: 3 <= 4}`:

**Master** (25 inlined `LTE(` leaves, full type-dispatch case tree inlined at the call site):
```
letrec [0] thunk @[37] let [0] Num(!3);
                           [1] Num(!4)
       in case ✳0 of
         Num → case ✳0 of
           _ → case ✳3 of
             Num → case ✳0 of _ → LTE(✳2, ✳0)
             ... (25 LTE( leaves total across the type-dispatch tree)
```

**Option A** (single `App` into the LTE global, 0 inlined leaves):
```
letrec [0] thunk let [0] Num(!3); [1] Num(!4) in →⊗51(✳0, ✳1);
       [1] Pair(!:x, ✳0);
       [2] Cons(✳1, ⊗82);
       [3] Block(✳2, !0);
       [4] Block(⊗82, !0)
in `✳3 ✳4
```
`⊗51` is the LTE global (confirmed via `eu dump runtime`), now emitted by the encoder as a single `Op::FusedPrimop`.

## Correctness

- `cargo test` (default bytecode engine): **1272 + 480 (harness) + other suites, all green, 0 failed**
- `EU_HEAPSYN=1 cargo test --test harness_test`: **480/480 green**
- `EU_GC_VERIFY=2 cargo test --test harness_test`: **480/480 green**
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- Prelude blob regenerated (`cargo xtask prelude-compile`) and confirmed byte-identical to master's own regenerated blob (SHA-256 `693916522...ce6f96a6` both) — Option A only changes user-code call-site compilation, not prelude global-form encoding, so this is expected and confirms the change is correctly scoped.

## Measurement protocol

Both binaries (`experiment/suppress-inline-fusible` and `origin/master`) freshly built (`cargo clean && cargo build --release`), **each with its own freshly regenerated prelude blob** (master's original release build had no blob and compiled the prelude from source every run — inflating all master numbers by a fixed per-invocation cost; this was caught and corrected before the final numbers below). Wall time via `timeout 600 ./target/release/eu --heap-limit-mib 12288 <case>`, external median of 7 runs per cell, foreground.

## fib(30) tick count — the bellwether

| | Ticks |
|---|---|
| Master (fair build) | 115,779,125 (matches bead-cited baseline 115,779,257) |
| Option A | **102,316,435** |

**11.6% tick reduction** — proves the fused op now executes inside fib's direct arithmetic (previously flat/inert under the merged PR #980 global-form-only fusion).

## Results table (N=7 medians, wall ms)

`bc/hs` = Option-A-bytecode / Option-A-HeapSyn (this is what the "1.25× bar" is about, and the number to compare against Option C). `delta` = Option-A-bytecode vs Master-bytecode wall (fair build).

### Regression set

| Case | A-bc | A-hs | bc/hs | M-bc | delta vs master |
|---|---:|---:|---:|---:|---:|
| fib(30) | 3033 | 2490 | 1.218 | 3785 | **-19.9%** |
| drop_cons | 129 | 93 | 1.387 | 113 | +14.2% |
| short_lived | 168 | 146 | 1.151 | 166 | +1.2% |
| aoc day03 p2 | 1404 | 957 | 1.467 | 1440 | -2.5% |
| aoc day09 p1 | 5068 | 4361 | 1.162 | 5178 | -2.1% |

### Protected wins (must not regress)

| Case | A-bc | A-hs | bc/hs | M-bc | delta vs master |
|---|---:|---:|---:|---:|---:|
| generations | 125 | 109 | 1.147 | 129 | -3.1% |
| hof-fold(10k) | 1633 | 2206 | 0.740 | 1670 | -2.2% |
| aoc day07 p2 | 1651 | 2022 | 0.817 | 1551 | +6.4% |
| aoc day11 p1 | 1516 | 1626 | 0.932 | 1514 | +0.1% |

## Interpretation (measurement only, not a recommendation)

- fib improves substantially (bc/hs closes from ~1.5x baseline territory down to 1.22x, and it's clearly no longer flat/inert vs master).
- The other regression-set cases (drop_cons, short_lived, day03, day09) show small deltas in both directions, within noise-ish range except drop_cons (+14.2%, worth a look — small absolute times (~130ms) so more sensitive to noise).
- Protected wins are essentially unaffected (day07 shows +6.4%, small absolute time, worth re-checking with more runs before treating as signal).
- An earlier draft of this measurement (before master was rebuilt with its own blob) showed a spurious +80% "regression" on aoc day03 p2 — that was a build-fairness artifact (master was compiling the prelude from source every invocation) and is **not** in the numbers above. Flagging this so the record is honest about the false start.

This data is for comparison against Option C (shared `StgSyn::FusedPrimop` node, avoiding App+enter overhead) — not a merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)