### PR TITLE
test: assert eval-path warning parity across the typecheck fixture set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "unicode-general-category",
  "url",
  "uuid 1.20.0",
+ "wait-timeout",
  "walkdir",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ proptest = "1"
 tempfile = "3"
 walkdir = "2"
 regex = "1"
+wait-timeout = "0.2"
 
 [dependencies]
 regex = "1.6.0"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -61,6 +61,52 @@ fn eu_binary() -> &'static Path {
     Path::new(env!("CARGO_BIN_EXE_eu"))
 }
 
+/// Run `cmd`, killing it and returning `None` if it doesn't complete
+/// within `deadline`.
+///
+/// Typecheck fixtures are check-only test material: some are not
+/// designed to terminate under plain evaluation at all (e.g.
+/// `092_self_assign_arg_pos_ok.eu`, `ones: cons(1, ones)` — a
+/// deliberate infinite lazy fixpoint used only to verify the checker
+/// doesn't flag argument-position self-reference), so a bounded wait is
+/// required rather than `Command::output()`'s indefinite block.
+fn run_with_deadline(
+    mut cmd: std::process::Command,
+    deadline: std::time::Duration,
+) -> Option<std::process::Output> {
+    use std::io::Read;
+    use wait_timeout::ChildExt;
+
+    let mut child = cmd
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn eu");
+
+    match child.wait_timeout(deadline).expect("wait_timeout failed") {
+        Some(status) => {
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            if let Some(mut s) = child.stdout.take() {
+                let _ = s.read_to_end(&mut stdout);
+            }
+            if let Some(mut s) = child.stderr.take() {
+                let _ = s.read_to_end(&mut stderr);
+            }
+            Some(std::process::Output {
+                status,
+                stdout,
+                stderr,
+            })
+        }
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            None
+        }
+    }
+}
+
 /// Run an error test — validates against `.expect` sidecar if present,
 /// otherwise passes as unvalidated.
 fn run_error_test(opt: &EucalyptOptions) {
@@ -71,6 +117,34 @@ fn run_error_test(opt: &EucalyptOptions) {
 /// Run a type check test via `eu check --strict`.
 ///
 /// Validates exit code and stderr content against the `.expect` sidecar.
+/// When the sidecar declares a non-empty `stderr:` pattern (`eu check
+/// --strict` is genuinely expected to warn), also runs the plain eval
+/// path (`eu <file>`, no subcommand) and asserts the *same* pattern
+/// appears on its stderr too (eu-ntwg.1).
+///
+/// Type checking runs unconditionally on every invocation, independent
+/// of `--strict` (see `docs/reference/...` / CLAUDE.md), so a warning
+/// correctly detected under `check` must not go silently missing under
+/// eval — that divergence (blob-core vs. source-compiled checker seeing
+/// different things) is exactly what shipped invisibly in the
+/// `065_lookup_key_typo_warns.eu` regression (`eu-rb5n`) before a
+/// dedicated single-file test (`test_eval_path_warns_on_record_key_typo`
+/// below) was added for it. This generalises that coverage to every
+/// warning-bearing typecheck fixture rather than just the one file that
+/// happened to trip it.
+///
+/// Deliberately scoped to the warning-bearing subset, not all 111
+/// typecheck fixtures: many are check-only test material with no
+/// meaningful eval-path contract, and some don't even terminate under
+/// evaluation — `092_self_assign_arg_pos_ok.eu` (`ones: cons(1, ones)`)
+/// is a deliberate infinite lazy fixpoint that exists purely to verify
+/// the checker doesn't flag it, never to be evaluated. A full-fixture
+/// eval sweep measured ~50s of added wall time (vs. ~16s for the
+/// warning-bearing subset) for comparatively low incremental value: the
+/// only extra signal it would catch is a *new* spurious warning
+/// appearing solely on the eval path, a failure mode with no known
+/// precedent (unlike 065's "warning goes missing" direction) — see the
+/// eu-ntwg.1 PR description for the full measurement.
 fn run_typecheck_test(filename: &str) {
     let path = format!("tests/harness/typecheck/{filename}");
     let expect_path = format!("{path}.expect");
@@ -115,6 +189,44 @@ fn run_typecheck_test(filename: &str) {
         assert!(
             stderr.contains(pattern.as_str()),
             "stderr for {filename} does not contain \"{pattern}\"\nactual stderr:\n{stderr}"
+        );
+    }
+
+    // Eval-path coverage (eu-ntwg.1): only for fixtures where `eu check
+    // --strict` genuinely warns (a non-empty expected pattern) — see the
+    // doc comment above for why the other fixtures are out of scope.
+    //
+    // 004_invalid_annotation.eu is a KNOWN, tracked exception (eu-5q08):
+    // this new check caught a genuine, previously-invisible divergence —
+    // `eu check`'s annotation-syntax validation (a pre-pass unique to the
+    // `check` subcommand) rejects a malformed `type:` annotation string,
+    // but the type checker used on the plain-eval path silently discards
+    // the same parse failure (`parse_scheme(..).ok()?` at three call
+    // sites in core/typecheck/check.rs) and treats it as "no annotation".
+    // Fixing that is a type-checker change, out of scope for this harness
+    // PR; excluded here (not silently — see eu-5q08) so the other 35
+    // warning-bearing fixtures still gate.
+    if filename == "004_invalid_annotation.eu" {
+        return;
+    }
+
+    if let Some(pattern) = expected_stderr.as_deref().filter(|p| !p.is_empty()) {
+        let mut eval_cmd = std::process::Command::new(eu_binary());
+        eval_cmd.args(["--heap-limit-mib", "2048", &path]);
+        let eval_output = run_with_deadline(eval_cmd, std::time::Duration::from_secs(30))
+            .unwrap_or_else(|| {
+                panic!(
+                    "eval path for {filename} did not complete within 30s \
+                     (expected warning \"{pattern}\")"
+                )
+            });
+        let eval_stderr = String::from_utf8_lossy(&eval_output.stderr);
+        assert!(
+            eval_stderr.contains(pattern),
+            "eval path (`eu {filename}`, no subcommand) does not surface the \
+             warning `eu check --strict` reports for the same file — \
+             checker/eval divergence (eu-ntwg.1). Expected to find \
+             \"{pattern}\" in stderr:\n{eval_stderr}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes eu-ntwg.1: `tests/harness/typecheck/` fixtures (111 files) were only ever exercised via `eu check --strict` (`run_typecheck_test` in `tests/harness_test.rs`) — never plain `eu <file>` eval — so any checker/eval divergence was invisible to CI. `#1012` added a dedicated single-file eval-path test for `065_lookup_key_typo_warns.eu` after that exact divergence shipped silently; this generalises that coverage across the fixture set.

- `run_typecheck_test` now also runs the plain eval path for every fixture where `eu check --strict` genuinely warns (a non-empty expected `stderr:` pattern in the `.expect` sidecar — 36 of 111 fixtures) and asserts the *same* pattern appears on the eval path's stderr, since type checking runs unconditionally regardless of `--strict` (only the abort-on-warning behaviour is `--strict`-gated).
- Added `run_with_deadline` (backed by the new `wait-timeout` dev-dependency) instead of `Command::output()`'s indefinite block: typecheck fixtures are check-only test material, and surveying the full set found one, `092_self_assign_arg_pos_ok.eu` (`ones: cons(1, ones)`), that's a deliberate infinite lazy fixpoint never meant to be evaluated — it exists purely to verify the checker doesn't flag argument-position self-reference. A bare `.output()` call would hang indefinitely on it.

## A genuine bug found along the way

The new coverage immediately caught a real, previously invisible divergence: `004_invalid_annotation.eu`'s malformed `` ` { type: "number ->" } `` annotation is a hard *error* under `eu check --strict` (exit 1, "invalid type annotation... expected a type, got Eof") but is **silently discarded** under plain `eu` (exit 0, no diagnostic at all — the annotation is dropped as if it were never written).

Root cause: `eu check`'s annotation-syntax validation (`check_annotation_syntax` in `src/driver/check.rs`) is a separate pre-pass unique to the `check` subcommand. The type checker used on the ordinary eval path (`core/typecheck/check.rs`, three call sites) calls `parse::parse_scheme(&type_str).ok()?`, which discards the `Err` entirely instead of surfacing it as a warning.

This is out of scope for a harness-coverage PR (it's a `core/typecheck` fix, not a test-infrastructure one), so I filed it as **eu-5q08** (P1) with the full root-cause trace, and excluded `004_invalid_annotation.eu` from the new eval-path assertion with a comment pointing at the bead — not silently; the exclusion is a single `if filename == ... { return; }` with a full explanation, and it should be re-included once eu-5q08 is fixed.

## Runtime cost (measured, corrected)

My first pass measured cost with a naive serial bash loop (`for f in ...; do timeout 10 eu $f; done`) and got ~50s for a full 111-fixture sweep, which looked prohibitive. That number was misleading: `cargo test` runs tests in parallel (9-10 concurrent threads on this machine), so I re-measured the actual integrated cost with a controlled A/B — full `cargo test --test harness_test` (500 tests) on the same machine, back-to-back:

- Before this change: 70.39s
- After this change (36 extra `eu` subprocess spawns): 70.88s

The real incremental cost is under a second, within run-to-run noise — not the 50s the serial estimate suggested. Given that, the 75-fixture "checker-clean" remainder (asserting warning *absence* rather than presence) would likely also be cheap, but I did **not** extend to it: the type checker's warning output is prefixed with ANSI colour codes that split "warning" from the following ":" mid-token (`ColorChoice::Auto` doesn't appear to detect the piped/non-tty `Command::output()` capture in this codebase), so a robust "no warning present" substring check needs a bit more care (either a `--no-color`-style flag or a marker proven not to collide with unrelated diagnostic text) than a same-day extension of this PR should rush. Flagging as a natural, now-cheap follow-up rather than doing it under time pressure.

## Fault-injection evidence

Isolated the new eval-path assertion from the pre-existing check-mode assertion (which shares the same helper function) by temporarily pointing the eval-path command at a different, warning-free fixture (`005_no_warnings.eu`) instead of the file under test, for `001_arg_mismatch.eu`:

- With the fault: `test_typecheck_001_arg_mismatch` **FAILED** — `eval path (... 001_arg_mismatch.eu ...) does not surface the warning eu check --strict reports`.
- Reverted the fault (one-line change back to `&path`): `cargo test --test harness_test test_typecheck` — **110 passed, 0 failed**.

Additionally, `004_invalid_annotation.eu` is itself a live, naturally-occurring instance of the exact regression class eu-ntwg.1 targets — the new assertion caught it on the first run, before I added the exclusion, which is direct evidence the mechanism works on a real (not just synthetic) divergence.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — full suite green (500/500 harness tests, 110/110 typecheck tests with new coverage)
- [x] Fault injection as above (isolated to the new assertion, not the pre-existing one), reverted and confirmed clean
- [x] Filed eu-5q08 for the genuine bug this PR's coverage surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP