### PR TITLE
test(gc): fix three unit tests' assumptions broken by EU_GC_STRESS=1 (eu-swbz)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -61,6 +61,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo test
+      - name: Run lib unit tests under GC stress (eu-swbz)
+        # The other EU_GC_STRESS jobs in this workflow (test-gc-verified,
+        # test-aarch64-sequential, asan) all run `eu test tests/harness` —
+        # none of them exercise `cargo test --lib`, so GC-internal unit tests
+        # (eval::memory::{collect,heap}::tests::*) were never gated under this
+        # flag. `cargo test --lib` alone is cheap (~3s locally), so this is a
+        # small additional step rather than a new job.
+        run: cargo test --lib
+        env:
+          EU_GC_STRESS: "1"
       - name: Test doc examples
         if: runner.os == 'Linux'
         run: |

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -394,6 +394,25 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
         return collect_with_evacuation(roots, heap, clock, &candidates, dump_heap);
     }
 
+    collect_mark_in_place(roots, heap, clock, dump_heap);
+}
+
+/// The non-evacuating mark-and-sweep half of [`collect`]: mark reachable
+/// objects, then defer sweep to allocation time.
+///
+/// Factored out so [`collect`] (which first consults
+/// `analyze_collection_strategy` — including its `EU_GC_STRESS` override,
+/// see that method's doc comment) and the `#[cfg(test)]`-only
+/// `collect_mark_in_place_for_test` (which deliberately bypasses strategy
+/// analysis, so test scaffolding that needs a deterministic non-evacuating
+/// pass isn't subject to the ambient stress flag — eu-swbz) share one
+/// implementation rather than drifting apart.
+fn collect_mark_in_place(
+    roots: &mut dyn GcScannable,
+    heap: &mut Heap,
+    clock: &mut Clock,
+    dump_heap: bool,
+) {
     if dump_heap {
         eprintln!("GC!");
     }
@@ -448,6 +467,36 @@ pub fn collect(roots: &mut dyn GcScannable, heap: &mut Heap, clock: &mut Clock, 
 
     // After collection, flip mark state ready for next collection
     heap_view.heap.flip_mark_state();
+}
+
+/// Test-only entry point for a deterministic, non-evacuating mark-and-sweep
+/// pass that never consults `analyze_collection_strategy` (and so is never
+/// subject to `EU_GC_STRESS`'s force-evacuate-everything override).
+///
+/// Some tests use a "settling" collection purely as scaffolding — to pack
+/// live objects into `rest` blocks before the test's *own* deliberate,
+/// explicitly-candidated evacuation begins — and are not testing the
+/// strategy heuristic itself (that's what
+/// `heap::tests::test_collection_strategy_*` and
+/// `collect::tests::test_no_evacuation_when_not_fragmented` are for). Routing
+/// that scaffolding through plain `collect()` made such a test's setup
+/// non-deterministic under `EU_GC_STRESS=1` (eu-swbz,
+/// `test_evacuation_target_block_has_marked_lines_after_collection`): the
+/// settling pass would itself force-evacuate, changing how many pre-existing
+/// `rest` blocks the test's own explicit evacuation then had to distinguish
+/// from genuine targets — including, in the presence of the exact
+/// evacuation-target-recycling bug this test exists to catch, corrupting the
+/// test's own setup before its assertion ever ran (silently passing instead
+/// of failing). Use this whenever a test needs "pack objects into `rest`,
+/// deterministically, regardless of the ambient stress flag" rather than
+/// "collect with whatever strategy is currently in effect".
+#[cfg(test)]
+pub fn collect_mark_in_place_for_test(
+    roots: &mut dyn GcScannable,
+    heap: &mut Heap,
+    clock: &mut Clock,
+) {
+    collect_mark_in_place(roots, heap, clock, false)
 }
 
 /// Perform a collecting GC cycle with selective evacuation of fragmented blocks.
@@ -1444,32 +1493,28 @@ pub mod tests {
     ///
     /// `finalise_evacuation()` only *adds* target block(s) to `rest` (see its
     /// doc comment) — it never removes the pre-existing candidate blocks that
-    /// were already in `rest` going into the evacuation pass. When more than
-    /// one pre-existing `rest` block is evacuated *from* simultaneously
-    /// (which happens whenever this test's own candidate list —
-    /// `2..2+rest_count`, intentionally "every rest block" — covers more than
-    /// one block), a fully-drained source block legitimately ends up with
-    /// zero marked lines and rides along into `unswept` in the very same
-    /// `defer_sweep()` call as the genuine target(s). That is correct GC
-    /// behaviour, not a bug: nothing should mark a block whose entire live
-    /// content was copied elsewhere. So "new in `unswept`" alone is not
-    /// sufficient to identify "is an evacuation target" — the test also
-    /// excludes any address that was already present in `rest` immediately
-    /// before the evacuation call (eu-swbz).
-    ///
-    /// Under `EU_GC_STRESS=1` this distinction is exercised on every run: the
-    /// "mark-in-place settling" `collect()` two lines below internally calls
-    /// `analyze_collection_strategy()` (see `collect`'s own body), which
-    /// under stress unconditionally evacuates every unpinned block instead of
-    /// only fragmented ones — so the settling pass itself typically leaves
-    /// *multiple* rest blocks where the non-stressed heuristic leaves at most
-    /// one, and this test's own (always-evacuate-every-rest-block) candidate
-    /// list then evacuates multiple blocks in the same pass every time.
-    /// Confirmed empirically (not just reasoned): under `EU_GC_STRESS=1` the
-    /// block this test previously flagged as "zero marked lines" is exactly
-    /// one of the addresses returned by `rest_block_base_addresses()`
-    /// *before* `collect_with_evacuation` runs — i.e. a source block, not a
-    /// target.
+    /// were already in `rest` going into the evacuation pass. If the
+    /// "settling" collection below ever left more than one pre-existing
+    /// `rest` block for this test's own (always-evacuate-every-rest-block)
+    /// candidate list to evacuate simultaneously, a fully-drained *source*
+    /// block would legitimately end up with zero marked lines too (nothing
+    /// should mark a block whose entire live content was copied elsewhere)
+    /// and ride into `unswept` alongside the genuine target(s) — making "new
+    /// in `unswept`" alone insufficient to identify a target, and (eu-swbz,
+    /// confirmed via Wicket's fault injection during review) *indistinguishable
+    /// from the exact bug this test exists to catch*: with the bug present,
+    /// the settling pass's own evacuation target is itself silently
+    /// unmarked, so it looks exactly like a legitimately-drained source by
+    /// the time this test's explicit phase runs — an address-based exclusion
+    /// added to handle the legitimate case ends up hiding the buggy one too,
+    /// letting the bug pass silently under `EU_GC_STRESS=1` instead of
+    /// failing. Rather than trying to make that distinction more precise,
+    /// the settling collection below is deliberately routed through
+    /// `collect_mark_in_place_for_test` — which never evacuates, regardless
+    /// of the ambient stress flag — so this test's own setup is always
+    /// exactly one pre-existing `rest` block in both configurations, and the
+    /// original single-candidate assertion logic is correct without any
+    /// address-exclusion mechanism at all.
     ///
     /// ## Pass/fail criterion
     ///
@@ -1510,11 +1555,14 @@ pub mod tests {
         };
 
         // Mark-in-place collection to settle live objects into rest blocks.
-        // Under EU_GC_STRESS=1 this internally forces evacuation too (see the
-        // doc comment above) — that's fine, it just means `rest_count` below
-        // may legitimately be larger than under a non-stressed run.
+        // Deliberately NOT `collect()`: this is test scaffolding, not the
+        // strategy heuristic under test, and must stay deterministic
+        // (exactly one resulting rest block) regardless of EU_GC_STRESS —
+        // see the doc comment above for why routing it through `collect()`
+        // made this test's own setup non-deterministic, and in the presence
+        // of the very bug it guards against, silently un-testing it.
         let mut roots = vec![root_ptr];
-        collect(&mut roots, &mut heap, &mut clock, false);
+        collect_mark_in_place_for_test(&mut roots, &mut heap, &mut clock);
         heap.flush_unswept();
 
         let rest_count = heap.rest_block_count();
@@ -1530,13 +1578,8 @@ pub mod tests {
         // Force evacuation of all rest blocks (indices 2..2+rest_count is a
         // conventional way to include every block in the evacuation candidate
         // set — the exact indices do not matter as long as all rest blocks
-        // are selected). Capture which addresses are the pre-existing SOURCE
-        // blocks going into this pass, so they can be excluded from the
-        // "evacuation target" set below — evacuating from them legitimately
-        // leaves them at zero marked lines, which is not what this test's
-        // invariant is about (see the doc comment above).
+        // are selected).
         let candidates: Vec<usize> = (2..2 + rest_count).collect();
-        let pre_evacuation_rest: HashSet<usize> = heap.rest_block_base_addresses();
         collect_with_evacuation(&mut roots, &mut heap, &mut clock, &candidates, false);
 
         // After collect_with_evacuation:
@@ -1544,24 +1587,17 @@ pub mod tests {
         //   defer_sweep()         → rest (including target) to unswept
         // So rest is empty and the former target is in unswept.
         let unswept_after: HashSet<usize> = heap.unswept_block_base_addresses();
-        let new_blocks: Vec<usize> = unswept_after
-            .difference(&unswept_before)
-            .copied()
-            .filter(|addr| !pre_evacuation_rest.contains(addr))
-            .collect();
+        let new_blocks: Vec<usize> = unswept_after.difference(&unswept_before).copied().collect();
 
-        // If no new (genuinely-target) block appeared in unswept, either
-        // nothing was evacuated, or every "new" block was actually one of the
-        // pre-existing source blocks drained down to nothing.  Either way
-        // there is no target to check here — skip rather than fail.
+        // If no new block appeared in unswept, the evacuation target was never
+        // allocated (nothing was actually evacuated).  Skip rather than fail.
         if new_blocks.is_empty() {
             return;
         }
 
-        // Each remaining new block — i.e. a block that appeared in `unswept`
-        // after the evacuation pass AND was not already a pre-existing `rest`
-        // block going in — is either the active evacuation target or one of
-        // the `filled_evacuation_blocks`.  ALL of them must have at least one
+        // Each new block that appeared in unswept after the evacuation pass is
+        // either the active evacuation target or one of the
+        // `filled_evacuation_blocks`.  ALL of them must have at least one
         // marked line; a zero-marked block would be fully recycled by
         // `lazy_sweep_next()`, overwriting live evacuated data.
         for &target_base in &new_blocks {

--- a/src/eval/memory/collect.rs
+++ b/src/eval/memory/collect.rs
@@ -1056,14 +1056,33 @@ pub mod tests {
         collect(&mut ptrs.clone(), &mut heap, &mut clock, false);
 
         let strategy = heap.analyze_collection_strategy();
-        // When all blocks are dense, strategy should be MarkInPlace
-        // (or at worst, the candidate list should be empty)
         let candidates = strategy.candidates();
-        assert!(
-            candidates.is_empty(),
-            "densely packed heap should not have evacuation candidates, got {:?}",
-            candidates
-        );
+
+        // eu-swbz: EU_GC_STRESS=1 makes `analyze_collection_strategy` skip
+        // its fragmentation analysis entirely and unconditionally select
+        // every unpinned block for evacuation, so that evacuation
+        // pointer-update bugs surface on every platform (see that method's
+        // stress-mode branch). "A dense heap has no evacuation candidates"
+        // is a real property of the non-stressed heuristic this test is
+        // meant to exercise, not of stress mode's deliberate override —
+        // branch on the flag so the test still exercises something real
+        // (the override firing correctly) under stress, instead of failing
+        // on an assumption stress mode is designed to violate.
+        if heap.gc_stress() {
+            assert!(
+                !candidates.is_empty(),
+                "EU_GC_STRESS=1 must select every unpinned block for evacuation \
+                 even when the heap is densely packed, got an empty candidate list"
+            );
+        } else {
+            // When all blocks are dense, strategy should be MarkInPlace
+            // (or at worst, the candidate list should be empty)
+            assert!(
+                candidates.is_empty(),
+                "densely packed heap should not have evacuation candidates, got {:?}",
+                candidates
+            );
+        }
     }
 
     /// Test that evacuation correctly updates internal pointers.
@@ -1423,6 +1442,35 @@ pub mod tests {
     /// target is in `unswept`.  The test captures `unswept` base addresses
     /// before and after the evacuation GC pass to find the new block.
     ///
+    /// `finalise_evacuation()` only *adds* target block(s) to `rest` (see its
+    /// doc comment) — it never removes the pre-existing candidate blocks that
+    /// were already in `rest` going into the evacuation pass. When more than
+    /// one pre-existing `rest` block is evacuated *from* simultaneously
+    /// (which happens whenever this test's own candidate list —
+    /// `2..2+rest_count`, intentionally "every rest block" — covers more than
+    /// one block), a fully-drained source block legitimately ends up with
+    /// zero marked lines and rides along into `unswept` in the very same
+    /// `defer_sweep()` call as the genuine target(s). That is correct GC
+    /// behaviour, not a bug: nothing should mark a block whose entire live
+    /// content was copied elsewhere. So "new in `unswept`" alone is not
+    /// sufficient to identify "is an evacuation target" — the test also
+    /// excludes any address that was already present in `rest` immediately
+    /// before the evacuation call (eu-swbz).
+    ///
+    /// Under `EU_GC_STRESS=1` this distinction is exercised on every run: the
+    /// "mark-in-place settling" `collect()` two lines below internally calls
+    /// `analyze_collection_strategy()` (see `collect`'s own body), which
+    /// under stress unconditionally evacuates every unpinned block instead of
+    /// only fragmented ones — so the settling pass itself typically leaves
+    /// *multiple* rest blocks where the non-stressed heuristic leaves at most
+    /// one, and this test's own (always-evacuate-every-rest-block) candidate
+    /// list then evacuates multiple blocks in the same pass every time.
+    /// Confirmed empirically (not just reasoned): under `EU_GC_STRESS=1` the
+    /// block this test previously flagged as "zero marked lines" is exactly
+    /// one of the addresses returned by `rest_block_base_addresses()`
+    /// *before* `collect_with_evacuation` runs — i.e. a source block, not a
+    /// target.
+    ///
     /// ## Pass/fail criterion
     ///
     /// - **With the fix**: `mark_region_in_block` searched `evacuation_target`
@@ -1462,6 +1510,9 @@ pub mod tests {
         };
 
         // Mark-in-place collection to settle live objects into rest blocks.
+        // Under EU_GC_STRESS=1 this internally forces evacuation too (see the
+        // doc comment above) — that's fine, it just means `rest_count` below
+        // may legitimately be larger than under a non-stressed run.
         let mut roots = vec![root_ptr];
         collect(&mut roots, &mut heap, &mut clock, false);
         heap.flush_unswept();
@@ -1479,8 +1530,13 @@ pub mod tests {
         // Force evacuation of all rest blocks (indices 2..2+rest_count is a
         // conventional way to include every block in the evacuation candidate
         // set — the exact indices do not matter as long as all rest blocks
-        // are selected).
+        // are selected). Capture which addresses are the pre-existing SOURCE
+        // blocks going into this pass, so they can be excluded from the
+        // "evacuation target" set below — evacuating from them legitimately
+        // leaves them at zero marked lines, which is not what this test's
+        // invariant is about (see the doc comment above).
         let candidates: Vec<usize> = (2..2 + rest_count).collect();
+        let pre_evacuation_rest: HashSet<usize> = heap.rest_block_base_addresses();
         collect_with_evacuation(&mut roots, &mut heap, &mut clock, &candidates, false);
 
         // After collect_with_evacuation:
@@ -1488,17 +1544,24 @@ pub mod tests {
         //   defer_sweep()         → rest (including target) to unswept
         // So rest is empty and the former target is in unswept.
         let unswept_after: HashSet<usize> = heap.unswept_block_base_addresses();
-        let new_blocks: Vec<usize> = unswept_after.difference(&unswept_before).copied().collect();
+        let new_blocks: Vec<usize> = unswept_after
+            .difference(&unswept_before)
+            .copied()
+            .filter(|addr| !pre_evacuation_rest.contains(addr))
+            .collect();
 
-        // If no new block appeared in unswept, the evacuation target was never
-        // allocated (nothing was actually evacuated).  Skip rather than fail.
+        // If no new (genuinely-target) block appeared in unswept, either
+        // nothing was evacuated, or every "new" block was actually one of the
+        // pre-existing source blocks drained down to nothing.  Either way
+        // there is no target to check here — skip rather than fail.
         if new_blocks.is_empty() {
             return;
         }
 
-        // Each new block that appeared in unswept after the evacuation pass is
-        // either the active evacuation target or one of the
-        // `filled_evacuation_blocks`.  ALL of them must have at least one
+        // Each remaining new block — i.e. a block that appeared in `unswept`
+        // after the evacuation pass AND was not already a pre-existing `rest`
+        // block going in — is either the active evacuation target or one of
+        // the `filled_evacuation_blocks`.  ALL of them must have at least one
         // marked line; a zero-marked block would be fully recycled by
         // `lazy_sweep_next()`, overwriting live evacuated data.
         for &target_base in &new_blocks {

--- a/src/eval/memory/heap.rs
+++ b/src/eval/memory/heap.rs
@@ -2779,6 +2779,21 @@ impl Heap {
         heap_state.rest.len()
     }
 
+    /// Whether this heap was constructed with `EU_GC_STRESS=1` (eu-swbz).
+    ///
+    /// Tests that assert on `analyze_collection_strategy()`'s output — or on
+    /// anything downstream of it — must account for stress mode: it forces
+    /// `SelectiveEvacuation` over every unpinned block on every collection,
+    /// unconditionally, regardless of fragmentation (see
+    /// `analyze_collection_strategy`'s stress-mode branch). Reading this
+    /// cached field (rather than re-reading the env var independently) keeps
+    /// a test's branch in sync with what the heap under test actually
+    /// observed at construction time.
+    #[cfg(test)]
+    pub fn gc_stress(&self) -> bool {
+        self.gc_stress
+    }
+
     /// Return the number of unswept blocks (for test diagnostics)
     #[cfg(test)]
     pub fn unswept_block_count(&self) -> usize {
@@ -2999,7 +3014,34 @@ pub mod tests {
         }
 
         let strategy = heap.analyze_collection_strategy();
-        assert_eq!(strategy, CollectionStrategy::MarkInPlace);
+
+        // eu-swbz: under EU_GC_STRESS=1, `analyze_collection_strategy` skips
+        // the fragmentation-based analysis this test otherwise exercises and
+        // unconditionally forces `SelectiveEvacuation` over every unpinned
+        // block, precisely so evacuation pointer-update bugs surface on every
+        // platform (see the stress-mode branch's doc comment). A dense heap
+        // choosing `MarkInPlace` is a real property of the non-stressed
+        // fragmentation heuristic; assert that heuristic only when stress
+        // mode isn't overriding it, and assert the override's own documented
+        // behaviour when it is — so this test still exercises something real
+        // in both configurations rather than being skipped under stress.
+        if heap.gc_stress() {
+            match strategy {
+                CollectionStrategy::SelectiveEvacuation(blocks) => {
+                    assert!(
+                        !blocks.is_empty(),
+                        "EU_GC_STRESS=1 must select every unpinned block for evacuation, \
+                         got an empty candidate list"
+                    );
+                }
+                other => panic!(
+                    "EU_GC_STRESS=1 must force SelectiveEvacuation regardless of density, \
+                     got {other:?}"
+                ),
+            }
+        } else {
+            assert_eq!(strategy, CollectionStrategy::MarkInPlace);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reproduced all three EU_GC_STRESS=1 unit-test failures (`eval::memory::collect::tests::test_no_evacuation_when_not_fragmented`, `eval::memory::collect::tests::test_evacuation_target_block_has_marked_lines_after_collection`, `eval::memory::heap::tests::test_collection_strategy_mark_in_place`) and root-caused each individually. **All three are category (a): a test assumption legitimately violated by the stress flag's own documented, intentional behaviour — not a genuine GC bug.** No GC production code changed; this is a test-side fix per the "prefer test-side unless mechanism-level evidence says GC-side" guidance.

**Revised after Wicket's first review** (see "Revision" section below) — the original test #2 fix passed review's own fault-injection but Wicket went further and found it was vacuous under stress against the *original production bug it exists to guard*. Fixed by decoupling the test's settling-phase collection from the ambient stress flag entirely, per Wicket's suggested direction. The corrected claim: test #2 now exercises the same real invariant in both configurations, not a stress-specific weakened one — see below.

## Per-test root cause

### 1 & 3 — `test_no_evacuation_when_not_fragmented` / `test_collection_strategy_mark_in_place`

Both assert a densely-packed heap's `analyze_collection_strategy()` chooses `MarkInPlace` / returns an empty candidate list. `analyze_collection_strategy()`'s `gc_stress` branch (`src/eval/memory/heap.rs`) is explicitly documented: "GC stress mode: force `SelectiveEvacuation` on every collection so that evacuation pointer-update bugs surface on any platform, not just the aarch64 CI runner." Under the flag it skips fragmentation analysis entirely and unconditionally evacuates every unpinned block — the exact property these two tests assert doesn't hold. **Mechanism, not hand-wave**: this is the flag doing precisely what its own doc comment says it does.

Fix: added `Heap::gc_stress()` (a `#[cfg(test)]` accessor reading the heap's own cached flag, keeping the test in sync with what the heap under test actually observed at construction) and branched each assertion — under stress, assert the override's own documented behaviour (`SelectiveEvacuation`, non-empty candidates); otherwise assert the original density heuristic. Both tests exercise something real in **both** configurations rather than being skipped or weakened to vacuity under stress. **Unchanged by the revision** — Wicket reviewed these cleanly.

### 2 — `test_evacuation_target_block_has_marked_lines_after_collection`

**Original fix (reviewed and sent back — see "Revision" below for what actually shipped).**

Investigated carefully before concluding (a), since it's the test that literally exists to guard a previously-fixed evacuation-target-recycling bug (test119/monad_utility aarch64 crash) — a genuine (b) finding here would need to stop and report before any fix, per the checkpoint rule.

Root-caused with temporary diagnostic instrumentation (added, run under both configurations, reverted before committing):

- Unstressed: `rest_count = 1` before the test's own evacuation call → 1 pre-existing candidate → 2 new blocks appear in `unswept` afterward, **both** with 256 marked lines (512 small objects don't fit one fresh target block, so evacuation fills one and retires it to `filled_evacuation_blocks`, both are genuine targets). Test passes.
- Stressed: `rest_count = 2` before the test's own evacuation call (because the test's *first*, "mark-in-place settling" `collect()` call internally consults `analyze_collection_strategy()` too, so under stress it *also* force-evacuates, leaving 2 rest blocks where the non-stressed heuristic leaves 1). The test's own candidate list (`2..2+rest_count`, "every rest block" by design) then evacuates **both** pre-existing blocks simultaneously.

`finalise_evacuation()` only *adds* the new target block(s) to `rest`; it never removes the pre-existing candidate blocks that were already there. When a source block is fully drained, it legitimately has zero marked lines and rides into `unswept` alongside the genuine target — correct GC behaviour, not a bug. My original fix addressed this by capturing `rest_block_base_addresses()` immediately before the evacuation call and excluding those addresses from the "new block" set the assertion checks.

**What Wicket found wrong with that fix**: fault-injecting the *original production bug* (removing the `evacuation_target`/`filled_evacuation_blocks` search from `mark_region_in_block`, restoring the exact pre-fix test119/monad_utility recycling bug) with my address-exclusion fix in place, the test correctly failed unstressed but **passed silently under `EU_GC_STRESS=1`**, reproduced consistently across 5 runs. Mechanism: with the bug present, the settling-phase evacuation (forced by stress) *is itself* the recycling bug in miniature — its own target never gets marked, so it's indistinguishable from a legitimately-drained source by the time the test's explicit phase runs. The address-exclusion added to handle the *legitimate* drained-source case ended up hiding the *buggy* one too, since both present identically (0 marks, present in `rest` going in). My original claim "both tests now exercise something real in both configurations" was **not accurate for test #2** — under stress, in exactly the scenario it exists to catch, it was vacuous.

## Revision (Wicket's suggested direction, implemented)

Rather than making the address-exclusion logic smarter (which would still be trying to distinguish two states that present identically), decoupled the test's settling-phase collection from the ambient `EU_GC_STRESS` override entirely — the settling `collect()` call is test scaffolding (pack objects into `rest` before the test's own deliberate, explicitly-candidated evacuation begins), not the strategy heuristic under test, and has no reason to be subject to the stress override at all.

- Extracted the non-evacuating mark-and-sweep half of `collect()` into a shared `collect_mark_in_place()` helper (no behaviour change for production — `collect()` still calls it in exactly the same branch as before).
- Added a `#[cfg(test)]`-only `collect_mark_in_place_for_test()` entry point that calls it directly, **bypassing `analyze_collection_strategy()` (and so `gc_stress`) entirely**.
- Routed the test's settling call through this new entry point instead of `collect()`.
- **Removed the `pre_evacuation_rest` address-exclusion mechanism entirely** — with the settling phase now deterministic, `rest_count` is always 1 in both configurations, and the *original, pre-fix* assertion logic (no exclusion needed) is correct in both. The test body for the evacuation-and-assertion phase is now unchanged from before any of this PR's work — only the settling-phase call changed.

### Verification of the revision

Both required, both performed:

- **My own fault injection** (unchanged from before): reverted all three files to the pre-fix baseline (`a9add2b5`), confirmed the original three test failures reproduce exactly under `EU_GC_STRESS=1`, restored, reconfirmed green in both configs.
- **Wicket's fault injection** (the one that failed before): reintroduced the exact original production bug (temporarily removed the `evacuation_target`/`filled_evacuation_blocks` search from `mark_region_in_block`) with this revision's fix in place. The test now **fails correctly under both configurations** — ran 5 times under `EU_GC_STRESS=1` for consistency (matching Wicket's own verification rigor), failed every time with the expected panic message. Restored, reconfirmed green.

## CI reachability

None of the three existing `EU_GC_STRESS` CI jobs (`test-gc-verified`, `test-aarch64-sequential`, `asan`) run `cargo test --lib` — they all run `eu test tests/harness` via the compiled binary. So these GC-internal unit tests were **never gated by CI**, even before this fix — that's a real gap, not just this PR's excuse for not noticing sooner. Added a step to the main "Test Suite" job (`.github/workflows/build-rust.yaml`, all three OS matrix legs — ubuntu/macos/windows) running `EU_GC_STRESS=1 cargo test --lib` right after the existing `cargo test` step. Cheap: `cargo test --lib` alone runs in ~3s locally. **Unchanged by the revision** — Wicket reviewed this cleanly.

## Diagnostic signal (requested)

All three behave identically under `EU_HEAPSYN=1` and `EU_PREDECODE=0` combined with `EU_GC_STRESS=1` — verified, not just reasoned (ran `cargo test --lib` under all four combinations). Expected: these are pure `Heap`/`collect()`-level unit tests that construct and drive the heap directly, never invoking engine dispatch, so the execution-engine selector flags are inert here.

## Test status (post-revision)

- `cargo test`: green, unstressed and under `EU_GC_STRESS=1` (1308 lib + 500 harness + all other suites).
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 EU_GC_POISON=1 cargo test --lib`: green.
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 cargo test --test harness_test`: green (500/500).
- **Fault-injection (mine)**: reverted all three fix files to `a9add2b5`, reran `EU_GC_STRESS=1 cargo test --lib`, reproduced the original three failures exactly, restored, reconfirmed green in both modes.
- **Fault-injection (Wicket's, the one that previously failed)**: reintroduced the original production bug with the fix in place — test #2 now fails under both configurations, verified over 5 stressed runs. Restored, reconfirmed green.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --all`: clean.
- CI workflow YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Notes for review

This touches `src/eval/memory/` (test code only, no production GC logic changed) — recorded-review rule applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
