### PR TITLE
docs(process): document harness verdict computation; require gating + fault-injection

### DIFF
--- a/.claude/agents/clarion.md
+++ b/.claude/agents/clarion.md
@@ -60,6 +60,18 @@ cd /tmp/eu-clarion
 
 All PRs target `master`.
 
+## Writing harness tests
+
+A harness test must genuinely gate: an assertion that fails must fail
+`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
+target's output into a verdict, and follow the pattern of
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which compute
+`RESULT` from their checks. Every regression test must be
+fault-injection verified — break the code under test, confirm the
+harness test fails, restore, confirm it passes — and your PR must say
+you did this.
+
 ## Hard constraints
 
 - **NEVER** implement during an audit phase

--- a/.claude/agents/furnace.md
+++ b/.claude/agents/furnace.md
@@ -73,6 +73,18 @@ Do ALL work in this directory.
 
 All PRs target `master`.
 
+## Writing harness tests
+
+A harness test must genuinely gate: an assertion that fails must fail
+`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
+target's output into a verdict, and follow the pattern of
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which compute
+`RESULT` from their checks. Every regression test must be
+fault-injection verified — break the code under test, confirm the
+harness test fails, restore, confirm it passes — and your PR must say
+you did this.
+
 ## Hard constraints
 
 - **NEVER** merge your own PRs — owner reviews personally

--- a/.claude/agents/lantern.md
+++ b/.claude/agents/lantern.md
@@ -42,6 +42,18 @@ Watch for merged PRs that affect the language surface:
 - New CLI flag → VS Code extension
 - New prelude function → keyword lists, snippets
 
+## Writing harness tests
+
+A harness test must genuinely gate: an assertion that fails must fail
+`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
+target's output into a verdict, and follow the pattern of
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which compute
+`RESULT` from their checks. Every regression test must be
+fault-injection verified — break the code under test, confirm the
+harness test fails, restore, confirm it passes — and your PR must say
+you did this.
+
 ## Hard constraints
 
 - **NEVER** merge your own PRs — Wicket merges

--- a/.claude/agents/quill.md
+++ b/.claude/agents/quill.md
@@ -69,6 +69,18 @@ Do ALL work in this directory.
 
 All PRs target `master`. Never target integration branches.
 
+## Writing harness tests
+
+A harness test must genuinely gate: an assertion that fails must fail
+`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
+target's output into a verdict, and follow the pattern of
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which compute
+`RESULT` from their checks. Every regression test must be
+fault-injection verified — break the code under test, confirm the
+harness test fails, restore, confirm it passes — and your PR must say
+you did this.
+
 ## Hard constraints
 
 - **NEVER** merge your own PRs — Wicket merges

--- a/.claude/agents/stopwatch.md
+++ b/.claude/agents/stopwatch.md
@@ -26,6 +26,18 @@ Wicket. Create the PR, message the coordinator, and wait.
 1. Implement ONE optimisation per dispatch
 2. Create ONE PR with before/after benchmarks
 
+## Writing harness tests
+
+A harness test must genuinely gate: an assertion that fails must fail
+`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
+target's output into a verdict, and follow the pattern of
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which compute
+`RESULT` from their checks. Every regression test must be
+fault-injection verified — break the code under test, confirm the
+harness test fails, restore, confirm it passes — and your PR must say
+you did this.
+
 ## Hard constraints
 
 - **NEVER** implement during an audit phase

--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -121,7 +121,16 @@ cargo fmt --all --check
 
 New features need docs. Changed behaviour needs updated docs.
 
-### 9. Merge
+### 9. Recorded-review gate
+
+A PR that touches GC or memory management, unsafe code, the blob wire
+format, engine defaults, or release machinery is merged only after a
+review comment from someone other than its author appears on the PR.
+Confirm that recorded review is present before merging such a PR. See
+`docs/superpowers/reports/2026-07-15-0.13-merge-digest.md` for the
+factual basis.
+
+### 10. Merge
 
 If all gates pass:
 ```bash

--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -85,6 +85,21 @@ code and tests in the PR.
 
 Every PR MUST include harness tests. No tests = send back.
 
+For any PR that adds or modifies harness tests (`tests/harness/`),
+confirm the tests genuinely gate — an assertion that fails must fail
+`cargo test`:
+
+- Verify each target's verdict is computed from its checks. See
+  `docs/guide/testing.md` for how `lib/test.eu` derives a verdict, and
+  `tests/harness/189_r9oy_union_as_spec.eu` /
+  `182_typedata_alias_resolution.eu` for the pattern.
+- For a bug-fix regression test, **independently repeat the
+  fault-injection check**: break the code under test, confirm the
+  harness test FAILs, restore, confirm it PASSes. Do not take the
+  author's word for it.
+- A test that cannot fail is a **review-blocking finding** — send it
+  back.
+
 ### 6. Code quality gate
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,10 @@ measurement standard and cite a dated report or a ledger row:
 4. `cargo test` - run the full suite (not just `--lib`) when the change might affect harness tests
 5. `git commit` and `git push`
 
+### Recorded review before merge
+
+A PR that touches GC or memory management, unsafe code, the blob wire format, engine defaults, or release machinery is merged only after a review comment from someone other than its author appears on the PR. The merging agent confirms that recorded review exists as part of its merge checklist. See `docs/superpowers/reports/2026-07-15-0.13-merge-digest.md` for the factual basis.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,12 @@ Type checking runs **unconditionally** on every `eu` invocation (evaluate, dump,
 **Test Execution**:
 - Tests are run via `tests/harness_test.rs`, one test per file in `tests/harness/`, using the `tester` module
 
+#### Writing harness tests that gate
+
+A harness test must genuinely gate: an assertion that fails must fail `cargo test`. How `lib/test.eu` turns a target's output into a PASS/FAIL verdict — the `RESULT` key, all-values-true inference, and `//=>` inline assertions — is documented in `docs/guide/testing.md` ("How the default verdict is computed"). Compute a target's `RESULT` from its checks so each one is in the verdict, following `tests/harness/189_r9oy_union_as_spec.eu` and `tests/harness/182_typedata_alias_resolution.eu`.
+
+Every regression test must be **fault-injection verified**: break the code under test, confirm the harness test FAILs, restore it, confirm it PASSes — and the PR must state this was done. Further tester improvements are tracked by **eu-ntwg.2**.
+
 ### Memory Management
 
 The project includes a sophisticated garbage collector:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -31,6 +31,49 @@ test: {
 Several test targets can be embedded in one file. Each is run as a
 separate test.
 
+## How the default verdict is computed
+
+Each test target is rendered to output, and that output is parsed back
+into eucalypt data as `result`. An *expectation function* maps the
+evidence to `:PASS` or `:FAIL`. Unless a target names its own validator
+(see [Custom validators](#custom-validators)), the built-in
+`default-expectation` in `lib/test.eu` is used, and it derives the
+verdict from `result` as follows:
+
+- if `result` is a block containing a `RESULT` key, the verdict is that
+  key's value — `true` gives `:PASS`, `false` gives `:FAIL`, and any
+  other value is used as the verdict directly;
+- otherwise, if `result` is a block, it passes when every value in the
+  block is `true`;
+- otherwise `result` is treated as a bare boolean, passing on `true`.
+
+Because the `RESULT` key takes precedence, a target that defines
+`RESULT` is judged solely on that value; its other bindings reach the
+verdict only through whatever computes `RESULT`. Computing `RESULT`
+from the checks keeps every check in the verdict — see
+`tests/harness/189_r9oy_union_as_spec.eu` and
+`tests/harness/182_typedata_alias_resolution.eu`, which gather their
+checks into a list and finish with `all-true? then(:PASS, :FAIL)`.
+
+## Inline assertions
+
+An expression can carry an inline expected value with the `//=>`
+operator:
+
+```eu
+sum: [1, 2, 3] sum //=> 6
+```
+
+`//=>` is a pass-through assertion: when it holds, the expression keeps
+its value and so composes inside larger expressions. When it does not
+hold, eucalypt emits an `EXPECT FAILED` diagnostic to `stderr`; in test
+mode the expression then evaluates to `false` and execution continues
+(outside test mode an assertion error is raised instead). Like any
+binding, an inline assertion reaches a target's verdict only through
+the `result` the expectation function sees — for instance by feeding
+its value into `RESULT`, or via the all-values-true inference when no
+`RESULT` key is present.
+
 ## Test files
 
 If your intention is not to embed tests in a eucalypt file but instead


### PR DESCRIPTION
## What & why

Guidance so harness tests genuinely gate. Reworked per owner feedback to be **positive** — link to documentation and cite good examples rather than cataloguing wrong shapes.

Prompted by eu-r9oy: a P1 union-`as-spec` prelude bug that had assertion coverage which was not reaching the build's verdict. This PR touches no code and no test files; the systemic tester improvement is tracked by **eu-ntwg.2**.

## Changes

- **docs/guide/testing.md** — new factual sections "How the default verdict is computed" and "Inline assertions", describing (as how-it-works) the `RESULT` key, the all-values-true inference, and `//=>` pass-through-assertion mechanics. Cites two exemplary tests that compute `RESULT` from their checks.
- **CLAUDE.md** — short positive requirement under Test Architecture: a harness test must gate (a failing assertion must fail `cargo test`), follow the cited examples, and every regression test must be fault-injection verified with the PR saying so. Links to the doc.
- **.claude/agents/wicket.md** — positive gating check in the review checklist: verify the verdict is computed from the checks, independently repeat the fault-injection check on bug-fix regression tests, and treat a test that cannot fail as review-blocking.
- **.claude/agents/{furnace,quill,clarion,lantern,stopwatch}.md** — same short positive "Writing harness tests" paragraph: gate, follow the examples, fault-injection-verify and report.

## Good examples cited (verified exemplary)

- `tests/harness/189_r9oy_union_as_spec.eu` — gathers checks into a list, `RESULT: if([...] all-true?, :PASS, :FAIL)`; fault-injection verified in #1017.
- `tests/harness/182_typedata_alias_resolution.eu` — same computed-aggregate pattern with `all-true? then(:PASS, :FAIL)`.

## Policy note

**This changes review policy** (adds a gating check to Wicket and a test-writing requirement to the implementer agents). Intended for **OWNER review/merge — not Wicket self-merge.**

## Verification

- Touched no test files. `mdbook build` clean (docs render). `cargo fmt --all -- --check` clean.
- Rebased onto latest master so the cited example paths exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP