### PR TITLE
chore: re-include 004_invalid_annotation in eval-path parity check (eu-5q08)

### DIFF
--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -196,20 +196,14 @@ fn run_typecheck_test(filename: &str) {
     // --strict` genuinely warns (a non-empty expected pattern) — see the
     // doc comment above for why the other fixtures are out of scope.
     //
-    // 004_invalid_annotation.eu is a KNOWN, tracked exception (eu-5q08):
-    // this new check caught a genuine, previously-invisible divergence —
-    // `eu check`'s annotation-syntax validation (a pre-pass unique to the
-    // `check` subcommand) rejects a malformed `type:` annotation string,
-    // but the type checker used on the plain-eval path silently discards
-    // the same parse failure (`parse_scheme(..).ok()?` at three call
-    // sites in core/typecheck/check.rs) and treats it as "no annotation".
-    // Fixing that is a type-checker change, out of scope for this harness
-    // PR; excluded here (not silently — see eu-5q08) so the other 35
-    // warning-bearing fixtures still gate.
-    if filename == "004_invalid_annotation.eu" {
-        return;
-    }
-
+    // 004_invalid_annotation.eu used to be excluded here (eu-5q08): `eu
+    // check`'s annotation-syntax pre-pass rejected a malformed `type:`
+    // string, but the plain-eval-path checker silently discarded the same
+    // parse failure via `parse_scheme(..).ok()?`, treating it as "no
+    // annotation". That divergence is fixed (`extract_annotation` in
+    // `core/typecheck/check.rs` now emits an `invalid type annotation`
+    // warning), so 004 is covered by this general mechanism like every
+    // other warning-bearing fixture.
     if let Some(pattern) = expected_stderr.as_deref().filter(|p| !p.is_empty()) {
         let mut eval_cmd = std::process::Command::new(eu_binary());
         eval_cmd.args(["--heap-limit-mib", "2048", &path]);
@@ -229,34 +223,6 @@ fn run_typecheck_test(filename: &str) {
              \"{pattern}\" in stderr:\n{eval_stderr}"
         );
     }
-}
-
-/// Run the plain `eu` eval path (no subcommand) on a `tests/harness/typecheck`
-/// fixture and assert that stderr contains `pattern` (eu-5q08).
-///
-/// Type checking runs unconditionally on every `eu` invocation, not just
-/// `eu check`, so a fixture whose `eu check --strict` run produces a
-/// warning must produce the same warning text on plain eval too. This is
-/// deliberately narrower than a general eval/check parity harness (tracked
-/// as `PR #1026`, `eu-ntwg.1`, which asserts this across the whole
-/// `tests/harness/typecheck` fixture set and specifically excludes
-/// `004_invalid_annotation.eu` with a comment citing this bead) — it exists
-/// so eu-5q08's regression is gated on its own even if #1026 has not yet
-/// merged. If #1026 lands first, its exclusion for `004_invalid_annotation.eu`
-/// should be removed so the two mechanisms do not silently overlap.
-fn run_typecheck_eval_path_test(filename: &str, pattern: &str) {
-    let path = format!("tests/harness/typecheck/{filename}");
-
-    let output = std::process::Command::new(eu_binary())
-        .args([&path, "--heap-limit-mib", "2048"])
-        .output()
-        .expect("failed to run eu (eval path)");
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(pattern),
-        "eval-path stderr for {filename} does not contain \"{pattern}\"\nactual stderr:\n{stderr}"
-    );
 }
 
 /// Run `eu doc` on a fixture file and assert that stdout contains all the given patterns.
@@ -2109,22 +2075,18 @@ pub fn test_typecheck_003_annotation_mismatch() {
     run_typecheck_test("003_annotation_mismatch.eu");
 }
 
+/// Also gates the eu-5q08 regression: a malformed `type:` annotation used to
+/// be a hard error under `eu check --strict` but silently discarded (no
+/// diagnostic at all, exit 0) under plain `eu` evaluation, even though type
+/// checking runs unconditionally on every invocation. `extract_annotation`
+/// in `core/typecheck/check.rs` discarded the `parse_scheme` `Err` via
+/// `.ok()?` instead of surfacing it as a `TypeWarning`. Now that the fix is
+/// in place, `run_typecheck_test`'s general eval-path parity check (see its
+/// doc comment) covers this fixture like every other warning-bearing one,
+/// so the once-separate standalone eval-path test has been folded in here.
 #[test]
 pub fn test_typecheck_004_invalid_annotation() {
     run_typecheck_test("004_invalid_annotation.eu");
-}
-
-/// Regression for eu-5q08: a malformed `type:` annotation used to be a hard
-/// error under `eu check --strict` but silently discarded (no diagnostic at
-/// all, exit 0) under plain `eu` evaluation, even though type checking runs
-/// unconditionally on every invocation. `extract_annotation` in
-/// `core/typecheck/check.rs` discarded the `parse_scheme` `Err` via
-/// `.ok()?` instead of surfacing it as a `TypeWarning`. See
-/// `run_typecheck_eval_path_test` for how this differs from — and is meant
-/// to be superseded by — the broader eval/check parity harness in #1026.
-#[test]
-pub fn test_typecheck_004_invalid_annotation_eval_path_warns() {
-    run_typecheck_eval_path_test("004_invalid_annotation.eu", "invalid type annotation");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR #1026 (eu-ntwg.1) added a general eval/check parity assertion to `run_typecheck_test`: for any `tests/harness/typecheck` fixture whose `.expect` sidecar declares a non-empty `stderr:` warning pattern, the test now also runs the plain `eu` eval path and asserts the same pattern appears. `004_invalid_annotation.eu` was excluded from that assertion at the time because PR #1027 (eu-5q08) — which fixes the underlying divergence — hadn't merged yet.

#1027 has since merged: `extract_annotation` in `src/core/typecheck/check.rs` now emits an `invalid type annotation` `TypeWarning` instead of silently discarding the `parse_scheme` error via `.ok()?`. The planned follow-up — removing the 004 exclusion so the general mechanism covers it — never happened. This PR does that.

## Changes

- Removed the `if filename == "004_invalid_annotation.eu" { return; }` early-return in `run_typecheck_test` (`tests/harness_test.rs`). 004's `.expect` sidecar has a non-empty `stderr: "invalid type annotation"` pattern, so it now genuinely joins the eval-path-parity-covered set (36 warning-bearing fixtures instead of 35).
- Folded away `test_typecheck_004_invalid_annotation_eval_path_warns` and its `run_typecheck_eval_path_test` helper. **Rationale**: with the exclusion gone, this standalone test is fully redundant with the general mechanism — same fixture, same expected pattern (`"invalid type annotation"`), essentially the same assertion (run the eval path, check stderr contains the pattern). The original doc comment on the helper explicitly said it existed "so eu-5q08's regression is gated on its own even if #1026 has not yet merged" and "should be removed so the two mechanisms do not silently overlap" once #1026 landed. `test_typecheck_004_invalid_annotation` (which calls the now-uncapped `run_typecheck_test`) covers both the `eu check --strict` path and the eval path, so I kept that as the single source of truth and added a doc comment on it noting it also gates the eu-5q08 regression.
- Tidied the now-outdated sequencing comments describing the #1026/#1027 merge dance (they're gone along with the removed helper/test, since that dance is now resolved).

## Fault injection (mandatory verification)

To confirm the re-included assertion genuinely gates:
1. Temporarily reverted `extract_annotation` in `src/core/typecheck/check.rs` to the pre-#1027 behaviour (`parse::parse_scheme(&type_str).ok()?`, discarding the parse error instead of calling `warn_invalid_annotation`).
2. Ran `cargo test --test harness_test test_typecheck_004` — **FAILED** as expected:
   ```
   eval path (`eu 004_invalid_annotation.eu`, no subcommand) does not surface the warning
   `eu check --strict` reports for the same file — checker/eval divergence (eu-ntwg.1).
   Expected to find "invalid type annotation" in stderr:
   ```
3. Restored the fix, confirmed `git diff` on `check.rs` was clean, re-ran the test — **PASSED**.

## Test plan

- [x] `cargo test` — full suite green (500 passed in `harness_test.rs`, down from the prior 501 by exactly the one folded test; no other regressions)
- [x] `cargo test --test harness_test test_typecheck_004` — passes, now exercising the eval-path parity assertion for 004
- [x] `cargo fmt --all` — no diff
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Fault injection performed and documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)