### PR TITLE
chore: bump version to 0.14.0 for development cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "eucalypt"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "base64",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["fuzz"]
 
 [package]
 name = "eucalypt"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
 


### PR DESCRIPTION
Opens the 0.14 development cycle by bumping the eucalypt version from 0.13.1 to 0.14.0.

Per project convention, the version bump commit is what makes CI mint a correctly-numbered release candidate, so it lands at the start of the cycle rather than on release day. 0.13.1 has shipped.

## Changes
- `Cargo.toml`: version `0.13.1` -> `0.14.0`
- `Cargo.lock`: eucalypt package entry updated to `0.14.0`

CHANGELOG's `## [Unreleased]` section is already open (from 860f4b3a / d48b509e), so no changelog changes are needed. No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py2HEaF87JJWPcDBiBic3g