### PR TITLE
docs(process): owner-hold PRs are owner-merged only

### DIFF
--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -130,7 +130,15 @@ Confirm that recorded review is present before merging such a PR. See
 `docs/superpowers/reports/2026-07-15-0.13-merge-digest.md` for the
 factual basis.
 
-### 10. Merge
+### 10. Owner-hold gate
+
+A PR whose body or comments carry "Do not merge — owner review" (or an
+equivalent explicit hold) is merged by the owner alone. The hold binds
+you regardless of later activity, review state, or CI, and is released
+only when the owner says so on the PR or to the coordinator. See the PR
+#1002 formal re-review comment (2026-07-15) for the factual basis.
+
+### 11. Merge
 
 If all gates pass:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,10 @@ measurement standard and cite a dated report or a ledger row:
 
 A PR that touches GC or memory management, unsafe code, the blob wire format, engine defaults, or release machinery is merged only after a review comment from someone other than its author appears on the PR. The merging agent confirms that recorded review exists as part of its merge checklist. See `docs/superpowers/reports/2026-07-15-0.13-merge-digest.md` for the factual basis.
 
+### Owner-hold PRs
+
+A PR whose body or comments carry "Do not merge — owner review" (or an equivalent explicit hold) is merged by the owner alone. The hold binds every agent regardless of later activity, review state, or CI, and is released only when the owner says so on the PR or to the coordinator. See the PR #1002 formal re-review comment (2026-07-15) for the factual basis.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->
 ## Beads Issue Tracker


### PR DESCRIPTION
## What & why

Codifies the do-not-merge standing rule from the PR #1002 formal re-review: a PR placed on explicit owner hold is merged by the owner alone. Framed as the affirmative process (who merges, who releases the hold), consistent with the positive-guidance principle from the #1018 rework.

## Changes (2-3 sentences each)

- **CLAUDE.md** — new "Owner-hold PRs" subsection under Development Workflow, adjacent to the recorded-review rule.
- **.claude/agents/wicket.md** — new "Owner-hold gate" in the merge checklist (before Merge, renumbered).

Both state: a PR whose body or comments carry "Do not merge — owner review" (or an equivalent explicit hold) is merged by the owner alone; the hold binds every agent regardless of later activity, review state, or CI, and is released only when the owner says so on the PR or to the coordinator. Cite the PR #1002 formal re-review comment (2026-07-15) as the factual basis.

## Policy note

**This changes merge policy.** Intended for **OWNER review/merge — not Wicket self-merge.**

## Verification

No code or docs/ touched. `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP