### PR TITLE
chore: open Unreleased section for next development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to eucalypt are documented here.
 
+## [Unreleased]
+
 ## [0.13.1] - 2026-07-20
 
 ### Changed


### PR DESCRIPTION
## Summary

Skill step 9 of the release process: open the next `[Unreleased]` section in `CHANGELOG.md` now that 0.13.1 has shipped, so the next development cycle has somewhere to land entries. Replicates commit `a29d33f3`'s shape exactly (which did the same thing after 0.13.0) — a bare `## [Unreleased]` heading (plus its blank line) added directly above the current top version heading. Nothing else in the diff.

## Test status

- `cargo fmt --all`: no changes (already clean).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: full suite green — 1310 lib + 501 harness + all other suites (including doctests), 0 failures.

## Notes for review

Docs-only, single-line diff. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)