### PR TITLE
feat(bytecode): branch-table side-pool + BranchPredecoded + ticks-first ledger (eu-2sa6.13)

### DIFF
--- a/docs/superpowers/reports/2026-07-13-predecode-ticks-first.md
+++ b/docs/superpowers/reports/2026-07-13-predecode-ticks-first.md
@@ -8,41 +8,58 @@
 - **Protocol:** `docs/superpowers/engine-ab/PROTOCOL.md`
 - **Status:** TICKS-FIRST only. Wall median-of-N runs are **deferred** to a quiet
   window (the measurement box was under concurrent build/review load); no wall
-  ratio is quoted here, per PROTOCOL §2 ("if the machine is loaded, say so").
-  The `results.jsonl` rows will be appended once the wall medians exist, using
-  the deterministic figures below unchanged.
+  ratio is quoted here, per PROTOCOL §2. The `results.jsonl` rows will be
+  appended once the wall medians exist, using the deterministic figures below
+  unchanged.
 
-## 1. Deterministic reference (HeapSyn `-S`) — the load-independent layer
+> **Correction (2026-07-13, post-review).** The first version of this report
+> measured with `eu run <file>` and **no `-t <target>`** (and, for `021`, no
+> `--allow-io`). That renders the *whole document*, which for some benches
+> evaluates extra work the bench target does not: `020_lookup_curve` defines
+> `total40`/`total250` as top-level bindings that the `bench-lookup-curve`
+> target *also* references, so the whole-document render evaluated them twice
+> (Wicket's "2× + 682" signature — thank you); `015` rendered extra top-level
+> blocks (+35 M ticks); and `021_io_loop` ran with no `--allow-io`, so its io
+> loop never executed (1,518 ticks instead of 3.97 M). Every figure below is
+> now measured the way the canonical suite / `cargo xtask engine-ab` measures
+> (`base_cmd`, `xtask/src/engine_ab.rs`): `EU_HEAPSYN=1 eu -S --heap-limit-mib
+> 12288 [--allow-io] -t <target> <file>`, parsing the `-S` `Ticks`/`Allocs`/
+> `Collections` lines. Rows corrected: **015, 020, 021** (others moved by
+> ≤~1,200 ticks — the small whole-document render overhead). The step-neutral
+> conclusion in §2 is unchanged.
 
-Read from `EU_HEAPSYN=1 eu -S`, `--heap-limit-mib 12288` (0 collections, matching
-production). These are the `hs_ticks`/`hs_allocs`/`gc` columns of the eventual
-ledger rows. **Confidence: measured-verified** (deterministic).
+## 1. Deterministic reference (HeapSyn `-S -t <target>`) — the load-independent layer
 
-| Bench | Class | hs_ticks | hs_allocs | gc |
-|---|---|---|---|---|
-| 015_block_merge | D | 134,179,383 | 645,066 | 0 |
-| 016_import_export_yaml | I | 59,895,722 | 1,922,943 | 0 |
-| 017_import_export_toml | I | 59,722,384 | 1,286,727 | 0 |
-| 018_string_scale | G | 76,815,495 | 364,229 | 0 |
-| 019_list_scale | H | 55,803,922 | 156,222 | 0 |
-| 020_lookup_curve | E | 3,442,892 | 11,107,135 | 0 |
-| 021_io_loop | L | 1,518 | 552 | 0 |
-| 022_hof_fold | C | 52,225,882 | 180,203 | 0 |
+`--heap-limit-mib 12288` (0 collections, matching production). These are the
+`hs_ticks`/`hs_allocs`/`gc` columns of the eventual ledger rows. **Confidence:
+measured-verified** (deterministic; `020` independently reproduced by review).
 
-## 2. Engine dispatch-step counts (bytecode `machine_ticks`) — byte vs pre-decode
+| Bench | Class | Target | hs_ticks | hs_allocs | gc |
+|---|---|---|---|---|---|
+| 015_block_merge | D | bench-block-merge | 98,788,746 | 472,734 | 0 |
+| 016_import_export_yaml | I | bench-import-yaml | 59,894,595 | 1,922,737 | 0 |
+| 017_import_export_toml | I | bench-import-toml | 59,721,271 | 1,286,587 | 0 |
+| 018_string_scale | G | bench-string-scale | 76,814,993 | 364,176 | 0 |
+| 019_list_scale | H | bench-list-scale | 55,803,488 | 156,182 | 0 |
+| 020_lookup_curve | E | bench-lookup-curve | 1,721,105 | 5,553,215 | 0 |
+| 021_io_loop | L | bench-io-loop | 3,971,300 | 545,675 | 0 |
+| 022_hof_fold | C | bench-hof-fold | 52,225,448 | 180,163 | 0 |
 
-The bytecode engine's own `machine_ticks` counts dispatch steps. This is
-deterministic and characterises whether the pre-decoded representation changes
-*how many* steps run (as opposed to the per-step cost). **Confidence:
-measured-verified** (deterministic).
+## 2. Engine dispatch-step counts (bytecode `-S -t <target>` Ticks) — byte vs pre-decode
+
+The bytecode engine's own `Ticks` counts dispatch steps; deterministic, so it
+characterises whether the pre-decoded representation changes *how many* steps
+run (vs. the per-step cost). Compute benches only (io/import excluded).
+**Confidence: measured-verified** (`020` independently reproduced by review:
+byte 164,630,267 / predecode 164,589,685).
 
 | Bench | byte steps | predecode steps | Δ |
 |---|---|---|---|
-| 015_block_merge | 134,020,092 | 133,968,976 | −0.0% |
-| 018_string_scale | 76,731,485 | 76,689,477 | −0.1% |
-| 019_list_scale | 55,719,907 | 55,707,901 | −0.0% |
-| 020_lookup_curve | 329,261,216 | 329,180,052 | −0.0% |
-| 022_hof_fold | 52,125,870 | 52,105,864 | −0.0% |
+| 015_block_merge | 98,669,543 | 98,633,467 | −0.04% |
+| 018_string_scale | 76,730,983 | 76,688,977 | −0.05% |
+| 019_list_scale | 55,719,473 | 55,707,469 | −0.02% |
+| 020_lookup_curve | 164,630,267 | 164,589,685 | −0.02% |
+| 022_hof_fold | 52,125,436 | 52,105,432 | −0.04% |
 
 **Reading this honestly:** on the canonical suite the pre-decoded engine is
 **step-count-neutral** — it runs essentially the same number of dispatch steps
@@ -54,7 +71,7 @@ as the byte engine. This is expected and correct:
   measurement — and cannot show up in a step count.
 - BV2 Ann-elimination *does* remove steps, but only where `Op::Ann` nodes sit in
   the hot path. The canonical compute benches have very few (their hot loops are
-  prelude combinators over data), so the step reduction here is ~0.0–0.1%. A
+  prelude combinators over data), so the step reduction here is ~0.0–0.05%. A
   heavily-annotated hot path shows more: `fib(30)` drops 722,435→623,927 bc
   steps (−13.6%) — a workload-dependent figure, not representative of this suite.
 

--- a/docs/superpowers/reports/2026-07-13-predecode-ticks-first.md
+++ b/docs/superpowers/reports/2026-07-13-predecode-ticks-first.md
@@ -1,0 +1,74 @@
+# Pre-decoded IR — ticks-first measurement (eu-2sa6.13)
+
+- **Date:** 2026-07-13
+- **Commit:** 39f9731c (branch `feat/predecode-branch-pool`)
+- **Host:** Darwin-25.5.0-arm64
+- **Toolchain:** rustc 1.97.0 (2d8144b78 2026-07-07)
+- **Prelude config:** blob (fresh `lib/prelude.blob`, 269176 bytes)
+- **Protocol:** `docs/superpowers/engine-ab/PROTOCOL.md`
+- **Status:** TICKS-FIRST only. Wall median-of-N runs are **deferred** to a quiet
+  window (the measurement box was under concurrent build/review load); no wall
+  ratio is quoted here, per PROTOCOL §2 ("if the machine is loaded, say so").
+  The `results.jsonl` rows will be appended once the wall medians exist, using
+  the deterministic figures below unchanged.
+
+## 1. Deterministic reference (HeapSyn `-S`) — the load-independent layer
+
+Read from `EU_HEAPSYN=1 eu -S`, `--heap-limit-mib 12288` (0 collections, matching
+production). These are the `hs_ticks`/`hs_allocs`/`gc` columns of the eventual
+ledger rows. **Confidence: measured-verified** (deterministic).
+
+| Bench | Class | hs_ticks | hs_allocs | gc |
+|---|---|---|---|---|
+| 015_block_merge | D | 134,179,383 | 645,066 | 0 |
+| 016_import_export_yaml | I | 59,895,722 | 1,922,943 | 0 |
+| 017_import_export_toml | I | 59,722,384 | 1,286,727 | 0 |
+| 018_string_scale | G | 76,815,495 | 364,229 | 0 |
+| 019_list_scale | H | 55,803,922 | 156,222 | 0 |
+| 020_lookup_curve | E | 3,442,892 | 11,107,135 | 0 |
+| 021_io_loop | L | 1,518 | 552 | 0 |
+| 022_hof_fold | C | 52,225,882 | 180,203 | 0 |
+
+## 2. Engine dispatch-step counts (bytecode `machine_ticks`) — byte vs pre-decode
+
+The bytecode engine's own `machine_ticks` counts dispatch steps. This is
+deterministic and characterises whether the pre-decoded representation changes
+*how many* steps run (as opposed to the per-step cost). **Confidence:
+measured-verified** (deterministic).
+
+| Bench | byte steps | predecode steps | Δ |
+|---|---|---|---|
+| 015_block_merge | 134,020,092 | 133,968,976 | −0.0% |
+| 018_string_scale | 76,731,485 | 76,689,477 | −0.1% |
+| 019_list_scale | 55,719,907 | 55,707,901 | −0.0% |
+| 020_lookup_curve | 329,261,216 | 329,180,052 | −0.0% |
+| 022_hof_fold | 52,125,870 | 52,105,864 | −0.0% |
+
+**Reading this honestly:** on the canonical suite the pre-decoded engine is
+**step-count-neutral** — it runs essentially the same number of dispatch steps
+as the byte engine. This is expected and correct:
+
+- Operand pre-decode (the design's headline) reduces the *per-step CPU cost*
+  (typed field reads instead of byte re-decode + `Op::from_u8` + bounds checks),
+  **not the number of steps**. That is a wall/CPU-time effect — the **deferred**
+  measurement — and cannot show up in a step count.
+- BV2 Ann-elimination *does* remove steps, but only where `Op::Ann` nodes sit in
+  the hot path. The canonical compute benches have very few (their hot loops are
+  prelude combinators over data), so the step reduction here is ~0.0–0.1%. A
+  heavily-annotated hot path shows more: `fib(30)` drops 722,435→623,927 bc
+  steps (−13.6%) — a workload-dependent figure, not representative of this suite.
+
+So the pre-decoded engine's value on this suite is entirely in per-step wall
+cost, which this report deliberately does **not** quote (noisy box). The
+`022_hof_fold`/`019_list_scale` measured-single wall spot-check taken during
+implementation (ratio 0.982 / 0.991, predecode ≤ byte) is **context only**, not
+a protocol figure.
+
+## 3. What lands in `results.jsonl`, and when
+
+Nothing is appended yet. When the quiet-window wall runs complete (via `cargo
+xtask engine-ab` on an unloaded machine, interleaved bc/hs, median-of-N per
+PROTOCOL §3), one row per bench will be appended carrying the §1 `hs_ticks`/
+`hs_allocs`/`gc` above verbatim plus the fresh `bc_wall_med`/`hs_wall_med`/
+`ratio`. Until then no wall-derived number may gate a release or enter
+CHANGELOG/ROADMAP (PROTOCOL §5).

--- a/src/eval/bytecode/cont.rs
+++ b/src/eval/bytecode/cont.rs
@@ -37,6 +37,32 @@ pub enum BcContinuation {
         /// Source annotation at the point the case was pushed.
         annotation: Smid,
     },
+    /// The pre-decoded (`EU_PREDECODE`) form of [`BcContinuation::Branch`]
+    /// (design §1.2, drop_cons residual): instead of owning a fresh GC-heap
+    /// `Array<Option<CodeRef>>` rebuilt on every `Case` dispatch, it references
+    /// the Case's densified branch table by `(start, len)` index into the
+    /// **off-heap, immutable** `DecodedProgram::branches` pool. Every field is
+    /// inert — the pool indices, the fallback ordinal (with the `NO_BRANCH`
+    /// sentinel) and `min_tag` are all plain scalars — so the only GC pointer to
+    /// scan is `environment` (see the `GcScannable` impl below), strictly less
+    /// surface than `Branch`'s scanned `Array` backing. `(start, len)` indices
+    /// (not a slice) are used deliberately so the reference survives any pool
+    /// growth (the pool is a `Vec`); the resolver reads `branches[start + (tag -
+    /// min_tag)]` at match time.
+    BranchPredecoded {
+        /// Lowest tag in the branch run.
+        min_tag: Tag,
+        /// Start index into `DecodedProgram::branches`.
+        branch_start: u32,
+        /// Number of entries in this Case's branch run.
+        branch_len: u16,
+        /// Fallback body ordinal, or `NO_BRANCH` for none.
+        fallback: CodeRef,
+        /// Environment of the case statement.
+        environment: RefPtr<BcEnvFrame>,
+        /// Source annotation at the point the case was pushed.
+        annotation: Smid,
+    },
     /// Update thunk in environment at index i.
     Update {
         environment: RefPtr<BcEnvFrame>,
@@ -174,6 +200,14 @@ impl GcScannable for BcContinuation {
                     out.push(ScanPtr::from_non_null(scope, *environment));
                 }
             }
+            BcContinuation::BranchPredecoded { environment, .. } => {
+                // The branch run lives in the off-heap `branches` pool; the
+                // `(start, len)`/`fallback`/`min_tag` fields are inert scalars.
+                // Only the case environment is a GC pointer.
+                if marker.mark(*environment) {
+                    out.push(ScanPtr::from_non_null(scope, *environment));
+                }
+            }
             BcContinuation::ApplyTo { args, .. } => {
                 if marker.mark_array(args) {
                     if let Some(backing_ptr) = args.allocated_data() {
@@ -248,6 +282,13 @@ impl GcScannable for BcContinuation {
                 }
             }
             BcContinuation::Update { environment, .. } => {
+                if let Some(new) = heap.forwarded_to(*environment) {
+                    *environment = new;
+                }
+            }
+            BcContinuation::BranchPredecoded { environment, .. } => {
+                // Only the environment can be forwarded; the pool indices,
+                // fallback ordinal and min_tag are inert.
                 if let Some(new) = heap.forwarded_to(*environment) {
                     *environment = new;
                 }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -363,6 +363,7 @@ impl BcMachineState {
         for cont in self.stack.iter().rev() {
             let smid = match cont {
                 BcContinuation::Branch { annotation, .. }
+                | BcContinuation::BranchPredecoded { annotation, .. }
                 | BcContinuation::ApplyTo { annotation, .. }
                 | BcContinuation::SeqBind { annotation, .. }
                 | BcContinuation::FusedPrimopLeft { annotation, .. }
@@ -991,6 +992,38 @@ pub fn return_data(
                 return Err(ExecutionError::NoBranchForDataTag(ann, tag, expected));
             }
         }
+        BcContinuation::BranchPredecoded {
+            min_tag,
+            branch_start,
+            branch_len,
+            fallback,
+            environment,
+            annotation,
+        } => {
+            // Same control flow as `Branch`, resolving the branch run from the
+            // off-heap `branches` pool instead of a GC `Array`.
+            let body = branch_pool_match(decoded, branch_start, branch_len, min_tag, tag);
+            if let Some(body) = body {
+                let env = if args.is_empty() {
+                    environment
+                } else {
+                    env_from_data_args(state, view, args, environment)?
+                };
+                state.current = BcValue::Closure(BcClosure::new(body, env));
+            } else if fallback != NO_BRANCH {
+                let cur = state.current.clone();
+                let env = view.from_value(cur, environment, state.annotation)?;
+                state.current = BcValue::Closure(BcClosure::new(fallback, env));
+            } else {
+                let expected = branch_pool_expected(decoded, branch_start, branch_len, min_tag);
+                let ann = if annotation.is_valid() {
+                    annotation
+                } else {
+                    state.annotation
+                };
+                return Err(ExecutionError::NoBranchForDataTag(ann, tag, expected));
+            }
+        }
         BcContinuation::Update { environment, index } => {
             let cur = state.current.clone();
             view.scoped(environment).update(&view, index, cur)?;
@@ -1273,6 +1306,23 @@ pub fn return_native(
                 ));
             }
         }
+        BcContinuation::BranchPredecoded {
+            fallback,
+            environment,
+            ..
+        } => {
+            // A native only ever takes the fallback (it matches no data tag), so
+            // the branch pool is not consulted here.
+            if fallback != NO_BRANCH {
+                let env = view.from_value(BcValue::Native(value), environment, state.annotation)?;
+                state.current = BcValue::Closure(BcClosure::new(fallback, env));
+            } else {
+                return Err(ExecutionError::NoBranchForNative(
+                    state.annotation,
+                    value.type_description().to_string(),
+                ));
+            }
+        }
         BcContinuation::Update { environment, index } => {
             // Memoise the value into the thunk's slot; leave `current` as the
             // native so it is re-processed against the next continuation.
@@ -1368,6 +1418,7 @@ pub fn return_fun(
     state: &mut BcMachineState,
     view: MutatorHeapView<'_>,
     prog: &BytecodeProgram,
+    decoded: &DecodedProgram,
 ) -> Result<(), ExecutionError> {
     let Some(cont) = state.stack.pop() else {
         state.terminated = true;
@@ -1417,6 +1468,29 @@ pub fn return_fun(
                     .filter(|i| branch_table.get(*i).flatten().is_some())
                     .map(|i| min_tag + i as u8)
                     .collect();
+                let ann = if annotation.is_valid() {
+                    annotation
+                } else {
+                    state.annotation
+                };
+                return Err(ExecutionError::CannotReturnFunToCase(ann, expected));
+            }
+        }
+        BcContinuation::BranchPredecoded {
+            min_tag,
+            branch_start,
+            branch_len,
+            fallback,
+            environment,
+            annotation,
+        } => {
+            // Dynamic typing: a `case` scrutinee may resolve to a lambda; it
+            // takes the fallback, or errors listing the branched tags.
+            if fallback != NO_BRANCH {
+                let env = view.from_value(BcValue::Closure(fun), environment, state.annotation)?;
+                state.current = BcValue::Closure(BcClosure::new(fallback, env));
+            } else {
+                let expected = branch_pool_expected(decoded, branch_start, branch_len, min_tag);
                 let ann = if annotation.is_valid() {
                     annotation
                 } else {
@@ -2126,7 +2200,7 @@ pub fn step(
     };
     match dispatch {
         Dispatch::Native(n) => return_native(state, view, n),
-        Dispatch::Fun => return_fun(state, view, prog),
+        Dispatch::Fun => return_fun(state, view, prog, decoded),
         Dispatch::Op => handle_op(state, view, prog, decoded),
     }
 }
@@ -2171,6 +2245,44 @@ fn make_arg_array_pd(
         array.push(&view, v);
     }
     Ok(array)
+}
+
+/// Resolve a [`BcContinuation::BranchPredecoded`] run for `tag`: the body
+/// ordinal for that tag, or `None` if the tag is out of range or has no branch.
+/// Reads the off-heap `branches` pool by index (no per-Case GC allocation).
+fn branch_pool_match(
+    decoded: &DecodedProgram,
+    branch_start: u32,
+    branch_len: u16,
+    min_tag: Tag,
+    tag: Tag,
+) -> Option<CodeRef> {
+    if tag < min_tag {
+        return None;
+    }
+    let idx = (tag - min_tag) as usize;
+    if idx >= branch_len as usize {
+        return None;
+    }
+    match decoded.branches[branch_start as usize + idx] {
+        NO_BRANCH => None,
+        ord => Some(ord),
+    }
+}
+
+/// The data tags a [`BcContinuation::BranchPredecoded`] run actually branches
+/// on, for the "no branch for tag" error messages. Mirrors the byte path's
+/// `Branch` error-list construction over the pool instead of a GC `Array`.
+fn branch_pool_expected(
+    decoded: &DecodedProgram,
+    branch_start: u32,
+    branch_len: u16,
+    min_tag: Tag,
+) -> Vec<u8> {
+    (0..branch_len as usize)
+        .filter(|i| decoded.branches[branch_start as usize + i] != NO_BRANCH)
+        .map(|i| min_tag + i as u8)
+        .collect()
 }
 
 /// Execute the current (arity-0) closure's node from its pre-decoded `Instr`.
@@ -2244,20 +2356,16 @@ pub fn handle_op_predecoded(
             state.pending_bif_args = decoded.refs[start..start + len].iter().copied().collect();
         }
         Op::Case => {
+            // Reference the decode-time branch run in the off-heap `branches`
+            // pool by `(start, len)` — no per-Case GC `Array` rebuild (design
+            // §1.2). `min_tag`/`fallback` (with the `NO_BRANCH` sentinel) and the
+            // indices are inert, so the pushed continuation scans only its env.
             let (start, len) = instr.pool();
-            let mut branch_table = Array::with_capacity(&view, len);
-            for e in &decoded.branches[start..start + len] {
-                branch_table.push(&view, if *e == NO_BRANCH { None } else { Some(*e) });
-            }
-            let fallback = if instr.b == NO_BRANCH {
-                None
-            } else {
-                Some(instr.b)
-            };
-            state.stack.push(BcContinuation::Branch {
+            state.stack.push(BcContinuation::BranchPredecoded {
                 min_tag: instr.min_tag(),
-                branch_table,
-                fallback,
+                branch_start: start as u32,
+                branch_len: len as u16,
+                fallback: instr.b,
                 environment: env,
                 annotation: state.annotation,
             });
@@ -2540,7 +2648,7 @@ pub fn step_predecoded(
     };
     match dispatch {
         Dispatch::Native(n) => return_native(state, view, n),
-        Dispatch::Fun => return_fun(state, view, prog),
+        Dispatch::Fun => return_fun(state, view, prog, decoded),
         Dispatch::Op => handle_op_predecoded(state, view, prog, decoded),
     }
 }
@@ -4568,7 +4676,13 @@ mod tests {
             annotation: Default::default(),
         });
 
-        return_fun(&mut state, view, &BytecodeProgram::default()).unwrap();
+        return_fun(
+            &mut state,
+            view,
+            &BytecodeProgram::default(),
+            &DecodedProgram::default(),
+        )
+        .unwrap();
 
         let c = state.current.as_closure().unwrap();
         assert_eq!(c.code(), 10);
@@ -4595,7 +4709,13 @@ mod tests {
             annotation: Default::default(),
         });
 
-        return_fun(&mut state, view, &BytecodeProgram::default()).unwrap();
+        return_fun(
+            &mut state,
+            view,
+            &BytecodeProgram::default(),
+            &DecodedProgram::default(),
+        )
+        .unwrap();
 
         assert_eq!(state.current.as_closure().unwrap().code(), 10);
         assert_eq!(state.stack.len(), 1);


### PR DESCRIPTION
## Branch-table side-pool + ticks-first ledger (eu-2sa6.13 follow-up)

Follow-up to #1002. Two parts, both agreed with the coordinator:

### 1. Branch-table side-pool + `BranchPredecoded` continuation (design §1.2)

Removes the drop_cons residual. Under the pre-decoded engine a `Case` no longer
rebuilds a fresh GC-heap `Array<Option<CodeRef>>` on **every** dispatch. The
densified branch table already lives once in the off-heap, immutable
`DecodedProgram::branches` pool; the new `BcContinuation::BranchPredecoded`
variant references its run by `(branch_start, branch_len)` **index** (not a
borrowed slice, so it survives any pool growth) plus `min_tag` and a
`NO_BRANCH`-sentinel `fallback`.

**GC surface (the sensitive bit):** `BranchPredecoded` scans/updates **only its
`environment`** — strictly less than `Branch`, which also marks and forwards its
`Array` backing. The pool indices, the fallback ordinal and `min_tag` are inert
scalars, never scanned. Documented in `cont.rs`. The byte path keeps `Branch`
unchanged.

`return_data`/`return_fun`/`return_native` each gain a `BranchPredecoded` arm
resolving the branch and expected-tags from the pool (`branch_pool_match` /
`branch_pool_expected`); a native only ever takes the fallback, so its arm needs
no pool access at all.

Output/alloc **identical** — the Case branch `Array` was never counted in
`state.allocs`, so this is purely a wall / GC-pressure win.

### 2. Ticks-first ledger measurement (wall deferred)

Per the ticks-first directive, the deterministic (load-independent) data is
captured now; wall median-of-N runs are deferred to a quiet window (the box was
under build/review load). Full detail:
`docs/superpowers/reports/2026-07-13-predecode-ticks-first.md`.

**Honest headline:** on the canonical suite the pre-decoded engine is
**step-count-neutral** vs the byte engine (−0.0…−0.1% bc dispatch steps across
015/018/019/020/022). This is correct and expected — operand pre-decode reduces
*per-step CPU cost* (typed field reads vs byte re-decode), **not** the number of
steps, so the win is a wall effect and is the **deferred** measurement. BV2
Ann-elimination removes steps only where hot-path `Op::Ann` nodes exist, which
the compute benches have few of (fib's −13.6% step drop is workload-specific,
not representative). No wall number is quoted here and no `results.jsonl` row is
appended until the quiet-window medians exist — the deterministic `hs_ticks`/
`hs_allocs`/`gc` for all eight benches are recorded in the report and will drop
into those rows verbatim.

### Gate matrix (host Darwin-25.5.0-arm64, rustc 1.97.0, fresh blob)

| Gate | Result |
|---|---|
| Byte path `cargo test` — full suite | **green** (1299 lib + 495 harness), incl. tick-parity tripwire (1.12 cap) |
| `EU_PREDECODE=1 cargo test` — full suite | **green** (1299 lib + 495 harness), incl. tripwire (1.13 predecode cap) + differential vs HeapSyn |
| `EU_PREDECODE=1 EU_GC_VERIFY=2 EU_GC_POISON=1 EU_GC_STRESS=1` harness | **green** (495/495) — validates the new continuation's GC surface |
| clippy `--all-targets` | clean |
| Byte-identical output vs byte engine | yes (whole suite) |

Wall/median-of-N ratios: **deferred** to a quiet window (coordinator scheduling).

Do not merge — Wicket reviews, owner re-reviews pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
