### PR TITLE
docs: 0.13 documentation review phase 1 — audit + mechanical fixes (eu-2sa6.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to eucalypt are documented here.
 ### Changed
 
 - **`eu.build` metadata sanitised** — the `github-env` block that captured all `GITHUB_*` environment variables from the CI runner (including filesystem paths, actor IDs, and workflow internals) has been replaced with a curated set of build metadata: version, commit, build number, URL, timestamp, target triple, Rust version, build profile, and prelude blob status (#917)
-- **`to-data` / `from-data` moved to `lib/reflect.eu`** — moved out of the prelude into the optional `reflect` library (`{ import: "resource:reflect" }`); the prelude re-exports both for backward compatibility. `to-spec` removed — `as-spec` is now the single canonical name (#920)
+- **`to-data` / `from-data` moved to `lib/reflect.eu`** — moved out of the prelude into the optional `reflect` library (`{ import: "reflect.eu" }`); the prelude re-exports both for backward compatibility. `to-spec` removed — `as-spec` is now the single canonical name (#920)
 
 ### Fixed
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Imports and Modules](guide/imports-and-modules.md)
 - [Working with Data](guide/working-with-data.md)
 - [The Command Line](guide/command-line.md)
+- [Language Server Protocol](guide/lsp.md)
 - [YAML Embedding](guide/yaml-embedding.md)
 - [Testing with Eucalypt](guide/testing.md)
 - [Date, Time, and Random Numbers](guide/date-time-random.md)

--- a/docs/appendices/cheat-sheet.md
+++ b/docs/appendices/cheat-sheet.md
@@ -563,9 +563,10 @@ eu -Q file.eu               # Suppress prelude
 eu fmt file.eu              # Format source
 eu dump stg file.eu         # Dump STG syntax
 eu -- arg1 arg2             # Pass arguments (io.args)
-eu check file.eu            # Type-check, report warnings
+eu check file.eu            # Type-check only, report warnings
 eu check --strict file.eu   # Treat type warnings as errors
-eu --type-check file.eu     # Check then evaluate
+eu file.eu --strict         # Evaluate, abort first if type warnings
+eu file.eu --suppress-type-warnings  # Evaluate, silence warnings
 eu doc file.eu              # Extract documentation (Markdown)
 eu doc --format json file.eu # Extract as JSON Schema
 eu doc --check file.eu      # Report documentation coverage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,6 +295,18 @@ Validates transformed expressions before STG compilation:
 
 Eucalypt uses a Spineless Tagless G-machine (STG) as its evaluation model, providing lazy evaluation with memoisation.
 
+> **Note on execution engines**: the sections below describe the STG
+> tree-walk machine (`src/eval/machine/vm.rs`), historically the only
+> engine and still the differential-testing/performance baseline
+> (select it with `EU_HEAPSYN=1`). Since 0.12.0 the **default** engine
+> instead compiles the same STG syntax to a bytecode program and runs
+> it on a separate bytecode VM (`src/eval/bytecode/`: `opcode.rs`,
+> `program.rs`, `machine.rs`, `closure.rs`, `cont.rs`, `env_builder.rs`,
+> `encode.rs`). `EU_BYTECODE=1` is a redundant no-op now that bytecode
+> is the default. A full description of the bytecode engine's design
+> is a tracked documentation gap — see `docs/superpowers/specs/` for
+> the implementation-level design documents in the meantime.
+
 ### STG Syntax
 
 *Implementation*: `src/eval/stg/syntax.rs`
@@ -710,9 +722,8 @@ The prelude is:
 
 ## Further Reading
 
-- `implementation.md` - Brief implementation overview
-- `gc-implementation.md` - Detailed GC documentation
-- `command-line.md` - CLI usage guide
-- `syntax.md` - Language syntax reference
-- `operators-and-identifiers.md` - Operator definitions
-- `anaphora-and-lambdas.md` - Implicit parameter handling
+- [`development/gc-implementation.md`](development/gc-implementation.md) - Detailed GC documentation
+- [`guide/command-line.md`](guide/command-line.md) - CLI usage guide
+- [`reference/syntax.md`](reference/syntax.md) - Language syntax reference
+- [`reference/operators-and-identifiers.md`](reference/operators-and-identifiers.md) - Operator definitions
+- [`guide/anaphora.md`](guide/anaphora.md) - Implicit parameter handling

--- a/docs/development/type-alias-shorthand-spec.md
+++ b/docs/development/type-alias-shorthand-spec.md
@@ -3,7 +3,7 @@
 **Status**: Specification — ready to implement.
 **Date**: 2026-05-20
 **Branch**: `type-system-exploration`
-**Companions**: [alias-reference-tooling-spec.md](./alias-reference-tooling-spec.md) (A7 — alias-reference LSP support), [unit-visibility-spec.md](./unit-visibility-spec.md) (related metadata-convention work).
+**Companions**: `alias-reference-tooling-spec.md` (A7 — alias-reference LSP support; shipped in 0.6.2/0.7.0, spec file removed, see `ROADMAP.md`), [unit-visibility-spec.md](./unit-visibility-spec.md) (related metadata-convention work).
 
 **Scope note**: a metadata + alias-system extension; independent of the
 type-system roadmap (TS-A/TS-B). Earns its own bead.

--- a/docs/development/type-system-evolution.md
+++ b/docs/development/type-system-evolution.md
@@ -6,7 +6,8 @@
 
 This document gathers hypotheses about how eucalypt's gradual type system
 could evolve beyond the current spec ([gradual-typing-spec.md](./gradual-typing-spec.md))
-and the monad metadata follow-up ([monad-type-checking-spec.md](./monad-type-checking-spec.md)).
+and the monad metadata follow-up (`monad-type-checking-spec.md` — shipped
+in 0.6.2/0.7.0, spec file removed; see `ROADMAP.md`).
 Each hypothesis is sketched in enough detail to argue about. Nothing here
 is decided.
 
@@ -316,8 +317,8 @@ so annotating `merge` and the lens `over`-family activates it (the main
 remaining task is freshening row variables per use). Inferring *fresh*
 row variables for *unannotated* functions — so a generic block
 combinator becomes row-polymorphic without an annotation — is deferred
-to Phase B, bead **TS-B9**. See
-[row-polymorphism-and-dict-spec.md](./row-polymorphism-and-dict-spec.md).
+to Phase B, bead **TS-B9**. See `row-polymorphism-and-dict-spec.md`
+(shipped in 0.6.2/0.7.0, spec file removed; see `ROADMAP.md`).
 
 ---
 
@@ -627,7 +628,8 @@ of scope. B7 = check the prelude standalone once → cache a summary of
 its binding schemes *and* type aliases → seed every user-file check.
 LSP responsiveness is the motivation: for a tooling-first language the
 checker exists to support writing eucalypt. See
-[prelude-type-cache-spec.md](./prelude-type-cache-spec.md).
+`prelude-type-cache-spec.md` (shipped in 0.6.2/0.7.0, spec file
+removed; see `ROADMAP.md`).
 
 **Recommendation.** Phase B (TS-B7), prelude-scoped. Skip whole-program
 inference and general per-user-module summaries.
@@ -1037,7 +1039,8 @@ hang narrowing on.
 The consequence: narrowing cannot be a general mechanism keyed on
 syntax. It is a *special case in `synthesise_app`* that fires when the
 callee is a recognised brancher. The detailed design — settled in
-[literal-types-and-narrowing-spec.md](./literal-types-and-narrowing-spec.md)
+`literal-types-and-narrowing-spec.md` (shipped in 0.6.2/0.7.0, spec
+file removed; see `ROADMAP.md`)
 — makes recognition **structural**, not a table of prelude names:
 
 - The branch *intrinsics* `__IF`/`__AND`/`__OR`/`__COND` are recognised

--- a/docs/guide/advanced-topics.md
+++ b/docs/guide/advanced-topics.md
@@ -460,8 +460,8 @@ Group list elements by a key function:
 
 ```eu
 items: [
-  { type: "fruit" name: "apple" }
-  { type: "veg" name: "carrot" }
+  { type: "fruit" name: "apple" },
+  { type: "veg" name: "carrot" },
   { type: "fruit" name: "banana" }
 ]
 

--- a/docs/guide/command-line.md
+++ b/docs/guide/command-line.md
@@ -31,6 +31,8 @@ eu file.eu          # same as: eu run file.eu
 | `list-targets` | List export targets |
 | `fmt` | Format source files |
 | `lsp` | Start the Language Server Protocol server |
+| `check` | Check type annotations without evaluating |
+| `doc` | Extract documentation from source |
 
 ## Inputs
 
@@ -230,6 +232,21 @@ reproducible output:
 ```sh
 eu --seed 42 template.eu
 ```
+
+## IO Permission
+
+Programs that use the IO monad (`io.shell`, `io.exec`, and friends)
+must be run with `-I`/`--allow-io`, or evaluation fails with a
+permission error before any shell command runs:
+
+```sh
+eu -I deploy.eu
+eu --allow-io deploy.eu
+```
+
+This is a safety gate — code that shells out is not allowed to run
+by accident. See [IO and Shell Commands](io.md) for the full IO
+monad guide.
 
 ## The Formatter
 

--- a/docs/guide/date-time-random.md
+++ b/docs/guide/date-time-random.md
@@ -35,8 +35,8 @@ values:
 # Parse from a string
 d: cal.parse("2024-03-15T14:30:00Z")
 
-# Format to a custom string
-label: t"2024-03-15" cal.format("%Y-%m-%d")  # "2024-03-15"
+# Format as ISO8601 (cal.format takes no format-string argument)
+label: t"2024-03-15" cal.format  # "2024-03-15T00:00:00+00:00"
 ```
 
 ### Date-Time Arithmetic

--- a/docs/guide/expressions-and-pipelines.md
+++ b/docs/guide/expressions-and-pipelines.md
@@ -236,8 +236,8 @@ A more complete example:
 
 ```eu
 people: [
-  { name: "Alice" age: 30 }
-  { name: "Bob" age: 25 }
+  { name: "Alice" age: 30 },
+  { name: "Bob" age: 25 },
   { name: "Charlie" age: 35 }
 ]
 

--- a/docs/guide/functions-and-combinators.md
+++ b/docs/guide/functions-and-combinators.md
@@ -273,8 +273,12 @@ result: 5 ops.double ops.negate
 ```
 
 ```yaml
+ops: {}
 result: -10
 ```
+
+(`ops` renders as `{}` because its members are functions, which are
+never rendered — only the block itself, being a property, appears.)
 
 ## Currying
 
@@ -481,11 +485,19 @@ eu -e 'flip(-, 1, 3)'
 
 `flip` is useful for adapting functions to a pipeline:
 
-```eu,notest
+```eu
 ` :suppress
-with-tags: merge flip ({ tags: [:a, :b] })
+with-tags: flip(merge)({ tags: [:a, :b] })
 
 result: { name: "foo" } with-tags
+```
+
+```yaml
+result:
+  name: foo
+  tags:
+    - a
+    - b
 ```
 
 ### `complement`

--- a/docs/guide/io.md
+++ b/docs/guide/io.md
@@ -177,9 +177,14 @@ The pipeline style reads naturally: the command string flows into
 the first action:
 
 ```eu,notest
-io.bind(io.shell("echo hello"),
-  _(r): io.shell("echo got: {r.stdout}"))
+say(r): io.shell("echo got: {r.stdout}")
+
+io.bind(io.shell("echo hello"), say)
 ```
+
+(Eucalypt has no anonymous-lambda syntax — `_(r): expr` is
+declaration syntax, not a function value; the continuation must be a
+named function or a partially-applied one.)
 
 The `{ :io ... }` block is almost always preferable to explicit
 `io.bind` calls.

--- a/docs/guide/lists-and-transformations.md
+++ b/docs/guide/lists-and-transformations.md
@@ -405,9 +405,9 @@ Here is a more complete example combining multiple list operations:
 
 ```eu
 data: [
-  { name: "Alice" score: 85 }
-  { name: "Bob" score: 92 }
-  { name: "Charlie" score: 78 }
+  { name: "Alice" score: 85 },
+  { name: "Bob" score: 92 },
+  { name: "Charlie" score: 78 },
   { name: "Diana" score: 95 }
 ]
 

--- a/docs/guide/monads.md
+++ b/docs/guide/monads.md
@@ -42,7 +42,8 @@ The most common form tags the block with `:io`:
 }.(r.stdout)
 ```
 
-This desugars to:
+This desugars to (pseudocode — `λ` is not real eucalypt syntax;
+eucalypt has no lambda expressions):
 
 ```eu,notest
 io.bind(io.shell("echo hello"),

--- a/docs/guide/navigating-nested-data.md
+++ b/docs/guide/navigating-nested-data.md
@@ -53,8 +53,8 @@ Because `~` is a regular operator (left-associative, precedence
 
 ```eu
 people: [
-  { name: "Alice", email: "alice@example.com" }
-  { name: "Bob" }
+  { name: "Alice", email: "alice@example.com" },
+  { name: "Bob" },
   { name: "Charlie", email: "charlie@example.com" }
 ]
 
@@ -172,8 +172,8 @@ applied predicate — perfect for `filter` and `when`:
 
 ```eu
 servers: [
-  { host: "10.0.0.1", port: 8080 }
-  { name: "cache" }
+  { host: "10.0.0.1", port: 8080 },
+  { name: "cache" },
   { host: "10.0.0.2", port: 5432 }
 ]
 
@@ -383,7 +383,7 @@ the original positions.
 | Find by key at any depth | `deep-find` | `data deep-find(:host)` |
 | Get a value deep in a known structure | `view` + lens | `data view(‹:server :host›)` |
 | Modify a value deep in a structure | `over` + lens | `data over(‹:server :port›, + 1)` |
-| Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.upper)` |
+| Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.to-upper)` |
 | Collect values from all elements | `to-list-of` + `each` | `items to-list-of(each ∘ at(:name))` |
 | Sort/reverse/replace all foci | `parts-of` + traversal | `items over(parts-of(each ∘ at(:score)), sort-nums)` |
 

--- a/docs/guide/operators.md
+++ b/docs/guide/operators.md
@@ -37,8 +37,13 @@ result: ∅ set.to-list
 ```
 
 ```yaml
+∅: []
 result: []
 ```
+
+Unlike prefix/postfix/binary operator declarations, a nullary
+declaration has no parameter list — structurally it is a property
+declaration, so (unlike a function) it *is* rendered in the output.
 
 The empty set `∅` is the only nullary operator in the standard prelude,
 but you can define your own:
@@ -82,21 +87,24 @@ The prelude defines the standard precedence levels:
 | Level | Name | Operators |
 |-------|------|-----------|
 | 95 | prefix | `↑` (head) |
-| 90 | lookup | `.` |
-| 88 | bool-unary | `!`, `¬` |
+| 90 | lookup | `.`, `~` (safe lookup) |
+| 88 | bool-unary | `!`, `¬` (prefix); `✓` (postfix not-null) |
+| 88 | -- | `∘`, `;` (composition) |
 | 85 | exp | `^`, `!!` (nth) |
 | 80 | prod | `*`, `/`, `÷`, `%` |
 | 75 | sum | `+`, `-` |
-| 60 | shift | (shift operators) |
-| 55 | bitwise | (bitwise operators) |
+| 60 | shift | (shift operators, reserved) |
+| 55 | bitwise | (bitwise operators, reserved) — `‖` (cons) also uses this numeric level |
 | 50 | cmp | `<`, `>`, `<=`, `>=` |
 | 45 | append | `++`, `<<` |
+| 42 | map | `<$>` (functor map) |
 | 40 | eq | `=`, `!=` |
 | 35 | bool-prod | `&&`, `∧` |
 | 30 | bool-sum | `\|\|`, `∨` |
 | 20 | cat | (catenation) |
+| 15 | clause | `=>`, `⇒` (cond clause builder) |
 | 10 | apply | `@` |
-| 5 | meta | `//`, `//=`, `//=>`, `//=?`, `//!` |
+| 5 | meta | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` |
 
 Higher numbers bind more tightly:
 
@@ -149,21 +157,23 @@ Associativity can be `:left`, `:right`, or omitted (defaults to
 
 Two special operators are provided for testing:
 
-### `//=` (assert equals)
+### `//=` (expect equals)
 
-Asserts that the left side equals the right side at runtime, and
-returns the value if true. Panics if false:
+Expects the left side to equal the right side at runtime, returning
+`true` on success. Panics if false (or, in `eu test` mode, returns
+`false` instead of panicking):
 
 ```eu
-result: 2 + 2 //= 4
+result: 2 + 2 //= 4   # result: true
 ```
 
 ### `//=>` (assert equals with metadata)
 
-Like `//=` but also attaches the assertion as metadata:
+Like `//=` but returns the asserted *value* (not a boolean) on
+success, and also attaches the assertion as metadata:
 
 ```eu
-checked: 2 + 2 //=> 4
+checked: 2 + 2 //=> 4   # checked: 4
 ```
 
 Both are useful for embedding tests and sanity checks in code.

--- a/docs/guide/state-monad.md
+++ b/docs/guide/state-monad.md
@@ -17,8 +17,8 @@ same problem that `{ :random ... }` solves for PRNG streams.
 
 ```eu
 s0: { count: 0, name: "init" }
-s1: s0 merge({count: 1})
-s2: s1 merge({name: "updated"})
+s1: merge(s0, {count: 1})
+s2: merge(s1, {name: "updated"})
 ```
 
 ```yaml

--- a/docs/guide/string-interpolation.md
+++ b/docs/guide/string-interpolation.md
@@ -140,15 +140,22 @@ These use printf-style format codes:
 
 ```eu
 pi: 3.14159
+n: 42
 formatted: "{pi:%.2f}"
-padded: "{42:%06d}"
+padded: "{n:%06d}"
 ```
 
 ```yaml
 pi: 3.14159
+n: 42
 formatted: '3.14'
 padded: '000042'
 ```
+
+Bind the value to a name first, as above — a bare numeral inside the
+braces (e.g. `"{42:%06d}"`) is parsed as numbered string anaphora
+(`{0}`, `{1}`, ...), not a literal value, and silently produces an
+uncallable high-arity function instead of a formatted string.
 
 ## String Anaphora
 
@@ -365,7 +372,7 @@ endpoints:
 
 ```eu
 rows: [
-  { name: "Alice" score: 85 }
+  { name: "Alice" score: 85 },
   { name: "Bob" score: 92 }
 ]
 

--- a/docs/guide/type-checking.md
+++ b/docs/guide/type-checking.md
@@ -1,18 +1,22 @@
 # Type Checking
 
-Eucalypt includes an optional, advisory type checker. It never prevents
-your code from running — all existing code continues to work exactly as
-before. Think of it as a second pair of eyes that can catch common
-mistakes before they become confusing runtime errors.
+Eucalypt includes an advisory type checker that runs **unconditionally**
+on every `eu` invocation (evaluate, dump, test). It never prevents your
+code from running by default — all existing code continues to work
+exactly as before. Think of it as a second pair of eyes that can catch
+common mistakes before they become confusing runtime errors.
 
 ```sh
-eu check file.eu              # type-check, report warnings
-eu check file.eu --strict     # treat type warnings as errors
-eu --type-check file.eu       # check then evaluate
+eu check file.eu              # check-only: report warnings, don't evaluate
+eu check file.eu --strict     # treat type warnings as errors (exit 1)
+eu file.eu --strict           # evaluate, but abort first if there are warnings
+eu file.eu --suppress-type-warnings  # evaluate, silencing warning output
 ```
 
-Type issues are reported as **warnings**, not errors. Your code runs
-regardless.
+Type issues are reported as **warnings**, not errors, and only abort
+evaluation when `--strict` is passed. `--type-check` is a deprecated
+no-op flag kept for backwards compatibility — type checking already
+runs whether or not it is passed.
 
 ---
 

--- a/docs/guide/working-with-data.md
+++ b/docs/guide/working-with-data.md
@@ -219,7 +219,7 @@ summary:
 eu sales=sales.csv -j -e '{
   total: sales map(.amount num) foldl(+, 0)
   count: sales count
-  regions: sales map(.region) unique
+  regions: sales map(.region) set.from-list set.to-list
 }'
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -302,16 +302,16 @@ sophisticated means of combining block data are available too.
 
 > **Note:** This merge is similar to the effect of *merge keys* in
 > YAML, where a special `<<` mapping key causes a similar merge to
-> occur. Not all YAML processors support this and nor does eucalypt at
-> present, but it probably will some day.
+> occur. Eucalypt's YAML importer supports merge keys too — see
+> [Import Formats](../reference/import-formats.md#merge-keys).
 
 Be aware that eucalypt has nothing like virtual functions. The
 functions in scope when an expression is created are the ones that are
 applied. So if you redefine an `f` like this, in an overriding
 block...
 
-```eu,notest
-{ f(x): x+1 a: f(2) } { f(x): x-2 }
+```eu
+{ f(x): x+1 a: f(2) } { f(x): x - 2 }
 ```
 
 ...the definition of `a` will not see it.
@@ -526,10 +526,10 @@ cargo install --path .
 eu --version
 ```
 
-...prints the version:
+...prints the version, e.g.:
 
 ```text
-eu 0.3.0
+eu - Eucalypt v0.12.1
 ```
 
 ...and...
@@ -554,20 +554,23 @@ Commands:
   list-targets  List targets defined in the source
   fmt           Format eucalypt source files
   lsp           Start the Language Server Protocol server
+  check         Check type annotations in eucalypt source files
+  doc           Extract documentation from eucalypt source files
   help          Print this message or the help of the given subcommand(s)
 
 Arguments:
   [FILES]...  Files to process (used when no subcommand specified)
 
 Options:
-  -L, --lib-path <LIB_PATH>                Add directory to lib path
-  -Q, --no-prelude                         Don't load the standard prelude
-  -d, --debug                              Turn on debug features
-  -S, --statistics                         Print metrics to stderr before exiting
-      --statistics-file <STATISTICS_FILE>  Write statistics as JSON to a file
-  -h, --help                               Print help
-  -V, --version                            Print version
+      --source-prelude  Force source-prelude pipeline even when pre-compiled blob is available
+  -h, --help            Print help
+  -V, --version         Print version
 ```
+
+Most of the options familiar from older versions (`-L`, `-Q`, `-d`,
+`-S`, `--statistics-file`, and many more) now live under the `run`
+subcommand — see `eu run --help` or the [CLI
+Reference](../reference/cli.md) for the full list.
 
 Use `eu <command> --help` for detailed help on each subcommand.
 
@@ -641,7 +644,7 @@ needed.
 **Problem:** Given a list of users in JSON, extract just their names.
 
 ```sh
-eu -e 'map(.name)' <<'JSON'
+eu u=- -e 'u map(.name)' <<'JSON'
 [
   {"name": "Alice", "role": "admin"},
   {"name": "Bob", "role": "user"},
@@ -669,9 +672,9 @@ threshold and format them.
 ```eu
 # products.eu
 products: [
-  { name: "Widget" price: 9.99 }
-  { name: "Gadget" price: 24.99 }
-  { name: "Gizmo" price: 49.99 }
+  { name: "Widget" price: 9.99 },
+  { name: "Gadget" price: 24.99 },
+  { name: "Gizmo" price: 49.99 },
   { name: "Doohickey" price: 4.99 }
 ]
 
@@ -894,12 +897,12 @@ while `deep-query("**.port", data)` matches at any depth.
 
 **Problem:** Extract timestamps and levels from log lines.
 
-```eu,notest
+```eu
 # logs.eu
 lines: [
-  "2024-03-15 10:30:00 ERROR Connection timeout"
-  "2024-03-15 10:30:05 INFO Retry attempt 1"
-  "2024-03-15 10:30:10 ERROR Connection timeout"
+  "2024-03-15 10:30:00 ERROR Connection timeout",
+  "2024-03-15 10:30:05 INFO Retry attempt 1",
+  "2024-03-15 10:30:10 ERROR Connection timeout",
   "2024-03-15 10:30:15 INFO Connected"
 ]
 
@@ -922,10 +925,10 @@ eu logs.eu -e errors
 **Output:**
 
 ```yaml
-- timestamp: '2024-03-15 10:30:00'
+- timestamp: "2024-03-15 10:30:00"
   level: ERROR
   message: Connection timeout
-- timestamp: '2024-03-15 10:30:10'
+- timestamp: "2024-03-15 10:30:10"
   level: ERROR
   message: Connection timeout
 ```
@@ -961,8 +964,8 @@ repetitive structure.
 ```eu
 # events.eu
 events: [
-  { name: "Launch" date: t"2024-01-15" }
-  { name: "Review" date: t"2024-06-01" }
+  { name: "Launch" date: t"2024-01-15" },
+  { name: "Review" date: t"2024-06-01" },
   { name: "Release" date: t"2024-09-30" }
 ]
 
@@ -1043,8 +1046,8 @@ overlaps.
 
 ```eu
 items: [
-  { name: "A" tags: ["fast", "reliable", "cheap"] }
-  { name: "B" tags: ["fast", "expensive"] }
+  { name: "A" tags: ["fast", "reliable", "cheap"] },
+  { name: "B" tags: ["fast", "expensive"] },
   { name: "C" tags: ["reliable", "cheap", "slow"] }
 ]
 
@@ -1630,8 +1633,8 @@ A more complete example:
 
 ```eu
 people: [
-  { name: "Alice" age: 30 }
-  { name: "Bob" age: 25 }
+  { name: "Alice" age: 30 },
+  { name: "Bob" age: 25 },
   { name: "Charlie" age: 35 }
 ]
 
@@ -2093,9 +2096,9 @@ Here is a more complete example combining multiple list operations:
 
 ```eu
 data: [
-  { name: "Alice" score: 85 }
-  { name: "Bob" score: 92 }
-  { name: "Charlie" score: 78 }
+  { name: "Alice" score: 85 },
+  { name: "Bob" score: 92 },
+  { name: "Charlie" score: 78 },
   { name: "Diana" score: 95 }
 ]
 
@@ -2274,15 +2277,22 @@ These use printf-style format codes:
 
 ```eu
 pi: 3.14159
+n: 42
 formatted: "{pi:%.2f}"
-padded: "{42:%06d}"
+padded: "{n:%06d}"
 ```
 
 ```yaml
 pi: 3.14159
+n: 42
 formatted: '3.14'
 padded: '000042'
 ```
+
+Bind the value to a name first, as above — a bare numeral inside the
+braces (e.g. `"{42:%06d}"`) is parsed as numbered string anaphora
+(`{0}`, `{1}`, ...), not a literal value, and silently produces an
+uncallable high-arity function instead of a formatted string.
 
 ## String Anaphora
 
@@ -2499,7 +2509,7 @@ endpoints:
 
 ```eu
 rows: [
-  { name: "Alice" score: 85 }
+  { name: "Alice" score: 85 },
   { name: "Bob" score: 92 }
 ]
 
@@ -2796,8 +2806,12 @@ result: 5 ops.double ops.negate
 ```
 
 ```yaml
+ops: {}
 result: -10
 ```
+
+(`ops` renders as `{}` because its members are functions, which are
+never rendered — only the block itself, being a property, appears.)
 
 ## Currying
 
@@ -3004,11 +3018,19 @@ eu -e 'flip(-, 1, 3)'
 
 `flip` is useful for adapting functions to a pipeline:
 
-```eu,notest
+```eu
 ` :suppress
-with-tags: merge flip ({ tags: [:a, :b] })
+with-tags: flip(merge)({ tags: [:a, :b] })
 
 result: { name: "foo" } with-tags
+```
+
+```yaml
+result:
+  name: foo
+  tags:
+    - a
+    - b
 ```
 
 ### `complement`
@@ -3163,8 +3185,13 @@ result: ∅ set.to-list
 ```
 
 ```yaml
+∅: []
 result: []
 ```
+
+Unlike prefix/postfix/binary operator declarations, a nullary
+declaration has no parameter list — structurally it is a property
+declaration, so (unlike a function) it *is* rendered in the output.
 
 The empty set `∅` is the only nullary operator in the standard prelude,
 but you can define your own:
@@ -3208,21 +3235,24 @@ The prelude defines the standard precedence levels:
 | Level | Name | Operators |
 |-------|------|-----------|
 | 95 | prefix | `↑` (head) |
-| 90 | lookup | `.` |
-| 88 | bool-unary | `!`, `¬` |
+| 90 | lookup | `.`, `~` (safe lookup) |
+| 88 | bool-unary | `!`, `¬` (prefix); `✓` (postfix not-null) |
+| 88 | -- | `∘`, `;` (composition) |
 | 85 | exp | `^`, `!!` (nth) |
 | 80 | prod | `*`, `/`, `÷`, `%` |
 | 75 | sum | `+`, `-` |
-| 60 | shift | (shift operators) |
-| 55 | bitwise | (bitwise operators) |
+| 60 | shift | (shift operators, reserved) |
+| 55 | bitwise | (bitwise operators, reserved) — `‖` (cons) also uses this numeric level |
 | 50 | cmp | `<`, `>`, `<=`, `>=` |
 | 45 | append | `++`, `<<` |
+| 42 | map | `<$>` (functor map) |
 | 40 | eq | `=`, `!=` |
 | 35 | bool-prod | `&&`, `∧` |
 | 30 | bool-sum | `\|\|`, `∨` |
 | 20 | cat | (catenation) |
+| 15 | clause | `=>`, `⇒` (cond clause builder) |
 | 10 | apply | `@` |
-| 5 | meta | `//`, `//=`, `//=>`, `//=?`, `//!` |
+| 5 | meta | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` |
 
 Higher numbers bind more tightly:
 
@@ -3275,21 +3305,23 @@ Associativity can be `:left`, `:right`, or omitted (defaults to
 
 Two special operators are provided for testing:
 
-### `//=` (assert equals)
+### `//=` (expect equals)
 
-Asserts that the left side equals the right side at runtime, and
-returns the value if true. Panics if false:
+Expects the left side to equal the right side at runtime, returning
+`true` on success. Panics if false (or, in `eu test` mode, returns
+`false` instead of panicking):
 
 ```eu
-result: 2 + 2 //= 4
+result: 2 + 2 //= 4   # result: true
 ```
 
 ### `//=>` (assert equals with metadata)
 
-Like `//=` but also attaches the assertion as metadata:
+Like `//=` but returns the asserted *value* (not a boolean) on
+success, and also attaches the assertion as metadata:
 
 ```eu
-checked: 2 + 2 //=> 4
+checked: 2 + 2 //=> 4   # checked: 4
 ```
 
 Both are useful for embedding tests and sanity checks in code.
@@ -4122,8 +4154,8 @@ Because `~` is a regular operator (left-associative, precedence
 
 ```eu
 people: [
-  { name: "Alice", email: "alice@example.com" }
-  { name: "Bob" }
+  { name: "Alice", email: "alice@example.com" },
+  { name: "Bob" },
   { name: "Charlie", email: "charlie@example.com" }
 ]
 
@@ -4241,8 +4273,8 @@ applied predicate — perfect for `filter` and `when`:
 
 ```eu
 servers: [
-  { host: "10.0.0.1", port: 8080 }
-  { name: "cache" }
+  { host: "10.0.0.1", port: 8080 },
+  { name: "cache" },
   { host: "10.0.0.2", port: 5432 }
 ]
 
@@ -4452,7 +4484,7 @@ the original positions.
 | Find by key at any depth | `deep-find` | `data deep-find(:host)` |
 | Get a value deep in a known structure | `view` + lens | `data view(‹:server :host›)` |
 | Modify a value deep in a structure | `over` + lens | `data over(‹:server :port›, + 1)` |
-| Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.upper)` |
+| Transform all elements | `over` + `each` | `items over(each ∘ at(:name), str.to-upper)` |
 | Collect values from all elements | `to-list-of` + `each` | `items to-list-of(each ∘ at(:name))` |
 | Sort/reverse/replace all foci | `parts-of` + traversal | `items over(parts-of(each ∘ at(:score)), sort-nums)` |
 
@@ -5305,7 +5337,7 @@ summary:
 eu sales=sales.csv -j -e '{
   total: sales map(.amount num) foldl(+, 0)
   count: sales count
-  regions: sales map(.region) unique
+  regions: sales map(.region) set.from-list set.to-list
 }'
 ```
 
@@ -5377,6 +5409,8 @@ eu file.eu          # same as: eu run file.eu
 | `list-targets` | List export targets |
 | `fmt` | Format source files |
 | `lsp` | Start the Language Server Protocol server |
+| `check` | Check type annotations without evaluating |
+| `doc` | Extract documentation from source |
 
 ## Inputs
 
@@ -5577,6 +5611,21 @@ reproducible output:
 eu --seed 42 template.eu
 ```
 
+## IO Permission
+
+Programs that use the IO monad (`io.shell`, `io.exec`, and friends)
+must be run with `-I`/`--allow-io`, or evaluation fails with a
+permission error before any shell command runs:
+
+```sh
+eu -I deploy.eu
+eu --allow-io deploy.eu
+```
+
+This is a safety gate — code that shells out is not allowed to run
+by accident. See [IO and Shell Commands](io.md) for the full IO
+monad guide.
+
 ## The Formatter
 
 Format eucalypt source files:
@@ -5659,6 +5708,103 @@ Provides syntax error diagnostics and formatting support.
 - `--` passes arguments available via `io.args`
 - `eu fmt` formats source files; `eu test` runs tests; `eu lsp`
   starts the language server
+
+---
+
+# Language Server Protocol (LSP) Support
+
+Eucalypt includes a built-in LSP server for editor integration.
+Start it with `eu lsp`.
+
+## Editor Setup
+
+### Emacs (eglot)
+
+Add to your eucalypt-mode configuration:
+
+```elisp
+(add-to-list 'eglot-server-programs '(eucalypt-mode "eu" "lsp"))
+```
+
+### VS Code
+
+Install the eucalypt VS Code extension, which configures the
+language server automatically.
+
+## Features
+
+### Diagnostics
+
+- Parse errors appear as you type
+- Type warnings from `eu check` appear after a short debounce
+  (300ms after the last keystroke)
+- Pipeline errors (e.g. invalid monad spec) surface as warnings
+  with source locations
+
+### Hover
+
+- Declaration names show documentation and type annotations
+- Prelude functions show their type signatures
+- Monad tags (`:for`, `:io`) show monad description and binding
+  type
+- Bracket pair delimiters show pair name, mode, and documentation
+
+### Completion
+
+- Names from the current file, prelude, and imported files
+- Monad tag completion after `{ :`
+- Dotted access completion (e.g. `str.` offers string functions)
+
+### Go-to-definition
+
+- Jump to declaration in the current file
+- Jump into imported files
+- Jump to prelude source (via temp file)
+- Jump to bracket pair definitions from bracket delimiters
+
+### Inlay Hints
+
+- Monadic block binding types (e.g. `x: number` for
+  `{ :for x: [1,2,3] }`)
+- Operator fixity on operator declarations
+- Parameter names at multi-argument call sites
+
+### Code Actions
+
+- **Wrap as namespace** — wrap a single declaration's value into
+  a block, or wrap multiple selected declarations into a new
+  namespace with reference prefixing
+- **Promote metadata** — expand shortcut form to block
+  (e.g. `` ` "doc" `` → `` ` { doc: "doc" } ``)
+- **Demote metadata** — collapse single-field block to shortcut
+- **Add metadata field** — add type, doc, target, export, monad,
+  format, or type-def metadata
+- **Let-block toggle** — convert between `{ x: 1 }` and
+  `{ :let x: 1 }`
+- **Qualify name** — suggest `str.split` for unresolved `split`
+
+### Other
+
+- Document symbols (outline)
+- Folding ranges
+- Semantic tokens (syntax highlighting)
+- Document highlight (matching bracket pairs)
+- Find references
+- Rename symbol
+- Selection range
+- Formatting
+
+## Architecture
+
+The LSP server uses a two-tier architecture:
+
+1. **AST-level** (immediate): parse errors, completion, hover,
+   semantic tokens — works on every keystroke, even on broken
+   input
+2. **Pipeline-level** (debounced): type checking, import
+   resolution, monadic binding types — runs the full
+   desugarer/type checker pipeline after 300ms of no changes,
+   with green node comparison to skip unchanged documents
 
 ---
 
@@ -5890,8 +6036,8 @@ values:
 # Parse from a string
 d: cal.parse("2024-03-15T14:30:00Z")
 
-# Format to a custom string
-label: t"2024-03-15" cal.format("%Y-%m-%d")  # "2024-03-15"
+# Format as ISO8601 (cal.format takes no format-string argument)
+label: t"2024-03-15" cal.format  # "2024-03-15T00:00:00+00:00"
 ```
 
 ### Date-Time Arithmetic
@@ -6185,9 +6331,14 @@ The pipeline style reads naturally: the command string flows into
 the first action:
 
 ```eu,notest
-io.bind(io.shell("echo hello"),
-  _(r): io.shell("echo got: {r.stdout}"))
+say(r): io.shell("echo got: {r.stdout}")
+
+io.bind(io.shell("echo hello"), say)
 ```
+
+(Eucalypt has no anonymous-lambda syntax — `_(r): expr` is
+declaration syntax, not a function value; the continuation must be a
+named function or a partially-applied one.)
 
 The `{ :io ... }` block is almost always preferable to explicit
 `io.bind` calls.
@@ -6347,7 +6498,8 @@ The most common form tags the block with `:io`:
 }.(r.stdout)
 ```
 
-This desugars to:
+This desugars to (pseudocode — `λ` is not real eucalypt syntax;
+eucalypt has no lambda expressions):
 
 ```eu,notest
 io.bind(io.shell("echo hello"),
@@ -6849,8 +7001,8 @@ same problem that `{ :random ... }` solves for PRNG streams.
 
 ```eu
 s0: { count: 0, name: "init" }
-s1: s0 merge({count: 1})
-s2: s1 merge({name: "updated"})
+s1: merge(s0, {count: 1})
+s2: merge(s1, {name: "updated"})
 ```
 
 ```yaml
@@ -7043,19 +7195,23 @@ declarations through `state.bind` / `state.return` automatically.
 
 # Type Checking
 
-Eucalypt includes an optional, advisory type checker. It never prevents
-your code from running — all existing code continues to work exactly as
-before. Think of it as a second pair of eyes that can catch common
-mistakes before they become confusing runtime errors.
+Eucalypt includes an advisory type checker that runs **unconditionally**
+on every `eu` invocation (evaluate, dump, test). It never prevents your
+code from running by default — all existing code continues to work
+exactly as before. Think of it as a second pair of eyes that can catch
+common mistakes before they become confusing runtime errors.
 
 ```sh
-eu check file.eu              # type-check, report warnings
-eu check file.eu --strict     # treat type warnings as errors
-eu --type-check file.eu       # check then evaluate
+eu check file.eu              # check-only: report warnings, don't evaluate
+eu check file.eu --strict     # treat type warnings as errors (exit 1)
+eu file.eu --strict           # evaluate, but abort first if there are warnings
+eu file.eu --suppress-type-warnings  # evaluate, silencing warning output
 ```
 
-Type issues are reported as **warnings**, not errors. Your code runs
-regardless.
+Type issues are reported as **warnings**, not errors, and only abort
+evaluation when `--strict` is passed. `--type-check` is a deprecated
+no-op flag kept for backwards compatibility — type checking already
+runs whether or not it is passed.
 
 ---
 
@@ -8452,8 +8608,8 @@ Group list elements by a key function:
 
 ```eu
 items: [
-  { type: "fruit" name: "apple" }
-  { type: "veg" name: "carrot" }
+  { type: "fruit" name: "apple" },
+  { type: "veg" name: "carrot" },
   { type: "fruit" name: "banana" }
 ]
 
@@ -9296,6 +9452,52 @@ But:
 - they cannot be accessed by lookup, so there is no way of forming a
   qualified name to access an operator
 - they cannot be overridden by generalised lookup
+
+## Operator Precedence Table
+
+Operator precedence determines how operator expressions are parsed
+when parentheses are omitted — higher numbers bind more tightly. This
+table is verified against `named_precedence` in
+`src/core/metadata.rs` and the operator declarations in
+`lib/prelude.eu`:
+
+| Prec | Name | Assoc | Operators | Description |
+|------|------|-------|-----------|-------------|
+| 95 | -- | prefix | `↑` | Head (tight prefix) |
+| 90 | lookup | left | `.` (built-in) | Property lookup |
+| 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
+| 90 | call | left | (built-in) | Function call |
+| 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
+| 88 | -- | -- | `∘`, `;` | Composition |
+| 85 | exp | right | `^` | Power |
+| 85 | exp | -- | `!!` (nth) | Indexing |
+| 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
+| 75 | sum | left | `+`, `-` | Addition, subtraction |
+| 60 | shift | -- | (shift ops) | Reserved |
+| 55 | bitwise | -- | (bitwise ops) | Reserved — `‖` (cons) also uses this numeric level, `precedence: 55` in `lib/prelude.eu` |
+| 50 | cmp | left | `<`, `>`, `<=`, `>=` | Comparison |
+| 45 | append | left | `++` | List concatenation |
+| 45 | append | left | `<<` | Deep merge |
+| 42 | map | left | `<$>` | Functor map |
+| 40 | eq | left | `=`, `!=` | Equality |
+| 35 | bool-prod | left | `&&`, `∧` | Logical AND |
+| 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
+| 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
+| 15 | clause | left | `=>`, `⇒` | Cond clause builder (`condition => result`) |
+| 10 | apply | left | `@` | Function application |
+| 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
+
+**User-defined operators** default to left-associative, precedence 50.
+Set custom values via metadata:
+
+```eu,notest
+` { associates: :right precedence: :sum }
+(x +++ y): x + y
+```
+
+See [Agent Reference §2](agent-reference.md) for the full named-level
+list and more examples.
 
 ---
 
@@ -10415,9 +10617,12 @@ using the `-x` command line option:
 ```sh
 eu -x json # for JSON
 eu -x text # for plain text
+eu -x html # for HTML
 ```
 
-JSON is such a common case that there is a shortcut: `-j`.
+JSON is such a common case that there is a shortcut: `-j`. See
+[Export Formats](export-formats.md) for the complete list (yaml, json,
+toml, edn, text, html, eu).
 
 ### Output targets
 
@@ -10604,14 +10809,19 @@ eu --error-format human file.eu     # default human-readable (explicit)
 
 ### Type Checking
 
-Run the type checker before evaluation with `--type-check`. Type warnings
-are reported to stderr but do not abort evaluation unless `--strict` is also
-passed:
+The type checker runs unconditionally on every `eu` invocation. Type
+warnings are reported to stderr but do not abort evaluation unless
+`--strict` is also passed:
 
 ```sh
-eu --type-check file.eu             # warn on type issues, then evaluate
-eu --type-check --strict file.eu    # abort on first type warning
+eu file.eu                          # warn on type issues, then evaluate
+eu file.eu --strict                 # abort before evaluation on first type warning
+eu file.eu --suppress-type-warnings # evaluate, silencing warning output (checker still runs)
 ```
+
+`--type-check` is a deprecated no-op flag (kept for backwards
+compatibility) — type checking already runs whether or not it is
+passed.
 
 For checking without evaluating, use the `check` subcommand (see below).
 
@@ -11122,6 +11332,7 @@ Eucalypt can export to the following formats:
 | TOML | `-x toml` | TOML output |
 | EDN | `-x edn` | EDN output |
 | Text | `-x text` | Plain text output |
+| HTML | `-x html` | HTML output |
 | Eucalypt | `-x eu` | Eucalypt-syntax output; preserves symbols as `:name` |
 
 The output format can also be inferred from the output file extension
@@ -13336,6 +13547,18 @@ Validates transformed expressions before STG compilation:
 
 Eucalypt uses a Spineless Tagless G-machine (STG) as its evaluation model, providing lazy evaluation with memoisation.
 
+> **Note on execution engines**: the sections below describe the STG
+> tree-walk machine (`src/eval/machine/vm.rs`), historically the only
+> engine and still the differential-testing/performance baseline
+> (select it with `EU_HEAPSYN=1`). Since 0.12.0 the **default** engine
+> instead compiles the same STG syntax to a bytecode program and runs
+> it on a separate bytecode VM (`src/eval/bytecode/`: `opcode.rs`,
+> `program.rs`, `machine.rs`, `closure.rs`, `cont.rs`, `env_builder.rs`,
+> `encode.rs`). `EU_BYTECODE=1` is a redundant no-op now that bytecode
+> is the default. A full description of the bytecode engine's design
+> is a tracked documentation gap — see `docs/superpowers/specs/` for
+> the implementation-level design documents in the meantime.
+
 ### STG Syntax
 
 *Implementation*: `src/eval/stg/syntax.rs`
@@ -13751,12 +13974,11 @@ The prelude is:
 
 ## Further Reading
 
-- `implementation.md` - Brief implementation overview
-- `gc-implementation.md` - Detailed GC documentation
-- `command-line.md` - CLI usage guide
-- `syntax.md` - Language syntax reference
-- `operators-and-identifiers.md` - Operator definitions
-- `anaphora-and-lambdas.md` - Implicit parameter handling
+- [`development/gc-implementation.md`](development/gc-implementation.md) - Detailed GC documentation
+- [`guide/command-line.md`](guide/command-line.md) - CLI usage guide
+- [`reference/syntax.md`](reference/syntax.md) - Language syntax reference
+- [`reference/operators-and-identifiers.md`](reference/operators-and-identifiers.md) - Operator definitions
+- [`guide/anaphora.md`](guide/anaphora.md) - Implicit parameter handling
 
 ---
 
@@ -14914,9 +15136,10 @@ eu -Q file.eu               # Suppress prelude
 eu fmt file.eu              # Format source
 eu dump stg file.eu         # Dump STG syntax
 eu -- arg1 arg2             # Pass arguments (io.args)
-eu check file.eu            # Type-check, report warnings
+eu check file.eu            # Type-check only, report warnings
 eu check --strict file.eu   # Treat type warnings as errors
-eu --type-check file.eu     # Check then evaluate
+eu file.eu --strict         # Evaluate, abort first if type warnings
+eu file.eu --suppress-type-warnings  # Evaluate, silence warnings
 eu doc file.eu              # Extract documentation (Markdown)
 eu doc --format json file.eu # Extract as JSON Schema
 eu doc --check file.eu      # Report documentation coverage

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -29,30 +29,37 @@ evaluation and purely functional semantics.
 - [Operators](https://curvelogic.github.io/eucalypt/guide/operators.html): Custom binary/prefix/postfix operators, precedence, associativity, assertion operators, metadata operator, deep merge, and functor map
 - [Anaphora (Implicit Parameters)](https://curvelogic.github.io/eucalypt/guide/anaphora.html): Expression anaphora, block anaphora, string anaphora, generalised lookup, sections, and pseudo-lambdas
 - [Block Manipulation](https://curvelogic.github.io/eucalypt/guide/block-manipulation.html): Block merge, deep merge, inspecting blocks, reconstructing blocks, transforming blocks, and modifying nested values
+- [Navigating Nested Data](https://curvelogic.github.io/eucalypt/guide/navigating-nested-data.html): Safe key access with `~`, shape checks with `match?`, and lenses/traversals for deep get/set operations
+- [Lenses](https://curvelogic.github.io/eucalypt/guide/lenses.html): What a lens and a traversal are, `view`/`over`/`to-list-of`/`parts-of`, and composing optics with `∘` and `‹›`
 - [Imports and Modules](https://curvelogic.github.io/eucalypt/guide/imports-and-modules.html): Basic imports, scoped imports, named imports, data file imports, git imports, and streaming imports
 - [Working with Data](https://curvelogic.github.io/eucalypt/guide/working-with-data.html): Processing JSON/YAML/TOML/CSV/XML, named inputs, combining sources, evaluands, collecting inputs, and output formats
 - [The Command Line](https://curvelogic.github.io/eucalypt/guide/command-line.html): Command structure, subcommands, inputs/outputs, evaluands, targets, arguments, environment variables, formatter, and debugging
+- [Language Server Protocol](https://curvelogic.github.io/eucalypt/guide/lsp.html): Editor setup, diagnostics, hover, completion, go-to-definition, inlay hints, and code actions provided by `eu lsp`
 - [YAML Embedding](https://curvelogic.github.io/eucalypt/guide/yaml-embedding.html): The eu, eu::suppress, and eu::fn YAML tags for embedding eucalypt expressions in YAML files
 - [Testing with Eucalypt](https://curvelogic.github.io/eucalypt/guide/testing.html): Built-in test runner, simple tests, test files, test formats, and custom validators
 - [Date, Time, and Random Numbers](https://curvelogic.github.io/eucalypt/guide/date-time-random.html): ZDT literals, parsing/formatting dates, date arithmetic, the random stream, and random generation functions
+- [IO and Shell Commands](https://curvelogic.github.io/eucalypt/guide/io.html): The IO monad, `io.shell`/`io.exec`, `{ :io ... }` blocks, and the `--allow-io` safety gate
+- [Monads and the monad() Utility](https://curvelogic.github.io/eucalypt/guide/monads.html): Built-in `io`/`random` monads, monadic blocks and bracket pairs, and building custom monads with `monad()`
+- [The State Monad](https://curvelogic.github.io/eucalypt/guide/state-monad.html): Threading block-valued state through a sequence of operations with the optional `state.eu` library
+- [Type Checking](https://curvelogic.github.io/eucalypt/guide/type-checking.html): The always-on gradual type checker, annotation syntax, `eu check`, `--strict`, and what it does and doesn't catch
 - [Advanced Topics](https://curvelogic.github.io/eucalypt/guide/advanced-topics.html): Metadata system, sets, deep find/query with wildcards, type predicates, sorting, grouping, format specifiers, and version assertions
 
 ## Reference
 
 - [Language Syntax Reference](https://curvelogic.github.io/eucalypt/reference/syntax.html): Complete syntax reference for the block DSL and expression DSL, including primitives, declarations, operators, and anaphora
-- [Operator Precedence Table](https://curvelogic.github.io/eucalypt/reference/operators-and-identifiers.html): Normal and operator identifiers, scope rules, single-quote identifiers, and prefix operators
-- [Prelude Reference](https://curvelogic.github.io/eucalypt/reference/prelude/index.html): Index of all 218 prelude functions across 11 categories
-- [Lists](https://curvelogic.github.io/eucalypt/reference/prelude/lists.html): 64 list functions including construction, transformation, combining, splitting, folding, predicates, and sorting
-- [Blocks](https://curvelogic.github.io/eucalypt/reference/prelude/blocks.html): 52 block functions including construction, merging, lookup, transformation, alteration, and deep find/query
-- [Strings](https://curvelogic.github.io/eucalypt/reference/prelude/strings.html): 26 string functions including splitting, joining, regex, case conversion, base64, and SHA-256
-- [Numbers and Arithmetic](https://curvelogic.github.io/eucalypt/reference/prelude/numbers.html): 14 numeric functions including inc/dec, predicates, parsing, rounding, and min/max
-- [Booleans and Comparison](https://curvelogic.github.io/eucalypt/reference/prelude/booleans.html): 13 entries including true/false/null, if/then/when, panic/assert, and boolean logic operators
-- [Combinators](https://curvelogic.github.io/eucalypt/reference/prelude/combinators.html): 12 combinators including identity, const, compose, flip, apply, curry, uncurry, and cond
-- [Calendar](https://curvelogic.github.io/eucalypt/reference/prelude/calendar.html): 5 date-time functions for creating, parsing, formatting, and decomposing ZDT values
-- [Sets](https://curvelogic.github.io/eucalypt/reference/prelude/sets.html): 11 set operations including from-list, to-list, add, remove, contains, union, intersect, and diff
-- [Random Numbers](https://curvelogic.github.io/eucalypt/reference/prelude/random.html): monadic random namespace with stream, int, float, choice, shuffle, sample, and derived combinators
-- [Metadata](https://curvelogic.github.io/eucalypt/reference/prelude/metadata.html): 7 metadata functions including with-meta, meta, merge-meta, validator, check, and checked
-- [IO](https://curvelogic.github.io/eucalypt/reference/prelude/io.html): 9 IO bindings including io.env, io.args, io.random, eu.build, and eu.requires
+- [Operators and Identifiers](https://curvelogic.github.io/eucalypt/reference/operators-and-identifiers.html): Normal and operator identifiers, scope rules, single-quote identifiers, and prefix operators
+- [Prelude Reference](https://curvelogic.github.io/eucalypt/reference/prelude/index.html): Index of all 370 prelude functions across 11 categories
+- [Lists](https://curvelogic.github.io/eucalypt/reference/prelude/lists.html): 91 list functions including construction, transformation, combining, splitting, folding, predicates, and sorting
+- [Blocks](https://curvelogic.github.io/eucalypt/reference/prelude/blocks.html): 66 block functions including construction, merging, lookup, transformation, alteration, and deep find/query
+- [Strings](https://curvelogic.github.io/eucalypt/reference/prelude/strings.html): 36 string functions including splitting, joining, regex, case conversion, base64, and SHA-256
+- [Numbers and Arithmetic](https://curvelogic.github.io/eucalypt/reference/prelude/numbers.html): 30 numeric functions including inc/dec, predicates, parsing, rounding, and min/max
+- [Booleans and Comparison](https://curvelogic.github.io/eucalypt/reference/prelude/booleans.html): 12 entries including true/false/null, if/then/when, panic/assert, and boolean logic operators
+- [Combinators](https://curvelogic.github.io/eucalypt/reference/prelude/combinators.html): 14 combinators including identity, const, compose, flip, apply, curry, uncurry, and cond
+- [Calendar](https://curvelogic.github.io/eucalypt/reference/prelude/calendar.html): 8 date-time functions for creating, parsing, formatting, and decomposing ZDT values
+- [Sets](https://curvelogic.github.io/eucalypt/reference/prelude/sets.html): 14 set operations including from-list, to-list, add, remove, contains, union, intersect, and diff
+- [Random Numbers](https://curvelogic.github.io/eucalypt/reference/prelude/random.html): 15 entries in the monadic random namespace — stream, int, float, choice, shuffle, sample, and derived combinators
+- [Metadata](https://curvelogic.github.io/eucalypt/reference/prelude/metadata.html): 4 metadata functions — with-meta, meta, raw-meta, and merge-meta
+- [IO](https://curvelogic.github.io/eucalypt/reference/prelude/io.html): 80 IO bindings including io.env, io.args, io.random, eu.build, and eu.requires
 - [CLI Reference](https://curvelogic.github.io/eucalypt/reference/cli.html): Complete command line reference including subcommands, inputs, outputs, evaluands, targets, formatting, LSP, and debugging
 - [Import Formats](https://curvelogic.github.io/eucalypt/reference/import-formats.html): Import scopes, simple and git imports, YAML features (anchors, merge keys, timestamps), and streaming imports
 - [Export Formats](https://curvelogic.github.io/eucalypt/reference/export-formats.html): Supported export formats (YAML, JSON, TOML, EDN, text) and output options

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -296,9 +296,12 @@ using the `-x` command line option:
 ```sh
 eu -x json # for JSON
 eu -x text # for plain text
+eu -x html # for HTML
 ```
 
-JSON is such a common case that there is a shortcut: `-j`.
+JSON is such a common case that there is a shortcut: `-j`. See
+[Export Formats](export-formats.md) for the complete list (yaml, json,
+toml, edn, text, html, eu).
 
 ### Output targets
 
@@ -485,14 +488,19 @@ eu --error-format human file.eu     # default human-readable (explicit)
 
 ### Type Checking
 
-Run the type checker before evaluation with `--type-check`. Type warnings
-are reported to stderr but do not abort evaluation unless `--strict` is also
-passed:
+The type checker runs unconditionally on every `eu` invocation. Type
+warnings are reported to stderr but do not abort evaluation unless
+`--strict` is also passed:
 
 ```sh
-eu --type-check file.eu             # warn on type issues, then evaluate
-eu --type-check --strict file.eu    # abort on first type warning
+eu file.eu                          # warn on type issues, then evaluate
+eu file.eu --strict                 # abort before evaluation on first type warning
+eu file.eu --suppress-type-warnings # evaluate, silencing warning output (checker still runs)
 ```
+
+`--type-check` is a deprecated no-op flag (kept for backwards
+compatibility) — type checking already runs whether or not it is
+passed.
 
 For checking without evaluating, use the `check` subcommand (see below).
 

--- a/docs/reference/export-formats.md
+++ b/docs/reference/export-formats.md
@@ -11,6 +11,7 @@ Eucalypt can export to the following formats:
 | TOML | `-x toml` | TOML output |
 | EDN | `-x edn` | EDN output |
 | Text | `-x text` | Plain text output |
+| HTML | `-x html` | HTML output |
 | Eucalypt | `-x eu` | Eucalypt-syntax output; preserves symbols as `:name` |
 
 The output format can also be inferred from the output file extension

--- a/docs/reference/operators-and-identifiers.md
+++ b/docs/reference/operators-and-identifiers.md
@@ -133,3 +133,49 @@ But:
 - they cannot be accessed by lookup, so there is no way of forming a
   qualified name to access an operator
 - they cannot be overridden by generalised lookup
+
+## Operator Precedence Table
+
+Operator precedence determines how operator expressions are parsed
+when parentheses are omitted — higher numbers bind more tightly. This
+table is verified against `named_precedence` in
+`src/core/metadata.rs` and the operator declarations in
+`lib/prelude.eu`:
+
+| Prec | Name | Assoc | Operators | Description |
+|------|------|-------|-----------|-------------|
+| 95 | -- | prefix | `↑` | Head (tight prefix) |
+| 90 | lookup | left | `.` (built-in) | Property lookup |
+| 90 | lookup | left | `~` | Safe key lookup (null-propagating) |
+| 90 | call | left | (built-in) | Function call |
+| 88 | bool-unary | prefix | `!`, `¬` | Boolean negation |
+| 88 | bool-unary | postfix | `✓` | Not-null check (true if not null) |
+| 88 | -- | -- | `∘`, `;` | Composition |
+| 85 | exp | right | `^` | Power |
+| 85 | exp | -- | `!!` (nth) | Indexing |
+| 80 | prod | left | `*`, `/`, `÷`, `%` | Multiplication, floor division, precise division, floor modulo |
+| 75 | sum | left | `+`, `-` | Addition, subtraction |
+| 60 | shift | -- | (shift ops) | Reserved |
+| 55 | bitwise | -- | (bitwise ops) | Reserved — `‖` (cons) also uses this numeric level, `precedence: 55` in `lib/prelude.eu` |
+| 50 | cmp | left | `<`, `>`, `<=`, `>=` | Comparison |
+| 45 | append | left | `++` | List concatenation |
+| 45 | append | left | `<<` | Deep merge |
+| 42 | map | left | `<$>` | Functor map |
+| 40 | eq | left | `=`, `!=` | Equality |
+| 35 | bool-prod | left | `&&`, `∧` | Logical AND |
+| 30 | bool-sum | left | `\|\|`, `∨` | Logical OR |
+| 20 | cat | left | *(catenation)* | Juxtaposition / pipeline |
+| 15 | clause | left | `=>`, `⇒` | Cond clause builder (`condition => result`) |
+| 10 | apply | left | `@` | Function application |
+| 5 | meta | left | `//`, `//<<`, `//=`, `//=>`, `//=?`, `//=?>`, `//!` | Metadata and assertions |
+
+**User-defined operators** default to left-associative, precedence 50.
+Set custom values via metadata:
+
+```eu,notest
+` { associates: :right precedence: :sum }
+(x +++ y): x + y
+```
+
+See [Agent Reference §2](agent-reference.md) for the full named-level
+list and more examples.

--- a/docs/superpowers/reports/2026-07-13-docs-review.md
+++ b/docs/superpowers/reports/2026-07-13-docs-review.md
@@ -1,0 +1,436 @@
+# 0.13 Documentation Review — Phase 1 Audit Report
+
+**Bead**: eu-2sa6.15 (absorbs eu-lyu9, eu-p7tk, eu-1n5z)
+**Date**: 2026-07-13
+**Scope**: everything under `docs/`, `README.md`, and the generated
+artefacts (`docs/llms.txt`, `docs/llms-full.txt`, `docs/reference/prelude/`).
+**Method**: every file was read; every runnable `eu`/`sh` example was
+executed against a freshly built `eu 0.12.1` release binary
+(`cargo build --release`, prelude blob compiled via
+`cargo xtask prelude-compile`) and compared against its documented
+output. `docs/reference/prelude/` was regenerated with `eu doc
+--output-dir` and diffed against the committed files.
+`docs/llms-full.txt` was regenerated with
+`scripts/generate-llms-full.sh` and diffed. A repo-wide Python script
+checked every `[text](path)` internal markdown link resolves. The
+existing `scripts/test-doc-examples.py` harness (exit-code-only,
+CI-run) was also executed for completeness.
+
+This report is Deliverable 1 (audit). Deliverable 2 (the mechanical-fix
+PR) is on the same branch, `docs/full-review-phase1`, off `master`.
+
+---
+
+## Headline numbers
+
+- **31 confirmed factual/example errors** fixed in the mechanical-fix PR
+  (see §3), across 24 documentation files, plus 6 harness test files
+  and `CHANGELOG.md` (the eu-1n5z reflect-import idiom cleanup).
+- **`docs/reference/prelude/*.md`**: **no drift** — byte-identical to a
+  fresh `eu doc --output-dir` regeneration. eu-p7tk's premise ("badly
+  stale") does not hold for the prelude reference pages specifically.
+- **`docs/llms-full.txt`**: was **also already byte-identical** to a
+  fresh regeneration *before* this review's other edits landed (so
+  eu-p7tk's specific complaint about `llms-full.txt` itself appears to
+  have been resolved by an earlier commit, `22390547`). It has now been
+  regenerated again to absorb this review's ~30 content fixes across
+  the source docs it concatenates.
+- **`docs/llms.txt`** (hand-maintained, no generator) was genuinely
+  stale: prelude counts were off by 40–70% per category (218 claimed
+  vs. 370 actual total), and 6 of 20 guide chapters were missing from
+  its index entirely. Fixed.
+- **eu-lyu9** (idiot brackets / lens coverage): **substantially already
+  resolved** by prior work — see §5.
+- **eu-1n5z** (reflect.eu import idiom): was **not** resolved — fixed
+  in this PR (6 harness files + CHANGELOG.md), harness re-verified
+  green.
+- **#1 remaining gap, unambiguously**: `docs/architecture.md` describes
+  only the legacy HeapSyn tree-walk VM and has zero mention of the
+  bytecode engine (BV1) that has been the *default* since 0.12.0. A
+  light pointer/note was added as a mechanical fix (§3); a full
+  rewrite of the "STG Compilation and Evaluation Model" section is
+  phase-2 work (§6, ranked #1).
+
+---
+
+## 1. Per-file verdict
+
+Legend: **accurate** (no issues found) / **stale** (correct-at-the-time
+content now contradicts current behaviour) / **gap** (missing content,
+nothing wrong with what's there) / **broken-example** (a code sample
+errors or produces output that doesn't match what's claimed) /
+**fixed** (was one of the above, corrected in this PR's mechanical-fix
+commit).
+
+### Getting Started (`welcome/`)
+
+| File | Verdict | Notes |
+|---|---|---|
+| `welcome/index.md` | fixed | hyphenated-identifier example bug (`x-2` parsed as one identifier, not `x - 2`); stale YAML-merge-keys disclaimer ("eucalypt doesn't support this... yet") — it does, since the CSV/YAML import work. |
+| `welcome/what-is-eucalypt.md` | accurate | |
+| `welcome/quick-start.md` | fixed | frozen `eu --version`/`eu --help` transcripts were badly stale (`eu 0.3.0`; missing `check`/`doc` subcommands; listed global options that have moved under `eu run --help`). Regenerated against the current binary. |
+| `welcome/by-example.md` | fixed | 4 examples had missing commas in multi-line list literals (§3.1), silently producing 1-element merged blocks instead of the claimed N-element lists; example 2's `eu -e 'map(.name)' <<JSON` doesn't bind stdin the way shown, fixed to `eu u=- -e 'u map(.name)'`. |
+
+### The Eucalypt Guide (`guide/`)
+
+| File | Verdict | Notes |
+|---|---|---|
+| `blocks-and-declarations.md` | accurate | |
+| `expressions-and-pipelines.md` | fixed | missing-comma list bug (§3.1). |
+| `lists-and-transformations.md` | fixed | missing-comma list bug (§3.1). |
+| `string-interpolation.md` | fixed | missing-comma list bug; `"{42:%06d}"` collided with numbered string anaphora (bare numeral inside braces is an anaphor index, not a literal) — bound to a name instead. |
+| `functions-and-combinators.md` | fixed | `flip` pipeline-adaptation example was unparseable (`merge flip ({...})`); corrected to `flip(merge)({...})`. `ops: {...}` example's expected output omitted the (correctly rendered) empty `ops: {}` line. |
+| `operators.md` | fixed | `//=` was documented as "returns the value if true" — it returns `true` (a bool); `//=>` is the one that returns the value. Nullary-operator example's expected output omitted the rendered `∅: []` line (nullary declarations have no params, so — unlike functions — they *are* rendered). Precedence table was missing `~`, `✓`, `∘`/`;`, `<$>`, `=>`/`⇒`. |
+| `anaphora.md` | accurate | |
+| `block-manipulation.md` | accurate | |
+| `navigating-nested-data.md` | fixed | 2× missing-comma list bug; `str.upper` doesn't exist (`str.to-upper`). |
+| `lenses.md` | accurate | every example executed and matched; good eu-lyu9 coverage (§5). |
+| `imports-and-modules.md` | accurate | |
+| `working-with-data.md` | fixed | `unique` doesn't exist in the prelude — replaced with `set.from-list set.to-list`. |
+| `command-line.md` | fixed | subcommand table was missing `check` and `doc`; zero mention anywhere of `-I`/`--allow-io`, the mandatory safety gate for all IO operations — added a new "IO Permission" section. |
+| `yaml-embedding.md` | accurate (not independently re-executed against the YAML-tag pipeline — flagged, not a known issue) | |
+| `testing.md` | accurate (not independently re-executed — flagged, not a known issue) | |
+| `date-time-random.md` | fixed | `cal.format("%Y-%m-%d")` doesn't exist — `cal.format` takes no format-string argument, always ISO8601 (`lib/prelude.eu:1882-1883`). |
+| `io.md` | fixed | `_(r): io.shell(...)` inline-lambda example doesn't parse (eucalypt has no lambda syntax) — replaced with a named function. |
+| `monads.md` | fixed | added a one-line caveat that the `λr. ...` desugaring pseudocode isn't real eucalypt syntax (it directly contradicts the "no lambda syntax" rule with no disclaimer). |
+| `state-monad.md` | fixed | the chapter's own opening/motivating example (`s0 merge({count: 1})`) silently no-ops due to the catenation-puts-receiver-last rule — `merge(a,b)` has `b` win, but catenation makes `s0` the *last* (winning) arg, backwards from intent. Fixed to direct-call form `merge(s0, {count: 1})`. |
+| `type-checking.md` | fixed | opened with "Eucalypt includes an **optional**, advisory type checker" and showed `eu --type-check file.eu # check then evaluate` as the way to enable it. Both wrong: type checking is unconditional since 0.11, and `--type-check` is a deprecated no-op. Rewrote the intro and command trio. |
+| `advanced-topics.md` | fixed | `group-by` example had the missing-comma list bug. |
+
+### Reference (`reference/`)
+
+| File | Verdict | Notes |
+|---|---|---|
+| `syntax.md` | accurate | |
+| `operators-and-identifiers.md` | fixed | **structural gap**: `SUMMARY.md` titles this page "Operator Precedence Table" but the file contained no such table (it's entirely about identifier syntax/shadowing). Added the full verified precedence table (reusing already fact-checked content from `agent-reference.md` §2, not new research). |
+| `cli.md` | fixed | "Type Checking" section claimed `--type-check` is required to run the checker — wrong, same issue as the guide chapter; rewrote. `--suppress-type-warnings` flag was completely undocumented — added. `-x html` export format was undocumented in the Outputs section — added, with a pointer to `export-formats.md`. |
+| `error-messages.md` | gap | still 4 lines, self-labelled "under construction." No mechanical fix possible — this is a phase-2 content-authoring task (see §6). |
+| `export-formats.md` | fixed | table was missing the `html` format (`-x html`, confirmed real via `src/export/mod.rs:29-40` and live test) — added. |
+| `import-formats.md` | accurate (YAML anchors/merge-keys/timestamps content not independently re-verified against `src/import/yaml.rs` — flagged, not a known issue) | |
+| `agent-reference.md` | accurate | this file is well-maintained; used throughout this review as a source of already-verified ground truth (its precedence table, type-form table, and prelude examples were all spot-checked and hold up). |
+| `prelude/*.md` (11 category pages + index) | accurate | byte-identical to fresh `eu doc --output-dir` regeneration — **no drift**. |
+
+### Appendices
+
+| File | Verdict | Notes |
+|---|---|---|
+| `appendices/cheat-sheet.md` | fixed | same `--type-check` staleness as above — corrected the CLI quick-reference block. |
+| `appendices/syntax-gotchas.md` | accurate | well-maintained; no stale facts found. See §6 for one recommended new-content addition. |
+| `appendices/migration.md` | accurate | correctly scoped as a historical v0.2→v0.3 document; not confused with current version. |
+
+### Understanding / meta / generated
+
+| File | Verdict | Notes |
+|---|---|---|
+| `architecture.md` | fixed (partial) + flagged | **severe staleness**: the entire "STG Compilation and Evaluation Model" section describes only the tree-walk `MachineState` (`src/eval/machine/vm.rs`) with zero mention that this is now the *opt-in* engine (`EU_HEAPSYN=1`) and that the bytecode VM (`src/eval/bytecode/`) has been the *default* since 0.12.0. Added a factual note/pointer as a safe mechanical fix (does not invent the missing architectural description — that's phase-2, ranked #1, see §6). Also fixed: "Further Reading" section listed six bare filenames as plain text (not links), two of which (`implementation.md`, `anaphora-and-lambdas.md`) don't exist anywhere in the tree; converted to real relative links and dropped/redirected the phantom entries. |
+| `eucalypt-style.md` | accurate | spot-checked examples run correctly; style guidance (prefer `then`/pipelines/point-free) still matches current idiom. |
+| `faq.md` | accurate | no stale engine/type-checking claims found. |
+| `understanding/philosophy.md` | accurate | |
+| `understanding/lazy-evaluation.md` | accurate | |
+| `README.md` | accurate | installation instructions and the one code example both verified correct. |
+| `docs/SUMMARY.md` | fixed | `docs/guide/lsp.md` (94 lines, real content, matches current LSP source module-for-module) existed but was **completely absent from the table of contents** — unreachable in the built book, absent from `llms-full.txt`/`llms.txt`. Added. Everything else in `SUMMARY.md` resolves to a real file; every `docs/**/*.md` not listed is legitimately internal (`docs/development/*`, `docs/superpowers/*`, `docs/reference/prelude/supplements/*` raw fragments) — no other orphans. |
+| `docs/llms.txt` | fixed | hand-maintained, no generator (confirmed via repo-wide grep — distinct from `llms-full.txt`, which has `scripts/generate-llms-full.sh`). Prelude category counts were stale by 40-70% (see headline numbers). Six guide chapters were missing from its index entirely: Navigating Nested Data, Lenses, IO and Shell Commands, Monads, The State Monad, Type Checking. Both fixed. |
+| `docs/llms-full.txt` | fixed (regenerated) | was already byte-identical to a fresh regen before this review's other content fixes; regenerated once more at the end to pick up all ~30 source-doc corrections. |
+| `docs/reference/prelude/*.md` | accurate | see above. |
+| `docs/development/*.md` (14 files) | fixed (2 files) | `type-system-evolution.md` and `type-alias-shorthand-spec.md` linked to 4 spec files (`monad-type-checking-spec.md`, `row-polymorphism-and-dict-spec.md`, `prelude-type-cache-spec.md`, `literal-types-and-narrowing-spec.md`, `alias-reference-tooling-spec.md`) deleted in commit `30bad306` ("remove shipped specs, add ROADMAP.md" — the features shipped in 0.6.2/0.7.0). De-linked with a "shipped, spec removed, see ROADMAP.md" note rather than pointing at a 404. The other 12 development docs were not in scope for deep review (internal/dev-facing, not part of the mdbook) but no other broken links were found there. |
+| `docs/superpowers/**` | out of scope | internal perf-engineering working docs, correctly excluded from the book and from `test-doc-examples.py`'s scan (see its `find_doc_files` exclusion list). Not reviewed for prose accuracy — see §6 for the one open question (engine-ab protocol / fusion / wire-format-v2 user-doc visibility). |
+
+---
+
+## 2. eu-p7tk status (docs/llms-full.txt stale)
+
+**Verdict: not currently true, or already resolved.** A byte-for-byte
+regeneration via `scripts/generate-llms-full.sh` against the
+pre-this-review tree produced **zero diff**. Git blame shows a prior
+commit (`22390547`, "docs: fix dangling doc links, add head-operator
+mentions, regenerate llms-full.txt") already did this. Recommend
+closing eu-p7tk as already resolved, or repurposing it to mean "keep
+`llms-full.txt` regenerated as part of every docs PR" (there's no CI
+check enforcing that today — see §6).
+
+---
+
+## 3. Fix inventory (mechanical-fix PR, same branch)
+
+### 3.1 Missing-comma list-literal bug (cross-cutting)
+
+A cross-cutting authoring habit: multi-line list literals of block
+elements written one-per-line with **no trailing commas**:
+
+```eu
+people: [
+  { name: "Alice" age: 30 }
+  { name: "Bob" age: 25 }
+]
+```
+
+Lists require commas (stated correctly elsewhere in the same docs).
+Without them, adjacent `{...}{...}` block literals inside `[...]`
+catenate as a **block merge** (later keys win) instead of forming list
+elements — silently producing a 1-element list containing the
+merged/last block, with no parse error. Found and fixed in **10
+locations across 6 files** (`guide/expressions-and-pipelines.md`,
+`guide/lists-and-transformations.md`, `guide/string-interpolation.md`,
+`guide/navigating-nested-data.md` ×2, `guide/advanced-topics.md`,
+`welcome/by-example.md` ×4). A full repo-wide regex sweep was run to
+confirm no further instances remain in the reviewed tree (a handful of
+matches in `agent-reference.md`, `cheat-sheet.md`, and
+`syntax-gotchas.md` were checked individually and are **not** bugs —
+either genuinely standalone one-liner examples, or, in
+`syntax-gotchas.md`'s case, the deliberate "WRONG" illustration of
+this exact gotcha for imports).
+
+### 3.2 Type-checking staleness (cross-cutting)
+
+Three files described `--type-check` as the flag that enables the
+type checker and/or described type checking as optional/opt-in.
+Ground truth (`src/driver/options.rs:82-85`, CLAUDE.md): type checking
+is **unconditional** since 0.11; `--type-check` is a documented
+no-op kept for backwards compatibility. Fixed in
+`guide/type-checking.md`, `reference/cli.md`, `appendices/cheat-sheet.md`.
+(`docs/development/gradual-typing-spec.md:679` has the same stale
+line but was left untouched as a historical design document, same
+treatment as `appendices/migration.md`.)
+
+### 3.3 Everything else
+
+See the per-file table in §1 for the itemised list; each entry there
+names the specific error and fix. All fixes were verified by executing
+the corrected example against the release binary and diffing against
+the documented "expected output" block, except where noted as
+cosmetic-only.
+
+### 3.4 eu-1n5z (reflect.eu import idiom)
+
+Bead's own acceptance criteria: "All reflect-library imports across
+`tests/` and `CHANGELOG.md` use `{ import: "reflect.eu" }`; full
+harness still green." Done — `resource:reflect` → `reflect.eu` in 6
+harness test files (`174_sv1_typedata.eu`, `175_sv2_to_spec.eu`,
+`177_sv_optional_fields_to_data.eu`, `178_sv_optional_fields_to_spec.eu`,
+`182_typedata_alias_resolution.eu`, `183_widen_type_def_literals.eu`)
+and `CHANGELOG.md:33`. All 6 affected tests re-run individually and
+pass (`cargo test --release --test harness_test`); full suite
+(`cargo test --release`) is green: 1274 + 111 + 7 + 1 + 3 + 489 + 12 +
+111 + 11 + 3 = all passed, 0 failed.
+
+### 3.5 Broken internal links
+
+Repo-wide script found 4 raw matches; 2 were false positives (a regex
+literal `\d+` inside fenced code being mis-parsed as a markdown link
+target by the checker script itself) and 2 were real but already
+correct in context (a prelude-reference *supplement fragment*'s
+relative link resolves correctly once merged into its parent page,
+which was confirmed by checking the actual generated
+`docs/reference/prelude/index.md`, not the raw supplement file). The
+5 **genuinely** broken links found and fixed were plain-text (not
+markdown-syntax) filename references in `architecture.md`'s "Further
+Reading" section and true `[text](path)` links to 4 now-deleted spec
+files in `docs/development/type-system-evolution.md` and
+`type-alias-shorthand-spec.md` (§1, "Understanding / meta / generated"
+row for those files).
+
+---
+
+## 4. Verification performed
+
+- `cargo build --release` (toolchain: `stable-aarch64-apple-darwin`,
+  `RUSTC=.../rustc RUSTDOC=.../rustdoc` explicitly set — the `rustup`
+  shim on this machine breaks `rustc -vV`/doctest sub-invocations
+  without it).
+- `cargo xtask prelude-compile` (prelude blob regenerated, used for
+  all example verification).
+- `eu doc --output-dir docs/reference/prelude` — zero diff before and
+  after all other edits (prelude reference pages were and remain
+  accurate).
+- `scripts/generate-llms-full.sh` — zero diff before this review's
+  other fixes; regenerated again after, to absorb them (308
+  insertions / 85 deletions reflecting the ~30 source-doc fixes).
+- `python3 scripts/test-doc-examples.py --eu ./target/release/eu
+  --timeout 30` — 243 passed, 0 failed, 342 skipped (585 total), both
+  before and after this review's fixes. This harness only checks exit
+  code, not output content — it is why the missing-comma bugs (§3.1)
+  and several others were invisible to CI despite being wrong. Three
+  previously-`notest` blocks were fixed and converted to tested
+  (`welcome/index.md`, `welcome/by-example.md` example 10,
+  `guide/functions-and-combinators.md`'s `flip` example), raising the
+  passed count from 240 to 243.
+- `mdbook build` — clean, no warnings, `guide/lsp.html` now appears in
+  the built site.
+- Custom Python link-checker across every `.md` under `docs/` — 0 real
+  broken links remaining (2 known false positives from the checker's
+  own regex, documented in §3.5).
+- `cargo test --release` (full suite) — every test binary green:
+  `harness_test` 489/489, `lsp_test` 111/111, `property_test` 11/11,
+  `bytecode_io_differential_test` 7/7, `conform_test` 1/1,
+  `fuzz_regression_test` 3/3, `io_args_test` 12/12, lib tests
+  1274/1274, doctests 3/3 (2 ignored, pre-existing). No regressions
+  from the reflect.eu import-idiom fix or any other change in this PR.
+- Every individual example fix in §1/§3 was independently re-run
+  against the release binary and its output diffed against the
+  documented expected output before being committed to the docs.
+
+---
+
+## 5. eu-lyu9 status (idiot brackets / lens coverage)
+
+**Verdict: substantially already resolved.** The bead's three
+sub-concerns:
+
+1. **Idiot brackets undocumented** — no longer true. Documented in
+   four consistent places: `reference/agent-reference.md` §1.3.1,
+   `guide/operators.md` "## Idiot Brackets" (guide-level introduction
+   with the bracket-pair table), `reference/syntax.md`, and
+   `appendices/syntax-gotchas.md`'s "Idiot Bracket Gotchas" /
+   "Monad Bracket Restrictions" sections. All examples tested and
+   correct.
+2. **agent-reference.md gotcha/style coverage re-review** — not
+   independently re-verified line-by-line against
+   `syntax-gotchas.md` in this pass (both files were read and
+   spot-checked as part of this review and no gaps were found, but a
+   systematic side-by-side diff was not performed). Low-priority
+   remainder if still wanted.
+3. **Lens library only a "side topic," no introduction** — no longer
+   true. `guide/lenses.md` is a full 289-line narrative chapter,
+   correctly sequenced in `SUMMARY.md`, and `guide/navigating-nested-data.md`
+   independently introduces "what a lens is" before referencing the
+   fuller chapter. Every example in both files was executed and
+   matched documented output.
+
+**Minor non-blocking observation**: the lens API surface (constructors,
+`view`/`over`/`to-list-of`/`parts-of`, composition) is now documented in
+*three* places (`agent-reference.md` §11, `guide/lenses.md`,
+`guide/navigating-nested-data.md`'s own subsection) — currently
+consistent, but three parallel expositions risk drifting apart on a
+future API change. Not fixed in this pass (would require judgement
+about which to trim — phase-2 material, see §6).
+
+Recommend: close eu-lyu9, or narrow it to just item 2 above if the
+owner still wants that specific side-by-side pass.
+
+---
+
+## 6. Phase-2 content plan (ranked)
+
+Nothing below was implemented in this pass — per the bead's scope,
+phase 1 is audit + safe mechanical fixes only; these all require new
+prose/explanation, which is content-authoring work.
+
+1. **`docs/architecture.md` bytecode engine rewrite (highest priority).**
+   The "STG Compilation and Evaluation Model" section needs a real
+   description of the bytecode VM (`src/eval/bytecode/`: `opcode.rs`,
+   `program.rs`, `machine.rs`, `closure.rs`, `cont.rs`,
+   `env_builder.rs`, `encode.rs`) alongside the existing HeapSyn
+   tree-walk description — what gets compiled to bytecode, roughly how
+   dispatch works, why it's the default, and where the perf story
+   currently stands (`docs/superpowers/reports/2026-07-12-transition-review-*.md`
+   has the source material). This is the single most consequential gap
+   found in this review: the primary architecture document is silent
+   on the default execution engine.
+2. **`docs/reference/error-messages.md`.** Still a 4-line stub,
+   self-labelled "under construction" since at least the last several
+   releases. Needs actual content — a guide to reading eucalypt's
+   diagnostic format, common error categories, and how to interpret
+   stack traces / source locations.
+3. **`lib/reflect.eu` (to-data/from-data/as-spec) has zero guide-level
+   coverage.** Confirmed via grep: no mention in any `guide/*.md` or
+   `reference/agent-reference.md`. `lens.eu` and `state.eu` both have
+   dedicated guide chapters; `reflect.eu` ships alongside them with
+   none. Needs at minimum a short guide chapter or a subsection of
+   `type-checking.md` (since it's about projecting type-data values).
+4. **New syntax-gotcha entries** (small, well-scoped, but genuinely new
+   prose, so deferred): (a) a numeral inside string-interpolation
+   braces (`"{42}"`) collides with numbered string anaphora rather than
+   being treated as a literal — found while fixing
+   `guide/string-interpolation.md`'s format-specifier example, not
+   previously documented anywhere; (b) a hyphenated variable reference
+   immediately after an operator with no surrounding whitespace
+   (`x-2`) lexes as a single identifier rather than `x - 2` — found
+   while fixing `welcome/index.md`'s virtual-functions example, also
+   not previously documented; (c) the `!` type-string prefix
+   ("asserted" annotation — checker trusts the type without verifying
+   the body, `src/core/typecheck/check.rs:895-899`) is used in
+   `guide/type-checking.md:261` with zero explanation anywhere,
+   including the type-form tables in `agent-reference.md` and
+   `cheat-sheet.md`.
+5. **YAML cosmetic-output drift across many guide examples** (low
+   priority, high volume). Many "expected output" blocks show
+   flow-style or single-quoted YAML (`b: [2, 3]`, `label: '99'`) where
+   the actual emitter always uses block style and double-quotes
+   punctuation-bearing strings (`b:\n  - 2\n  - 3`,
+   `label: "99"`). Semantically identical, cosmetically wrong —
+   dozens of instances across the guide. A doctest harness that
+   diffs *rendered output*, not just exit code, would catch these
+   automatically and is the real fix (see item 7).
+6. **`docs/superpowers/engine-ab/PROTOCOL.md` / fusion / wire-format-v2
+   visibility** — flagged per the dispatch brief, not decided here.
+   These are internal perf-engineering artefacts (confirmed: zero
+   mentions anywhere in `guide/`, `reference/`, `understanding/`,
+   `welcome/`, `faq.md`, `architecture.md`, `eucalypt-style.md`).
+   Recommend they stay internal-only (they're not user-visible
+   language/CLI surface), with the possible exception of a one-line
+   mention of "bytecode wire format" in the architecture.md rewrite
+   (item 1) if useful context. Owner call.
+7. **`scripts/test-doc-examples.py` only checks exit code, not output
+   content.** This is *why* the missing-comma bug (§3.1, 10 instances)
+   and several other wrong-output-but-non-erroring examples survived
+   in the tree undetected by CI across multiple releases. Extending
+   the harness to optionally assert against a documented "expected
+   output" fenced block (where one immediately follows the `eu` block)
+   would have caught most of what a human reviewer had to find by
+   hand in this pass. Not attempted here — a harness change, not a
+   docs change, and a bigger lift than "phase 1 mechanical fix."
+8. **Duplicate lens-API exposition** (§5) — decide whether
+   `guide/navigating-nested-data.md`'s constructor subsection should
+   forward-reference `guide/lenses.md` instead of restating the table,
+   to reduce future drift risk. Low priority, cosmetic.
+9. **`docs/development/gradual-typing-spec.md:679`** still shows the
+   stale `eu --type-check` invocation trio. Left untouched in phase 1
+   as a historical design document (same treatment as
+   `appendices/migration.md`), but if the owner wants historical specs
+   corrected too rather than left as a snapshot of design-time intent,
+   this is a trivial follow-up.
+
+---
+
+## 7. Files changed in the mechanical-fix commit
+
+```
+CHANGELOG.md
+docs/SUMMARY.md
+docs/appendices/cheat-sheet.md
+docs/architecture.md
+docs/development/type-alias-shorthand-spec.md
+docs/development/type-system-evolution.md
+docs/guide/advanced-topics.md
+docs/guide/command-line.md
+docs/guide/date-time-random.md
+docs/guide/expressions-and-pipelines.md
+docs/guide/functions-and-combinators.md
+docs/guide/io.md
+docs/guide/lists-and-transformations.md
+docs/guide/monads.md
+docs/guide/navigating-nested-data.md
+docs/guide/operators.md
+docs/guide/state-monad.md
+docs/guide/string-interpolation.md
+docs/guide/type-checking.md
+docs/guide/working-with-data.md
+docs/llms-full.txt        (regenerated)
+docs/llms.txt
+docs/reference/cli.md
+docs/reference/export-formats.md
+docs/reference/operators-and-identifiers.md
+docs/welcome/by-example.md
+docs/welcome/index.md
+docs/welcome/quick-start.md
+tests/harness/174_sv1_typedata.eu
+tests/harness/175_sv2_to_spec.eu
+tests/harness/177_sv_optional_fields_to_data.eu
+tests/harness/178_sv_optional_fields_to_spec.eu
+tests/harness/182_typedata_alias_resolution.eu
+tests/harness/183_widen_type_def_literals.eu
+```
+
+`docs/reference/prelude/*.md` was regenerated but produced no diff
+(already accurate) and is therefore not in the changed-files list
+above.

--- a/docs/welcome/by-example.md
+++ b/docs/welcome/by-example.md
@@ -28,7 +28,7 @@ needed.
 **Problem:** Given a list of users in JSON, extract just their names.
 
 ```sh
-eu -e 'map(.name)' <<'JSON'
+eu u=- -e 'u map(.name)' <<'JSON'
 [
   {"name": "Alice", "role": "admin"},
   {"name": "Bob", "role": "user"},
@@ -56,9 +56,9 @@ threshold and format them.
 ```eu
 # products.eu
 products: [
-  { name: "Widget" price: 9.99 }
-  { name: "Gadget" price: 24.99 }
-  { name: "Gizmo" price: 49.99 }
+  { name: "Widget" price: 9.99 },
+  { name: "Gadget" price: 24.99 },
+  { name: "Gizmo" price: 49.99 },
   { name: "Doohickey" price: 4.99 }
 ]
 
@@ -281,12 +281,12 @@ while `deep-query("**.port", data)` matches at any depth.
 
 **Problem:** Extract timestamps and levels from log lines.
 
-```eu,notest
+```eu
 # logs.eu
 lines: [
-  "2024-03-15 10:30:00 ERROR Connection timeout"
-  "2024-03-15 10:30:05 INFO Retry attempt 1"
-  "2024-03-15 10:30:10 ERROR Connection timeout"
+  "2024-03-15 10:30:00 ERROR Connection timeout",
+  "2024-03-15 10:30:05 INFO Retry attempt 1",
+  "2024-03-15 10:30:10 ERROR Connection timeout",
   "2024-03-15 10:30:15 INFO Connected"
 ]
 
@@ -309,10 +309,10 @@ eu logs.eu -e errors
 **Output:**
 
 ```yaml
-- timestamp: '2024-03-15 10:30:00'
+- timestamp: "2024-03-15 10:30:00"
   level: ERROR
   message: Connection timeout
-- timestamp: '2024-03-15 10:30:10'
+- timestamp: "2024-03-15 10:30:10"
   level: ERROR
   message: Connection timeout
 ```
@@ -348,8 +348,8 @@ repetitive structure.
 ```eu
 # events.eu
 events: [
-  { name: "Launch" date: t"2024-01-15" }
-  { name: "Review" date: t"2024-06-01" }
+  { name: "Launch" date: t"2024-01-15" },
+  { name: "Review" date: t"2024-06-01" },
   { name: "Release" date: t"2024-09-30" }
 ]
 
@@ -430,8 +430,8 @@ overlaps.
 
 ```eu
 items: [
-  { name: "A" tags: ["fast", "reliable", "cheap"] }
-  { name: "B" tags: ["fast", "expensive"] }
+  { name: "A" tags: ["fast", "reliable", "cheap"] },
+  { name: "B" tags: ["fast", "expensive"] },
   { name: "C" tags: ["reliable", "cheap", "slow"] }
 ]
 

--- a/docs/welcome/index.md
+++ b/docs/welcome/index.md
@@ -296,16 +296,16 @@ sophisticated means of combining block data are available too.
 
 > **Note:** This merge is similar to the effect of *merge keys* in
 > YAML, where a special `<<` mapping key causes a similar merge to
-> occur. Not all YAML processors support this and nor does eucalypt at
-> present, but it probably will some day.
+> occur. Eucalypt's YAML importer supports merge keys too — see
+> [Import Formats](../reference/import-formats.md#merge-keys).
 
 Be aware that eucalypt has nothing like virtual functions. The
 functions in scope when an expression is created are the ones that are
 applied. So if you redefine an `f` like this, in an overriding
 block...
 
-```eu,notest
-{ f(x): x+1 a: f(2) } { f(x): x-2 }
+```eu
+{ f(x): x+1 a: f(2) } { f(x): x - 2 }
 ```
 
 ...the definition of `a` will not see it.

--- a/docs/welcome/quick-start.md
+++ b/docs/welcome/quick-start.md
@@ -50,10 +50,10 @@ cargo install --path .
 eu --version
 ```
 
-...prints the version:
+...prints the version, e.g.:
 
 ```text
-eu 0.3.0
+eu - Eucalypt v0.12.1
 ```
 
 ...and...
@@ -78,20 +78,23 @@ Commands:
   list-targets  List targets defined in the source
   fmt           Format eucalypt source files
   lsp           Start the Language Server Protocol server
+  check         Check type annotations in eucalypt source files
+  doc           Extract documentation from eucalypt source files
   help          Print this message or the help of the given subcommand(s)
 
 Arguments:
   [FILES]...  Files to process (used when no subcommand specified)
 
 Options:
-  -L, --lib-path <LIB_PATH>                Add directory to lib path
-  -Q, --no-prelude                         Don't load the standard prelude
-  -d, --debug                              Turn on debug features
-  -S, --statistics                         Print metrics to stderr before exiting
-      --statistics-file <STATISTICS_FILE>  Write statistics as JSON to a file
-  -h, --help                               Print help
-  -V, --version                            Print version
+      --source-prelude  Force source-prelude pipeline even when pre-compiled blob is available
+  -h, --help            Print help
+  -V, --version         Print version
 ```
+
+Most of the options familiar from older versions (`-L`, `-Q`, `-d`,
+`-S`, `--statistics-file`, and many more) now live under the `run`
+subcommand — see `eu run --help` or the [CLI
+Reference](../reference/cli.md) for the full list.
 
 Use `eu <command> --help` for detailed help on each subcommand.
 

--- a/tests/harness/174_sv1_typedata.eu
+++ b/tests/harness/174_sv1_typedata.eu
@@ -1,5 +1,5 @@
 #!/usr/bin/env eu
-{ import: "resource:reflect" }
+{ import: "reflect.eu" }
 # Tests for SV1 s-string type-data semantics:
 # compile-time validation, to-data projection, from-data round-trip.
 

--- a/tests/harness/175_sv2_to_spec.eu
+++ b/tests/harness/175_sv2_to_spec.eu
@@ -1,4 +1,4 @@
-{ import: "resource:reflect"
+{ import: "reflect.eu"
   doc: "174 sv2 to-spec / as-spec" }
 
 ` { target: :test }

--- a/tests/harness/177_sv_optional_fields_to_data.eu
+++ b/tests/harness/177_sv_optional_fields_to_data.eu
@@ -1,5 +1,5 @@
 #!/usr/bin/env eu
-{ import: "resource:reflect" }
+{ import: "reflect.eu" }
 # Criterion 8: to-data of a record with optional fields emits [:t-field :optional T] wrappers.
 # Round-trip: from-data re-renders optional fields with the ? suffix.
 

--- a/tests/harness/178_sv_optional_fields_to_spec.eu
+++ b/tests/harness/178_sv_optional_fields_to_spec.eu
@@ -1,5 +1,5 @@
 #!/usr/bin/env eu
-{ import: "resource:reflect" }
+{ import: "reflect.eu" }
 # Criterion 9: to-spec handles optional fields correctly in match? patterns.
 
 schema: s"{ name: string, age?: number }" as-spec

--- a/tests/harness/182_typedata_alias_resolution.eu
+++ b/tests/harness/182_typedata_alias_resolution.eu
@@ -1,4 +1,4 @@
-{ import: "resource:reflect"
+{ import: "reflect.eu"
   doc: "182 typedata alias resolution" }
 
 # Type aliases in s-strings should be resolved after type checking,

--- a/tests/harness/183_widen_type_def_literals.eu
+++ b/tests/harness/183_widen_type_def_literals.eu
@@ -1,4 +1,4 @@
-{ import: "resource:reflect"
+{ import: "reflect.eu"
   doc: "183 widen literal types in synthesised type-def aliases" }
 
 ` { target: :test }


### PR DESCRIPTION
## Summary

Phase 1 of the full documentation review programme (bead eu-2sa6.15, owner-mandated). Two deliverables, both on this branch:

1. **Audit report**: `docs/superpowers/reports/2026-07-13-docs-review.md` — per-file verdict, every factual error found with correcting fact + source citation, completeness gaps, and a ranked phase-2 content plan.
2. **Mechanical-fix commit**: 31 confirmed factual/example errors fixed across 24 doc files, plus the eu-1n5z reflect-import-idiom cleanup (6 harness test files + CHANGELOG.md).

Do NOT merge — this is for review. See the audit report for full detail; headline findings below.

## Headline findings

- `docs/reference/prelude/*.md` and `docs/llms-full.txt`: **no drift found** — both are already byte-identical to a fresh regeneration. eu-p7tk's premise doesn't hold for these specifically (see report §2).
- `docs/llms.txt` (hand-maintained, no generator): prelude category counts were stale by 40-70% (218 claimed vs 370 actual), and 6 of 20 guide chapters were missing from its index. Fixed.
- **Cross-cutting bug**: 10 examples across 6 files had multi-line list literals with missing commas — silently catenates as a block *merge* instead of forming a list, producing confidently-wrong documented output with no parse error. Fixed everywhere found.
- **Type-checking staleness**: 3 files described `--type-check` as the flag that enables the checker; it's actually unconditional since 0.11 and the flag is a deprecated no-op. Fixed.
- **`docs/architecture.md`**: severe gap — describes only the legacy HeapSyn tree-walk VM, zero mention that the bytecode engine has been the *default* since 0.12.0. Added a factual pointer as a safe mechanical fix; full rewrite flagged as #1 phase-2 priority (new content, out of phase-1 scope).
- **eu-lyu9** (idiot brackets / lens coverage): found substantially already resolved by prior work.
- **eu-1n5z** (reflect.eu import idiom): was not resolved — fixed here, all 6 affected harness tests + full suite re-verified green.
- Several fabricated/broken examples fixed: `unique()` doesn't exist, `cal.format()` takes no format-string arg, an inline `_(r): expr` "lambda" doesn't parse (no lambda syntax in eucalypt), `//=` returns bool not value, `str.upper` doesn't exist, a `flip()` pipeline example was unparseable, state-monad's own opening example silently no-ops due to the catenation-puts-receiver-last rule.
- `SUMMARY.md` was missing `guide/lsp.md` — a real, accurate, 94-line chapter that was completely unreachable in the built book.

## Verification

- `cargo build --release` + `cargo xtask prelude-compile`
- `eu doc --output-dir docs/reference/prelude` — zero diff
- `scripts/generate-llms-full.sh` — regenerated to absorb all fixes
- `python3 scripts/test-doc-examples.py --eu ./target/release/eu --timeout 30` — 243 passed, 0 failed (up from 240; three previously-`notest` examples were fixed and made testable)
- `mdbook build` — clean
- Custom repo-wide internal-link checker — 0 real broken links remaining
- `cargo test --release` (full suite) — every test binary green, 0 regressions (harness_test 489/489, lsp_test 111/111, property_test 11/11, and all others)
- Every individual example fix was independently re-run against the release binary and diffed against its documented expected output before being committed

## Test plan

- [x] Full `cargo test --release` suite green
- [x] `mdbook build` clean
- [x] `eu doc` regeneration produces no diff (prelude reference still accurate)
- [x] `scripts/generate-llms-full.sh` regeneration absorbs all fixes
- [x] `scripts/test-doc-examples.py` all passing
- [x] Repo-wide internal link check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRUGGB4wXRfywnDArH2suk