### PR TITLE
docs: fix self-shadowing example in testing.md (unbreak master)

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -61,7 +61,7 @@ An expression can carry an inline expected value with the `//=>`
 operator:
 
 ```eu
-sum: [1, 2, 3] sum //=> 6
+total: [1, 2, 3] sum //=> 6
 ```
 
 `//=>` is a pass-through assertion: when it holds, the expression keeps


### PR DESCRIPTION
## What & why

Master is red from #1018: the inline-assertion example in `docs/guide/testing.md` bound `sum: [1, 2, 3] sum`, where the binding name shadows the prelude `sum` it calls. That makes it a self-reference, so eu fails with "infinite loop detected: binding refers to itself", and the doctest step (`scripts/test-doc-examples.py`, run over all docs in CI's Test Suite job) reported 244 passed, 1 failed.

Fix: rename the binding to `total`.

## Verification

- `total: [1, 2, 3] sum //=> 6` evaluates to `total: 6` (exit 0) through a built eu binary.
- `python3 scripts/test-doc-examples.py --file docs/guide/testing.md` → **3 passed, 0 failed**.
- Re-checked the other eu block added to that file in #1018 for the same shadowing shape; no others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP