### PR TITLE
test(bytecode): tripwire + document source-prelude tick handicap (eu-2sa6.5)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -127,6 +127,24 @@ jobs:
       - name: Run harness on the bytecode + blob path
         run: ./target/release/eu test --allow-io tests/harness
 
+  tick-parity:
+    name: Source-prelude tick-parity tripwire
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # This test (tests/tick_parity_test.rs) compares default vs
+      # --source-prelude tick counts on a fused, strict-recursion fixture
+      # and only has teeth when the eu binary it spawns embeds a prelude
+      # blob (eu-2sa6.5) — without this step, default and --source-prelude
+      # would exercise the identical code path and the comparison would be
+      # vacuously true. Generate the blob before `cargo test` so the
+      # compiled CARGO_BIN_EXE_eu carries it.
+      - name: Generate prelude blob
+        run: cargo run --package xtask -- prelude-compile
+      - name: Run tick-parity tripwire
+        run: cargo test --test tick_parity_test
+
   blob-determinism:
     name: Prelude blob determinism
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to eucalypt are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Documented and tripwired the source-prelude fallback's performance handicap** — root-caused the +10.6% tick regression on arithmetic-dense, strictly-recursive code (`fib(30)`: 88,853,885 blob-path ticks vs 98,277,770 on `--source-prelude`/`EU_SOURCE_PRELUDE=1`) to demand-analysis strictness divergence, *not* a fused-primop gap (`emit_fixtures_and_globals` already emits byte-identical fused encodings on both paths). The blob path keeps prelude references `Var::Free` until `inject_prelude_inline_cores` exposes their strict shape to demand analysis before the general inline pass; the source-prelude path merges the prelude directly, resolving every reference to `Var::Bound` before `cook()` runs, so no free-variable name is left for an equivalent injection to catch (confirmed via `eu dump cooked --debug-format`: zero `Var::Free` nodes on that path). A full unification of the two prelude-loading pipelines is deferred to a follow-on bead so it doesn't run ahead of the 0.13 lever-(a) predecoded-IR work. This is **not a fix** — it adds `tests/tick_parity_test.rs`, a tripwire asserting the source-prelude handicap on a small fused/strict-recursion fixture stays within its documented bound (capped at 12%), and `docs/development/prelude-blob.md`, documenting the handicap and its cause. Released binaries are unaffected — they always embed the pre-compiled blob (eu-2sa6.5)
+
 ## [0.12.1] - Unreleased
 
 ### Fixed

--- a/docs/development/prelude-blob.md
+++ b/docs/development/prelude-blob.md
@@ -1,0 +1,91 @@
+# The prelude blob and the source-prelude fallback
+
+Every `eu` invocation loads the standard library (`lib/prelude.eu`) before
+running user code. There are two ways this happens:
+
+1. **Blob path (default, and what release binaries embed).** A
+   pre-compiled `lib/prelude.blob` — built by `cargo xtask
+   prelude-compile` — is embedded into the binary at compile time
+   (`src/driver/resources.rs`, gated on `cfg(prelude_blob_ok)`, set by
+   `build.rs` when the blob is present and its embedded source hash
+   matches `lib/prelude.eu`). At runtime the prelude's operators, type
+   summary, and compiled STG globals are loaded straight from the blob;
+   the prelude source is never parsed, cooked, or merged.
+2. **Source-prelude fallback.** Used when no blob is embedded (a plain
+   checkout with `lib/prelude.blob` absent — it is git-ignored — or a
+   stale blob whose hash doesn't match), or when explicitly requested via
+   `--source-prelude` / `EU_SOURCE_PRELUDE=1`. `lib/prelude.eu` is loaded,
+   translated, and merged into the user's core expression like any other
+   input, then compiled from scratch on every invocation.
+
+## The two paths are correctness-equivalent but not performance-equivalent
+
+Both paths produce identical results for identical eucalypt programs — the
+fallback exists precisely so a plain checkout without a generated blob
+still works correctly. But they are **not tick-equivalent** on
+arithmetic-dense, strictly-recursive code. On the naive-fibonacci benchmark
+(`tests/harness/bench/001_naive_fib.eu`, `fib(30)`):
+
+| Configuration | VM ticks |
+|---|---|
+| Blob embedded | 88,853,885 |
+| `--source-prelude` fallback | 98,277,770 (+10.6%) |
+
+### Why
+
+Root-caused in bead `eu-2sa6.5` (2026-07-13). It is **not** a gap in
+fused-primop codegen — `emit_fixtures_and_globals`
+(`src/eval/bytecode/encode.rs`) emits byte-identical fused `Op::FusedPrimop`
+encodings for the intrinsic global forms on both paths. The actual cause is
+that demand analysis infers different strictness for user-defined
+recursive functions on the two paths:
+
+- **Blob path**: the prelude is never merged into user code, so
+  references like `<=`, `+`, `-` remain `Var::Free` in the user's core
+  expression. `Loader::inject_prelude_inline_cores`
+  (`src/driver/source.rs`) injects the blob's pre-computed `inline_cores`
+  set — a small, already-resolved subset of prelude combinators and
+  intrinsic aliases — as a flat `Let` immediately before the general
+  inline pass, matched by free-variable name. This exposes the strict,
+  `Case`-on-first-argument shape of the arithmetic/comparison intrinsics
+  to demand analysis, which can then infer that (e.g.) a naive `fib`'s
+  recursive argument is used strictly — no thunk is allocated for `n - 1`
+  before the recursive call.
+- **Source-prelude path**: the prelude *is* merged into user code
+  (`merge_units`), so by the time `cook()` runs every prelude reference
+  has already been resolved to `Var::Bound` inside one large merged
+  `letrec` — confirmed directly via `eu dump cooked --debug-format`, which
+  shows zero `Var::Free` nodes and thousands of `Var::Bound` ones on this
+  path. There is no free-variable name left for a
+  `inject_prelude_inline_cores`-style injection to intercept, and the
+  general inline pass (`tag_combinators` + `reduce::inline_pass`) does not
+  perform the same fold — a sweep of 2 through 12 inline iterations left
+  ticks unchanged at 98,277,770, ruling out "just iterate further" as a
+  fix. `fib`'s recursive argument is inferred `Lazy`, so each call
+  allocates and later forces a thunk.
+
+Unifying the two paths — making the source-prelude fallback build the same
+in-memory global-slot / `Ref::G` structure the blob embeds, rather than
+merging prelude source directly — is a real fix, but a substantial one. It
+is tracked as a follow-on bead and deliberately deferred so it doesn't run
+ahead of the 0.13 lever-(a) predecoded-IR work.
+
+## What this means in practice
+
+- **Released binaries are unaffected.** `cargo xtask prelude-compile` runs
+  before every release build (`.github/workflows/build-rust.yaml`,
+  `test-bytecode-blob` / release jobs), so shipped binaries always embed
+  the blob and never take the source-prelude tick handicap.
+- **A plain `cargo build`/`cargo test` on a fresh checkout** — where
+  `lib/prelude.blob` has not been generated — silently uses the
+  source-prelude fallback. This is correct but ~10% slower on
+  arithmetic-heavy workloads. Run `cargo xtask prelude-compile` locally if
+  you are taking performance measurements.
+- **`tests/tick_parity_test.rs`** is a tripwire, not a fix: it asserts the
+  source-prelude tick handicap on a small fused/strict-recursion fixture
+  stays within its documented bound (capped at 12%, with headroom over the
+  measured ~10.6%). It only has teeth when the `eu` binary it spawns
+  embeds a blob — see the `tick-parity` CI job, which generates one first.
+  If you are benchmarking anything performance-sensitive, always confirm
+  which path is active (`cargo xtask prelude-compile` beforehand, or check
+  for the `precompiled prelude not found` build warning).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,7 +17,10 @@ eu --help # lists command line options
 
 - `--source-prelude` - Force the source-prelude pipeline even when a pre-compiled
   prelude blob is available. Use this when you need to trace through prelude source
-  during debugging, or when the cached blob is suspected to be stale.
+  during debugging, or when the cached blob is suspected to be stale. Note this
+  pipeline is correctness-equivalent to the blob path but carries a documented
+  performance handicap (~10% on arithmetic-dense code) — see
+  [`docs/development/prelude-blob.md`](../development/prelude-blob.md).
 
 ## Command Structure
 

--- a/tests/fixtures/tick_parity_fib.eu
+++ b/tests/fixtures/tick_parity_fib.eu
@@ -1,0 +1,11 @@
+# Fixture for the source-prelude tick-parity tripwire (eu-2sa6.5).
+#
+# Deliberately small (fib(20), not fib(30) as in the bench suite) so the
+# comparison runs twice per `cargo test` invocation without materially
+# slowing the suite down. Exercises the same strict-recursion + fused
+# arithmetic shape (`<=`, `-`, `+`) that exposed the ~10.6% source-prelude
+# tick handicap.
+fib(n): if(n <= 1, 1, fib(n - 1) + fib(n - 2))
+
+` { target: :tick-parity-fib }
+tick-parity-fib: fib(20)

--- a/tests/tick_parity_test.rs
+++ b/tests/tick_parity_test.rs
@@ -1,0 +1,131 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Source-prelude tick-parity tripwire (eu-2sa6.5).
+//!
+//! Spawns the compiled `eu` binary as a subprocess and depends on
+//! `tempfile` (a non-wasm32 dev-dependency, `Cargo.toml`), so this test is
+//! excluded from the wasm32 target — matching `property_test.rs` /
+//! `fuzz_regression_test.rs`.
+//!
+//! ## Background
+//!
+//! `fib(30)` executes in 88,853,885 VM ticks when `lib/prelude.blob` is
+//! embedded in the binary, but 98,277,770 ticks (+10.6%) when the blob is
+//! absent and the driver falls back to compiling the prelude from source
+//! (`--source-prelude` / `EU_SOURCE_PRELUDE=1`, or simply no blob present
+//! at build time). Root-caused 2026-07-13 (bead eu-2sa6.5): this is *not*
+//! a fusion gap — `emit_fixtures_and_globals` in
+//! `src/eval/bytecode/encode.rs` fuses the same intrinsic global forms on
+//! both paths, byte-identically. The real cause is demand-analysis
+//! strictness divergence:
+//!
+//! - **Blob path**: the prelude source is never merged into the user's
+//!   core expression (`prepare.rs` filters it out of `inputs` once
+//!   `has_prelude_blob()` is true). References like `<=`/`+`/`-` in user
+//!   code stay `Var::Free` until `Loader::inject_prelude_inline_cores`
+//!   (`src/driver/source.rs`) injects the blob's pre-resolved
+//!   `inline_cores` set as a flat `Let`, matched purely by free-variable
+//!   name, immediately before the general inline pass. That exposes the
+//!   strict `Case`-on-`L(0)` shape of the arithmetic/comparison
+//!   intrinsics to demand analysis, which infers `fib`'s recursive
+//!   argument as `Strict` — no per-call thunk allocation.
+//! - **Source-prelude path**: the prelude *is* one of the merge inputs, so
+//!   `merge_units` folds it directly into the user's core expression.  By
+//!   the time `cook()` runs, every prelude reference has already been
+//!   resolved to `Var::Bound` (verified directly: `eu dump cooked
+//!   --debug-format` on the source path contains zero `Free(...)` nodes
+//!   and thousands of `Bound(...)` ones) — there is no `Var::Free` name
+//!   left for a `inject_prelude_inline_cores`-style injection to catch.
+//!   `fib`'s argument demand is inferred `Lazy`, so each recursive call
+//!   allocates and later forces a thunk for `n - 1` / `n - 2`.
+//!
+//! A sweep of the general inline pass's iteration count (2 through 12)
+//! confirmed this isn't an under-iterated fixed point either: ticks were
+//! flat at 98,277,770 regardless, because the general inliner simply
+//! doesn't perform the same fold as the blob path's dedicated
+//! peel/fixed-point/pre-substitute pipeline.
+//!
+//! Unifying the two paths (making the source-prelude fallback build the
+//! same in-memory global-slot/`Ref::G` structure the blob embeds, instead
+//! of merging the prelude source directly) is a substantial redesign,
+//! deliberately deferred to a follow-on bead so it doesn't run ahead of
+//! the lever-(a) predecoded-IR work. See `docs/development/prelude-blob.md`
+//! for the user-facing summary of the handicap.
+//!
+//! ## What this test asserts
+//!
+//! Not an exact tick count (too brittle across codegen changes) — instead
+//! that the source-prelude handicap on a fused, strict-recursion program
+//! stays within its documented bound (~10.6%, capped here at 12% to leave
+//! headroom for measurement noise while still catching regressions).
+//!
+//! If the binary under test was built *without* a prelude blob (e.g. a
+//! bare `cargo test` run without first running `cargo xtask
+//! prelude-compile`), both configurations exercise the identical
+//! source-fallback code path and the comparison is vacuously true — this
+//! test only has teeth when a blob is embedded in the `eu` binary it
+//! spawns. CI exercises the real comparison via the dedicated
+//! `tick-parity` job in `.github/workflows/build-rust.yaml`, which
+//! generates the blob before compiling the test binary.
+
+use std::path::Path;
+
+/// The documented handicap is ~10.6% (98,277,770 / 88,853,885 on
+/// `fib(30)`); cap at 12% so the tripwire has a little headroom for
+/// measurement noise but still fails if the gap widens materially.
+const MAX_SOURCE_PRELUDE_RATIO: f64 = 1.12;
+
+fn eu_binary() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_eu"))
+}
+
+/// Run the tick-parity fixture and return `machine_ticks` from the
+/// `--statistics-file` JSON output.
+fn run_ticks(source_prelude: bool, stats_path: &Path) -> u64 {
+    let mut cmd = std::process::Command::new(eu_binary());
+    cmd.args(["run", "-t", "tick-parity-fib", "--statistics-file"])
+        .arg(stats_path)
+        .args(["--heap-limit-mib", "2048"])
+        .arg("tests/fixtures/tick_parity_fib.eu");
+    if source_prelude {
+        cmd.arg("--source-prelude");
+    }
+
+    let output = cmd.output().expect("failed to run eu");
+    assert!(
+        output.status.success(),
+        "eu exited with {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json_text = std::fs::read_to_string(stats_path)
+        .unwrap_or_else(|e| panic!("reading statistics file {}: {e}", stats_path.display()));
+    let json: serde_json::Value =
+        serde_json::from_str(&json_text).expect("statistics file is not valid JSON");
+    json["machine_ticks"]
+        .as_u64()
+        .expect("statistics JSON missing machine_ticks")
+}
+
+#[test]
+fn source_prelude_tick_parity_tripwire() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let blob_stats = dir.path().join("blob-stats.json");
+    let source_stats = dir.path().join("source-stats.json");
+
+    let blob_ticks = run_ticks(false, &blob_stats);
+    let source_ticks = run_ticks(true, &source_stats);
+
+    let ratio = source_ticks as f64 / blob_ticks as f64;
+
+    assert!(
+        source_ticks as f64 <= blob_ticks as f64 * MAX_SOURCE_PRELUDE_RATIO,
+        "source-prelude tick handicap has grown beyond the documented bound \
+         (eu-2sa6.5): default={blob_ticks} ticks, --source-prelude={source_ticks} ticks, \
+         ratio={ratio:.4} > {MAX_SOURCE_PRELUDE_RATIO}. If this binary embeds no prelude \
+         blob, default and --source-prelude use the identical code path and this assertion \
+         should be trivially satisfied — a failure here with no blob present points at a \
+         different regression, not the known handicap."
+    );
+}


### PR DESCRIPTION
## Summary

`eu-2sa6.5` reported the source-prelude fallback (`--source-prelude` / `EU_SOURCE_PRELUDE=1`, or a plain checkout without `lib/prelude.blob`) running `fib(30)` in **98,277,770** VM ticks vs **88,853,885** with the blob embedded (+10.6%), and asked for the runtime source-prelude path to apply the same global-form fusion the blob path uses.

**That premise turned out to be false** — both paths already emit byte-identical fused encodings. This PR does not "fix" the handicap (the coordinator agreed, after reviewing the evidence below, that the real fix is a substantial redesign deferred to a follow-on bead — see "Disposition" below). It **documents the actual cause** and **lands a tripwire** so the handicap is tracked and can't silently widen.

## Investigation (checkpoint findings, verbatim)

### 1. Reproduction

Built with the prelude blob regenerated and embedded, then compared `--source-prelude` against the default:

```
BLOB path:   Ticks : 88,853,885
SOURCE path: Ticks : 98,277,770
```

Exact match to the bead's figures.

### 2. The bead's stated mechanism is empirically false

Instrumented `emit_fixtures_and_globals` (`src/eval/bytecode/encode.rs`) — the function shared by both `encode()` (source path) and `encode_prelude()` (blob-build path). **All 8 fusible intrinsic global forms fuse identically on both paths** (slots 14–17, 49–52). `fib`'s compiled STG has identical op counts on both paths: 25 `ADD`, 50 `SUB`, 25 `LTE`, and the same `fused[14/15/51]` markers from the #982 direct-inline `FusedPrimop` path. Global-form fusion is not the gap.

### 3. Actual root cause: demand-analysis strictness divergence

Diffing the compiled STG for `fib` between the two paths, the sole hot-path difference is a `seq` on the recursive-call argument:

- **Blob**: `... in seq ✳0 in →✳2(✳0)` — `n-1` is forced before the direct recursive call.
- **Source**: `... in →✳2(✳0)` — no `seq`; `n-1` is passed as a freshly-allocated thunk, forced lazily inside the callee.

Confirmed by dumping `user_demand_sigs`:
- **Blob**: `sig[fib] = Demand { strictness: Strict, ... }`
- **Source**: `sig[fib] = Demand { strictness: Lazy, ... }`

**Mechanism**: `Loader::inject_prelude_inline_cores` (`src/driver/source.rs`) is a no-op without a blob. On the blob path, the prelude source is *never merged* into the user's core expression (`prepare.rs` filters it out of `inputs` once `has_prelude_blob()` is true), so references like `<=`, `+`, `-` stay `Var::Free` in user code. `inject_prelude_inline_cores` injects the blob's pre-resolved `inline_cores` set (a small, already-substituted subset of prelude combinators/intrinsic aliases) as a flat `Let`, matched purely by free-variable name, immediately before the general inline pass — exposing the strict `Case`-on-`L(0)` shape of the arithmetic/comparison intrinsics to demand analysis. On the source path, the prelude *is* one of the merge inputs (`merge_units` folds it directly into user code), and by the time `cook()` runs every prelude reference has already been resolved to `Var::Bound` — **confirmed directly**: `eu dump cooked --debug-format` on the source path contains **zero `Var::Free` nodes and 2,622 `Var::Bound` nodes**. There is no free-variable name left for a `Var::Free`-name-matching injection to intercept.

### 4. Ruled out the cheap alternative

Swept the general inline pass's iteration count (`prepare.rs`, `for _ in 0..2 { loader.inline()?; }`) from 2 through 12 on the source path. Ticks were **flat at 98,277,770 at every iteration count** — the general inliner isn't under-iterated, it structurally doesn't perform the same fold as the blob path's dedicated peel/fixed-point/pre-substitute pipeline (`xtask/src/main.rs`'s `inline_cores` construction).

## Disposition (coordinator-agreed)

Two options were considered for a real fix:
1. Make the source-prelude fallback build the same in-memory global-slot/`Ref::G` structure the blob embeds at runtime (skip only the serialization step) — parity by construction, single pipeline, but a substantial redesign touching `src/driver/prepare.rs`, `src/driver/source.rs`'s merge/cook sequencing, and `src/eval/stg/compiler.rs`'s prelude-globals wiring.
2. Teach demand analysis to see through known-strict prelude/intrinsic operator calls directly on the `Var::Bound` representation — smaller footprint, but leaves two divergent strictness mechanisms and touches core demand-analysis semantics for what is fundamentally a config-parity bug.

**Option 2 was rejected.** Option 1 is the correct long-term unification but is deliberately **deferred to its own follow-on bead** (to be filed) so it doesn't run ahead of the 0.13 lever-(a) predecoded-IR work. This PR lands the interim path instead:

## What's in this PR

- **`tests/tick_parity_test.rs`** — spawns the compiled `eu` binary twice (default vs `--source-prelude`) against a small fib-like fixture, reads `machine_ticks` from `--statistics-file` JSON, and asserts `source_ticks <= blob_ticks * 1.12` (documented handicap ~10.6%, capped with headroom for noise). Not a magic-number assertion — survives future codegen changes as long as the gap doesn't widen. Gracefully vacuous (trivially passes) when the binary under test embeds no blob at all (both configs then use the same code path) — see the new `tick-parity` CI job below, which ensures the check has teeth.
- **`tests/fixtures/tick_parity_fib.eu`** — small (`fib(20)`) fixture exercising the same fused/strict-recursion shape, kept fast (~1s for both runs) and separate from the real `fib(30)` benchmark in `tests/harness/bench/`.
- **`.github/workflows/build-rust.yaml`** — new `tick-parity` job that generates the blob (`cargo xtask prelude-compile`) before `cargo test --test tick_parity_test`, so the tripwire is exercised for real in CI (the default `test` job's binary has no blob, so the check would otherwise be vacuous there).
- **`docs/development/prelude-blob.md`** — new doc explaining the blob vs source-prelude paths, the measured handicap, its root cause (as above), and that released binaries always embed the blob and are unaffected.
- **`docs/reference/cli.md`** — cross-reference from `--source-prelude` to the new doc.
- **`CHANGELOG.md`** — entry under `## [Unreleased]` (0.12.1's section is untouched, as it's released).

## Gates

- `cargo test` — green on the default (bytecode) engine: 1,274 + 7 + 1 + 3 + 489 + 12 + 111 + 11 + 1 (tick-parity, real comparison, blob confirmed active) + 3 doc-tests, 0 failed.
- `cargo test` under `EU_HEAPSYN=1` — green, same counts, 0 failed.
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 ./target/release/eu test --allow-io tests/harness` — exit 0, all named tests PASS.
- `cargo fmt --all` — clean.
- `cargo clippy --all-targets -- -D warnings` (native) — clean.
- `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` — clean.
- `cargo clippy --target wasm32-unknown-unknown --tests -- -D warnings` — the new test is `#![cfg(not(target_arch = "wasm32"))]`-gated (matches `property_test.rs`/`fuzz_regression_test.rs`, since it spawns a subprocess and uses the non-wasm32 `tempfile` dev-dependency) and compiles cleanly standalone; pre-existing wasm32 `--tests` failures (`lsp_test.rs`'s unconditional `lsp_types` usage, one pre-existing `fragmentation_error` dead-code warning in `heap.rs`) were confirmed present on unmodified `master` via `git stash` and are unrelated to this change.
- Manually verified fixture ratio: 799,059 / 722,435 ≈ 1.1061 (consistent with the fib(30) ratio of 1.10608), comfortably under the 1.12 tripwire.

## Note for the record

Demand-analysis divergence means **all historical source-prelude-configuration measurements carried this ~10.6% handicap** without anyone knowing why. Any past perf comparison run under `--source-prelude`/`EU_SOURCE_PRELUDE=1` (or without a generated blob) should be treated as measuring source-prelude-fallback performance, not blob-path (release) performance — the two are not interchangeable for benchmarking purposes.

Do NOT merge — owner review requested.
