### PR TITLE
[spike] pre-decode IR falsification experiment (eu-2sa6.9)

### DIFF
--- a/docs/superpowers/reports/2026-07-13-predecode-spike.md
+++ b/docs/superpowers/reports/2026-07-13-predecode-spike.md
@@ -1,0 +1,289 @@
+# Pre-decode IR falsification spike — the 0.13 Tier-1 GATE experiment
+
+- **Bead:** eu-2sa6.9 (0.13 Tier-1 GATE, the pre-decode spike)
+- **Author:** Furnace
+- **Date:** 2026-07-13
+- **Branch:** `spike/predecode-ir` (base `master` @ `7a82ad2f`, PR #986 merged;
+  spike commit `37045ba7`)
+- **Toolchain:** rustc 1.97.0 (2d8144b78), clean release build; embedded prelude
+  blob regenerated BEFORE building (`cargo run -p xtask --release --
+  prelude-compile` → 265438 bytecode bytes / 2634 constants / 548 global forms,
+  blob 457443 bytes) so global-form fusion is present (the fair-blob discipline
+  the plan mandates; a blob-less build would contaminate the ratios per
+  eu-2sa6.5).
+- **Host:** Apple M-series, macOS 26.5.1 (Darwin 25.5.0), aarch64. Shared dev
+  machine; load noted with every measurement (interleaving is the noise defence).
+- **Status:** THROWAWAY SPIKE — the DATA is the deliverable, not mergeable code.
+  Draft PR, do not merge.
+
+> The falsification target (review B §2a / exec-summary §6): is the residual
+> ~1.6–1.8×/tick bytecode↔HeapSyn gap on op-dense / alloc-bound cases caused by
+> the **byte-stream re-decode + dispatch envelope** (the 14.5% decode bucket,
+> `Op::from_u8` match, bounds-checked reads, per-op operand reconstruction), or
+> is it inherent to code being off the GC heap? If the former, decode-once into a
+> flat typed instruction representation should move drop_cons decisively toward
+> HeapSyn.
+
+---
+
+## 1. Verdict — **CONFIRMED**
+
+Pre-decoding the operand stream into a typed, off-GC-heap instruction record
+**removes the entire measured decode bucket (14.3% → 0.0% of main-thread
+self-time) and cuts per-tick mutator cost by a consistent ~18–22% on every one
+of the four cases**, with *identical tick and allocation counts* (it is a
+representation change, not a semantic one). This:
+
+- flips **naive_fib below HeapSyn** (per-tick 1.47× → 1.20×; wall-mutator
+  1.13× → 0.92×),
+- brings **short_lived** (per-tick 1.35× → 1.09×) and **aoc25 day03-p2**
+  (per-tick 1.47× → 1.14×) to ≈ parity, and
+- moves **drop_cons**, the extreme LET-per-cons + CASE probe, **decisively** —
+  per-tick 1.60× → 1.25× (wall-mutator 1.55× → 1.22×; ~60% of the excess-over-
+  HeapSyn closed) — though it does **not** reach ≤ 1.1× on operand-pre-decode
+  alone.
+
+"The gap barely moves" (the refutation criterion) is clearly false: the decode
+bucket vanishes and per-tick cost drops ~21% on the primary probe. The
+irreducibility hypothesis is **falsified**. Lever (a) — decode-once-at-load into
+a flat typed IR — is validated as the decisive *per-tick* lever and should be the
+0.13 centrepiece.
+
+**The one honest nuance:** this spike pre-decoded only the *operands* (refs,
+arg-offsets, form headers, branch-table entries) into the record; it still
+**rebuilds the per-Case branch-table GC `Array` on every Case evaluation**
+(continuation type unchanged). drop_cons's residual 1.25×/tick localises in the
+profile to exactly that rebuild (`Array<Option<u64>>::push`, still 2.8% under
+predecode) plus the shared dispatch + managed-alloc envelope. A **production**
+lever (a) must also materialise branch tables and form-header arrays *into the
+record* (as review B §2a specifies: "`FormHeader`s … branch tables (pre-built
+`Array`s) … materialised into the record") to close drop_cons the rest of the
+way. Operand-pre-decode alone gets 3/4 cases to ≤ 1.1× and drop_cons ~60% there.
+
+---
+
+## 2. Tick-identity proof (the representation-change invariant)
+
+Flag OFF vs ON, same binary, `-S` (deterministic ticks) and rendered output:
+
+| Case | ticks (bc, flag OFF) | ticks (bc, flag ON) | allocs OFF/ON | output OFF == ON |
+|------|---------------------:|--------------------:|--------------:|:----------------:|
+| 005_drop_cons | 2,980,164 | 2,980,164 | 400,076 / 400,076 | ✅ (`a`) |
+| 001_naive_fib | 88,853,753 | 88,853,753 | — / — | ✅ (`1346269`) |
+| 007_short_lived | 5,346,038 | 5,346,038 | — / — | ✅ (`990000`) |
+| aoc25 day03-p2 | 50,389,079 | 50,389,079 | — / — | ✅ (`172162399742349`) |
+
+Ticks and allocations are **bit-identical** flag-on vs flag-off on every measured
+case, and rendered results match — exactly as a pure representation change
+requires. (Correctness gates §5 extend this to the full harness.)
+
+---
+
+## 3. Three-mode measurement (same binary, interleaved triples)
+
+Protocol: for each case, each round runs `[bc-predecode, bc-normal, hs]` as an
+interleaved triple; 11 rounds; `timeout 600 --heap-limit-mib 12288`; foreground.
+The headline metric is the **`-S` VM Mutator** figure (eval-only; excludes
+parse/compile/render) — the precise, drift-robust metric the 07-12 spike used for
+the sub-200ms cases (wall-clock at `/usr/bin/time -p` 0.01s granularity is
+startup-dominated and useless below ~200ms; it is reported as a cross-check for
+the long cases in §3.2). Medians of 11; load 2.6→3.8 over the run.
+
+### 3.1 VM-Mutator medians (eval-only, seconds)
+
+| Case | bc-predecode | bc-normal | hs | **pd/hs** | bc/hs | **pd/bc** |
+|------|-------------:|----------:|---:|----------:|------:|----------:|
+| drop_cons   | 0.063551 | 0.080924 | 0.052097 | **1.220** | 1.553 | **0.785** |
+| naive_fib   | 1.693074 | 2.078210 | 1.846638 | **0.917** | 1.125 | **0.815** |
+| short_lived | 0.105238 | 0.129748 | 0.100100 | **1.051** | 1.296 | **0.811** |
+| day03-p2    | 1.002020 | 1.292105 | 0.908183 | **1.103** | 1.423 | **0.775** |
+
+min/max spread (s): drop_cons pd 0.0574/0.0704, bc 0.0730/0.0884, hs
+0.0463/0.0566; fib pd 1.6515/1.7553, bc 2.0267/2.1516, hs 1.8103/1.9265;
+short_lived pd 0.0934/0.1158, bc 0.1157/0.1425, hs 0.0909/0.1111; day03 pd
+0.9706/1.0911, bc 1.2413/1.3612, hs 0.8589/0.9798.
+
+The **`pd/bc` column is the drift-immune finding** (same binary, same session,
+same load): pre-decoding removes **18.5–22.5%** of mutator time on every case.
+
+### 3.2 Per-tick cost (the invariant; ns/tick = mutator ÷ ticks)
+
+| Case | ticks bc / hs | ns/tick bc-normal | ns/tick bc-predecode | ns/tick hs | per-tick **bc/hs** | per-tick **pd/hs** | per-tick reduction |
+|------|--------------:|------------------:|---------------------:|-----------:|-------------------:|-------------------:|-------------------:|
+| drop_cons   | 2,980,164 / 3,060,166 | 27.2 | 21.3 | 17.0 | 1.60 | **1.25** | −21.5% |
+| naive_fib   | 88,853,753 / 115,779,125 | 23.4 | 19.1 | 15.9 | 1.47 | **1.20** | −18.6% |
+| short_lived | 5,346,038 / 5,547,645 | 24.3 | 19.7 | 18.0 | 1.35 | **1.09** | −18.9% |
+| day03-p2    | 50,389,079 / 52,119,226 | 25.6 | 19.9 | 17.4 | 1.47 | **1.14** | −22.5% |
+
+Per-tick is the honest cross-engine comparison (fib wins *wall* despite a higher
+per-tick cost because fusion already cut its tick count 23% below HeapSyn). The
+~18–22% per-tick reduction is remarkably uniform — the signature of removing a
+*fixed per-op* envelope, exactly what a byte-stream re-decode is.
+
+### 3.3 Wall-clock cross-check (long cases, `/usr/bin/time -p` real, median of 11)
+
+For the cases where the mutator dominates and 0.01s resolution is adequate,
+wall-clock corroborates: naive_fib pd/hs **0.906**, bc/hs 1.104; short_lived
+pd/hs **0.917**, bc/hs 1.167. (drop_cons/day03 wall is startup-dominated /
+was mis-pathed in the first pass; the §3.1 mutator figures supersede.)
+
+### 3.4 Anchoring to the 07-12 baseline
+
+The 07-12 allocation-gap spike measured drop_cons bc/hs = **1.765×** and per-tick
+bc 30.6 / hs 17.0 ns (1.80×/tick). This session's bc/hs is **1.55×** (per-tick
+1.60×) — lower, consistent with the documented 10–35% machine/load drift (07-09
+§1.2–1.3; this run was low-load, 2.6–3.8). The drift-immune `pd/bc` ratio and the
+profile bucket shares (§4) are what the verdict rests on, not the absolute bc/hs.
+
+---
+
+## 4. Profile — the decode bucket vanishes
+
+`/usr/bin/sample` @ 1 kHz, main-thread self-time, on `drop_cons` scaled to
+`take(1000000)` (~4s steady-state window), matching the 07-12 methodology.
+
+### 4.1 Leaf self-time of the decode symbols (samples ≈ ms)
+
+| symbol (self-time) | bc-normal | bc-predecode |
+|--------------------|----------:|-------------:|
+| `read_ref` | 175 | **0** |
+| `read_arg_offsets` | 134 | **0** |
+| `read_form_header` | 29 | **0** |
+| `arg_ref` collect (`try_process`/`from_iter`) | 45 | **0** |
+| `resolve_ref` | 8 | 23 |
+| **decode bucket total** | **383 (14.3%)** | **0 (0.0%)** |
+| `handle_op` / `handle_op_predecoded` (self) | 857 (32.0%) | 636 (31.1%) |
+| **main-thread eu self-time total** | **2675** | **2042 (−23.7%)** |
+
+The measured decode bucket (**14.3%**) matches review B's projected **14.5%** to
+within noise, and pre-decoding removes it **entirely** — `read_ref`,
+`read_arg_offsets`, `read_form_header` and the per-op `arg_ref` collect drop to
+**zero** samples. `handle_op`'s own self-time also falls 857 → 636 (−25.8%
+absolute) as `Op::from_u8`, the per-read bounds checks and operand
+reconstruction disappear (it stays ~31% of the pie only because the whole pie
+shrank). Total main-thread CPU: **−23.7%**, consistent with the −18–22% mutator
+wall reduction in §3.1.
+
+### 4.2 Where drop_cons's residual 1.25×/tick goes (bc-predecode profile)
+
+After the decode bucket is gone, the remaining bc-predecode self-time is:
+dispatch (`handle_op_predecoded` 636 + `dispatch` 265), managed alloc
+(`try_allocate` 143 + `find_space` 51 + bump), env-frame + branch-table `Array`
+builds (`Array<BcValue>::push` 68 + `Array<Option<u64>>::push` **57** — the
+per-Case branch-table **rebuild** this spike kept), `enter_local` 88, and the
+return/saturate envelope (`return_data` 54, `return_fun` 50,
+`env_from_data_args` 45, `make_arg_array` 40, `saturate_with_array` 51). The
+`Array<Option<u64>>::push` 57 (2.8%) is the clearest **bytecode-only** residual a
+production lever removes by materialising the branch table into the record; the
+rest is the dispatch + alloc envelope shared with (and, for env-build, *cheaper*
+than) HeapSyn.
+
+---
+
+## 5. Correctness gates (all green)
+
+- **Flag OFF, `cargo test --release`:** green — 1272 lib + 480 harness + all
+  integration targets, 0 failed. (Only the `rustdoc` doctest driver errors, a
+  pre-existing rustup-shim quirk on this host, unrelated to the change.)
+- **Flag ON, `EU_PREDECODE=1 cargo test --release --test harness_test`:** green
+  — 480 passed, 0 failed.
+- **Tick-identity flag-on vs flag-off:** bit-identical on all four measured cases
+  (§2), and outputs match.
+- **`EU_GC_VERIFY=2` + `EU_GC_STRESS=1`, flag ON:** clean on drop_cons and
+  short_lived (exit 0, correct results) — the pre-decode cache lives on the
+  system heap, holds no GC pointers, and is never scanned; nothing new enters the
+  collector's scan set.
+- **clippy `--all-targets -D warnings`:** clean. **`cargo fmt --all`:** applied.
+
+---
+
+## 6. What the spike did (mechanism)
+
+Behind `EU_PREDECODE=1`:
+
+- A `Vec<Option<Instr>>` sized to `code.len()`, indexed by **byte offset**, is
+  added to `BytecodeMachine`. `Instr` is a typed enum, one variant per opcode,
+  holding the decoded operands (scalars, `DecodedRef`s, inline `SmallVec`s of
+  refs / offsets / `FormHeader`s / branch entries) — **no GC pointer lives in
+  it**, so it stays off the collector's scan set.
+- On first execution of an offset, `handle_op_predecoded` decodes the opcode once
+  (`decode_instr`, mirroring `handle_op`'s byte-reads exactly) and memoises it;
+  every subsequent execution dispatches over the typed record — HeapSyn's
+  `match code` shape (`vm.rs:427`) but with the code off the GC heap. Because the
+  code buffer is immutable, lazy caching is sound; after warmup the steady-state
+  loop is pure typed dispatch.
+- **`CodeRef` offsets are unchanged** (still byte offsets). Every child offset a
+  node holds (branch target, body, scrutinee, atom) maps 1:1 into the same cache
+  when the closure carrying it is later entered — so the value model, env frames,
+  and continuations are byte-for-byte identical; only the decode is replaced.
+- Wired into the main dispatch loop (`run` / `drive_whnf` via `dispatch`) **and**
+  the re-entrant intrinsic-force loop (`drive_to_whnf` via `BcBifContext`), so
+  both the top-level computation and intrinsic-internal forcing run pre-decoded.
+- Flag OFF ⇒ the byte path is unchanged and taken verbatim (byte-identical).
+
+Files: `src/eval/bytecode/machine.rs` (the `Instr` enum + `decode_instr` +
+`handle_op_predecoded` + `step_predecoded`, and the `dispatch` / `drive_to_whnf`
+branch + machine/`BcBifContext` fields), `src/eval/bytecode/mod.rs`
+(`predecode_enabled()`). Measurement scripts: `measure_mutator.sh` (the precise
+`-S` VM-Mutator harness), `measure_predecode.sh` (wall cross-check).
+
+---
+
+## 7. What a production lever (a) should look like
+
+The spike confirms the mechanism; a production implementation should go two steps
+further than this throwaway did, because the profile shows exactly where the
+residual is:
+
+1. **Decode once at load, eagerly, by reachability walk** (not lazily): from the
+   root/global/template entry offsets, decode-and-follow into the flat IR so the
+   steady-state loop never branches on a cold slot, and the byte buffer can be
+   dropped from the hot path entirely (kept only as the BV5 blob / serialisation
+   wire form, decoded once per process — exactly review B §3's end-state).
+2. **Materialise the branch tables and form-header arrays *into the record*,**
+   not just the operand refs. This spike kept the per-Case GC `Array` rebuild
+   (the `Array<Option<u64>>::push` 2.8% residual) and the per-Let form-header
+   loop; a production lever should hold the branch table as a pre-built,
+   shareable structure referenced by the `Branch` continuation (a refcount-style
+   clone, as HeapSyn does at `vm.rs:470`) so no per-Case rebuild occurs. This is
+   what closes drop_cons's remaining 1.25×/tick — operand-pre-decode alone got it
+   60% of the way; the branch-table materialisation is the rest.
+3. **Fold BV2 in for free** (review B §3): in a typed record the `Smid` is just a
+   field (or a side table keyed by instruction index), so `Op::Ann` /
+   `Op::DirectApp` annotation handling collapses into the record — same refactor.
+4. Keep `handle_op_predecoded`'s `match Instr` dense and `#[repr]`-friendly so
+   LLVM lowers it to a jump table; the spike's version already removes
+   `Op::from_u8`, which is the bulk of lever (e).
+
+Order relative to the 0.13 roadmap: this is the real content of "Phase-4 collapse
+at parity" (eu-oufc). BV3 register frames are orthogonal and should land *after*
+pre-decode (on the cheap dispatch loop, not the expensive one); fused primops
+(shipped) are complementary tick-count reducers. The evidence here supports
+review B's reframing of the flattened-node interpreter from "rejected fallback"
+to **destination**: the byte stream is the right serialisation format and the
+wrong execution format.
+
+---
+
+## Appendix — reproduction
+
+```sh
+git worktree add /tmp/eu-predecode -b spike/predecode-ir origin/master
+cd /tmp/eu-predecode
+TC=~/.rustup/toolchains/stable-aarch64-apple-darwin/bin
+RUSTC=$TC/rustc $TC/cargo run -p xtask --release -- prelude-compile   # fair blob FIRST
+RUSTC=$TC/rustc $TC/cargo build --release
+
+# tick-identity + correctness
+EU=./target/release/eu
+$EU -S tests/harness/bench/005_drop_cons.eu -t bench-drop-cons | grep Ticks
+EU_PREDECODE=1 $EU -S tests/harness/bench/005_drop_cons.eu -t bench-drop-cons | grep Ticks   # identical
+EU_PREDECODE=1 EU_GC_VERIFY=2 EU_GC_STRESS=1 $EU tests/harness/bench/005_drop_cons.eu -t bench-drop-cons
+
+# interleaved three-mode VM-Mutator medians (the headline table)
+ROUNDS=11 bash measure_mutator.sh
+
+# profile the decode bucket (read_* symbols) shrinking to zero
+EU_PREDECODE=1 $EU --heap-limit-mib 12288 /tmp/big_drop1m.eu -t bench-drop-cons >/dev/null 2>&1 &
+TPID=$!; sleep 0.4; sample $(pgrep -P $TPID | head -1) 4 1 -f /tmp/sample_bc_predecode.txt -mayDie
+```

--- a/measure_mutator.sh
+++ b/measure_mutator.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Interleaved three-mode VM-Mutator measurement (eu-2sa6.9 pre-decode spike).
+# Uses the -S "VM Mutator" figure (eval-only, excludes parse/compile/render) —
+# the precise metric the 07-12 spike used for sub-200ms cases. Modes interleaved
+# as triples each round: bc-predecode, bc-normal, hs.
+set -u
+EU=/tmp/eu-predecode/target/release/eu
+ROUNDS=${ROUNDS:-11}
+HEAP="--heap-limit-mib 12288"
+
+CASES=(
+  "drop_cons|.|tests/harness/bench/005_drop_cons.eu|bench-drop-cons"
+  "naive_fib|.|tests/harness/bench/001_naive_fib.eu|bench-naive-fib"
+  "short_lived|.|tests/harness/bench/007_short_lived.eu|bench-short-lived"
+  "aoc25_day03_p2|examples/aoc25|day03.eu|part-2"
+)
+
+median() { printf '%s\n' "$@" | sort -n | awk '{a[NR]=$1} END{if(NR%2){print a[(NR+1)/2]}else{printf "%.6f\n",(a[NR/2]+a[NR/2+1])/2}}'; }
+minmax() { printf '%s\n' "$@" | sort -n | awk 'NR==1{min=$1}{max=$1}END{printf "%.6f/%.6f",min,max}'; }
+
+# extract the VM-section Mutator seconds
+mutator() { # env dir file target
+  ( cd "$2" && env $1 timeout 600 $EU $HEAP -S "$3" -t "$4" 2>&1 ) \
+    | awk '/Mutator/{v=$3; gsub(/s$/,"",v); print v; exit}'
+}
+
+echo "load at start: $(uptime | sed 's/.*load aver[a-z]*: //')"
+echo "rounds: $ROUNDS   metric: VM Mutator (s), eval-only"
+echo
+for spec in "${CASES[@]}"; do
+  IFS='|' read -r label dir file tgt <<< "$spec"
+  declare -a PD=() BC=() HS=()
+  for r in $(seq 1 $ROUNDS); do
+    PD+=( "$(mutator EU_PREDECODE=1 "$dir" "$file" "$tgt")" )
+    BC+=( "$(mutator '' "$dir" "$file" "$tgt")" )
+    HS+=( "$(mutator EU_HEAPSYN=1 "$dir" "$file" "$tgt")" )
+  done
+  pd=$(median "${PD[@]}"); bc=$(median "${BC[@]}"); hs=$(median "${HS[@]}")
+  echo "== $label =="
+  echo "  bc-predecode: med=${pd}s  min/max=$(minmax "${PD[@]}")"
+  echo "  bc-normal   : med=${bc}s  min/max=$(minmax "${BC[@]}")"
+  echo "  hs          : med=${hs}s  min/max=$(minmax "${HS[@]}")"
+  awk "BEGIN{printf \"  RATIO  bc-predecode/hs = %.3f   bc-normal/hs = %.3f   predecode/normal = %.3f\n\", $pd/$hs, $bc/$hs, $pd/$bc}"
+  echo
+done
+echo "load at end: $(uptime | sed 's/.*load aver[a-z]*: //')"

--- a/measure_predecode.sh
+++ b/measure_predecode.sh
@@ -3,7 +3,7 @@
 # Modes per case, interleaved as triples each round: bc-predecode, bc-normal, hs.
 # Wall time via /usr/bin/time -p (real), timeout 600, --heap-limit-mib 12288.
 set -u
-EU=./target/release/eu
+EU=/tmp/eu-predecode/target/release/eu
 ROUNDS=${ROUNDS:-11}
 HEAP="--heap-limit-mib 12288"
 

--- a/measure_predecode.sh
+++ b/measure_predecode.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Interleaved three-mode measurement for the pre-decode spike (eu-2sa6.9).
+# Modes per case, interleaved as triples each round: bc-predecode, bc-normal, hs.
+# Wall time via /usr/bin/time -p (real), timeout 600, --heap-limit-mib 12288.
+set -u
+EU=./target/release/eu
+ROUNDS=${ROUNDS:-11}
+HEAP="--heap-limit-mib 12288"
+
+# case spec: label|dir|file|target
+CASES=(
+  "drop_cons|.|tests/harness/bench/005_drop_cons.eu|bench-drop-cons"
+  "naive_fib|.|tests/harness/bench/001_naive_fib.eu|bench-naive-fib"
+  "short_lived|.|tests/harness/bench/007_short_lived.eu|bench-short-lived"
+  "aoc25_day03_p2|examples/aoc25|day03.eu|part-2"
+)
+
+median() { printf '%s\n' "$@" | sort -n | awk '{a[NR]=$1} END{if(NR%2){print a[(NR+1)/2]}else{printf "%.4f\n",(a[NR/2]+a[NR/2+1])/2}}'; }
+spread() { printf '%s\n' "$@" | sort -n | awk 'NR==1{min=$1} {max=$1} END{printf "%.4f/%.4f",min,max}'; }
+
+runwall() { # env-prefix dir file target
+  local envp="$1" dir="$2" file="$3" tgt="$4"
+  ( cd "$dir" && env $envp /usr/bin/time -p timeout 600 $EU $HEAP "$file" -t "$tgt" >/dev/null 2>/tmp/pd_time.txt )
+  grep '^real' /tmp/pd_time.txt | awk '{print $2}'
+}
+
+echo "load at start: $(uptime | sed 's/.*load averages*: //')"
+echo "rounds: $ROUNDS"
+echo
+
+for spec in "${CASES[@]}"; do
+  IFS='|' read -r label dir file tgt <<< "$spec"
+  declare -a PD=() BC=() HS=()
+  for r in $(seq 1 $ROUNDS); do
+    PD+=( "$(runwall EU_PREDECODE=1 "$dir" "$file" "$tgt")" )
+    BC+=( "$(runwall '' "$dir" "$file" "$tgt")" )
+    HS+=( "$(runwall EU_HEAPSYN=1 "$dir" "$file" "$tgt")" )
+  done
+  pd_med=$(median "${PD[@]}"); bc_med=$(median "${BC[@]}"); hs_med=$(median "${HS[@]}")
+  pd_sp=$(spread "${PD[@]}"); bc_sp=$(spread "${BC[@]}"); hs_sp=$(spread "${HS[@]}")
+  # ticks (deterministic; one capture each)
+  pd_tk=$(cd "$dir" && EU_PREDECODE=1 timeout 600 $EU $HEAP -S "$file" -t "$tgt" 2>&1 | grep Ticks | grep -oE '[0-9,]+')
+  bc_tk=$(cd "$dir" && timeout 600 $EU $HEAP -S "$file" -t "$tgt" 2>&1 | grep Ticks | grep -oE '[0-9,]+')
+  hs_tk=$(cd "$dir" && EU_HEAPSYN=1 timeout 600 $EU $HEAP -S "$file" -t "$tgt" 2>&1 | grep Ticks | grep -oE '[0-9,]+')
+  ratio_pd=$(awk "BEGIN{printf \"%.3f\", $pd_med/$hs_med}")
+  ratio_bc=$(awk "BEGIN{printf \"%.3f\", $bc_med/$hs_med}")
+  echo "== $label =="
+  echo "  bc-predecode: med=$pd_med  spread(min/max)=$pd_sp  ticks=$pd_tk"
+  echo "  bc-normal   : med=$bc_med  spread(min/max)=$bc_sp  ticks=$bc_tk"
+  echo "  hs          : med=$hs_med  spread(min/max)=$hs_sp  ticks=$hs_tk"
+  echo "  RATIO bc-predecode/hs = $ratio_pd    bc-normal/hs = $ratio_bc"
+  echo
+done
+echo "load at end: $(uptime | sed 's/.*load averages*: //')"

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2116,6 +2116,591 @@ pub fn step(
     }
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// Pre-decoded typed-instruction execution (EU_PREDECODE spike, eu-2sa6.9)
+//
+// Falsification experiment for review B §2a: is the residual bytecode↔HeapSyn
+// per-tick gap on op-dense / alloc-bound cases the byte-stream *re-decode*
+// envelope (`read_ref` / `read_arg_offsets` / `read_form_header` +
+// `Op::from_u8` + per-read bounds checks + operand reconstruction — the 14.5%
+// decode bucket), or is it inherent to code being off the GC heap?
+//
+// Mechanism: decode each opcode ONCE (lazily, on first execution) from the byte
+// stream into a fixed typed `Instr` record, cached by byte offset in a non-GC
+// `Vec<Option<Instr>>`. `handle_op_predecoded` then dispatches over the typed
+// record — structurally HeapSyn's `match code` (vm.rs:427) but with the code
+// off the GC heap (never scanned/evacuated/forwarded). `CodeRef` offsets are
+// UNCHANGED (still byte offsets into `prog.code`), so every child offset
+// (branch / body / scrutinee / atom) maps 1:1 into the same cache when the
+// closure holding it is later entered — the value model, env frames, and
+// continuations are all identical. Flag OFF ⇒ byte-identical current behaviour;
+// the two paths perform the SAME decode, so tick counts are identical (a
+// representation change, not a semantic one). Throwaway spike quality.
+// ════════════════════════════════════════════════════════════════════════
+
+/// Inline operand buffers for a pre-decoded instruction, sized to the common
+/// small arity. A larger operand list spills to the system heap ONCE, at decode
+/// time — never re-decoded on the hot path.
+type PdRefs = SmallVec<[DecodedRef; 8]>;
+type PdOffs = SmallVec<[CodeRef; 8]>;
+type PdHeaders = SmallVec<[FormHeader; 8]>;
+type PdBranches = SmallVec<[Option<CodeRef>; 8]>;
+
+/// One pre-decoded instruction: the typed form of an opcode and its operands,
+/// decoded once from the byte stream. Every field is a scalar / index / small
+/// inline buffer — no GC-managed pointer lives here, so the cache is never part
+/// of the collector's scan set (the `EU_GC_VERIFY=2` invariant).
+pub enum Instr {
+    Atom(DecodedRef),
+    Cons {
+        tag: u8,
+        arg_refs: PdRefs,
+    },
+    Case {
+        scr_off: CodeRef,
+        min_tag: u8,
+        branch_table: PdBranches,
+        fallback: Option<CodeRef>,
+    },
+    Seq {
+        scr_off: CodeRef,
+        body_off: CodeRef,
+    },
+    Ann {
+        smid: Smid,
+        body_off: CodeRef,
+    },
+    FusedPrimop {
+        primop_id: u8,
+        left_off: CodeRef,
+        right_off: CodeRef,
+    },
+    BlackHole,
+    App {
+        eager: bool,
+        callable: DecodedRef,
+        arg_offs: PdOffs,
+    },
+    Let {
+        headers: PdHeaders,
+        body_off: CodeRef,
+    },
+    LetRec {
+        headers: PdHeaders,
+        body_off: CodeRef,
+    },
+    DirectApp {
+        eager: bool,
+        smid: Smid,
+        callable: DecodedRef,
+        arg_offs: PdOffs,
+    },
+    Bif {
+        intrinsic: u8,
+        arg_refs: PdRefs,
+    },
+    Meta {
+        meta_ref: DecodedRef,
+        body_ref: DecodedRef,
+    },
+    DeMeta {
+        scr_off: CodeRef,
+        handler_off: CodeRef,
+        or_else_off: CodeRef,
+    },
+    LookupLit {
+        smid: Smid,
+        key: DecodedRef,
+        obj: DecodedRef,
+        default_off: CodeRef,
+    },
+}
+
+/// Decode the single opcode at byte offset `off` into a typed `Instr`. Mirrors
+/// `handle_op`'s byte-reads for each opcode *exactly* (same reads, same order),
+/// so the cached record is a faithful once-decoded copy of the byte-stream node.
+fn decode_instr(code: &[u8], off: usize) -> Result<Instr, ExecutionError> {
+    let mut pc = off;
+    let op = Op::from_u8(read_u8(code, &mut pc)).ok_or_else(|| {
+        ExecutionError::Panic(Default::default(), "bytecode: invalid opcode".to_string())
+    })?;
+    Ok(match op {
+        Op::Atom => Instr::Atom(read_ref(code, &mut pc)?),
+        Op::Cons => {
+            let tag = read_u8(code, &mut pc);
+            let arg_offs = read_arg_offsets(code, &mut pc);
+            let arg_refs = arg_offs
+                .iter()
+                .map(|o| arg_ref(code, *o))
+                .collect::<Result<_, _>>()?;
+            Instr::Cons { tag, arg_refs }
+        }
+        Op::Case => {
+            let scr_off = read_u32(code, &mut pc);
+            let min_tag = read_u8(code, &mut pc);
+            let len = read_u8(code, &mut pc) as usize;
+            let mut branch_table = PdBranches::with_capacity(len);
+            for _ in 0..len {
+                let e = read_u32(code, &mut pc);
+                branch_table.push(if e == NO_BRANCH { None } else { Some(e) });
+            }
+            let has_fb = read_u8(code, &mut pc);
+            let fallback = if has_fb == 1 {
+                Some(read_u32(code, &mut pc))
+            } else {
+                None
+            };
+            Instr::Case {
+                scr_off,
+                min_tag,
+                branch_table,
+                fallback,
+            }
+        }
+        Op::Seq => {
+            let scr_off = read_u32(code, &mut pc);
+            let body_off = read_u32(code, &mut pc);
+            Instr::Seq { scr_off, body_off }
+        }
+        Op::Ann => {
+            let smid = Smid::from(read_u32(code, &mut pc));
+            let body_off = read_u32(code, &mut pc);
+            Instr::Ann { smid, body_off }
+        }
+        Op::FusedPrimop => {
+            let primop_id = read_u8(code, &mut pc);
+            let left_off = read_u32(code, &mut pc);
+            let right_off = read_u32(code, &mut pc);
+            Instr::FusedPrimop {
+                primop_id,
+                left_off,
+                right_off,
+            }
+        }
+        Op::BlackHole => Instr::BlackHole,
+        Op::App => {
+            let flags = read_u8(code, &mut pc);
+            let eager = flags & super::FLAG_EAGER != 0;
+            let callable = read_ref(code, &mut pc)?;
+            let arg_offs = read_arg_offsets(code, &mut pc);
+            Instr::App {
+                eager,
+                callable,
+                arg_offs,
+            }
+        }
+        Op::Let => {
+            let count = read_u16(code, &mut pc) as usize;
+            let mut headers = PdHeaders::with_capacity(count);
+            for _ in 0..count {
+                headers.push(read_form_header(code, &mut pc));
+            }
+            let body_off = read_u32(code, &mut pc);
+            Instr::Let { headers, body_off }
+        }
+        Op::LetRec => {
+            let count = read_u16(code, &mut pc) as usize;
+            let mut headers = PdHeaders::with_capacity(count);
+            for _ in 0..count {
+                headers.push(read_form_header(code, &mut pc));
+            }
+            let body_off = read_u32(code, &mut pc);
+            Instr::LetRec { headers, body_off }
+        }
+        Op::DirectApp => {
+            let flags = read_u8(code, &mut pc);
+            let eager = flags & super::FLAG_EAGER != 0;
+            let smid = Smid::from(read_u32(code, &mut pc));
+            let callable = read_ref(code, &mut pc)?;
+            let arg_offs = read_arg_offsets(code, &mut pc);
+            Instr::DirectApp {
+                eager,
+                smid,
+                callable,
+                arg_offs,
+            }
+        }
+        Op::Bif => {
+            let intrinsic = read_u8(code, &mut pc);
+            let arg_offs = read_arg_offsets(code, &mut pc);
+            let arg_refs = arg_offs
+                .iter()
+                .map(|o| arg_ref(code, *o))
+                .collect::<Result<_, _>>()?;
+            Instr::Bif {
+                intrinsic,
+                arg_refs,
+            }
+        }
+        Op::Meta => {
+            let meta_off = read_u32(code, &mut pc);
+            let body_off = read_u32(code, &mut pc);
+            let meta_ref = arg_ref(code, meta_off)?;
+            let body_ref = arg_ref(code, body_off)?;
+            Instr::Meta { meta_ref, body_ref }
+        }
+        Op::DeMeta => {
+            let scr_off = read_u32(code, &mut pc);
+            let handler_off = read_u32(code, &mut pc);
+            let or_else_off = read_u32(code, &mut pc);
+            Instr::DeMeta {
+                scr_off,
+                handler_off,
+                or_else_off,
+            }
+        }
+        Op::LookupLit => {
+            let smid = Smid::from(read_u32(code, &mut pc));
+            let key = read_ref(code, &mut pc)?;
+            let obj = read_ref(code, &mut pc)?;
+            let default_off = read_u32(code, &mut pc);
+            Instr::LookupLit {
+                smid,
+                key,
+                obj,
+                default_off,
+            }
+        }
+    })
+}
+
+/// Execute the current (arity-0) closure's node from its pre-decoded `Instr`.
+/// The typed twin of [`handle_op`]: identical control flow and side effects,
+/// but every operand comes from the cached record instead of a byte read.
+/// `table` is indexed by byte offset (its home in the machine); a cold offset
+/// is decoded once and memoised (the code is immutable, so caching is sound).
+pub fn handle_op_predecoded(
+    state: &mut BcMachineState,
+    view: MutatorHeapView<'_>,
+    prog: &BytecodeProgram,
+    table: &mut [Option<Instr>],
+) -> Result<(), ExecutionError> {
+    let code = prog.code.as_slice();
+    let closure = *state.current.as_closure().ok_or_else(|| {
+        ExecutionError::Panic(state.annotation, "handle_op on a native value".to_string())
+    })?;
+    let env = closure.env();
+    if closure.annotation().is_valid() {
+        state.annotation = closure.annotation();
+    }
+
+    let off = closure.code() as usize;
+    if table[off].is_none() {
+        table[off] = Some(decode_instr(code, off)?);
+    }
+    // `table` is a distinct object from `state`, so this immutable borrow of the
+    // cached record coexists with the `&mut state` the arms below mutate — the
+    // arms never touch `table`. This is the whole point: no re-decode here.
+    let instr = table[off].as_ref().expect("predecode slot populated above");
+
+    match instr {
+        Instr::Atom(dref) => match *dref {
+            DecodedRef::Local(i) => {
+                enter_local(state, view, env, i as usize)?;
+            }
+            DecodedRef::Global(i) => {
+                enter_global(state, view, i as usize)?;
+            }
+            DecodedRef::Value(k) => {
+                let native = match state.constants.get(k as usize) {
+                    Some(Ref::V(n)) => n.clone(),
+                    _ => {
+                        return Err(ExecutionError::Panic(
+                            state.annotation,
+                            format!("bytecode: constant {k} missing or not a native"),
+                        ))
+                    }
+                };
+                return_native(state, view, native)?;
+            }
+        },
+        Instr::Cons { tag, arg_refs } => {
+            return_data(state, view, prog, *tag, arg_refs)?;
+        }
+        Instr::Case {
+            scr_off,
+            min_tag,
+            branch_table,
+            fallback,
+        } => {
+            let mut arr = Array::with_capacity(&view, branch_table.len());
+            for b in branch_table.iter() {
+                arr.push(&view, *b);
+            }
+            state.stack.push(BcContinuation::Branch {
+                min_tag: *min_tag,
+                branch_table: arr,
+                fallback: *fallback,
+                environment: env,
+                annotation: state.annotation,
+            });
+            state.current = BcValue::Closure(BcClosure::new(*scr_off, env));
+        }
+        Instr::Seq { scr_off, body_off } => {
+            state.stack.push(BcContinuation::SeqBind {
+                body: *body_off,
+                environment: env,
+                annotation: state.annotation,
+            });
+            state.current = BcValue::Closure(BcClosure::new(*scr_off, env));
+        }
+        Instr::Ann { smid, body_off } => {
+            state.annotation = *smid;
+            state.current = BcValue::Closure(BcClosure::new(*body_off, env));
+        }
+        Instr::FusedPrimop {
+            primop_id,
+            left_off,
+            right_off,
+        } => {
+            state.stack.push(BcContinuation::FusedPrimopLeft {
+                primop_id: *primop_id,
+                right: *right_off,
+                environment: env,
+                annotation: state.annotation,
+            });
+            state.current = BcValue::Closure(BcClosure::new(*left_off, env));
+        }
+        Instr::BlackHole => {
+            return Err(ExecutionError::BlackHole(state.annotation));
+        }
+        Instr::App {
+            eager,
+            callable,
+            arg_offs,
+        } => {
+            let args = make_arg_array(view, code, env, arg_offs, *eager)?;
+            let callable = *callable;
+            state.stack.push(BcContinuation::ApplyTo {
+                args,
+                annotation: state.annotation,
+            });
+            enter_callable(state, view, env, callable)?;
+        }
+        Instr::Let { headers, body_off } => {
+            let count = headers.len();
+            state.allocs += count as u64;
+            let mut array = Array::with_capacity(&view, count);
+            for h in headers.iter() {
+                array.push(&view, BcValue::Closure(BcClosure::close(&bc_info(h), env)));
+            }
+            let new_env = view
+                .alloc(BcEnvFrame::new(array, state.annotation, Some(env)))?
+                .as_ptr();
+            state.current = BcValue::Closure(BcClosure::new(*body_off, new_env));
+        }
+        Instr::LetRec { headers, body_off } => {
+            let count = headers.len();
+            state.allocs += count as u64;
+            let mut array = Array::with_capacity(&view, count);
+            for _ in 0..count {
+                array.push(
+                    &view,
+                    BcValue::Closure(BcClosure::new(0, RefPtr::dangling())),
+                );
+            }
+            let frame = view
+                .alloc(BcEnvFrame::new(array.clone(), state.annotation, Some(env)))?
+                .as_ptr();
+            for (i, h) in headers.iter().enumerate() {
+                // SAFETY: array was pre-sized to `count` and i < count.
+                unsafe {
+                    array.set_unchecked(i, BcValue::Closure(BcClosure::close(&bc_info(h), frame)));
+                }
+            }
+            state.current = BcValue::Closure(BcClosure::new(*body_off, frame));
+        }
+        Instr::DirectApp {
+            eager,
+            smid,
+            callable,
+            arg_offs,
+        } => {
+            state.annotation = *smid;
+            let args = make_arg_array(view, code, env, arg_offs, *eager)?;
+            let callable = *callable;
+
+            let (callee_env, callee) = match callable {
+                DecodedRef::Local(i) => (
+                    env,
+                    view.scoped(env)
+                        .get(&view, i as usize)
+                        .ok_or(ExecutionError::BadEnvironmentIndex(i as usize))?,
+                ),
+                DecodedRef::Global(i) => (
+                    state.globals,
+                    view.scoped(state.globals)
+                        .get(&view, i as usize)
+                        .ok_or(ExecutionError::BadGlobalIndex(i as usize))?,
+                ),
+                DecodedRef::Value(_) => {
+                    return Err(ExecutionError::NotCallable(
+                        state.annotation,
+                        "native value".to_string(),
+                    ))
+                }
+            };
+            let BcValue::Closure(c) = callee else {
+                return Err(ExecutionError::NotCallable(
+                    state.annotation,
+                    "native value".to_string(),
+                ));
+            };
+
+            if c.update() {
+                state.stack.push(BcContinuation::ApplyTo {
+                    args,
+                    annotation: state.annotation,
+                });
+                if let DecodedRef::Local(i) | DecodedRef::Global(i) = callable {
+                    let hole = BcValue::Closure(BcClosure::new(state.blackhole, callee_env));
+                    view.scoped(callee_env).update(&view, i as usize, hole)?;
+                    state.stack.push(BcContinuation::Update {
+                        environment: callee_env,
+                        index: i as usize,
+                    });
+                }
+                state.current = callee;
+            } else if c.arity() as usize == args.len() {
+                state.current = BcValue::Closure(view.saturate_with_array(&c, args)?);
+            } else {
+                state.stack.push(BcContinuation::ApplyTo {
+                    args,
+                    annotation: state.annotation,
+                });
+                state.current = callee;
+            }
+        }
+        Instr::Bif {
+            intrinsic,
+            arg_refs,
+        } => {
+            state.pending_bif = Some(*intrinsic);
+            state.pending_bif_args = arg_refs.iter().copied().collect();
+        }
+        Instr::Meta { meta_ref, body_ref } => {
+            return_meta(state, view, env, *meta_ref, *body_ref)?;
+        }
+        Instr::DeMeta {
+            scr_off,
+            handler_off,
+            or_else_off,
+        } => {
+            state.stack.push(BcContinuation::DeMeta {
+                handler: *handler_off,
+                or_else: *or_else_off,
+                environment: env,
+            });
+            state.current = BcValue::Closure(BcClosure::new(*scr_off, env));
+        }
+        Instr::LookupLit {
+            smid,
+            key,
+            obj,
+            default_off,
+        } => {
+            let smid = *smid;
+            let default_off = *default_off;
+            state.annotation = smid;
+
+            let sym_id = match *key {
+                DecodedRef::Value(k) => match state.constants.get(k as usize) {
+                    Some(Ref::V(Native::Sym(id))) => *id,
+                    _ => {
+                        return Err(ExecutionError::NotValue(
+                            smid,
+                            "non-symbol key in LookupLit".to_string(),
+                        ))
+                    }
+                },
+                _ => {
+                    return Err(ExecutionError::NotValue(
+                        smid,
+                        "non-symbol key in LookupLit".to_string(),
+                    ))
+                }
+            };
+
+            let default_closure = BcClosure::new(default_off, env);
+
+            let (obj_slot, obj_value) = match *obj {
+                DecodedRef::Local(i) => (
+                    Some(i as usize),
+                    view.scoped(env)
+                        .get(&view, i as usize)
+                        .ok_or(ExecutionError::BadEnvironmentIndex(i as usize))?,
+                ),
+                DecodedRef::Global(i) => (
+                    None,
+                    view.scoped(state.globals)
+                        .get(&view, i as usize)
+                        .ok_or(ExecutionError::BadGlobalIndex(i as usize))?,
+                ),
+                DecodedRef::Value(_) => {
+                    return Err(ExecutionError::NotCallable(
+                        smid,
+                        "native value".to_string(),
+                    ))
+                }
+            };
+            let BcValue::Closure(obj_closure) = obj_value else {
+                return Err(ExecutionError::NotCallable(
+                    smid,
+                    "native value".to_string(),
+                ));
+            };
+
+            let is_block = decode_cons(prog, &obj_closure)
+                .is_some_and(|(t, _)| t == DataConstructor::Block.tag());
+            if is_block {
+                state.current = bc_lookup_in_block(prog, state, view, &obj_closure, sym_id)
+                    .unwrap_or(BcValue::Closure(default_closure));
+            } else {
+                state.stack.push(BcContinuation::LookupLitForce {
+                    key: sym_id,
+                    smid,
+                    default_closure,
+                });
+                if let (Some(i), true) = (obj_slot, obj_closure.update()) {
+                    let hole = BcValue::Closure(BcClosure::new(state.blackhole, env));
+                    view.scoped(env).update(&view, i, hole)?;
+                    state.stack.push(BcContinuation::Update {
+                        environment: env,
+                        index: i,
+                    });
+                }
+                state.current = BcValue::Closure(obj_closure);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The pre-decoded twin of [`step`]: dispatch on the current value, routing an
+/// arity-0 closure through [`handle_op_predecoded`] instead of [`handle_op`].
+pub fn step_predecoded(
+    state: &mut BcMachineState,
+    view: MutatorHeapView<'_>,
+    prog: &BytecodeProgram,
+    table: &mut [Option<Instr>],
+) -> Result<(), ExecutionError> {
+    enum Dispatch {
+        Native(Native),
+        Fun,
+        Op,
+    }
+    let dispatch = match &state.current {
+        BcValue::Native(n) => Dispatch::Native(n.clone()),
+        BcValue::Closure(c) if c.arity() > 0 => Dispatch::Fun,
+        BcValue::Closure(_) => Dispatch::Op,
+    };
+    match dispatch {
+        Dispatch::Native(n) => return_native(state, view, n),
+        Dispatch::Fun => return_fun(state, view, prog),
+        Dispatch::Op => handle_op_predecoded(state, view, prog, table),
+    }
+}
+
 /// The bytecode execution machine: owns the heap, program and machine state,
 /// and drives the `step` dispatch loop with periodic GC (spec §6). The
 /// parallel-engine counterpart to the HeapSyn `Machine`.
@@ -2144,6 +2729,14 @@ pub struct BytecodeMachine<'a> {
     /// Active `render-as` capture emitters (a stack); emit BIFs route to the
     /// top one when non-empty, else to `emitter` (mirrors `Machine`).
     capture_emitters: Vec<OwnedCaptureEmitter>,
+    /// `EU_PREDECODE` spike (eu-2sa6.9): when true, dispatch runs the opcodes
+    /// from the pre-decoded [`Instr`] cache instead of re-reading the byte
+    /// stream. Off ⇒ byte-identical current behaviour.
+    predecode: bool,
+    /// Pre-decoded instruction cache, indexed by byte offset into `program.code`
+    /// (empty unless `predecode`). Lives on the system heap, holds no GC
+    /// pointers, and is never scanned by the collector — code stays off-heap.
+    predecoded: Vec<Option<Instr>>,
 }
 
 impl<'a> BytecodeMachine<'a> {
@@ -2196,6 +2789,13 @@ impl<'a> BytecodeMachine<'a> {
             constants,
         );
         state.blackhole = program.blackhole;
+        let predecode = super::predecode_enabled();
+        let mut predecoded: Vec<Option<Instr>> = Vec::new();
+        if predecode {
+            // One slot per code byte; only opcode-start offsets are ever
+            // populated (lazily, on first execution). Sized once at load.
+            predecoded.resize_with(program.code.len(), || None);
+        }
         Ok(BytecodeMachine {
             heap,
             program,
@@ -2211,6 +2811,8 @@ impl<'a> BytecodeMachine<'a> {
             intrinsics,
             emitter,
             capture_emitters: Vec::new(),
+            predecode,
+            predecoded,
         })
     }
 
@@ -2288,7 +2890,12 @@ impl<'a> BytecodeMachine<'a> {
             let view = MutatorHeapView::new(&self.heap);
             // Mirror the HeapSyn `handle_instruction` map_err (vm.rs): attach
             // the env/stack traces at the raise point before unwinding.
-            if let Err(e) = step(&mut self.state, view, &self.program) {
+            let res = if self.predecode {
+                step_predecoded(&mut self.state, view, &self.program, &mut self.predecoded)
+            } else {
+                step(&mut self.state, view, &self.program)
+            };
+            if let Err(e) = res {
                 return Err(attach_trace(&self.state, view, e));
             }
         }
@@ -2341,6 +2948,8 @@ impl<'a> BytecodeMachine<'a> {
                     metrics: &mut self.metrics,
                     clock: &mut self.clock,
                     dump_heap: self.dump_heap,
+                    predecode: self.predecode,
+                    predecoded: &mut self.predecoded,
                 };
                 // Emit BIFs route to the active capture emitter, else the main one.
                 let emitter: &mut dyn Emitter = match self.capture_emitters.last_mut() {
@@ -3192,6 +3801,12 @@ struct BcBifContext<'ctx, 'a> {
     metrics: &'ctx mut Metrics,
     clock: &'ctx mut Clock,
     dump_heap: bool,
+    /// `EU_PREDECODE` spike: route the re-entrant force loop (`drive_to_whnf`)
+    /// through the pre-decoded [`Instr`] cache too, so intrinsic-internal
+    /// forcing is measured under the same representation as the main loop.
+    predecode: bool,
+    /// The machine's pre-decoded instruction cache (shared with the main loop).
+    predecoded: &'ctx mut Vec<Option<Instr>>,
 }
 
 impl BcBifContext<'_, '_> {
@@ -3363,7 +3978,12 @@ impl BcBifContext<'_, '_> {
                 // here. The nested BIF error (below) is left raw, matching the
                 // HeapSyn sub-evaluation loop — it is wrapped once at the outer
                 // BIF site when it unwinds.
-                if let Err(e) = step(self.state, view, self.program) {
+                let res = if self.predecode {
+                    step_predecoded(self.state, view, self.program, self.predecoded)
+                } else {
+                    step(self.state, view, self.program)
+                };
+                if let Err(e) = res {
                     return Err(attach_trace(self.state, view, e));
                 }
             }
@@ -4739,6 +5359,8 @@ mod tests {
                 metrics: &mut m.metrics,
                 clock: &mut m.clock,
                 dump_heap: m.dump_heap,
+                predecode: m.predecode,
+                predecoded: &mut m.predecoded,
             };
             ctx.run_subrun_capture_lifecycle().unwrap();
         }

--- a/src/eval/bytecode/mod.rs
+++ b/src/eval/bytecode/mod.rs
@@ -49,3 +49,13 @@ pub fn bytecode_enabled() -> bool {
 pub fn heapsyn_enabled() -> bool {
     std::env::var("EU_HEAPSYN").as_deref() == Ok("1")
 }
+
+/// Whether the pre-decoded typed-instruction execution path is selected via
+/// `EU_PREDECODE=1` (the eu-2sa6.9 falsification spike). When set, the bytecode
+/// engine decodes each opcode ONCE into a typed `Instr` record (cached by byte
+/// offset in a non-GC `Vec`) and dispatches over the typed fields instead of
+/// re-reading the byte stream on every execution. Flag OFF ⇒ byte-identical
+/// current behaviour; the decode is the same, so tick counts are unchanged.
+pub fn predecode_enabled() -> bool {
+    std::env::var("EU_PREDECODE").as_deref() == Ok("1")
+}


### PR DESCRIPTION
**Throwaway spike — do NOT merge.** The DATA is the deliverable (0.13 Tier-1 GATE, eu-2sa6.9). Report: `docs/superpowers/reports/2026-07-13-predecode-spike.md`.

## Verdict: CONFIRMED

Tests review B §2a's hypothesis that the residual bytecode↔HeapSyn per-tick gap is the byte-stream **re-decode + dispatch envelope**, not code-off-heap residency. Behind `EU_PREDECODE=1`, each opcode is decoded **once** (lazily, cached by byte offset in a non-GC `Vec<Instr>`) and dispatched over typed fields — HeapSyn's `match code` shape but with code off the GC heap.

**Result:** pre-decoding removes the **entire 14.3% decode bucket** (profile: `read_ref`/`read_arg_offsets`/`read_form_header` → **0 samples**) and cuts **per-tick mutator cost 18–22% uniformly**, with **identical tick and allocation counts**.

| Case | per-tick bc/hs | per-tick **pd/hs** | pd/bc (same binary) |
|------|---------------:|-------------------:|--------------------:|
| drop_cons   | 1.60 | **1.25** | 0.785 |
| naive_fib   | 1.47 | **1.20** | 0.815 |
| short_lived | 1.35 | **1.09** | 0.811 |
| day03-p2    | 1.47 | **1.14** | 0.775 |

Flips **naive_fib below HeapSyn**, brings short_lived / day03 to ≈ parity, moves drop_cons decisively (~60% of the excess-over-HeapSyn closed). drop_cons's residual 1.25×/tick localises in the profile to the per-Case branch-table GC `Array` **rebuild** this spike deliberately kept — a production lever (a) must also materialise branch tables + form-header arrays into the record (review B §2a) to close it.

## Correctness (all green)
- `cargo test` flag OFF: 1272 lib + 480 harness, 0 failed.
- `EU_PREDECODE=1 cargo test --test harness_test`: 480, 0 failed.
- Tick-identical flag-on vs flag-off on all four cases; outputs match.
- `EU_GC_VERIFY=2` + `EU_GC_STRESS=1` flag-on: clean (cache holds no GC pointers).
- clippy `--all-targets -D warnings` clean; `cargo fmt` applied.

## Scope
`src/eval/bytecode/machine.rs` (`Instr` + `decode_instr` + `handle_op_predecoded` + `step_predecoded`, `dispatch`/`drive_to_whnf` branch), `src/eval/bytecode/mod.rs` (`predecode_enabled()`). Flag OFF = byte-identical. Measurement harness: `measure_mutator.sh`, `measure_predecode.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk