### PR TITLE
fix: surface malformed type annotations as warnings on the eval path (eu-5q08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to eucalypt are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A malformed `type:` annotation was a hard error under `eu check --strict` but silently discarded (exit 0, no diagnostic) under plain `eu` evaluation** — despite type checking running unconditionally on every invocation (per the documented contract). Three call sites in `core/typecheck/check.rs` and `driver/check.rs` (`extract_annotation`, used for ordinary declarations, and `parse_operator_overloads`, used for operator definitions whose `Meta` wrapper is stripped before the checker's normal per-node walk ever sees it) discarded the `parse_scheme` parse error via `.ok()?`, treating the annotation as though it were simply absent. Parse failures now surface as an `invalid type annotation: <parse error>` `TypeWarning`, flowing through the same unconditional warning pipeline as every other type diagnostic — visible on stderr under plain `eu`, promoted to a hard error under `--strict`, silenced by `--suppress-type-warnings`. Deduplicated by source location (`Smid`) so the same malformed annotation, which the checker's `Let` pre-seeding and synthesis passes each visit independently, is not reported twice. The prelude remains warning-free (`cargo xtask prelude-compile` unaffected; the prelude's cached type-check path discards operator-annotation warnings the same way it already discarded its primary check warnings). Regression-tested via `tests/harness_test.rs`'s `test_typecheck_004_invalid_annotation_eval_path_warns`, fault-injection verified (eu-5q08)
+
 ## [0.13.0] - Unreleased
 
 ### Added

--- a/src/core/typecheck/check.rs
+++ b/src/core/typecheck/check.rs
@@ -23,7 +23,7 @@
 //!
 //! Type issues are always warnings — they never prevent evaluation.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
@@ -346,6 +346,17 @@ pub struct Checker {
     /// `recognise_brancher` and `classify_lam_body` when the head
     /// expression is a `Var::Free` in prelude-cached user-file checks.
     seed_branch_shapes: HashMap<String, BranchShape>,
+
+    /// `Smid`s of `type:`/`__type_hint:` annotations whose syntax has
+    /// already produced an `invalid type annotation` warning (eu-5q08).
+    ///
+    /// `extract_annotation` is invoked more than once per malformed
+    /// annotation in normal control flow — once while pre-seeding a `Let`
+    /// frame (`annotation_scheme_of`), once during synthesis
+    /// (`synthesise_meta`), and again if the binding also carries
+    /// `type-def:`/`result-def:` metadata — so this set prevents the same
+    /// parse failure from being reported more than once.
+    warned_annotation_smids: HashSet<Smid>,
 }
 
 impl Default for Checker {
@@ -370,6 +381,7 @@ impl Checker {
             keep_root_scope: false,
             seed_branch_shapes: HashMap::new(),
             operator_overloads: HashMap::new(),
+            warned_annotation_smids: HashSet::new(),
         }
     }
 
@@ -887,7 +899,7 @@ impl Checker {
     /// - `is_hint`: came from `__type_hint` (monad binding) — the
     ///   annotation is for checking only, not for overriding the
     ///   synthesised type
-    fn extract_annotation(&self, meta: &RcExpr) -> Option<(Type, Vec<Constraint>, bool, bool)> {
+    fn extract_annotation(&mut self, meta: &RcExpr) -> Option<(Type, Vec<Constraint>, bool, bool)> {
         let block = match &*meta.inner {
             Expr::Block(_, b) => b,
             _ => return None,
@@ -907,13 +919,38 @@ impl Checker {
             (type_str, false)
         };
 
-        let (parsed, constraints) = parse::parse_scheme(&type_str).ok()?;
-        Some((
-            self.resolve_aliases_in_type(parsed),
-            constraints,
-            asserted,
-            is_hint,
-        ))
+        match parse::parse_scheme(&type_str) {
+            Ok((parsed, constraints)) => Some((
+                self.resolve_aliases_in_type(parsed),
+                constraints,
+                asserted,
+                is_hint,
+            )),
+            Err(e) => {
+                self.warn_invalid_annotation(meta.smid(), &e);
+                None
+            }
+        }
+    }
+
+    /// Emit an `invalid type annotation` warning for a `type:`/`__type_hint:`
+    /// string that failed to parse (eu-5q08).
+    ///
+    /// Previously the parse error was discarded (`.ok()?`), silently
+    /// treating a malformed annotation as if it were absent — a hard error
+    /// under `eu check --strict` but invisible under plain `eu` evaluation,
+    /// even though type checking runs unconditionally on every invocation.
+    /// The message mirrors `eu check`'s `check_annotation_syntax` pre-pass
+    /// (`invalid type annotation on '<name>': <parse error>`) so the two
+    /// paths agree; the binding name is not always available at this call
+    /// site, so it is omitted here in favour of the warning's `Smid`
+    /// location, which `to_diagnostic` renders as a source label.
+    /// Deduplicated by `Smid` — see `warned_annotation_smids`.
+    fn warn_invalid_annotation(&mut self, smid: Smid, err: &parse::ParseError) {
+        if self.warned_annotation_smids.insert(smid) {
+            self.warnings
+                .push(TypeWarning::new(format!("invalid type annotation: {err}")).at(smid));
+        }
     }
 
     /// Try to extract a `TypeScheme` from a binding value's `Meta` wrapper.
@@ -922,7 +959,7 @@ impl Checker {
     /// carries a `type:` or `__type_hint:` annotation, `None` otherwise.  The
     /// type variables in the annotation are quantified into the scheme via
     /// `infer_scheme`.  Alias references are resolved before quantification.
-    fn annotation_scheme_of(&self, value: &RcExpr) -> Option<TypeScheme> {
+    fn annotation_scheme_of(&mut self, value: &RcExpr) -> Option<TypeScheme> {
         if let Expr::Meta(_, _, meta) = &*value.inner {
             self.extract_annotation(meta)
                 .map(|(ty, constraints, _asserted, _is_hint)| {
@@ -3464,19 +3501,35 @@ pub fn type_check_with_operator_overloads(
     checker.into_warnings()
 }
 
-/// Parse a map of operator name → annotation string into TypeSchemes.
+/// Parse a map of operator name → (annotation string, definition `Smid`)
+/// into TypeSchemes.
 ///
-/// Strings that fail to parse are silently skipped (the constraint will
-/// stay gradual for those operators).
-pub fn parse_operator_overloads(raw: &HashMap<String, String>) -> HashMap<String, TypeScheme> {
-    raw.iter()
-        .filter_map(|(name, type_str)| {
-            let (ty, constraints) = parse::parse_scheme(type_str).ok()?;
-            let mut scheme = infer_scheme(ty);
-            scheme.constraints = constraints;
-            Some((name.clone(), scheme))
-        })
-        .collect()
+/// Strings that fail to parse produce an `invalid type annotation` warning
+/// (eu-5q08) instead of being silently skipped; the constraint stays
+/// gradual for that operator. Operator annotations are captured from the
+/// pre-cook expression (see `UnitInterface::extract_operators_from_expr`)
+/// because cook's `distribute_fixities` strips the `Meta` wrapper that
+/// carries `type:`, so this is the only call site that ever sees an
+/// operator's annotation — unlike `extract_annotation`, there is no
+/// duplicate-visit risk here, so no `Smid` dedup is needed.
+pub fn parse_operator_overloads(
+    raw: &HashMap<String, (String, Smid)>,
+) -> (HashMap<String, TypeScheme>, Vec<TypeWarning>) {
+    let mut overloads = HashMap::new();
+    let mut warnings = Vec::new();
+    for (name, (type_str, smid)) in raw {
+        match parse::parse_scheme(type_str) {
+            Ok((ty, constraints)) => {
+                let mut scheme = infer_scheme(ty);
+                scheme.constraints = constraints;
+                overloads.insert(name.clone(), scheme);
+            }
+            Err(e) => {
+                warnings.push(TypeWarning::new(format!("invalid type annotation: {e}")).at(*smid));
+            }
+        }
+    }
+    (overloads, warnings)
 }
 
 /// Extract type alias definitions from `expr` without running full type checking.

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -112,8 +112,15 @@ fn build_prelude_interface_for(prelude_key: &str) -> Result<UnitInterface, Eucal
 
     // Populate operator_overloads in the type summary from the pre-cook
     // operator info stored in unit_interface.
+    //
+    // Any operator-annotation parse-error warnings are discarded here, same
+    // as the primary `type_check_for_prelude` warnings above — the prelude
+    // is expected to stay warning-free (verified by `cargo xtask
+    // prelude-compile` and the full test suite), so there is nothing for a
+    // per-invocation cache build to usefully report.
     let operator_type_strings = loader.unit_interface().operator_type_strings();
-    let operator_overloads = parse_operator_overloads(&operator_type_strings);
+    let (operator_overloads, _operator_annotation_warnings) =
+        parse_operator_overloads(&operator_type_strings);
     summary.operator_overloads = operator_overloads;
 
     let mut ui = loader.unit_interface().clone();
@@ -487,7 +494,8 @@ pub fn run_type_checker(opt: &EucalyptOptions) -> Result<PipelineCheckResult, Eu
     loader.extract_operators();
     loader.extract_visibility();
     let operator_type_strings = loader.unit_interface().operator_type_strings();
-    let operator_overloads = parse_operator_overloads(&operator_type_strings);
+    let (operator_overloads, operator_annotation_warnings) =
+        parse_operator_overloads(&operator_type_strings);
 
     // Cook (resolve operator precedence).
     loader.cook()?;
@@ -510,6 +518,7 @@ pub fn run_type_checker(opt: &EucalyptOptions) -> Result<PipelineCheckResult, Eu
     } else {
         type_check_with_operator_overloads(&core_expr, operator_overloads)
     };
+    warnings.extend(operator_annotation_warnings);
     warnings.extend(deprecation_warnings);
 
     // Run content verifier to catch static errors (e.g. trivial self-assignment).
@@ -640,7 +649,8 @@ pub fn run_type_checker_from_blob_core(
     loader.extract_operators();
     loader.extract_visibility();
     let operator_type_strings = loader.unit_interface().operator_type_strings();
-    let operator_overloads = parse_operator_overloads(&operator_type_strings);
+    let (operator_overloads, operator_annotation_warnings) =
+        parse_operator_overloads(&operator_type_strings);
 
     loader.cook()?;
     loader.eliminate()?;
@@ -655,6 +665,7 @@ pub fn run_type_checker_from_blob_core(
     } else {
         type_check_with_operator_overloads(&core_expr, operator_overloads)
     };
+    warnings.extend(operator_annotation_warnings);
     warnings.extend(deprecation_warnings);
 
     let core_errors = loader.verify().unwrap_or_default();

--- a/src/driver/unit_interface.rs
+++ b/src/driver/unit_interface.rs
@@ -202,15 +202,17 @@ impl UnitInterface {
         collect_demands(expr, &mut self.demands);
     }
 
-    /// Build a `HashMap<String, String>` of operator name → raw `type:` annotation
-    /// from `self.operators`, suitable for `parse_operator_overloads`.
-    pub fn operator_type_strings(&self) -> HashMap<String, String> {
+    /// Build a `HashMap<String, (String, Smid)>` of operator name → (raw
+    /// `type:` annotation, definition location) from `self.operators`,
+    /// suitable for `parse_operator_overloads`. The `Smid` lets a malformed
+    /// annotation's warning (eu-5q08) point at the operator's definition.
+    pub fn operator_type_strings(&self) -> HashMap<String, (String, Smid)> {
         self.operators
             .iter()
             .filter_map(|(name, info)| {
                 info.type_annotation
                     .as_ref()
-                    .map(|s| (name.clone(), s.clone()))
+                    .map(|s| (name.clone(), (s.clone(), info.smid)))
             })
             .collect()
     }

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -119,6 +119,34 @@ fn run_typecheck_test(filename: &str) {
     }
 }
 
+/// Run the plain `eu` eval path (no subcommand) on a `tests/harness/typecheck`
+/// fixture and assert that stderr contains `pattern` (eu-5q08).
+///
+/// Type checking runs unconditionally on every `eu` invocation, not just
+/// `eu check`, so a fixture whose `eu check --strict` run produces a
+/// warning must produce the same warning text on plain eval too. This is
+/// deliberately narrower than a general eval/check parity harness (tracked
+/// as `PR #1026`, `eu-ntwg.1`, which asserts this across the whole
+/// `tests/harness/typecheck` fixture set and specifically excludes
+/// `004_invalid_annotation.eu` with a comment citing this bead) — it exists
+/// so eu-5q08's regression is gated on its own even if #1026 has not yet
+/// merged. If #1026 lands first, its exclusion for `004_invalid_annotation.eu`
+/// should be removed so the two mechanisms do not silently overlap.
+fn run_typecheck_eval_path_test(filename: &str, pattern: &str) {
+    let path = format!("tests/harness/typecheck/{filename}");
+
+    let output = std::process::Command::new(eu_binary())
+        .args([&path, "--heap-limit-mib", "2048"])
+        .output()
+        .expect("failed to run eu (eval path)");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(pattern),
+        "eval-path stderr for {filename} does not contain \"{pattern}\"\nactual stderr:\n{stderr}"
+    );
+}
+
 /// Run `eu doc` on a fixture file and assert that stdout contains all the given patterns.
 fn run_doc_test(path: &str, extra_args: &[&str], expected_patterns: &[&str]) {
     let output = std::process::Command::new(eu_binary())
@@ -1972,6 +2000,19 @@ pub fn test_typecheck_003_annotation_mismatch() {
 #[test]
 pub fn test_typecheck_004_invalid_annotation() {
     run_typecheck_test("004_invalid_annotation.eu");
+}
+
+/// Regression for eu-5q08: a malformed `type:` annotation used to be a hard
+/// error under `eu check --strict` but silently discarded (no diagnostic at
+/// all, exit 0) under plain `eu` evaluation, even though type checking runs
+/// unconditionally on every invocation. `extract_annotation` in
+/// `core/typecheck/check.rs` discarded the `parse_scheme` `Err` via
+/// `.ok()?` instead of surfacing it as a `TypeWarning`. See
+/// `run_typecheck_eval_path_test` for how this differs from — and is meant
+/// to be superseded by — the broader eval/check parity harness in #1026.
+#[test]
+pub fn test_typecheck_004_invalid_annotation_eval_path_warns() {
+    run_typecheck_eval_path_test("004_invalid_annotation.eu", "invalid type annotation");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes eu-5q08 (P1): a malformed `type:` annotation was a hard error under
`eu check --strict` but was **silently discarded** (exit 0, no diagnostic
at all) under plain `eu` evaluation, even though type checking runs
unconditionally on every `eu` invocation per the documented contract.

Repro:
```
` { type: "number ->" }
bad(x): x
```
`eu check --strict` correctly rejected this; plain `eu` printed `{}` and
exited 0, silently treating the malformed annotation as though it were
absent.

## Root cause

Three call sites discarded `parse::parse_scheme`'s `Err` via `.ok()?`,
converting a genuine parse failure into "no annotation present":

- `extract_annotation` (`src/core/typecheck/check.rs`) — used for
  ordinary declaration `type:`/`__type_hint:` annotations. `eu check`'s
  annotation-syntax pre-pass (`check_annotation_syntax` in
  `src/driver/check.rs`) is a *separate* walk over the raw AST that
  correctly validates annotations, but the eval path never runs it — it
  relies entirely on the bidirectional `Checker`, which had no equivalent
  validation.
- `parse_operator_overloads` (`src/core/typecheck/check.rs`) — used for
  **operator** definitions specifically. Cook's `distribute_fixities`
  strips the `Meta` wrapper (and its `type:` annotation) from operator
  bindings before the checker's normal per-declaration walk ever sees
  them, so a malformed annotation on an operator (`` `{type: "..."} (l +++ r): ... ``)
  was *only* ever reachable through this call site — fixing
  `extract_annotation` alone would not have covered it.

## Fix

Both sites now push a `TypeWarning` (`invalid type annotation: <parse
error>`) into the checker's normal warning pipeline instead of discarding
the error, so the diagnostic:

- appears on stderr under plain `eu` (previously invisible)
- is promoted to a hard error under `--strict` (previously already an
  error only via the separate `eu check` pre-pass)
- is silenced by `--suppress-type-warnings`, like any other warning
- matches `eu check`'s message content (`invalid type annotation: type
  annotation parse error at position N: ...`), so the two paths agree

**Deduplication**: `extract_annotation` is called multiple times per
malformed annotation in normal control flow (once pre-seeding a `Let`
frame, once during synthesis, and again for `type-def:`/`result-def:`
alias extraction) — a naive fix would emit the same warning 2-3 times for
one bad annotation. Added a `Smid`-keyed `HashSet` on `Checker` so each
distinct annotation location is reported exactly once, verified manually
(single warning line, confirmed with `eu` output below).

For `parse_operator_overloads` (a free function outside `Checker`, only
ever called once per operator per compile — no duplicate-visit risk), I
extended `UnitInterface::operator_type_strings()` to carry each
operator's `Smid` (already captured in `OperatorInfo`, just not
threaded through) alongside its annotation string, so the new warning
gets a real source location instead of `Smid::default()`.

**Prelude stays clean**: `cargo xtask prelude-compile` produces a
byte-identical `lib/prelude.blob` (confirmed via `git status`), and the
prelude-interface cache build in `driver/check.rs` discards the new
operator-annotation warnings the same way it already discarded the
primary `type_check_for_prelude` warnings — a per-process cache build has
nothing useful to report per-invocation, and the prelude has no malformed
annotations to report.

## Verification

```
$ eu tests/harness/typecheck/004_invalid_annotation.eu --heap-limit-mib 2048
warning: invalid type annotation: type annotation parse error at position 9: expected a type, got Eof
  ┌─ tests/harness/typecheck/004_invalid_annotation.eu:1:3
  │
1 │ ` { type: "number ->" }
  │   ^^^^^^^^^^^^^^^^^^^^^

---
{}
exit: 0

$ eu tests/harness/typecheck/004_invalid_annotation.eu --heap-limit-mib 2048 --strict
(same warning) exit: 1

$ eu tests/harness/typecheck/004_invalid_annotation.eu --heap-limit-mib 2048 --suppress-type-warnings
---
{}
exit: 0

$ eu check --strict tests/harness/typecheck/004_invalid_annotation.eu
tests/harness/typecheck/004_invalid_annotation.eu:1:11: error: invalid type annotation on 'bad': ...
(same warning, once) exit: 1
```

Also verified end-to-end for the operator call site with an ad hoc
`` `{type:"number ->"} (l +++ r): l + r `` fixture — warning surfaces
correctly with the operator's own source location.

**Engine parity**: confirmed identical output on both engines —
`EU_HEAPSYN=1 eu tests/harness/typecheck/004_invalid_annotation.eu
--heap-limit-mib 2048` produces the same single warning as the default
bytecode engine.

## Regression test

`004_invalid_annotation.eu` is excluded from #1026's new eval-path
parity assertion, with a comment citing this bead — #1026 was still
**open, not merged**, at the time of this PR, so per the dispatch
instructions I added an equivalent standalone regression test now rather
than depending on #1026 landing first:

`tests/harness_test.rs::test_typecheck_004_invalid_annotation_eval_path_warns`
— runs plain `eu` (no subcommand) on the fixture and asserts stderr
contains `"invalid type annotation"`.

**Fault-injection verified**: reverted `extract_annotation`'s fix back to
`parse::parse_scheme(&type_str).ok()` (the pre-fix discard behaviour) —
`test_typecheck_004_invalid_annotation_eval_path_warns` **FAILED**
(`eval-path stderr for 004_invalid_annotation.eu does not contain
"invalid type annotation"`) while the pre-existing
`test_typecheck_004_invalid_annotation` (`eu check --strict` test)
**still passed**, confirming the new test is exercising exactly the gap
this bead describes and not duplicating existing coverage. Restored the
fix — both tests pass again.

**Coordination note for the gatekeeper**: once #1026 merges, its
`004_invalid_annotation.eu` exclusion (in its version of
`run_typecheck_test`) should be removed so the eval-path assertion covers
this fixture through the general mechanism too. My standalone test here
can stay (it's a narrower, independently-gating regression test) or be
removed as redundant once #1026's broader coverage lands — gatekeeper's
call on sequencing.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — full suite green: 501/501 harness tests (500 + 1
      new), 111 typecheck tests, 111 LSP tests, 11 property tests, 1 tick
      parity test, 3 doc tests
- [x] `cargo xtask prelude-compile` — clean, byte-identical blob (no
      diff)
- [x] Fault-injection verified (see above)
- [x] Engine parity verified (bytecode + `EU_HEAPSYN=1`) for the repro
      file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYMBt4cY7VxeVUJYBPscHP