### PR TITLE
fix(test): gate harness verdict on genuine EXPECT FAILED diagnostics

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -55,6 +55,19 @@ from the checks keeps every check in the verdict — see
 `tests/harness/182_typedata_alias_resolution.eu`, which gather their
 checks into a list and finish with `all-true? then(:PASS, :FAIL)`.
 
+Regardless of `RESULT`, `default-expectation` also fails the target if
+`stderr` contains an `EXPECT FAILED` diagnostic (see
+[Inline assertions](#inline-assertions) below) — a target can no longer
+mask a genuinely failing `//=`/`//!`/`//=>`/`//=?`/`//=?>` assertion
+behind a `RESULT` that doesn't account for it, such as a hardcoded
+`RESULT: :PASS`. Tests that deliberately construct assertions expected
+to fail, to verify the assertion mechanism itself reports failure
+correctly, should use `unguarded-expectation` instead (a target-level
+`verify: ["unguarded-expectation"]`) — see
+`tests/harness/125_expectations.eu`, which checks that `//=` and `//!`
+correctly return `false` on mismatch and therefore genuinely triggers
+`EXPECT FAILED` diagnostics as part of passing.
+
 ## Inline assertions
 
 An expression can carry an inline expected value with the `//=>`
@@ -72,7 +85,20 @@ mode the expression then evaluates to `false` and execution continues
 binding, an inline assertion reaches a target's verdict only through
 the `result` the expectation function sees — for instance by feeding
 its value into `RESULT`, or via the all-values-true inference when no
-`RESULT` key is present.
+`RESULT` key is present — and, independently of `result`, through
+`default-expectation`'s `stderr` gate described above.
+
+Because a failing `//=>` returns `false` in test mode regardless of
+whether the *expected* value was `true` or `false`, an assertion that
+expects `false` cannot be told apart from a passing one by its return
+value alone: `x //=> false` evaluates to `false` both when `x` really
+is `false` (pass) and when `x` mismatches (fail). Hand-computing a
+`RESULT` with `all-true?` over such bindings therefore cannot
+distinguish pass from fail for expecting-`false` assertions. Use the
+raw predicate result instead (with `not()` where you want to assert
+absence), as `tests/harness/182_typedata_alias_resolution.eu` and
+`tests/harness/183_widen_type_def_literals.eu` do, rather than folding
+a `//=>`-wrapped expecting-`false` value into the aggregate.
 
 ## Test files
 

--- a/lib/test.eu
+++ b/lib/test.eu
@@ -19,10 +19,13 @@ A validation function accepts an evidence context with the following keys:
 as described below and must return :PASS or :FAIL.
 "
 validation: {
-  ` "By default we expect a RESULT key (PASS/FAIL) or infer from all values being true"
-  default-expectation(context): {
-    r: context.result
-    # Handle bare boolean results directly
+  ` "Core verdict computation shared by `default-expectation` and
+  `unguarded-expectation`: if `result` is a block containing a RESULT
+  key, the verdict is that key's value (true/false mapped to
+  :PASS/:FAIL, anything else used directly); otherwise if `result` is
+  a block, the verdict is whether every value in it is true;
+  otherwise `result` is treated as a bare boolean."
+  compute-verdict(r): {
     is-block: r block?
     has-result: if(is-block, r has(:RESULT), false)
     explicit: if(has-result, {
@@ -31,6 +34,30 @@ validation: {
     bare: if(r = true, :PASS, if(r = false, :FAIL, null))
     auto: if(is-block, r values all(= true) then(:PASS, :FAIL), null)
   }.( if(has-result, explicit, if(is-block, auto, bare)) )
+
+  ` "True if stderr contains an `EXPECT FAILED` diagnostic, meaning a
+  `//=`, `//!`, `//=>`, `//=?` or `//=?>` assertion genuinely
+  mismatched somewhere during evaluation of the target."
+  has-assertion-failure?(context): context.stderr any(str.contains?("EXPECT FAILED"))
+
+  ` "By default we expect a RESULT key (PASS/FAIL) or infer from all
+  values being true — see `compute-verdict`. A RESULT key that is
+  present but doesn't derive from the target's checks (e.g. a
+  hardcoded `RESULT: :PASS`) could otherwise let a failing `//=>` (or
+  other assertion) pass silently; to close that gap, any `EXPECT
+  FAILED` diagnostic on stderr forces the verdict to :FAIL regardless
+  of what RESULT says (eu-ntwg.2). Tests that deliberately exercise
+  the assertion-failure diagnostic path itself — verifying that `//=`
+  and friends correctly emit `false` on mismatch, e.g.
+  125_expectations.eu — should use `unguarded-expectation` instead."
+  default-expectation(context): if(has-assertion-failure?(context), :FAIL, compute-verdict(context.result))
+
+  ` "Like `default-expectation`, but does not fail merely because
+  stderr contains an `EXPECT FAILED` diagnostic. For tests that
+  deliberately construct assertions expected to fail, to verify the
+  assertion mechanism itself reports failure correctly — see
+  125_expectations.eu."
+  unguarded-expectation(context): compute-verdict(context.result)
 
   ` "Benchmark targets without explicit validations are report-only and always pass"
   bench-expectation(context): :PASS

--- a/src/driver/eval.rs
+++ b/src/driver/eval.rs
@@ -274,6 +274,26 @@ impl<'a> Executor<'a> {
         self.err = Some(err);
     }
 
+    /// Write diagnostic messages recorded during a run (e.g. `EXPECT
+    /// FAILED` from `__EXPECT`, via `IntrinsicMachine::record_diagnostic`)
+    /// to the active error sink: the captured buffer if `capture_output`
+    /// installed one (so the test harness's evidence.yaml can see them),
+    /// else the process stderr — mirroring where `diagnose()` sends
+    /// execution-error output (eu-ntwg.2).
+    ///
+    /// Takes `err` by explicit field reference (not `&mut self`) so it can
+    /// be called while another field (e.g. `self.out`, borrowed by the
+    /// still-live output emitter) is also mutably borrowed.
+    fn flush_diagnostics(err: &mut Option<Box<dyn Write + 'a>>, messages: Vec<String>) {
+        for msg in messages {
+            if let Some(err) = err {
+                let _ = writeln!(err, "{msg}");
+            } else {
+                eprintln!("{msg}");
+            }
+        }
+    }
+
     /// Use the STG machine
     pub fn execute(
         &mut self,
@@ -553,6 +573,9 @@ impl<'a> Executor<'a> {
                 // HeapSyn branch below).
                 collect_bytecode_stats(&m, stats);
 
+                let diagnostics = m.take_diagnostics();
+                Self::flush_diagnostics(&mut self.err, diagnostics);
+
                 result
             } else {
                 emitter.stream_start();
@@ -626,6 +649,9 @@ impl<'a> Executor<'a> {
                 // even on error (e.g. Interrupted) so that -S output is
                 // available.
                 collect_machine_stats(&machine, stats);
+
+                let diagnostics = machine.take_diagnostics();
+                Self::flush_diagnostics(&mut self.err, diagnostics);
 
                 result
             }

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -305,6 +305,9 @@ pub struct BcMachineState {
     /// (`vm.rs` — one per `let`/`letrec` binding) so `-S` allocation counts
     /// are cross-engine comparable.
     pub allocs: u64,
+    /// Diagnostic messages recorded during this run (e.g. `EXPECT FAILED`
+    /// from `__EXPECT`) — mirrors `MachineState::diagnostics` in `vm.rs`.
+    pub diagnostics: Vec<String>,
 }
 
 impl BcMachineState {
@@ -335,6 +338,7 @@ impl BcMachineState {
             bif_frames: Vec::new(),
             bif_arg_pool: Vec::new(),
             allocs: 0,
+            diagnostics: Vec::new(),
         }
     }
 
@@ -3027,6 +3031,13 @@ impl BytecodeMachine<'_> {
         self.state.yielded_io
     }
 
+    /// Drain diagnostic messages recorded during this run (see
+    /// `BcMachineState::diagnostics` doc). Leaves the buffer empty for the
+    /// next run.
+    pub fn take_diagnostics(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.state.diagnostics)
+    }
+
     /// The current source annotation (stamped onto IO errors).
     pub fn annotation(&self) -> Smid {
         self.state.annotation
@@ -4061,6 +4072,10 @@ impl IntrinsicMachine for BcBifContext<'_, '_> {
 
     fn test_mode(&self) -> bool {
         self.test_mode
+    }
+
+    fn record_diagnostic(&mut self, msg: String) {
+        self.state.diagnostics.push(msg);
     }
 
     fn block_index_enabled(&self) -> bool {

--- a/src/eval/machine/intrinsic.rs
+++ b/src/eval/machine/intrinsic.rs
@@ -477,6 +477,16 @@ pub trait IntrinsicMachine {
     /// panicking, allowing test harnesses to collect results.
     fn test_mode(&self) -> bool;
 
+    /// Record a diagnostic message (e.g. an `EXPECT FAILED` report from
+    /// `__EXPECT`) for the driver to flush to the active stderr sink once
+    /// the run completes.
+    ///
+    /// Intrinsics must not `eprintln!` diagnostics directly: that bypasses
+    /// the `Box<dyn Write>` stderr capture the test harness installs via
+    /// `Executor::capture_output`, so the diagnostic never reaches
+    /// `evidence.yaml` and can't gate a test's verdict (eu-ntwg.2).
+    fn record_diagnostic(&mut self, msg: String);
+
     /// Whether the mutable block-index optimisation is available.
     ///
     /// The optimisation caches a `SymbolId → position` map inside a block by

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -321,6 +321,14 @@ pub struct MachineState {
     pending_capture_start: Option<String>,
     /// Test mode flag — `__EXPECT` failures return false instead of panicking.
     test_mode: bool,
+    /// Diagnostic messages recorded during this run (e.g. `EXPECT FAILED`
+    /// from `__EXPECT`), drained by the driver after `run()` and written to
+    /// whichever stderr sink is active — a captured buffer under the test
+    /// harness (so evidence.yaml can see them), or the process stderr
+    /// otherwise. Kept as data rather than printed directly from the
+    /// intrinsic so the test harness can observe assertion failures instead
+    /// of them silently bypassing output capture (eu-ntwg.2).
+    diagnostics: Vec<String>,
     /// Pending BIF intrinsic index, set by `handle_instruction` when it
     /// encounters a `HeapSyn::Bif` node.
     ///
@@ -353,6 +361,7 @@ impl Default for MachineState {
             capture_results: Vec::new(),
             pending_capture_start: None,
             test_mode: false,
+            diagnostics: Vec::new(),
             pending_bif: None,
         }
     }
@@ -377,6 +386,12 @@ impl MachineState {
     /// from a normal termination.
     pub fn yielded_io(&self) -> bool {
         self.yielded_io
+    }
+
+    /// Drain diagnostic messages recorded during this run (see
+    /// `diagnostics` field doc). Leaves the buffer empty for the next run.
+    pub fn take_diagnostics(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.diagnostics)
     }
 
     /// Push a new continuation onto the stack
@@ -1468,6 +1483,10 @@ impl IntrinsicMachine for MachineState {
     fn test_mode(&self) -> bool {
         self.test_mode
     }
+
+    fn record_diagnostic(&mut self, msg: String) {
+        self.diagnostics.push(msg);
+    }
 }
 
 /// MachineState contains all the garbage collection roots
@@ -1784,6 +1803,10 @@ impl IntrinsicMachine for MachineBifContext<'_, '_> {
 
     fn test_mode(&self) -> bool {
         self.state.test_mode
+    }
+
+    fn record_diagnostic(&mut self, msg: String) {
+        self.state.diagnostics.push(msg);
     }
 
     /// Force `closure` to WHNF.
@@ -2282,6 +2305,13 @@ impl<'a> Machine<'a> {
     /// distinguish IO yield from normal termination.
     pub fn io_yielded(&self) -> bool {
         self.state.yielded_io()
+    }
+
+    /// Drain diagnostic messages recorded during this run (see
+    /// `MachineState::diagnostics` doc). Leaves the buffer empty for the
+    /// next run.
+    pub fn take_diagnostics(&mut self) -> Vec<String> {
+        self.state.take_diagnostics()
     }
 
     /// Return the IO constructor tag the machine yielded on.

--- a/src/eval/stg/expect.rs
+++ b/src/eval/stg/expect.rs
@@ -82,7 +82,9 @@ impl StgIntrinsic for Expect {
         } else {
             let expected_repr = str_arg(machine, view, &args[1])?;
             let actual_repr = render_debug_repr_forced(machine, view, &args[0]);
-            eprintln!("EXPECT FAILED: expected {expected_repr}, got {actual_repr}");
+            machine.record_diagnostic(format!(
+                "EXPECT FAILED: expected {expected_repr}, got {actual_repr}"
+            ));
 
             if machine.test_mode() {
                 // Test mode: return false, continue execution

--- a/tests/harness/125_expectations.eu
+++ b/tests/harness/125_expectations.eu
@@ -1,6 +1,12 @@
 "125 unified expectations"
 
-` { target: :test }
+` { target: :test
+    doc: "Deliberately constructs assertions expected to fail (eq-fail,
+      true-fail) to verify //= and //! report `false` correctly on
+      mismatch — this genuinely emits EXPECT FAILED diagnostics on
+      stderr as part of correct operation, so it must opt out of
+      default-expectation's stderr gate (eu-ntwg.2)."
+    verify: ["unguarded-expectation"] }
 test: {
   ` "//= returns true on success"
   eq-pass: (2 + 3 //= 5) //= true


### PR DESCRIPTION
## Summary

Closes the systemic half of eu-ntwg.2: `lib/test.eu`'s `default-expectation` judged a target solely on its `RESULT` key when present, so a hardcoded `RESULT: :PASS` could mask a genuinely failing `//=`/`//!`/`//=>`/`//=?`/`//=?>` assertion forever — the exact bug already observed in `175_sv2_to_spec.eu` during the eu-r9oy investigation (pre-release audit for that file, done separately by Wicket, found it currently clean but structurally unprotected).

- `default-expectation` now also fails a target if its captured `stderr` contains an `EXPECT FAILED` diagnostic, regardless of what `RESULT` says. Refactored the shared verdict logic into `compute-verdict`, and added `unguarded-expectation` (the old, RESULT-only behaviour) as an explicit opt-out for tests that deliberately trigger `EXPECT FAILED` to verify the assertion mechanism itself — `125_expectations.eu` now opts in via `verify: ["unguarded-expectation"]`.
- **Second trap (also in eu-ntwg.2's bead comment):** a `//=>` assertion expecting `false` returns `false` in test mode on both success *and* failure, so a hand-computed `RESULT` built from `all-true?` over such bindings can't tell them apart. The new stderr-based gate is immune to this (it doesn't look at return values at all), and `docs/guide/testing.md` now documents the trap and the `not()`-wrapped-raw-boolean convention (`182_typedata_alias_resolution.eu`/`183_widen_type_def_literals.eu`) for anyone hand-computing a `RESULT`.
- **Root cause dependency found along the way:** the stderr scan only works because of a deeper bug it uncovered — `Expect::execute` (`src/eval/stg/expect.rs`) printed `"EXPECT FAILED"` via a bare `eprintln!`, which writes straight to the process's real stderr and bypasses the `Box<dyn Write>` capture the test harness installs via `Executor::capture_output`. The diagnostic never reached `evidence.yaml`'s `stderr` field at all — confirmed with a hex/text dump of the evidence before the fix (`stderr: []` even though "EXPECT FAILED" printed to the terminal). Fixed by adding `IntrinsicMachine::record_diagnostic`, buffering messages on `MachineState` (HeapSyn) / `BcMachineState` (bytecode), and draining them in `Executor::try_execute` via a new `flush_diagnostics` (captured sink if present, else real stderr — preserving today's interactive `eu run` behaviour). Implemented for both engines.

## Audit finding

Empirically swept every harness file with a `target:` metadata block (81 files) for `EXPECT FAILED` under **current, passing** behaviour: only two intentionally trigger it — `049_tester.eu`'s `test-fail` target (already isolated via its own custom `verify: [:all-values-false]` validator, unaffected by `default-expectation` changes) and `125_expectations.eu` (fixed here). `175_sv2_to_spec.eu` and `134_match_predicate.eu` still use a hardcoded `RESULT: :PASS` but are now safe under the new stderr gate (verified via fault injection below) — I left them as-is rather than rewrite ~90 assertions, since the correctness fix no longer depends on how they compute `RESULT`; happy to convert them to a computed `RESULT` in a follow-up if the team prefers belt-and-braces over the docs-only convention note.

## Fault-injection evidence

All against `175_sv2_to_spec.eu` (still `RESULT: :PASS`), using `cargo test`/`eu test` directly, each restored afterward and confirmed `git status` clean:

1. **Expecting-true assertion, made to fail**: `t-prim-num: 42 match?(num-spec) //=> true` → `//=> false`. Pre-fix (stashed the fix, kept the fault): `175_sv2_to_spec...PASS` despite `EXPECT FAILED: expected false, got true` printing. Post-fix: `175_sv2_to_spec...FAIL`, and the evidence's `stderr` field now actually contains `"EXPECT FAILED: expected false, got true"` (previously `stderr: []` even when the diagnostic printed to the terminal — the root-cause bug above).
2. **Expecting-false assertion, made to fail (the "second trap")**: `t-prim-str-miss: 42 match?(str-spec) //=> false` → `"42" match?(str-spec) //=> false` (now genuinely matches, so the false-expecting assertion mismatches). Pre-fix: `PASS` (silently masked). Post-fix: `FAIL` on both the bytecode and `EU_HEAPSYN=1` engines.
3. **125_expectations.eu opt-out**: confirmed it still reports `PASS` with the fix in place (it deliberately triggers `EXPECT FAILED` via `eq-fail`/`true-fail`, and would otherwise be broken by the new gate without `unguarded-expectation`).
4. Confirmed non-test-mode (`eu run`) behaviour is unchanged: a failing `//=` still prints `EXPECT FAILED: ...` to the terminal followed by the usual `error: assertion failed` diagnostic and exits 1.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 1306+500+... all green (full suite, both `harness_test` at 500/500)
- [x] `EU_HEAPSYN=1 cargo test --test harness_test` — 500/500 (both engines wired for diagnostic capture)
- [x] Fault injection as above, verified fail-before/pass-after semantics flip correctly, all reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP