### PR TITLE
spike(blob): narrow inline_cores fusion of the hot map/foldl cluster — blob locality penalty (eu-v8n8)

### DIFF
--- a/tests/harness/188_v8n8_cluster_laziness.eu
+++ b/tests/harness/188_v8n8_cluster_laziness.eu
@@ -1,0 +1,31 @@
+#!/usr/bin/env eu
+# eu-v8n8 laziness preservation — the precise soundness property the fusion relies on.
+#
+# The flag-gated inline_cores fusion (EU_BLOB_INLINE_CLUSTER) inlines map/foldl into user
+# code, exposing them to per-invocation demand analysis. The hazard is NOT list elements
+# (eucalypt evaluates lists eagerly, so there is no element-laziness to break) but whether
+# inlining a fused body into an UNUSED, never-demanded position wrongly promotes it to
+# strict. Here an argument threaded through recursion but never scrutinised (the shape of
+# 181_cg3_bomb) has as its value a map / foldl application whose MAPPED FUNCTION / FOLD
+# OPERATOR is a bomb — so nothing fires at list construction (the elements are safe); only
+# actually running the map/foldl would apply the bomb. A correctly-lazy unused argument is
+# never demanded, so the bomb never fires.
+#
+# Must pass with the flag ON and OFF, on all three engines (bytecode / predecode /
+# HeapSyn). A failure means the demand-driven specialisation over-forced the inlined copy.
+# Complements 181_cg3_bomb (unused divergent arg) and 171_strict_prelude_args.
+
+# Bombs that fire only if the map/foldl actually runs (function applied / operator folded).
+bomb-fn(x): panic("laziness violated: an unused fused-map application was forced")
+bomb-op(acc, el): panic("laziness violated: an unused fused-foldl application was forced")
+
+# 181's pattern: lazy-arg is threaded through self-recursion but never scrutinised.
+pass-through(n, lazy-arg): if(n = 0, :PASS, pass-through(n - 1, lazy-arg))
+
+` :suppress
+unused-map: pass-through(30, [1, 2, 3] map(bomb-fn))
+
+` :suppress
+unused-fold: pass-through(30, foldl(bomb-op, 0, [1, 2, 3]))
+
+RESULT: [unused-map = :PASS, unused-fold = :PASS] all-true? then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2752,6 +2752,11 @@ pub fn test_187_sv_prefix_list() {
 }
 
 #[test]
+pub fn test_188_v8n8_cluster_laziness() {
+    run_test(&opts("188_v8n8_cluster_laziness.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -299,7 +299,63 @@ fn cmd_prelude_compile() -> Result<()> {
         resolved_map.insert(name.clone(), expanded.clone());
         resolved_cores.push((name.clone(), expanded));
     }
-    let inline_cores = resolved_cores;
+    let mut inline_cores = resolved_cores;
+
+    // ── 4c. Spike (eu-v8n8, flag-gated): fuse the low-density recursive hot
+    // helper cluster into inline_cores ────────────────────────────────────────
+    //
+    // Option A for the blob locality penalty (eu-ttpl blob-layout-forensics):
+    // the packing-density hit on string/list workloads comes from the recursive
+    // list helpers `map`/`foldl` running as un-fused standalone global closures
+    // (blob 018 same-block hit-rate 0.642 / ~65 frames-per-block vs source 0.870
+    // / 170). Their `cons`/`head`/`tail`/`nil?`/`if` operands are already in
+    // inline_cores; only these recursive wrappers are missing, because the
+    // fixed-point above admits only *closed* combinators and a self-referential
+    // lambda is not closed (the exact case eu-2sa6.12 §4.1 deferred).
+    //
+    // We force their outer lambda's closed flag so the runtime inline pass
+    // distributes them into user call sites (carrying their operands inline,
+    // packing densely). This is bounded and terminating: `reduce::distribute`
+    // substitutes inline_cores exactly once per Let scope and does not
+    // re-substitute into nested lambda bodies, and `prepare.rs` runs only two
+    // inline iterations — so recursion unrolls a fixed ~2 levels and the
+    // residual self-call stays `Var::Free` and resolves to the global slot
+    // (`Ref::G`) at STG compile. Semantics are preserved (the inlined copies are
+    // the same body); the effect is purely how densely their frames pack.
+    //
+    // Added AFTER the pre-expansion pass so the recursion never enters the
+    // forward-substitution loop. Injected alongside the pre-expanded operands in
+    // one Let scope (`inject_prelude_inline_cores`), so their `Var::Free`
+    // operand references bind to those siblings.
+    //
+    // OFF by default: without `EU_BLOB_INLINE_CLUSTER=1` the blob is generated
+    // byte-identically to master.
+    if std::env::var("EU_BLOB_INLINE_CLUSTER").as_deref() == Ok("1") {
+        const CLUSTER: &[&str] = &["map", "foldl"];
+        let mut added = 0usize;
+        for wanted in CLUSTER {
+            if inlinable_names.contains(*wanted) {
+                continue; // already fused by the fixed-point
+            }
+            let Some((name, body)) = binding_bodies.iter().find(|(n, _)| n == wanted) else {
+                continue;
+            };
+            let tagged = tag_combinators(body)
+                .with_context(|| format!("tag_combinators on cluster '{name}'"))?;
+            let peeled = peel_meta(&tagged);
+            // Force the outer lambda closed so the inline pass distributes it.
+            let forced = match &*peeled.inner {
+                Expr::Lam(smid, _, scope) => RcExpr::from(Expr::Lam(*smid, true, scope.clone())),
+                _ => peeled.clone(),
+            };
+            inline_cores.push((name.clone(), forced));
+            added += 1;
+        }
+        println!(
+            "  [SPIKE eu-v8n8] forced hot cluster into inline_cores: +{added} (total {})",
+            inline_cores.len()
+        );
+    }
 
     // ── 5. Build name→slot mapping from peeled bindings ──────────────────────
     let name_to_slot: HashMap<String, usize> = binding_bodies


### PR DESCRIPTION
## Narrow inline_cores fusion of the hot map/foldl cluster — blob locality penalty (eu-v8n8, owner option A)

Flag-gated spike (`EU_BLOB_INLINE_CLUSTER=1` at blob-generation), **OFF by default** — with the flag off the blob is byte-identical to master and CI/tripwires are untouched.

### The change

The blob string/list penalty (eu-2sa6.12 → eu-7xvv → eu-qm7f → eu-ttpl) is a packing-density/locality problem: the recursive list helpers `map`/`foldl` run as un-fused standalone global closures, packing frames at low density (018: 65 vs 156–170 fused; same-block hit-rate 0.642 vs 0.870 source). Their `cons`/`head`/`tail`/`nil?`/`if` operands and structural `=`/`JOIN` are already in `inline_cores`; only the recursive wrappers are missing, because the fixed-point admits only *closed* combinators and a self-referential lambda isn't closed (the case eu-2sa6.12 §4.1 deferred).

`xtask/src/main.rs` §4c force-includes `map`/`foldl` into `inline_cores` (forcing their outer-lambda closed flag) so the runtime inline pass distributes them into user call sites. Bounded/terminating: `reduce::distribute` substitutes `inline_cores` once per Let scope and never re-substitutes into nested lambda bodies, `prepare.rs` runs two inline iterations, and the residual self-call resolves to the global slot (`Ref::G`) at STG compile. Confirmed empirically — no hang, no bloat (inline_cores 133→135, blob +341 bytes, bytecode identical).

### ⚠️ HONEST REFRAME — this is NOT a tick-neutral locality fix; it OVERSHOOTS source

The original framing (locality/wall win, wall-parity with source) is wrong. Measured (verified same-session A/B, `-S -t <target>`, baseline reproduced exactly):

| Bench | metric | flag-off | flag-on | Δ |
|---|---|---|---|---|
| 018_string_scale | hs / bc / pd | 76.8M / 76.7M / 76.7M | 46.1M / 46.0M / 45.9M | **−40%** |
| 019_list_scale | hs | 55.8M | 51.2M | **−8%** |
| 022_hof_fold | hs / bc / pd | 52.2M / 52.1M / 52.1M | 2.23M / 2.13M / 2.03M | **−96%** |
| fib (control — no map/foldl) | all | unchanged | unchanged | **0%** |

The mechanism is bigger than packing density: inlining `map`/`foldl` into user code exposes them to per-invocation demand analysis, which specialises them strictly and collapses quadratic thunk churn — eu-2sa6.12 §6.4's demand-boundary hypothesis achieved via inlining (the §7 side-table couldn't, because these helpers are point-free).

**Because baseline ticks were identical across configs (76.8M both), source-prelude compilation never achieved this fusion either.** Flag-on blob does 018 in 46M ticks; **source still does 76.8M**. So this introduces a large cross-config tick divergence on map/foldl workloads (~**1.67×** on 018) — invisible to the fib-based tripwire (fib uses neither helper, so its ratio stays 1.106 byte / 1.1228 predecode, within caps) but real. See the sequencing section.

Hit-rate proxy (018, HeapSyn `EU_ENV_LAYOUT_HISTOGRAM`, flag-on): **0.784** (baseline 0.642 → 0.784, source 0.870). NOT apples-to-apples with the 0.85 gate — lookups dropped 74.7M→44.6M with the tick collapse, so this characterises the NEW regime, not the original tick-neutral gate. The density confirmation the report leads with: the hot traffic moved INTO dense user-code blocks (**133.9 frames/block, 98.9% of touches**) and out of the low-density blob prelude (34.7/block, now 1.1%) — exactly the mechanism.

### Laziness preservation

Eucalypt evaluates list ELEMENTS eagerly (lazy streams deferred), so element-laziness tests are inapplicable — verified even `cons(1, bomb) head` forces `bomb`, identically flag-on/flag-off. The real soundness property (inlining a fused body into an unused position must not promote it strict) is covered by new test **188_v8n8_cluster_laziness** (unused threaded arg = a map/foldl application with a bomb function): passes flag ON and OFF on all 3 engines, and has teeth (forcing the arg panics). Plus the existing strictness/laziness tests (170_strict_eager_eval, 171_strict_prelude_args, 179_cg3_strict_recurse, 181_cg3_bomb) pass flag-on on all 3 engines.

### Gate matrix (host Darwin-25.5.0-arm64, rustc 1.97.0)

| Gate | Result |
|---|---|
| Blob-gen flag-on | no hang/bloat; inline_cores 133→135; blob +341 B; bytecode identical |
| Flag-OFF full suite (byte/predecode/heapsyn) | green — byte-identical to master + new test |
| Flag-ON full suite (byte/predecode/heapsyn) | green; output byte-identical (495/495 harness) |
| Laziness (188 + 170/171/179/181) | pass flag-on AND off, 3 engines |
| Tripwires | unchanged (fib uses no map/foldl) — 1.106 byte / 1.1228 predecode, within caps |
| fmt / clippy | clean (my change; 2 pre-existing xtask warnings noted) |
| Wall | NOT measured (machine busy) — deferred to a quiet window per PROTOCOL |

### PROMOTION-BLOCKED-ON-SEQUENCING (owner decides)

This is a spike; promotion is an owner call because the change is **blob-only** and now **overshoots source**:

- `inject_prelude_inline_cores` is blob-only (`driver/source.rs`; no-op on the source-prelude path). So the fusion helps only released (blob) builds; source-prelude (dev) builds get nothing.
- It creates a new blob-vs-source **tick** divergence (~1.67× on 018) that the fib tripwire can't see. The absolute source-prelude handicap the tripwire guards is unchanged for fib, but map/foldl workloads now diverge sharply.
- This strengthens the case that **eu-npp9's scope must grow to include cluster fusion on the source merge-cook path**, so both configs converge — otherwise dev builds and released builds diverge in performance character on the exact workloads this targets.

Options for the owner: (a) sequence eu-npp9 (source-path fusion) first/together so both configs benefit; (b) promote blob-only now and accept the documented divergence until eu-npp9 lands; (c) fold cluster fusion into eu-npp9's scope directly. I did not attempt the source-path change (option c is eu-npp9's scope, not a flag on inline_cores).

Do not merge — Wicket reviews (directed mode); owner re-reviews. Wicket to independently reproduce the 022 −96% before it's load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
