### PR TITLE
feat(inline): copy-specialisation of recursive higher-order combinators (eu-dp0k)

### DIFF
--- a/docs/superpowers/specs/2026-07-13-recursive-combinator-copy-specialisation-design.md
+++ b/docs/superpowers/specs/2026-07-13-recursive-combinator-copy-specialisation-design.md
@@ -322,6 +322,40 @@ lambdas inlinable, and `inline_pass` distributes each into the user's call sites
 as a local specialised copy. No new source-path wiring is needed — the criterion
 change alone activates it.
 
+> **⚠ AMENDMENT (post-sign-off, eu-dp0k, 2026-07-14) — §3.1 above is WRONG.**
+> Implementation found the criterion alone does **not** fuse the source-prelude
+> path; `EU_SOURCE_PRELUDE=1` bench 022 stays quadratic (~52M ticks). Two
+> independent blockers, neither anticipated here:
+>
+> 1. **`distribute` is metadata-blind.** Prelude combinators are
+>    `Meta(Lam, docstring)`; `reduce::inlinable()` matches only bare
+>    `Lam(_, true, _)`, so documented combinators are never distributed on the
+>    source path. (The blob path works only because xtask `peel_meta`s the
+>    `inline_cores` before storing them.) This *is* the mechanism behind the
+>    §3.4 source-vs-blob divergence.
+> 2. **Demand-specialisation needs pre-expansion parity.** Even once the local
+>    copy exists, the source-path copy is not specialised strict (it stays
+>    quadratic) because it lacks the blob's pre-expanded `inline_cores`; the
+>    blob path gets a fully-specialised local `letrec`, the source path a
+>    partial one.
+>
+> **⚠ Type-annotation hazard (landmine for any fix).** A naive fix — peeling
+> `Meta` in `distribute` to make combinators inlinable — is *unsound*: type
+> annotations are also `Meta` nodes, so peeling strips them, and an annotated
+> identity like `` `{type:"number->number"} wrap(x): x`` inlined at
+> `wrap("hello")` silently loses its annotation and the type mismatch goes
+> undetected. Harness test **`104_suppress_type_warnings_ok.eu`** is the
+> tripwire; any source-path meta handling must preserve type/annotation
+> metadata while enabling combinator inlining.
+>
+> Source-path closure is tracked as the 0.13 release-blocker **eu-rb5n** (its
+> two sub-problems are the blockers above). eu-dp0k lands the **blob (default)
+> path only**; the "both configs fuse" gate is deferred to eu-rb5n by owner
+> decision. `EU_SOURCE_PRELUDE` is opt-in, so the default build is unaffected.
+> eu-rb5n also notes the eu-npp9 relationship: the Meta-blindness looks like the
+> same source-path mechanism behind the global-form divergence, so one PR may
+> close both.
+
 ### 3.2 Blob (generation) path
 
 On the blob path the prelude is pre-compiled; the combinator body reaches the

--- a/src/core/inline/tag.rs
+++ b/src/core/inline/tag.rs
@@ -257,14 +257,17 @@ fn all_free_vars_resolvable(expr: &RcExpr, set: &HashSet<String>, self_name: Opt
         Expr::Var(_, Var::Bound(_)) => true,
         Expr::Literal(_, _) => true,
         Expr::Intrinsic(_, _) => true,
-        Expr::App(_, f, xs) => {
-            all_free_vars_resolvable(f, set, self_name)
-                && xs
-                    .iter()
-                    .all(|x| all_free_vars_resolvable(x, set, self_name))
-        }
+        // Metadata (docstrings, type annotations) does not gate admission —
+        // only the wrapped value's free variables matter.
         Expr::Meta(_, inner, _) => all_free_vars_resolvable(inner, set, self_name),
-        _ => false,
+        // Every other shape (App, Let, Block, Lam, List, Lookup, Operator,
+        // ArgTuple): locally-bound names are `Var::Bound` (resolvable), so it
+        // suffices to check that every free variable among the children is in
+        // the set. This admits recursive combinators with `Let`/`Block` bodies
+        // (e.g. `scanr`) to `inline_cores`, completing the qualifying set.
+        _ => child_exprs(expr)
+            .iter()
+            .all(|c| all_free_vars_resolvable(c, set, self_name)),
     }
 }
 
@@ -363,15 +366,15 @@ pub mod tests {
         let set: HashSet<String> = HashSet::new();
         assert!(all_free_vars_in_set(&num(1), &set));
         assert!(all_free_vars_in_set(&bif("ADD"), &set));
-        // Lam nodes are not traversed by all_free_vars_in_set (falls through
-        // to the `_ => false` arm) — this is intentional: the function is
-        // used on lambda bodies, not on the Lam wrappers themselves.
+        // Lam bodies are now traversed (needed to admit combinators with
+        // nested-lambda or `Let`/`Block` bodies): a Lam whose body has no
+        // unresolved free vars is resolvable; its parameters are `Var::Bound`.
         let x = free("x");
-        let lam_expr = lam(vec![x.clone()], num(42));
-        assert!(
-            !all_free_vars_in_set(&lam_expr, &set),
-            "Lam node returns false (checked on body separately, not the wrapper)"
-        );
+        let lam_closed = lam(vec![x.clone()], num(42));
+        assert!(all_free_vars_in_set(&lam_closed, &set));
+        // A Lam whose body references an out-of-set free var is not resolvable.
+        let lam_free = lam(vec![x.clone()], var(free("external")));
+        assert!(!all_free_vars_in_set(&lam_free, &set));
         let _ = x;
     }
 
@@ -416,6 +419,31 @@ pub mod tests {
         let inner = var(free("if"));
         let meta_expr = RcExpr::from(Expr::Meta(Smid::default(), inner, num(42)));
         assert!(all_free_vars_in_set(&meta_expr, &set));
+    }
+
+    /// A `Let`-bodied expression is traversed: locally-bound names are
+    /// `Var::Bound` (resolvable), and external free vars are checked against the
+    /// set. This admits recursive combinators with `Let`/`Block` bodies (§3.2).
+    #[test]
+    pub fn test_all_free_vars_let_body_traversed() {
+        use std::collections::HashSet;
+        let mut set: HashSet<String> = HashSet::new();
+        set.insert("cons".to_string());
+        // let acc = cons(x, y) in acc  — `acc` is locally bound (Bound), `cons`
+        // is external and in the set, `x`/`y` are lambda-scoped Bound vars.
+        let body = let_(
+            vec![(
+                free("acc"),
+                app(var(free("cons")), vec![var(free("x")), var(free("y"))]),
+            )],
+            var(free("acc")),
+        );
+        let expr = lam(vec![free("x"), free("y")], body);
+        assert!(all_free_vars_in_set(&expr, &set));
+
+        // With `cons` absent from the set, the Let body's free var fails.
+        let empty: HashSet<String> = HashSet::new();
+        assert!(!all_free_vars_in_set(&expr, &empty));
     }
 
     #[test]

--- a/src/core/inline/tag.rs
+++ b/src/core/inline/tag.rs
@@ -1,9 +1,16 @@
 //! Tag selected lambdas as inlinable for inline pass
 use crate::core::{
-    binding::Var,
+    binding::{CoreBinding, Scope, Var},
+    error::CoreError,
     expr::{Expr, LamScope, LetType, RcExpr},
 };
 use std::collections::HashSet;
+
+/// Maximum core-expr node count for a recursive higher-order combinator body to
+/// qualify for copy-specialisation. Guards against a single pathologically large
+/// recursive combinator bloating user code at each call site. See design §1.2
+/// (`docs/superpowers/specs/2026-07-13-recursive-combinator-copy-specialisation-design.md`).
+const MAX_COPY_BODY_NODES: usize = 48;
 
 /// Walk the expression tagging combinators and destructuring lambdas.
 ///
@@ -15,18 +22,166 @@ use std::collections::HashSet;
 ///   `DestructureBlockLet` or `DestructureListLet`). This allows the inline
 ///   pass to distribute destructuring functions to their call sites so that
 ///   the subsequent fusion pass can simplify the resulting static lookups.
-pub fn tag_combinators(expr: &RcExpr) -> Result<RcExpr, crate::core::error::CoreError> {
+pub fn tag_combinators(expr: &RcExpr) -> Result<RcExpr, CoreError> {
+    tag_combinators_named(expr, None)
+}
+
+/// As [`tag_combinators`], but carrying the name of the binding whose value
+/// `expr` is (when known), so a self-recursive higher-order combinator can be
+/// recognised by the [`recursive_combinator`] criterion (design §1.1). The
+/// source path supplies each binding's name through the `Let` arm below;
+/// xtask's blob-gen fixed-point passes the binding name directly for the bare
+/// lambda it holds.
+pub fn tag_combinators_named(expr: &RcExpr, self_name: Option<&str>) -> Result<RcExpr, CoreError> {
     match &*expr.inner {
         Expr::Lam(s, false, scope) => {
             if closed_body(&scope.body) || destructuring(scope) {
                 Ok(RcExpr::from(Expr::Lam(*s, true, scope.clone())))
+            } else if self_name.is_some_and(|n| recursive_combinator(n, scope)) {
+                // Tag inlinable and still process the body: unlike a closed
+                // body, a recursive combinator body may hold nested inlinable
+                // lambdas that should be tagged too.
+                let body = tag_combinators_named(&scope.body, None)?;
+                Ok(RcExpr::from(Expr::Lam(
+                    *s,
+                    true,
+                    Scope {
+                        pattern: scope.pattern.clone(),
+                        body,
+                    },
+                )))
             } else {
                 // Recurse into the lambda body even if not itself inlinable
-                expr.walk_safe(&mut |e| tag_combinators(&e))
+                expr.walk_safe(&mut |e| tag_combinators_named(&e, None))
             }
         }
-        _ => expr.walk_safe(&mut |e| tag_combinators(&e)),
+        Expr::Meta(s, inner, m) => {
+            // Metadata (e.g. a docstring) wraps a binding value without changing
+            // its identity — thread the self-name through to the inner lambda so
+            // a documented recursive combinator is still recognised.
+            let new_inner = tag_combinators_named(inner, self_name)?;
+            let new_meta = tag_combinators_named(m, None)?;
+            Ok(RcExpr::from(Expr::Meta(*s, new_inner, new_meta)))
+        }
+        Expr::Let(s, scope, lt) => {
+            // Each binding value is tagged with its own name as self-context, so
+            // a self-recursive higher-order combinator bound here is recognised.
+            let bindings = scope
+                .pattern
+                .iter()
+                .map(|b| {
+                    tag_combinators_named(&b.expr, Some(&b.name))
+                        .map(|e| CoreBinding::with_demand(b.name.clone(), e, b.demand))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let body = tag_combinators_named(&scope.body, None)?;
+            Ok(RcExpr::from(Expr::Let(
+                *s,
+                Scope {
+                    pattern: bindings,
+                    body,
+                },
+                *lt,
+            )))
+        }
+        _ => expr.walk_safe(&mut |e| tag_combinators_named(&e, None)),
     }
+}
+
+/// A self-recursive higher-order combinator qualifies for copy-specialisation
+/// when **all** hold (design §1.1):
+/// 1. it applies one of its own parameters (higher-order), and
+/// 2. it recurses on its own name, and
+/// 3. its body is within [`MAX_COPY_BODY_NODES`].
+fn recursive_combinator(self_name: &str, scope: &LamScope<RcExpr>) -> bool {
+    applies_own_param(&scope.body, 0)
+        && references_name(&scope.body, self_name)
+        && node_count(&scope.body) <= MAX_COPY_BODY_NODES
+}
+
+/// Direct sub-expressions of a core node, for read-only structural traversal.
+fn child_exprs(expr: &RcExpr) -> Vec<&RcExpr> {
+    match &*expr.inner {
+        Expr::Let(_, scope, _) => {
+            let mut v: Vec<&RcExpr> = scope.pattern.iter().map(|b| &b.expr).collect();
+            v.push(&scope.body);
+            v
+        }
+        Expr::Lam(_, _, scope) => vec![&scope.body],
+        Expr::App(_, f, xs) => {
+            let mut v = vec![f];
+            v.extend(xs.iter());
+            v
+        }
+        Expr::Lookup(_, t, _, fallback) => {
+            let mut v = vec![t];
+            if let Some(f) = fallback {
+                v.push(f);
+            }
+            v
+        }
+        Expr::Meta(_, e, m) => vec![e, m],
+        Expr::List(_, xs) | Expr::ArgTuple(_, xs) | Expr::Soup(_, xs, _) => xs.iter().collect(),
+        Expr::Block(_, m) => m.values().collect(),
+        Expr::Operator(_, _, _, e) => vec![e],
+        _ => vec![],
+    }
+}
+
+/// True if `expr` applies, in function-head position, a parameter of the lambda
+/// whose body sits `depth` binding-scopes above (0 = that lambda's own body). A
+/// parameter reference of the target lambda is `Var::Bound { scope == depth }`;
+/// `Lam`/`Let` each add one scope as we descend.
+fn applies_own_param(expr: &RcExpr, depth: u32) -> bool {
+    match &*expr.inner {
+        Expr::Lam(_, _, scope) => applies_own_param(&scope.body, depth + 1),
+        Expr::Let(_, scope, _) => {
+            scope
+                .pattern
+                .iter()
+                .any(|b| applies_own_param(&b.expr, depth + 1))
+                || applies_own_param(&scope.body, depth + 1)
+        }
+        Expr::App(_, f, xs) => {
+            head_is_param_at(f, depth)
+                || applies_own_param(f, depth)
+                || xs.iter().any(|x| applies_own_param(x, depth))
+        }
+        // Non-binding nodes: children are at the same depth.
+        _ => child_exprs(expr)
+            .iter()
+            .any(|c| applies_own_param(c, depth)),
+    }
+}
+
+/// True if the application head `f` resolves to a bound variable of the scope at
+/// `depth` (curried applications peel the head).
+fn head_is_param_at(f: &RcExpr, depth: u32) -> bool {
+    match &*f.inner {
+        Expr::Var(_, Var::Bound(bv)) => bv.scope == depth,
+        Expr::App(_, g, _) => head_is_param_at(g, depth),
+        _ => false,
+    }
+}
+
+/// True if `expr` references the binding `name` anywhere — as a free variable
+/// or as a bound variable that preserves the name (the self-reference is
+/// `Var::Free(name)` after blob-gen peeling, `Var::Bound { name }` on the
+/// scoped source path).
+fn references_name(expr: &RcExpr, name: &str) -> bool {
+    match &*expr.inner {
+        Expr::Var(_, Var::Free(n)) => n == name,
+        Expr::Var(_, Var::Bound(bv)) => bv.name.as_deref() == Some(name),
+        _ => child_exprs(expr).iter().any(|c| references_name(c, name)),
+    }
+}
+
+/// Total core-expr node count (this node plus all descendants).
+fn node_count(expr: &RcExpr) -> usize {
+    1 + child_exprs(expr)
+        .iter()
+        .map(|c| node_count(c))
+        .sum::<usize>()
 }
 
 /// A lambda body is a closed expression if every node is one of:
@@ -78,15 +233,37 @@ fn destructuring(lam_scope: &LamScope<RcExpr>) -> bool {
 /// Used by xtask's fixed-point collection to determine which prelude
 /// bindings are safe to include as inline cores.
 pub fn all_free_vars_in_set(expr: &RcExpr, set: &HashSet<String>) -> bool {
+    all_free_vars_resolvable(expr, set, None)
+}
+
+/// As [`all_free_vars_in_set`], but the binding's **own name** counts as
+/// resolvable (a self-reference binds to the binding's own injected `Let` slot
+/// at runtime). Required for the blob-gen leg of the copy-specialisation
+/// criterion so a self-recursive combinator is not rejected on its own
+/// recursive reference. See design §3.2.
+pub fn all_free_vars_in_set_with_self(
+    expr: &RcExpr,
+    set: &HashSet<String>,
+    self_name: &str,
+) -> bool {
+    all_free_vars_resolvable(expr, set, Some(self_name))
+}
+
+fn all_free_vars_resolvable(expr: &RcExpr, set: &HashSet<String>, self_name: Option<&str>) -> bool {
     match &*expr.inner {
-        Expr::Var(_, Var::Free(name)) => set.contains(name.as_str()),
+        Expr::Var(_, Var::Free(name)) => {
+            self_name == Some(name.as_str()) || set.contains(name.as_str())
+        }
         Expr::Var(_, Var::Bound(_)) => true,
         Expr::Literal(_, _) => true,
         Expr::Intrinsic(_, _) => true,
         Expr::App(_, f, xs) => {
-            all_free_vars_in_set(f, set) && xs.iter().all(|x| all_free_vars_in_set(x, set))
+            all_free_vars_resolvable(f, set, self_name)
+                && xs
+                    .iter()
+                    .all(|x| all_free_vars_resolvable(x, set, self_name))
         }
-        Expr::Meta(_, inner, _) => all_free_vars_in_set(inner, set),
+        Expr::Meta(_, inner, _) => all_free_vars_resolvable(inner, set, self_name),
         _ => false,
     }
 }
@@ -270,5 +447,165 @@ pub mod tests {
         );
 
         assert_eq!(tag_combinators(&original).unwrap(), expected);
+    }
+
+    // ── recursive-combinator criterion tests (design §1.1) ────────────────────
+
+    /// Is the `Lam` bound to `name` in a top-level `Let` tagged inlinable?
+    fn binding_inlinable(expr: &RcExpr, name: &str) -> Option<bool> {
+        if let Expr::Let(_, scope, _) = &*expr.inner {
+            for b in &scope.pattern {
+                if b.name == name {
+                    if let Expr::Lam(_, inl, _) = &*b.expr.inner {
+                        return Some(*inl);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// `myfold(op, acc, xs)` — self-recursive AND applies its own parameter
+    /// `op`, within the size cap → tagged inlinable.
+    #[test]
+    fn test_recursive_combinator_tagged() {
+        let body = app(
+            bif("IF"),
+            vec![
+                app(bif("NILP"), vec![var(free("xs"))]),
+                var(free("acc")),
+                app(
+                    var(free("myfold")),
+                    vec![
+                        var(free("op")),
+                        app(
+                            var(free("op")),
+                            vec![var(free("acc")), app(bif("HEAD"), vec![var(free("xs"))])],
+                        ),
+                        app(bif("TAIL"), vec![var(free("xs"))]),
+                    ],
+                ),
+            ],
+        );
+        let f = lam(vec![free("op"), free("acc"), free("xs")], body);
+        let expr = let_(vec![(free("myfold"), f)], var(free("myfold")));
+        let tagged = tag_combinators(&expr).unwrap();
+        assert_eq!(binding_inlinable(&tagged, "myfold"), Some(true));
+    }
+
+    /// `fib(n)` — self-recursive but first-order (applies no parameter) → the
+    /// null control; NOT tagged.
+    #[test]
+    fn test_first_order_recursion_not_tagged() {
+        let body = app(
+            bif("IF"),
+            vec![
+                app(bif("LT"), vec![var(free("n")), num(2)]),
+                var(free("n")),
+                app(
+                    bif("ADD"),
+                    vec![
+                        app(
+                            var(free("fib")),
+                            vec![app(bif("SUB"), vec![var(free("n")), num(1)])],
+                        ),
+                        app(
+                            var(free("fib")),
+                            vec![app(bif("SUB"), vec![var(free("n")), num(2)])],
+                        ),
+                    ],
+                ),
+            ],
+        );
+        let f = lam(vec![free("n")], body);
+        let expr = let_(vec![(free("fib"), f)], var(free("fib")));
+        let tagged = tag_combinators(&expr).unwrap();
+        assert_eq!(binding_inlinable(&tagged, "fib"), Some(false));
+    }
+
+    /// `hof(f, x) = external(f(x))` — applies its parameter `f` and is not
+    /// closed (references the free var `external`), but is NOT self-recursive →
+    /// NOT tagged (the recursive leg fails; closed_body also fails).
+    #[test]
+    fn test_higher_order_non_recursive_not_tagged() {
+        let body = app(
+            var(free("external")),
+            vec![app(var(free("f")), vec![var(free("x"))])],
+        );
+        let g = lam(vec![free("f"), free("x")], body);
+        let expr = let_(vec![(free("hof"), g)], var(free("hof")));
+        let tagged = tag_combinators(&expr).unwrap();
+        assert_eq!(binding_inlinable(&tagged, "hof"), Some(false));
+    }
+
+    /// A self-recursive higher-order combinator whose body exceeds
+    /// `MAX_COPY_BODY_NODES` is NOT tagged (the size-cap leg fails).
+    #[test]
+    fn test_size_cap_excludes_oversized() {
+        let mut deep = var(free("xs"));
+        for _ in 0..(MAX_COPY_BODY_NODES + 4) {
+            deep = app(bif("ID"), vec![deep]);
+        }
+        let body = app(
+            bif("IF"),
+            vec![
+                app(bif("NILP"), vec![var(free("xs"))]),
+                var(free("acc")),
+                app(
+                    var(free("bigfold")),
+                    vec![
+                        var(free("op")),
+                        app(var(free("op")), vec![var(free("acc")), deep]),
+                        app(bif("TAIL"), vec![var(free("xs"))]),
+                    ],
+                ),
+            ],
+        );
+        let f = lam(vec![free("op"), free("acc"), free("xs")], body);
+        let expr = let_(vec![(free("bigfold"), f)], var(free("bigfold")));
+        let tagged = tag_combinators(&expr).unwrap();
+        assert_eq!(binding_inlinable(&tagged, "bigfold"), Some(false));
+    }
+
+    /// A bare lambda passed without a self-name (xtask style) is only tagged when
+    /// the name is supplied via [`tag_combinators_named`].
+    #[test]
+    fn test_named_entry_point_required_for_recursion() {
+        let body = app(
+            bif("IF"),
+            vec![
+                app(bif("NILP"), vec![var(free("xs"))]),
+                var(free("acc")),
+                app(
+                    var(free("g")),
+                    vec![
+                        var(free("op")),
+                        app(var(free("op")), vec![var(free("acc")), var(free("xs"))]),
+                    ],
+                ),
+            ],
+        );
+        // Close the self-reference `g` over a let so it is a named Bound var,
+        // then extract the lambda to feed the bare-lambda entry points.
+        let closed = let_(
+            vec![(
+                free("g"),
+                lam(vec![free("op"), free("acc"), free("xs")], body),
+            )],
+            var(free("g")),
+        );
+        let lam_expr = if let Expr::Let(_, scope, _) = &*closed.inner {
+            scope.pattern[0].expr.clone()
+        } else {
+            unreachable!()
+        };
+        // Without the name, the bare lambda is not tagged.
+        if let Expr::Lam(_, inl, _) = &*tag_combinators(&lam_expr).unwrap().inner {
+            assert!(!*inl, "bare lambda without self-name must not be tagged");
+        }
+        // With the name (xtask path), it is.
+        if let Expr::Lam(_, inl, _) = &*tag_combinators_named(&lam_expr, Some("g")).unwrap().inner {
+            assert!(*inl, "named entry must tag the recursive combinator");
+        }
     }
 }

--- a/tests/harness/188_v8n8_cluster_laziness.eu
+++ b/tests/harness/188_v8n8_cluster_laziness.eu
@@ -1,0 +1,31 @@
+#!/usr/bin/env eu
+# eu-v8n8 laziness preservation — the precise soundness property the fusion relies on.
+#
+# The flag-gated inline_cores fusion (EU_BLOB_INLINE_CLUSTER) inlines map/foldl into user
+# code, exposing them to per-invocation demand analysis. The hazard is NOT list elements
+# (eucalypt evaluates lists eagerly, so there is no element-laziness to break) but whether
+# inlining a fused body into an UNUSED, never-demanded position wrongly promotes it to
+# strict. Here an argument threaded through recursion but never scrutinised (the shape of
+# 181_cg3_bomb) has as its value a map / foldl application whose MAPPED FUNCTION / FOLD
+# OPERATOR is a bomb — so nothing fires at list construction (the elements are safe); only
+# actually running the map/foldl would apply the bomb. A correctly-lazy unused argument is
+# never demanded, so the bomb never fires.
+#
+# Must pass with the flag ON and OFF, on all three engines (bytecode / predecode /
+# HeapSyn). A failure means the demand-driven specialisation over-forced the inlined copy.
+# Complements 181_cg3_bomb (unused divergent arg) and 171_strict_prelude_args.
+
+# Bombs that fire only if the map/foldl actually runs (function applied / operator folded).
+bomb-fn(x): panic("laziness violated: an unused fused-map application was forced")
+bomb-op(acc, el): panic("laziness violated: an unused fused-foldl application was forced")
+
+# 181's pattern: lazy-arg is threaded through self-recursion but never scrutinised.
+pass-through(n, lazy-arg): if(n = 0, :PASS, pass-through(n - 1, lazy-arg))
+
+` :suppress
+unused-map: pass-through(30, [1, 2, 3] map(bomb-fn))
+
+` :suppress
+unused-fold: pass-through(30, foldl(bomb-op, 0, [1, 2, 3]))
+
+RESULT: [unused-map = :PASS, unused-fold = :PASS] all-true? then(:PASS, :FAIL)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2752,6 +2752,11 @@ pub fn test_187_sv_prefix_list() {
 }
 
 #[test]
+pub fn test_188_v8n8_cluster_laziness() {
+    run_test(&opts("188_v8n8_cluster_laziness.eu"));
+}
+
+#[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,7 +31,7 @@ use anyhow::{bail, Context, Result};
 use eucalypt::{
     core::{
         expr::{open_let_scope_full, Expr, RcExpr},
-        inline::tag::{all_free_vars_in_set, tag_combinators},
+        inline::tag::{all_free_vars_in_set_with_self, tag_combinators_named},
         typecheck::check::{parse_operator_overloads, type_check_for_prelude},
     },
     driver::source::SourceLoader,
@@ -254,11 +254,13 @@ fn cmd_prelude_compile() -> Result<()> {
             if inlinable_names.contains(name) {
                 continue;
             }
-            let tagged =
-                tag_combinators(body).with_context(|| format!("tag_combinators on '{name}'"))?;
+            let tagged = tag_combinators_named(body, Some(name))
+                .with_context(|| format!("tag_combinators on '{name}'"))?;
             let peeled = peel_meta(&tagged);
             if let Expr::Lam(_, true, scope) = &*peeled.inner {
-                if all_free_vars_in_set(&scope.body, &inlinable_names) {
+                // The binding's own name counts as resolvable so a self-recursive
+                // combinator is not rejected on its recursive reference (§3.2).
+                if all_free_vars_in_set_with_self(&scope.body, &inlinable_names, name) {
                     inlinable_names.insert(name.clone());
                     inline_cores.push((name.clone(), peeled.clone()));
                     added += 1;


### PR DESCRIPTION
## eu-dp0k — copy-specialisation of recursive higher-order combinators

Implements the owner-signed design (`docs/superpowers/specs/2026-07-13-recursive-combinator-copy-specialisation-design.md`, PR #1008) on **blob-path scope** (owner Option A). Source-path closure is the separate 0.13 release-blocker **eu-rb5n**.

### What landed

- **The §1 criterion in `tag_combinators`** (shared pipeline): a self-recursive lambda is tagged inlinable when it (1) applies one of its own parameters, (2) recurses on its own name, and (3) is within `MAX_COPY_BODY_NODES = 48`. de Bruijn depth tracking (`applies_own_param`), self-ref matching (`references_name`), `node_count`; threaded through `Meta` (docstrings) and `Let` arms; a name-passing `tag_combinators_named` entry.
- **The §3.2 blob-gen leg**: `all_free_vars_in_set_with_self` (the binding's own name resolves to its injected slot) + `tag_combinators_named` in xtask's fixed-point, plus an extension of the free-var traversal to `Let`/`Block`/`Lam` bodies so the **full qualifying set** is admitted (not 4/8). All 8 — `map`, `foldl`, `foldr`, `scanl`, `scanr`, `map2`, `drop-while`, `iterate` — are now in `inline_cores` (133 → 143).
- **Test 188** (v8n8 laziness preservation) ported from the closed spike branch; passes on all three engines. `170/171/179/181` stay green.

### Measurements (deterministic layers only — machine busy, no wall)

**Provenance.** baseline = `origin/master` clean worktree, binary `b2bf8a67…` / blob `e59640e6…` (461,638 B, 133 cores) — *exactly matches Wicket's adjudicated baseline*. full-8 = this branch @ `20eb69a4`, binary `1cea2b92…` / blob `ad09a865…` (463,305 B, 143 cores). Blob generation is deterministic (identical SHA across regens). bytecode engine, `-t <target>`, `--allow-io` for 021.

**Canonical suite ticks (blob/default config):**

| bench | baseline | full-8 | Δ |
|---|---|---|---|
| 015_block_merge | 98,669,543 | 96,009,128 | −2.70% |
| 016_import_export_yaml | 59,711,048 | 55,930,340 | −6.33% |
| 017_import_export_toml | 59,537,724 | 55,757,016 | −6.35% |
| 018_string_scale | 76,730,983 | 45,958,939 | −40.10% |
| 019_list_scale | 55,719,473 | 51,135,460 | −8.23% |
| 020_lookup_curve | 164,630,267 | 164,406,909 | −0.14% |
| 021_io_loop | 3,958,278 | 3,958,278 | 0.00% (io-bound) |
| 022_hof_fold | 52,125,436 | 2,085,398 | **−96.00%** |

No bench regresses; the full set slightly beats the map+foldl-only adjudicated figures on the transitive beneficiaries (016/017/019 via `filter`/`foldr`/`all`/`any`).

**Bloat (full-8 vs baseline):**

| metric | baseline | full-8 | Δ |
|---|---|---|---|
| inline_cores | 133 | 143 | +10 |
| blob size | 461,638 B | 463,305 B | **+1,667 B** |
| bytecode size | 269,176 B | 269,176 B | **0** |
| arena nodes | 7,104 | 7,104 | **0** |
| STG lambda forms | 352 | 352 | 0 |

The bytecode image is byte-for-byte unchanged — the growth is entirely source-side `inline_cores` payload (~167 B/core). (+10 = the 8 qualifying recursive combinators + 2 previously-rejected `Let`/`Block`-bodied combinators newly admissible via the broadened free-var traversal.)

### Gates

- Full **lib (1305)** + **harness (496)** suites green; `clippy --all-targets -D warnings` clean; `cargo fmt` clean.
- **GC verify/poison/stress**: 015/018/019/022 pass under `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1`.
- **fib tick-parity tripwire unmoved**: baseline == full-8 (bc 20,657,846; hs 26,378,436) — fib is first-order, does not qualify (null control).
- Blob determinism verified.

### Honest divergence disclosure (deferred gate)

The "both configs fuse" gate is **deferred to eu-rb5n by owner decision**. On this branch:
- **Blob (default) path fuses**: 022 = 2,085,398 ticks (bytecode).
- **Source-prelude path does NOT fuse**: `EU_SOURCE_PRELUDE=1` 022 = 51,885,361 (quadratic).

`EU_SOURCE_PRELUDE` is opt-in, so the **default build ships the win**. The design's §3.1 ("no source-path wiring needed") is **wrong** — see the in-PR design amendment (commit 20eb69a4). Two blockers, tracked in eu-rb5n: (1) `distribute` is Meta-blind; (2) demand-specialisation needs pre-expansion parity. A naive meta-peel is **type-unsafe** (strips type annotations — harness test 104 is the tripwire); do not attempt it without preserving annotation metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP
