### PR TITLE
fix(security): bump brace-expansion to >=2.1.2 (Dependabot #21)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -44,9 +44,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #21 (high severity): `brace-expansion` 2.0.0–2.1.1 is vulnerable to a DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)).
- `brace-expansion` is a transitive dev-dependency of the VS Code extension (pulled in via `minimatch`), not a direct dependency — nothing in `package.json` changes.
- Bumped the resolved version in `editors/vscode/package-lock.json` from `2.0.3` to the first patched release, `2.1.2`, via `npm audit fix`. `npm audit` now reports 0 vulnerabilities.

## Test plan
- [x] `npm audit` (before) confirmed the alert: `brace-expansion 2.0.0 - 2.1.1`, high severity, fix available via `npm audit fix`
- [x] `npm audit fix` in `editors/vscode/` — bumped `brace-expansion` to `2.1.2`, 0 vulnerabilities remaining
- [x] `npm audit` (after) confirms 0 vulnerabilities
- [x] `npm run compile` (`tsc -p ./`) passes with no errors
- [x] `git diff --stat` confirms the change is scoped to `editors/vscode/package-lock.json` only (lockfile-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)