### PR TITLE
release: bump version to 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to eucalypt are documented here.
 
-## [Unreleased]
+## [0.13.1] - 2026-07-20
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "eucalypt"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 
 [package]
 name = "eucalypt"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 


### PR DESCRIPTION
## Summary

Version bump trigger for the 0.13.1 release-candidate pipeline (which stamps versions from `Cargo.toml`). Replicates commit `2dfe795c`'s shape exactly (the 0.13.0 bump) — same three files, same single-line change in each:

1. `Cargo.toml`: `version = "0.13.0"` → `"0.13.1"`
2. `Cargo.lock`: the `eucalypt` package's own version entry, regenerated via `cargo check` (not hand-edited) — confirmed the resulting diff is the single expected line.
3. `CHANGELOG.md`: `## [Unreleased]` → `## [0.13.1] - 2026-07-20`

**Note on the CHANGELOG heading**: the 0.13.0 bump wrote `- Unreleased` as the date placeholder, which went stale and needed a follow-up fix (#1037). Wrote today's date (2026-07-20) directly this time instead of repeating that.

## Verification

- `grep`'d for hardcoded `0.13.0` strings across `src/`, `tests/`, and other file types — none found, so nothing needed fixing for the bump itself.
- `cargo fmt --all`: no changes (already clean).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: full suite green — 1310 lib + 501 harness + all other suites (including doctests), 0 failures. No test hardcoded the old version string.
- Sanity-checked version reporting:
  - `eu build.eu -t version` → `0.13.1+dev` (correct — this target reads `cargo.package.version` live from `Cargo.toml`).
  - `cargo run -- version` / `eu version` → `eu - Eucalypt v0.0.0.dev` — **this is expected, not a regression**: that subcommand reads the checked-in `build-meta.yaml` dev-placeholder file, which is only populated with real values by CI's release pipeline (`eu build.eu -t build-meta`) during an actual release build. Confirmed this is pre-existing, version-independent behaviour, not something this bump touches or should touch.

## Notes for review

This is release machinery — recorded-review rule applies. Base commit is `72b2ad68` (post-#1037, master green per run 29685034479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)