### PR TITLE
fix(import): restore XML entity/character refs in text content (eu-odkp)

### DIFF
--- a/src/import/xml.rs
+++ b/src/import/xml.rs
@@ -60,20 +60,33 @@ struct XmlImporter<'src> {
 impl<'src> XmlImporter<'src> {
     pub fn new(file_id: usize, text: &'src str) -> Self {
         let mut reader = Reader::from_str(text);
-        reader.config_mut().trim_text(true);
+        // Deliberately NOT `trim_text(true)`. quick-xml 0.41 emits entity /
+        // character references in text content as separate `Event::GeneralRef`
+        // events, interspersed with `Event::Text` fragments for the literal
+        // text either side. `trim_text(true)` trims each of those fragments
+        // *individually*, which discards the interior whitespace between a
+        // text fragment and a neighbouring reference (`"a "` + `"&amp;"` +
+        // `" b"` would trim to `"a"` + `"&"` + `"b"`, losing both spaces).
+        // Instead we accumulate raw text + resolved references into
+        // `text_buf` across a whole run and trim only the coalesced whole in
+        // `flush_text`, matching pre-0.12.0 behaviour exactly.
+        reader.config_mut().trim_text(false);
         XmlImporter { file_id, reader }
     }
 
     pub fn parse(&mut self) -> Result<RcExpr, SourceError> {
         let mut buf = Vec::new();
         let mut stack: VecDeque<ProtoElement> = VecDeque::new();
+        let mut text_buf = String::new();
 
         loop {
             match self.reader.read_event_into(&mut buf) {
                 Ok(Event::Start(ref event)) => {
+                    self.flush_text(&mut text_buf, &mut stack)?;
                     stack.push_back(self.to_proto_element(event)?);
                 }
                 Ok(Event::End(_)) => {
+                    self.flush_text(&mut text_buf, &mut stack)?;
                     if let Some(top) = stack.pop_back() {
                         let n = top.complete();
                         if let Some(top) = stack.back_mut() {
@@ -84,6 +97,7 @@ impl<'src> XmlImporter<'src> {
                     }
                 }
                 Ok(Event::Empty(ref event)) => {
+                    self.flush_text(&mut text_buf, &mut stack)?;
                     let n = self.to_proto_element(event)?.complete();
                     if let Some(top) = stack.back_mut() {
                         top.add(n);
@@ -92,25 +106,72 @@ impl<'src> XmlImporter<'src> {
                     }
                 }
                 Ok(Event::Text(event)) => {
-                    // quick-xml 0.41: `BytesText::unescape` was removed; decode
-                    // (character encoding) then unescape XML entities.
+                    // quick-xml 0.41: `BytesText::unescape` was removed. Text
+                    // fragments no longer contain entity syntax at all (those
+                    // arrive as separate `Event::GeneralRef` events below), so
+                    // simply decode the character encoding and accumulate.
                     let decoded = event.decode().map_err(|e| self.to_source_error(e))?;
-                    let text = quick_xml::escape::unescape(&decoded)
-                        .map_err(|e| self.to_source_error(e))?;
-                    if let Some(top) = stack.back_mut() {
-                        top.add(acore::str(&text));
+                    text_buf.push_str(&decoded);
+                }
+                Ok(Event::GeneralRef(bytes_ref)) => {
+                    // Character reference (`&#NN;` / `&#xNN;`) or predefined
+                    // entity reference (`&amp;`, `&lt;`, `&gt;`, `&quot;`,
+                    // `&apos;`) in text content. Resolve and append to the
+                    // same accumulating buffer as literal text so the whole
+                    // run is coalesced into a single text node.
+                    if let Some(ch) = bytes_ref
+                        .resolve_char_ref()
+                        .map_err(|e| self.to_source_error(e))?
+                    {
+                        text_buf.push(ch);
                     } else {
-                        return Err(SourceError::InvalidXml(
-                            "No top-level element".to_string(),
-                            self.file_id,
-                            self.span(),
-                        ));
+                        let name = bytes_ref.decode().map_err(|e| self.to_source_error(e))?;
+                        match quick_xml::escape::resolve_predefined_entity(&name) {
+                            Some(resolved) => text_buf.push_str(resolved),
+                            None => {
+                                return Err(SourceError::InvalidXml(
+                                    format!("Unknown entity reference: &{name};"),
+                                    self.file_id,
+                                    self.span(),
+                                ))
+                            }
+                        }
                     }
                 }
                 Err(e) => return Err(self.to_source_error(e)),
                 _ => (),
             }
         }
+    }
+
+    /// Flush the accumulated text run (literal text plus resolved
+    /// entity/character references) as a single text node, trimming the
+    /// *whole* coalesced run rather than each contributing fragment. A
+    /// whitespace-only run is dropped entirely, matching the previous
+    /// `trim_text(true)` behaviour of eliding insignificant whitespace
+    /// between elements.
+    fn flush_text(
+        &self,
+        text_buf: &mut String,
+        stack: &mut VecDeque<ProtoElement>,
+    ) -> Result<(), SourceError> {
+        if text_buf.is_empty() {
+            return Ok(());
+        }
+        let trimmed = text_buf.trim();
+        if !trimmed.is_empty() {
+            if let Some(top) = stack.back_mut() {
+                top.add(acore::str(trimmed));
+            } else {
+                return Err(SourceError::InvalidXml(
+                    "No top-level element".to_string(),
+                    self.file_id,
+                    self.span(),
+                ));
+            }
+        }
+        text_buf.clear();
+        Ok(())
     }
 
     /// A span indicating current reader position

--- a/tests/harness/190_odkp_xml_entity_refs.eu
+++ b/tests/harness/190_odkp_xml_entity_refs.eu
@@ -1,0 +1,19 @@
+{ doc: "eu-odkp: XML import must preserve entity and character references
+        in text content and coalesce the surrounding text into a single
+        text node. This is a regression since the quick-xml 0.25 to 0.41
+        bump silently dropped GeneralRef events and split text into
+        separate trimmed fragments. Exact round-trip fidelity to
+        pre-0.12.0 behaviour is required: the fixture must import as one
+        text node with entities resolved and interior spaces intact, not
+        as several stripped fragments with the entities dropped."
+  import: "root=xml@testdata/190_odkp_xml_entity_refs.xml" }
+
+# Fixture text: a &#38; b &lt;c&gt; &quot;d&quot; inside a single <r> element.
+expected: [:r, {}, c"a & b <c> \"d\""]
+
+# The whole point of the fix: text and resolved entity/character references
+# either side of a reference must coalesce into ONE text node with interior
+# spaces intact, not several trimmed fragments with the references dropped.
+t1: root //= expected
+
+RESULT: [t1] all-true? then(:PASS, :FAIL)

--- a/tests/harness/testdata/190_odkp_xml_entity_refs.xml
+++ b/tests/harness/testdata/190_odkp_xml_entity_refs.xml
@@ -1,0 +1,1 @@
+<r>a &#38; b &lt;c&gt; &quot;d&quot;</r>

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2885,6 +2885,15 @@ pub fn test_189_r9oy_union_as_spec() {
     run_test(&opts("189_r9oy_union_as_spec.eu"));
 }
 
+/// eu-odkp — regression test for XML import silently dropping entity /
+/// character references in text content (and splitting the surrounding
+/// text into separate trimmed nodes) since the quick-xml 0.25→0.41 bump.
+/// See the .eu file for full context.
+#[test]
+pub fn test_190_odkp_xml_entity_refs() {
+    run_test(&opts("190_odkp_xml_entity_refs.eu"));
+}
+
 #[test]
 pub fn test_typecheck_092_self_assign_arg_pos_ok() {
     run_typecheck_test("092_self_assign_arg_pos_ok.eu");


### PR DESCRIPTION
## Bug (eu-odkp, P1, data loss)

Since the quick-xml 0.25→0.41 bump (commit 7c2c665, 0.12.0), XML entity
and character references in **text content** are silently dropped, and
the surrounding text is split into separate trimmed nodes:

```
<r>a &amp; b</r>
  v0.11.1:        { "result": [ "r", {}, "a & b" ] }
  v0.13.1/master:  { "result": [ "r", {}, "a", "b" ] }   ← data loss
```

Root cause: newer quick-xml emits entity/character references in text
as separate `Event::GeneralRef` events rather than inline in
`Event::Text`. The event loop in `src/import/xml.rs::parse()` only
handled `Start`/`End`/`Empty`/`Text`; its wildcard `_ => ()` arm
discarded `GeneralRef` entirely. Attribute-value entity handling
(eu-cgys) was unaffected, which is why the existing attribute tests
kept passing while text silently lost data.

## Fix

- Stopped using `trim_text(true)` on the reader. It trims each
  `Text` fragment *individually*, and since entities now arrive as
  separate `GeneralRef` events, a naive per-fragment fix would still
  lose the interior whitespace between text and a reference (`"a "` +
  `"&amp;"` + `" b"` trims to `"a"` + `"&"` + `"b"`).
- Instead, `parse()` now accumulates literal text (`Event::Text`) and
  resolved references (`Event::GeneralRef`) into one per-run string
  buffer, and flushes a single trimmed text node at each element
  boundary (`Start`/`End`/`Empty`). Trimming the *whole* coalesced run
  — not each fragment — is what restores the pre-0.12.0 result exactly,
  including interior spaces.
- `GeneralRef` resolution uses quick-xml's own API: `BytesRef::resolve_char_ref()`
  for numeric character references (`&#NN;` / `&#xNN;`), and
  `quick_xml::escape::resolve_predefined_entity()` for the five
  predefined entities (`amp`/`lt`/`gt`/`quot`/`apos`).
- Attribute-value entity/whitespace-normalisation handling (eu-cgys) is
  completely untouched — a separate code path (`decoded_and_normalized_value`).

I verified the quick-xml 0.41 event stream empirically (a scratch
`cargo run --example`, since discarded) before writing the fix, per
`systematic-debugging`: confirmed `<r>a &amp; b &#38; c &lt;d&gt;</r>`
produces alternating `Text`/`GeneralRef` events, and that
`trim_text(true)` drops leading/trailing whitespace from *each*
fragment independently (losing the space either side of a reference),
while `trim_text(false)` preserves the raw fragments needed to
reconstruct the original run.

## Before / after (release build, both bead repro cases)

```
$ printf '<r>a &amp; b</r>' > min.xml
$ eu -j min.eu   # { import: "x=xml@min.xml" } / result: x
  before: { "result": [ "r", {}, "a", "b" ] }
  after:  { "result": [ "r", {}, "a & b" ] }

$ printf '<r>a &#38; b &lt;c&gt; &quot;d&quot;</r>' > full.xml
$ eu -j full.eu
  before: { "result": [ "r", {}, "a", "b", "c", "d" ] }
  after:  { "result": [ "r", {}, "a & b <c> \"d\"" ] }
```

Both now match v0.11.1 exactly.

## Tests

- New harness regression test `tests/harness/190_odkp_xml_entity_refs.eu`
  (+ fixture `tests/harness/testdata/190_odkp_xml_entity_refs.xml`,
  containing `<r>a &#38; b &lt;c&gt; &quot;d&quot;</r>`), following the
  `RESULT: [...] all-true? then(:PASS, :FAIL)` pattern from
  `189_r9oy_union_as_spec.eu` so a failing assertion genuinely fails
  `cargo test`. Registered in `tests/harness_test.rs` as
  `test_190_odkp_xml_entity_refs`.
- Existing XML harness tests (`047_xml_import.eu`, `111_parse_as_xml.eu`)
  and the eu-cgys attribute unit tests
  (`literal_attribute_whitespace_is_normalised_to_space`,
  `attribute_whitespace_character_references_survive`) still pass —
  attribute handling is unchanged.
- **TDD**: confirmed the new test is RED against pre-fix code (stashed
  the `xml.rs` change, ran `cargo test test_190_odkp_xml_entity_refs` →
  FAILED with `left: 1, right: 0`), then confirmed GREEN after
  restoring the fix.
- **Fault-injection verified**: after the fix passed, reverted the
  `Event::GeneralRef` arm to a no-op (dropping references again, as
  before), reran the harness test → FAILED (panicked, `left: 1, right: 0`
  mismatch). Restored the fix → PASSED again.
- Full `cargo test` (1310 lib tests, 502 harness tests, all other
  suites) is green; `cargo clippy --all-targets -- -D warnings` clean;
  `cargo fmt --all` clean.
- New/existing XML tests re-run under `EU_GC_VERIFY=2 EU_GC_STRESS=1`
  and pass (this change touches import parsing, not GC/allocator code,
  but verified per the workflow checklist regardless).

Closes/fixes eu-odkp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py2HEaF87JJWPcDBiBic3g