### PR TITLE
diag(perf): measure runtime env chain-walk depth, blob vs source (eu-qm7f)

### DIFF
--- a/docs/superpowers/reports/2026-07-13-blob-string-penalty-profile.md
+++ b/docs/superpowers/reports/2026-07-13-blob-string-penalty-profile.md
@@ -1,5 +1,21 @@
 # Blob prelude string/list penalty — predecode-engine profiling (eu-7xvv)
 
+> **CORRECTION (2026-07-13, eu-qm7f):** the "deep runtime lexical-environment
+> chains" mechanism this report treats as confirmed (§1, §5) has since been
+> **refuted by direct measurement**. A follow-on spike instrumented the
+> shared `EnvironmentFrame::get` walk with a hop-count histogram and found
+> runtime chain depth shallow and near-identical between blob and source on
+> both 018 and 019 (max depth 2-3, mean <1, lookup counts within ~0.3% of
+> each other) — not deeper under blob, contrary to this report's central
+> claim. See `docs/superpowers/reports/2026-07-13-env-walk-depth.md` for the
+> full measurement. **What still stands:** the profile-share evidence below
+> (§4 — `enter_local`'s self-time share genuinely grows under blob) is not
+> contradicted; only the *causal explanation* (longer walks) is. The
+> surviving candidate is a locality/per-hop cost, currently **projected**,
+> not measured. This banner is a correction notice only — the body below is
+> kept as the historical record and has not been rewritten; read it with
+> the above in mind.
+
 - **Date:** 2026-07-13
 - **Bead:** eu-7xvv (diagnose the MECHANISM of the blob-prelude per-tick string
   penalty under the pre-decoded engine). Report-only; no code changes.

--- a/docs/superpowers/reports/2026-07-13-env-walk-depth.md
+++ b/docs/superpowers/reports/2026-07-13-env-walk-depth.md
@@ -1,0 +1,367 @@
+# Runtime environment chain-walk depth — direct measurement (eu-qm7f)
+
+- **Date:** 2026-07-13
+- **Bead:** eu-qm7f, owner-mandated follow-up to eu-7xvv: "I want to
+  understand this accurately before we consider touching environments."
+  Directly measures runtime env chain-walk depth, blob vs source, to test the
+  "deep runtime lexical-environment chains" mechanism claimed in eu-2sa6.12
+  and repeated (on profile-share evidence, never on a direct depth
+  measurement) in eu-7xvv.
+- **Worktree/branch:** `/tmp/eu-stopwatch-qm7f`, `spike/env-walk-depth` off
+  `origin/master` at `9f1d661e` (merge of PR #1004). The eu-7xvv worktree
+  (`/tmp/eu-stopwatch-7xvv`) was stale against this, per the dispatch.
+- **Toolchain:** rustc 1.97.0 (`stable-aarch64-apple-darwin`), macOS 26.5.1,
+  Apple aarch64.
+- **Diagnosis only:** instrumentation added, no representation or
+  behavioural change. Clearly marked diagnostic in the source, gated by
+  `EU_ENV_DEPTH_HISTOGRAM=1`, disabled by default. No quiet machine was
+  needed — the histogram counts are deterministic (a property of the
+  compiled program and lookup sequence, not of timing), so ordinary machine
+  load does not affect them.
+
+---
+
+## 1. Headline finding — **outcome (b): equal depths, locality not depth**
+
+**The "deep runtime lexical-environment chains" mechanism claimed in
+eu-2sa6.12 and eu-7xvv is REFUTED by direct measurement.** Runtime
+environment chain-walk depth is **shallow in both blob and source
+configurations, on both benchmarks, and is not materially different between
+them**:
+
+| Bench | Config | Total lookups | Combined mean depth | Max depth |
+|---|---|--:|--:|--:|
+| 018_string_scale | blob | 75,295,727 | **0.656** | **2** |
+| 018_string_scale | source | 75,092,689 | **0.661** | **3** |
+| 019_list_scale | blob | 55,059,223 | **0.656** | **2** |
+| 019_list_scale | source | 54,843,184 | **0.662** | **3** |
+
+(Combined mean computed from the raw per-bucket hop counts across both the
+"annotated" and "unannotated" histograms — see §3 — not a simple average of
+the two printed means.) **Confidence: measured-verified** — every figure
+above was reproduced byte-identically across two independent runs on the
+byte engine, and byte-identically again on the pre-decoded engine (see §4);
+this is the strongest possible confidence bar for a deterministic count.
+
+This directly answers the dispatch's central question and overturns the
+eu-2sa6.12/eu-7xvv narrative: blob's env chains are **not** deeper than
+source's. Depths in both configs sit almost entirely in buckets 0 and 1 (a
+frame the lookup starts in, or one hop to its immediate parent); the deepest
+anything ever reaches is bucket 2 (blob) or bucket "3-4" (source, and only
+for a vanishingly small 21,001-lookup population on 018, 12,001 on 019 — see
+§3.3). This matches ROADMAP §10.2's own historical finding ("eucalypt's env
+chains are shallow, avg depth 2") almost exactly, and extends it: shallow
+chains are not an AoC-era artefact, they hold under the blob prelude too.
+
+**Static-vs-runtime reconciliation (explicitly requested):** the widely-cited
+"1874 thunks / 538 letrec / max pretty-print nesting 171" figure from
+eu-2sa6.12 §3.2 does **not** manifest as deep runtime chains — max observed
+runtime depth this session was **2**, nowhere near 171. This confirms, with a
+direct runtime measurement rather than an inference, what PR #997's
+Core-level reflatten experiment already suspected: that figure was an
+artefact of `dump runtime`'s whole-file pretty-printer indentation (all 352
+bindings concatenated), not a per-call lexical-chain depth. Laziness and the
+peeled-global entry pattern keep runtime chains shallow regardless of how
+deep the static, whole-file nesting proxy looked.
+
+---
+
+## 2. Instrumentation design
+
+Added to `src/eval/machine/env.rs` (`env_depth_diag` module) and wired at
+process exit in `src/bin/eu.rs`. Design choices, and why they cannot distort
+the counts:
+
+- **Gated by `EU_ENV_DEPTH_HISTOGRAM=1`**, cached once via `OnceLock`
+  (mirrors the `EU_STACK_DIAG` precedent in `src/eval/machine/vm.rs:1543`:
+  "checked once at startup to avoid an env-var lookup on every VM step").
+  Disabled (the default), it is a single cached-bool check per lookup — zero
+  behavioural effect, confirmed by the full harness suite (§5).
+- **A read-only shadow walk, not a modification of the real walk.** The
+  instrumentation is a **separate** traversal
+  (`EnvironmentFrame::diag_record_depth`) added alongside the unmodified
+  `cell()`/`get()` — it re-walks the same `next` chain purely to count hops,
+  touching no `bindings` array and returning nothing. `get()`'s actual return
+  value and the entire evaluation semantics are byte-for-byte unchanged
+  whether or not the flag is set (confirmed: full harness suite green with
+  the flag off, and output is identical with the flag on — every benchmark
+  in this report still printed `RESULT: PASS`). This was a deliberate
+  safety choice over rewriting `cell()` itself to count hops as a side
+  effect, to eliminate any risk of the diagnostic perturbing the measured
+  system.
+- **Deterministic, not wall-time.** Hop counts are a property of the
+  compiled program and the (deterministic, lazy) evaluation order, not of
+  scheduling or timing, so — per the dispatch's own framing — perturbation
+  from the extra shadow walk is acceptable and does not need a quiet
+  machine. This session's reruns (§4) confirm exact reproducibility.
+- **Attribution via the frame's own `annotation: Smid`.** Each lookup is
+  bucketed by whether the **starting** frame (the one `get()` was called on)
+  carries a valid or invalid (`Smid::default()`) source annotation.
+  `src/common/sourcemap.rs`'s own documented invariant — "Pre-compiled blobs
+  use `Smid::default()` (0) for all prelude locations" — makes this a
+  built-in, free, coarse "prelude-blob code vs user/source code" attribution
+  requiring no per-call-site instrumentation. See §3 for what it does and
+  doesn't show.
+- **Buckets:** 0, 1, 2, 3-4, 5-8, 9-16, 17-32, 33+ hops, plus running count,
+  sum (for mean), and max, using relaxed atomics (correctness of the final
+  dump doesn't depend on cross-thread ordering here — the eval thread is the
+  sole writer in every configuration tested).
+- **Dump point:** `src/bin/eu.rs`, immediately before `process::exit`, so it
+  fires exactly once per process regardless of which driver mode ran.
+
+---
+
+## 3. Full histograms
+
+### 3.1 018_string_scale
+
+**Blob** (predecode engine; byte-identical to byte engine, see §4):
+
+| | annotated (user / source-compiled) | unannotated (blob-loaded prelude) |
+|---|--:|--:|
+| count | 25,525,621 | 49,770,106 |
+| mean | 0.9742 | 0.4926 |
+| max | 2 | 1 |
+| bucket 0 | 728,076 | 25,252,600 |
+| bucket 1 | 24,727,542 | 24,517,506 |
+| bucket 2 | 70,003 | 0 |
+| bucket 3+ | 0 | 0 |
+
+**Source** (predecode engine; byte-identical to byte engine):
+
+| | annotated (user + source-compiled prelude) | unannotated |
+|---|--:|--:|
+| count | 74,679,627 | 413,062 |
+| mean | 0.6649 | 0.0000 |
+| max | 3 | 1 |
+| bucket 0 | 25,210,570 | 413,061 |
+| bucket 1 | 49,301,049 | 1 |
+| bucket 2 | 147,007 | 0 |
+| bucket 3-4 | 21,001 | 0 |
+
+Total lookups: blob 75,295,727 vs source 75,092,689 — **0.27% apart**,
+consistent with the identical HeapSyn tick counts re-verified on this build
+(§5): blob 76,814,993 vs source 76,751,915 (Δ0.08%). **The "ticks identical →
+lookup counts should be ~equal" assumption holds** (measured-verified).
+
+### 3.2 019_list_scale
+
+**Blob** (predecode; byte-identical to byte engine):
+
+| | annotated | unannotated |
+|---|--:|--:|
+| count | 18,507,117 | 36,552,106 |
+| mean | 0.9776 | 0.4927 |
+| max | 2 | 1 |
+| bucket 0 | 420,069 | 18,543,102 |
+| bucket 1 | 18,081,045 | 18,009,004 |
+| bucket 2 | 6,003 | 0 |
+
+**Source** (predecode; byte-identical to byte engine):
+
+| | annotated | unannotated |
+|---|--:|--:|
+| count | 54,645,122 | 198,062 |
+| mean | 0.6645 | 0.0000 |
+| max | 3 | 0 |
+| bucket 0 | 18,429,062 | 198,062 |
+| bucket 1 | 36,132,050 | 0 |
+| bucket 2 | 72,009 | 0 |
+| bucket 3-4 | 12,001 | 0 |
+
+Total: blob 55,059,223 vs source 54,843,184 — **0.39% apart**. Same
+signature as 018: near-equal counts, near-equal (shallow) depths.
+
+### 3.3 Attribution — what could and couldn't be attributed
+
+**The coarse annotated/unannotated split works exactly as designed and is
+informative, but there is no deep tail to attribute in the first place.**
+Since depths never exceed 2 (blob) or 3 (source), there is no "which
+prelude helper causes the deep walks" question to answer — nothing walks
+deep. What the split *does* show clearly:
+
+- Under blob, roughly two-thirds of all lookups (49.77M / 75.30M on 018) are
+  "unannotated" — i.e. happening while executing blob-loaded prelude
+  closures — and these are *shallower on average* (mean 0.49) than the
+  "annotated" user-code lookups (mean 0.97). This is the opposite of what a
+  "deep prelude chains" story would predict: prelude-body lookups are the
+  *shallow* half, not the deep half.
+- Under source, almost everything is "annotated" (74.68M / 74.98M lookups)
+  because source-compiled prelude carries real smids too, per
+  `sourcemap.rs`'s own documented invariant — the "unannotated" bucket
+  (413,062 lookups on 018) is a small residual, not a comparison population,
+  and its near-zero mean depth is unsurprising given its tiny size.
+- **The one place depth reaches 3-4 hops is exclusively under *source*, not
+  blob** (21,001 / 74.68M = 0.03% of lookups on 018; 12,001 / 54.65M = 0.02%
+  on 019). This is a curiosity worth naming rather than a mechanism: it is
+  too small a population (well under a tenth of a percent) to explain a
+  1.3-2x wall-clock or self-time-share penalty, and it points the *wrong*
+  direction (source has the deeper tail, not blob). I did not chase further
+  attribution of this specific population (e.g. via sampled call-stack
+  correlation) — it is not large enough to be load-bearing for the
+  blob-vs-source penalty this investigation is about, and a finer per-call
+  attribution (bucketing by specific prelude function or user binding) was
+  judged not worth the added instrumentation risk given the headline finding
+  already answers the question the bead was opened to test.
+
+**Conclusion on attribution:** the requested "coarse split (lookups executed
+inside prelude-global code vs user code)" was fully achievable (via the
+existing `annotation` field) and is reported above; a finer, per-function
+attribution was not attempted because there is no deep-tail population left
+to attribute once the headline finding — shallow, near-equal depths on both
+sides — is established.
+
+---
+
+## 4. Determinism and engine-independence
+
+Every histogram above was reproduced **byte-identically** across:
+
+- Two independent runs of the same config on the byte engine (018 blob and
+  source both re-run; every bucket, mean, and max identical to the
+  reported figures).
+- The byte engine vs the pre-decoded engine (`EU_PREDECODE=1`), for both
+  018 and 019, both blob and source — every bucket, mean, and max
+  identical between the two dispatch loops. This is exactly the
+  "byte-engine spot-check to confirm engine-independence" the dispatch
+  asked for, and it succeeded: the shared `EnvironmentFrame::get` code path
+  produces identical counts regardless of which dispatch loop calls it, as
+  expected from `BcEnvFrame` being a type alias for the same generic struct
+  (established in the prior eu-7xvv report).
+- HeapSyn (`EU_HEAPSYN=1`) on 018 blob was also checked as a bonus (not
+  requested, included because the instrumented code is shared by all three
+  engines at no extra cost): counts were **very close but not identical**
+  (25,574,555 vs byte/predecode's 25,525,621 annotated lookups on blob,
+  ~0.19% higher; same shape, same max depth 2, mean 0.977 vs 0.974). This
+  small divergence is plausible given HeapSyn's tree-walk evaluator can
+  differ in exact thunk-forcing order from the two bytecode engines; it does
+  not change the shallow-depth conclusion and is noted as **measured-single**
+  (only one HeapSyn run taken, not repeated) rather than re-litigated
+  further, since the byte/predecode agreement already meets the
+  measured-verified bar for the headline claim.
+
+**All of these figures are therefore measured-verified** per the reproduction
+bar stated in the dispatch ("label it measured-verified only after you've
+reproduced it twice") — reproduced twice on byte, and independently
+corroborated on predecode, with identical results.
+
+---
+
+## 5. Corroborating evidence: locality, not depth
+
+Re-verified on this build (post-PR #1004; measured-verified, deterministic
+layer):
+
+| Metric (018, HeapSyn) | blob | source |
+|---|--:|--:|
+| Ticks | 76,814,993 | 76,751,915 |
+| Allocs | 364,176 | 385,181 |
+
+| Metric (018, byte engine `-S`) | blob | source |
+|---|--:|--:|
+| Blocks Allocated | 3,779 | 3,534 |
+| Blocks Used | 3,777 | 3,532 |
+
+Blob has **fewer allocations** (364,176 vs 385,181, −5.5%) but **more
+resident blocks** (3,779 vs 3,534, +6.9%) — i.e. worse packing density: the
+same (or slightly less) logical work is spread across more heap blocks under
+blob. Combined with §1's finding that logical chain depth is not the
+differentiator, this is consistent with a **per-hop/locality cost**
+mechanism — each `EnvironmentFrame::get` hop is not walking further, but is
+more likely to touch a cold cache line or a different heap block under blob
+than under source, where `inline()`'s cross-binding fusion keeps hot-loop
+state packed into fewer, more reused frames. This is **projected** (reasoned
+from the block/alloc numbers, not independently measured via a cache-miss
+counter this session) but is the natural reading of "same ticks, same
+lookup counts, same depths, higher wall/self-time" once depth itself is
+ruled out.
+
+---
+
+## 6. Correctness verification (harness, all three engines)
+
+`cargo build --release`, `cargo clippy --all-targets -- -D warnings`
+(clean), `cargo fmt --all` (only reformatted the new code), then the full
+suite with the instrumentation compiled in but disabled by default:
+
+| Engine | Tests | Failures |
+|---|--:|--:|
+| bytecode (default) | 1,940 across all test binaries | **0** |
+| HeapSyn (`EU_HEAPSYN=1`) | 1,940 | **0** |
+| predecode (`EU_PREDECODE=1`) | 1,940 | **0** |
+
+Confirms the diagnostic instrumentation is behaviour-neutral by default, on
+every engine.
+
+---
+
+## 7. Verdict and mapping to sanctioned options
+
+**Verdict: outcome (b) — equal depths, locality-class explanation. The
+eu-2sa6.12 "deep runtime lexical-environment chains" narrative is refuted by
+direct measurement**, not merely re-characterised. The enter_local
+self-time-share growth under blob documented in eu-7xvv is real (that
+profile evidence stands — it is a *self-time share* measurement, not a
+depth measurement, and nothing here contradicts it) but its *cause* is not
+longer chain walks; both configs walk shallow, near-identical-length chains
+over near-identical numbers of lookups. The cost difference must be
+per-lookup/per-hop, most plausibly a locality/cache-layout effect (§5),
+though this session did not instrument cache misses directly.
+
+**No fix is recommended here (diagnosis-only scope), per the dispatch's own
+mapping of outcomes to already-sanctioned options:**
+
+- Outcome (a) (a named, blob-specific deep tail) would have evidenced
+  targeted STG-level generation flattening. **Does not apply** — there is no
+  deep tail, blob or source.
+- **Outcome (b) (this result: equal depths → locality) points at BV3
+  register frames + CG4 selective lifting** — the ROADMAP §10.2-sanctioned,
+  targeted representation/locality work, chosen specifically *because* the
+  0.10.0 flat-closures post-mortem already established that eucalypt's
+  chains are shallow and that a *uniform* representation change wastes a
+  capture-recipe tax for no depth-reduction win. This result extends that
+  finding (shallow chains hold for blob too) and is consistent with BV3/CG4
+  being the right-shaped fix *if* the blob penalty is worth targeting at
+  all, rather than any further blob-generation-level flattening work (which
+  §6 of the eu-2sa6.12 report and this report's §1 both show has nothing to
+  flatten).
+- Outcome (c) (shallow everywhere, profile attribution itself suspect) is
+  **partially the actual result but not the right frame**: depths are
+  shallow everywhere, but the enter_local profile-share evidence from
+  eu-7xvv is not thereby discredited — self-time share and chain depth are
+  different measurements, and this report does not re-run or challenge the
+  profiling. What's suspect is only the *causal story* connecting the two
+  (deep chains explaining the share), not the share measurement itself.
+
+**This gates eu-2sa6.18 differently than eu-7xvv projected**: eu-7xvv's
+"projected... inherent to the peel/global-slots form" conclusion was built
+on the (now refuted) deep-chains story. With depth ruled out, the remaining
+open question for eu-2sa6.18 is whether a locality-class fix (BV3/CG4, or
+denser blob-generation layout) can close the gap within the current
+peel/global-slots form, rather than requiring the in-memory co-compilation
+redesign eu-7xvv leaned toward. This report does not decide that — it only
+removes one candidate mechanism (depth) from consideration and points at the
+already-sanctioned alternative (BV3/CG4) as the next place evidence should
+be gathered, per the owner's request to understand the mechanism accurately
+before touching environments.
+
+---
+
+## 8. Evidence index
+
+- Instrumentation: `src/eval/machine/env.rs` (`env_depth_diag` module,
+  `EnvironmentFrame::diag_record_depth`), `src/bin/eu.rs` (dump call site).
+- Raw histogram output: reproduced inline in §3; not separately archived
+  (deterministic — reproducible via `EU_ENV_DEPTH_HISTOGRAM=1 ./target/
+  release/eu --heap-limit-mib 12288 [--source-prelude] [-t bench-string-scale
+  | -t bench-list-scale] tests/harness/bench/{018_string_scale,
+  019_list_scale}.eu`, with/without `EU_PREDECODE=1`/`EU_HEAPSYN=1`).
+- Corroborating `-S` output: §5, reproducible the same way with `-S` in
+  place of `EU_ENV_DEPTH_HISTOGRAM=1`.
+- Prior reports this builds on / revises: `docs/superpowers/reports/
+  2026-07-13-blob-string-penalty-diagnosis.md` (eu-2sa6.12, including its
+  §6/§7 addenda), `docs/superpowers/reports/
+  2026-07-13-blob-string-penalty-profile.md` (eu-7xvv).
+- ROADMAP context: `ROADMAP.md` §10.2 (flat closures post-mortem, avg depth
+  2), §6.4 item 4 / CG4 (globals O(1), no env walk; the higher-order-fold
+  cost is re-resolving a captured local through the env-walk).

--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -40,6 +40,8 @@ pub fn main() {
         .expect("failed to spawn main thread")
         .join()
         .expect("main thread panicked");
+    // DIAGNOSTIC ONLY (bead eu-qm7f): no-op unless EU_ENV_DEPTH_HISTOGRAM=1.
+    eucalypt::eval::machine::env::env_depth_diag::dump();
     process::exit(exit_code);
 }
 

--- a/src/eval/machine/env.rs
+++ b/src/eval/machine/env.rs
@@ -12,6 +12,127 @@ use crate::eval::memory::{
     syntax::{HeapSyn, Native, Ref, RefPtr},
 };
 
+/// DIAGNOSTIC ONLY (bead eu-qm7f): runtime environment chain-walk depth
+/// histogram, gated by `EU_ENV_DEPTH_HISTOGRAM=1` (follows the
+/// `EU_STACK_DIAG` precedent — env-var gated, cached once, stderr output).
+///
+/// Measures the hop count of every [`EnvironmentFrame::get`] lookup — the
+/// single walk implementation shared by HeapSyn's `Closing<S>` frames and
+/// both bytecode engines' `BcEnvFrame` (a type alias for this same generic
+/// struct) — without altering the lookup's behaviour or return value. The
+/// diagnostic performs its own read-only shadow traversal alongside the real
+/// one; it never influences what `get` returns, so enabling it cannot change
+/// program output, only add (deterministic, not wall-time) counters. Disabled
+/// (the default), this is a single cached-bool check per lookup.
+///
+/// Lookups are split into two histograms by the *starting* frame's
+/// `annotation` validity: `lib/prelude.blob`-loaded closures are documented
+/// (`common/sourcemap.rs`: "Pre-compiled blobs use `Smid::default()` (0) for
+/// all prelude locations") to carry an invalid (default) SMID, while
+/// user-authored and source-compiled-prelude code carries real source
+/// locations. This gives a coarse, free "prelude-blob code vs user/source
+/// code" attribution for which lookups are in the deep tail, without needing
+/// per-call-site instrumentation.
+pub mod env_depth_diag {
+    use super::Smid;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::OnceLock;
+
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+
+    pub fn enabled() -> bool {
+        *ENABLED.get_or_init(|| std::env::var("EU_ENV_DEPTH_HISTOGRAM").as_deref() == Ok("1"))
+    }
+
+    const BUCKET_NAMES: [&str; 8] = ["0", "1", "2", "3-4", "5-8", "9-16", "17-32", "33+"];
+
+    fn bucket(depth: usize) -> usize {
+        match depth {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            3..=4 => 3,
+            5..=8 => 4,
+            9..=16 => 5,
+            17..=32 => 6,
+            _ => 7,
+        }
+    }
+
+    struct Histogram {
+        buckets: [AtomicU64; 8],
+        count: AtomicU64,
+        sum: AtomicU64,
+        max: AtomicU64,
+    }
+
+    impl Histogram {
+        const fn new() -> Self {
+            Histogram {
+                buckets: [
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                    AtomicU64::new(0),
+                ],
+                count: AtomicU64::new(0),
+                sum: AtomicU64::new(0),
+                max: AtomicU64::new(0),
+            }
+        }
+
+        fn record(&self, depth: usize) {
+            self.buckets[bucket(depth)].fetch_add(1, Ordering::Relaxed);
+            self.count.fetch_add(1, Ordering::Relaxed);
+            self.sum.fetch_add(depth as u64, Ordering::Relaxed);
+            self.max.fetch_max(depth as u64, Ordering::Relaxed);
+        }
+
+        fn dump(&self, label: &str) {
+            let count = self.count.load(Ordering::Relaxed);
+            let sum = self.sum.load(Ordering::Relaxed);
+            let max = self.max.load(Ordering::Relaxed);
+            let mean = if count > 0 {
+                sum as f64 / count as f64
+            } else {
+                0.0
+            };
+            eprintln!("ENV_DEPTH_HISTOGRAM[{label}]: count={count} mean={mean:.4} max={max}");
+            for (i, name) in BUCKET_NAMES.iter().enumerate() {
+                eprintln!(
+                    "  bucket[{name}] = {}",
+                    self.buckets[i].load(Ordering::Relaxed)
+                );
+            }
+        }
+    }
+
+    static ANNOTATED: Histogram = Histogram::new();
+    static UNANNOTATED: Histogram = Histogram::new();
+
+    pub(super) fn record(start_annotation: Smid, depth: usize) {
+        if start_annotation.is_valid() {
+            ANNOTATED.record(depth);
+        } else {
+            UNANNOTATED.record(depth);
+        }
+    }
+
+    /// Dump both histograms to stderr. No-op unless `EU_ENV_DEPTH_HISTOGRAM=1`.
+    /// Called once at process exit (`src/bin/eu.rs`).
+    pub fn dump() {
+        if !enabled() {
+            return;
+        }
+        ANNOTATED.dump("annotated: user code / source-compiled prelude");
+        UNANNOTATED.dump("unannotated: blob-loaded prelude (Smid::default())");
+    }
+}
+
 /// Closure as stored in an environment frame
 ///
 /// A closure consist of a static part (InfoTable) that can be
@@ -380,6 +501,39 @@ where
         }
     }
 
+    /// DIAGNOSTIC ONLY (bead eu-qm7f, `EU_ENV_DEPTH_HISTOGRAM=1`): shadow-walk
+    /// the same chain `cell()` would traverse for `idx`, purely to count hops
+    /// into `env_depth_diag`'s histograms. Does not touch `self.bindings` or
+    /// return a value, so it cannot affect `get()`'s result. No-op (a single
+    /// cached-bool check) unless the env var is set.
+    fn diag_record_depth(&self, guard: &dyn MutatorScope, idx: usize) {
+        if !env_depth_diag::enabled() {
+            return;
+        }
+        let start_annotation = self.annotation;
+        let mut depth = 0usize;
+        let mut remaining = idx;
+        let mut len = self.logical_len();
+        let mut next = self.next;
+        loop {
+            if remaining < len {
+                env_depth_diag::record(start_annotation, depth);
+                return;
+            }
+            remaining -= len;
+            depth += 1;
+            match next {
+                Some(env_ptr) => {
+                    let scoped = ScopedPtr::from_non_null(guard, env_ptr);
+                    len = scoped.logical_len();
+                    next = scoped.next;
+                }
+                // Bad index (error path) -- not a normal lookup depth, skip.
+                None => return,
+            }
+        }
+    }
+
     /// Zero-based closure access (from top of environment)
     ///
     /// Uses guard for scoping derefs during navigation but then
@@ -387,6 +541,7 @@ where
     /// the returned value is not affected by subsequent updates and
     /// is useful mainly for immediate evaluation.
     pub fn get(&self, guard: &dyn MutatorScope, idx: usize) -> Option<C> {
+        self.diag_record_depth(guard, idx);
         if let Some((arr, i)) = self.cell(guard, idx) {
             arr.get(i)
         } else {


### PR DESCRIPTION
Owner-mandated follow-up to eu-7xvv (PR #1003): "I want to understand this accurately before we consider touching environments." **Diagnosis only** -- adds a small, disabled-by-default instrumentation to directly measure runtime environment chain-walk depth rather than infer it from profile shares. Do not merge without owner review.

## Headline finding -- outcome (b): the "deep chains" narrative is refuted

Runtime environment chain-walk depth is **shallow in both blob and source configs, on both 018_string_scale and 019_list_scale, and is not materially different between them** (max depth 2 blob / 3 source, mean well under 1, on both benchmarks). This directly contradicts eu-2sa6.12's and eu-7xvv's "deep runtime lexical-environment chains" mechanism claim, which was built on profile-share dominance and a whole-file `dump runtime` pretty-print proxy (1874 thunks / 171 max nesting) -- never on a direct depth measurement. That static figure does **not** manifest as deep runtime chains: max observed depth this session was 2, nowhere near 171, confirming (via direct measurement, not inference) what PR #997's Core-level reflatten experiment already suspected.

Total lookup counts are also nearly identical between configs (75.30M blob vs 75.09M on 018, 0.27% apart), matching the known identical-tick baseline (76.81M vs 76.75M) -- so neither lookup count nor lookup depth differs materially. The remaining candidate is a per-hop/locality cost: blob shows fewer allocations but *more* resident heap blocks (3,779 vs 3,534, +6.9%) for the same workload, consistent with worse packing density under blob rather than longer walks.

All headline figures were reproduced byte-identically across two independent runs on the byte engine, and again identically on the pre-decoded engine (`EU_PREDECODE=1`) -- confirming both determinism and engine-independence, since `BcEnvFrame` is a type alias for the same generic `EnvironmentFrame` HeapSyn uses. Labelled measured-verified per the bead's own bar ("reproduced it twice").

**Correction added to the eu-7xvv report (PR #1003, now on master):** `docs/superpowers/reports/2026-07-13-blob-string-penalty-profile.md` gets a dated banner at the top pointing here, stating its "deep chains" mechanism claim is refuted, and noting its profile-share evidence (`enter_local` costlier under blob) still stands with locality as the surviving (projected) candidate. Banner only -- the original report body is left as the historical record, per the PR #997 record-correction precedent.

## Instrumentation, and why the disabled path is safe on this hot path

`EU_ENV_DEPTH_HISTOGRAM=1`-gated (mirrors the `EU_STACK_DIAG` precedent -- cached bool, disabled by default). A **read-only shadow walk** alongside the unmodified `cell()`/`get()` in `src/eval/machine/env.rs`, so it cannot alter lookup behaviour or return values; dumped to stderr once at process exit (`src/bin/eu.rs`). Attribution uses the frame's existing `annotation: Smid` field -- blob-loaded prelude closures carry `Smid::default()` per `sourcemap.rs`'s own documented invariant, giving a free "prelude-blob code vs user code" split with no new per-call-site instrumentation.

`EnvironmentFrame::get` is on the hottest path in the VM (tens of millions of calls per benchmark run), so the guard matters:

- **Disabled-path cost is exactly one `OnceLock<bool>` read (a relaxed atomic load after first init) plus one `if`, added once at the top of `get()`.** No allocation, no closure, no extra parameter threading -- `diag_record_depth` returns immediately after that single check.
- The check is **cached once, not re-read from the environment on every call** -- same pattern as `MachineSettings::stack_diag` (`src/eval/machine/vm.rs:1543`, "checked once at startup to avoid an env-var lookup on every VM step").
- The actual walk (`cell()`) and its call sites are **untouched** -- the diagnostic is bolted on as a sibling call inside `get()`, not a modification of the existing recursive `cell()` function, so there is no risk of the disabled path pessimising codegen for the real lookup (no new branch inside the hot recursive helper itself).
- Verified rather than asserted: full harness suite (byte/HeapSyn/predecode, ~1940 tests each) green with the instrumentation compiled in but disabled; clippy `--all-targets -- -D warnings` clean; `cargo fmt --all` applied. No wall-clock claim is made about the disabled-path overhead in the report (it wasn't benchmarked) -- the argument for negligibility is structural (one cached bool check), not measured, and is offered here for reviewer scrutiny rather than asserted as fact.

## Verdict and mapping (no fix implemented, diagnosis-only)

Outcome (b) per the bead's own outcome mapping: equal depths -> locality-class explanation, not depth. This points at the ROADMAP-sanctioned **BV3 register frames + CG4 selective lifting** (the targeted fix ROADMAP S10.2 already settled on after the 0.10.0 flat-closures universal-representation attempt failed for the same reason -- chains are shallow, so depth-reduction has no win available) as the evidenced next place to look, rather than further blob-generation-level flattening (nothing left to flatten) or the in-memory co-compilation redesign eu-7xvv's now-refuted deep-chains story had leaned toward.

Full histograms (018 and 019, blob and source, byte/predecode/HeapSyn), the static-vs-runtime reconciliation, attribution discussion (what could and couldn't be attributed, given there's no deep tail to attribute), and confidence labels on every figure: `docs/superpowers/reports/2026-07-13-env-walk-depth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP
