### PR TITLE
fix(desugar): declaration label spans must exclude leading metadata (eu-1tkk.7.7)

### DIFF
--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -36,6 +36,28 @@ fn text_range_to_span(range: TextRange) -> Span {
     Span::new(start, end)
 }
 
+/// Span of a declaration, excluding any leading backtick metadata.
+///
+/// A `Declaration` node's own `text_range` runs from the start of its
+/// leading `DECL_META` (if present) through the end of its body, so minting
+/// a Smid directly from `decl.syntax().text_range()` makes any diagnostic
+/// built from that Smid report the declaration's doc comment as its source
+/// location instead of the declaration itself. Starting the span at the
+/// declaration head (falling back to the full range when there is no head,
+/// which should not normally happen) keeps the end position — and hence
+/// anything measuring the declaration's extent — unchanged while excluding
+/// the metadata (eu-1tkk.7.7).
+fn declaration_span_excluding_metadata(decl: &rowan_ast::Declaration) -> Span {
+    let full = text_range_to_span(decl.syntax().text_range());
+    match decl.head() {
+        Some(head) => {
+            let start = ByteIndex(head.syntax().text_range().start().into());
+            Span::new(start, full.end())
+        }
+        None => full,
+    }
+}
+
 /// Return type of `desugar_declaration_body_with_patterns`:
 /// `(body_expr, lambda_param_names, lambda_param_vars)`
 type PatternBodyResult = (RcExpr, Vec<String>, Vec<String>);
@@ -1107,8 +1129,8 @@ fn desugar_monadic_block(
     let mut name_value_pairs: Vec<(String, RcExpr, Smid)> = Vec::with_capacity(decls.len());
     for (i, decl) in decls.iter().enumerate() {
         let decl_name = bind_names[i].clone();
-        let span = name_identifier_span(decl)
-            .unwrap_or_else(|| text_range_to_span(decl.syntax().text_range()));
+        let span =
+            name_identifier_span(decl).unwrap_or_else(|| declaration_span_excluding_metadata(decl));
         let value = if let Some(body) = decl.body() {
             if let Some(soup) = body.soup() {
                 let expr = soup.desugar(desugarer)?;
@@ -1232,8 +1254,8 @@ fn desugar_monadic_block_implicit(
     let mut name_value_pairs: Vec<(String, RcExpr, Smid)> = Vec::with_capacity(decls.len());
     for (i, decl) in decls.iter().enumerate() {
         let decl_name = bind_names[i].clone();
-        let span = name_identifier_span(decl)
-            .unwrap_or_else(|| text_range_to_span(decl.syntax().text_range()));
+        let span =
+            name_identifier_span(decl).unwrap_or_else(|| declaration_span_excluding_metadata(decl));
         let value = if let Some(body) = decl.body() {
             if let Some(soup) = body.soup() {
                 let expr = soup.desugar(desugarer)?;
@@ -1640,7 +1662,7 @@ fn extract_rowan_declaration_components(
     decl: &rowan_ast::Declaration,
     desugarer: &mut Desugarer,
 ) -> Result<RowanDeclarationComponents, CoreError> {
-    let span = text_range_to_span(decl.syntax().text_range());
+    let span = declaration_span_excluding_metadata(decl);
 
     // Extract metadata first
     let metadata = if let Some(meta) = decl.meta() {

--- a/tests/diagnostics_metadata_span_test.rs
+++ b/tests/diagnostics_metadata_span_test.rs
@@ -1,0 +1,79 @@
+//! Regression test for eu-1tkk.7.7 (metadata-in-span).
+//!
+//! A declaration's label span must start at the declaration *head*, not at
+//! its leading backtick metadata. When a declaration carries doc metadata
+//! and participates in an error's stack trace (e.g. as the frame recording
+//! where a called function was defined), the Smid minted for that
+//! declaration must not resolve to a position on the metadata line.
+//!
+//! `tests/diagnostics/corpus/metadata_span.eu` line 1 is a backtick doc
+//! comment attached to `scale` (declared on line 2). Before the fix, the
+//! Smid minted for `scale`'s lambda spanned from the metadata's backtick
+//! through the end of the declaration body, so any diagnostic label built
+//! from that Smid reported line 1 (the doc comment) instead of line 2 (the
+//! declaration head). This test asserts no diagnostic label — primary or
+//! secondary — ever lands on the metadata line.
+use std::process::Command;
+
+/// Extract the JSON diagnostic object from combined stdout/stderr, scanning
+/// from the bottom (mirrors `tests/diagnostics_invariants.rs`'s
+/// `last_json_object`, since human-readable warnings may precede the JSON
+/// diagnostic line).
+fn last_json_object(streams: &[&str]) -> Option<serde_json::Value> {
+    for stream in streams {
+        for line in stream.lines().rev() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                if v.is_object() {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn declaration_label_span_excludes_leading_metadata() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/diagnostics/corpus/metadata_span.eu"
+    );
+    let out = Command::new(env!("CARGO_BIN_EXE_eu"))
+        .args(["--error-format", "json", "--heap-limit-mib", "2048"])
+        .arg(path)
+        .output()
+        .expect("run eu");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let v = last_json_object(&[&stderr, &stdout])
+        .unwrap_or_else(|| panic!("no JSON diagnostic parsed; stdout={stdout} stderr={stderr}"));
+
+    // Line 1 of the fixture is the backtick doc comment attached to `scale`
+    // (declared on line 2). No label — primary or secondary — should ever
+    // report line 1: that would mean a Smid's span still starts at the
+    // metadata rather than the declaration head.
+    let labels = v["labels"]
+        .as_array()
+        .cloned()
+        .unwrap_or_else(|| panic!("no labels array in diagnostic: {v}"));
+    assert!(
+        !labels.is_empty(),
+        "expected at least one label in diagnostic: {v}"
+    );
+
+    let on_metadata_line: Vec<&serde_json::Value> = labels
+        .iter()
+        .filter(|l| l["pos"]["file"].as_str() == Some(path) && l["pos"]["line"] == 1)
+        .collect();
+
+    assert!(
+        on_metadata_line.is_empty(),
+        "a label's span starts at the declaration's leading backtick metadata \
+         (line 1) rather than the declaration head (line 2): {on_metadata_line:?}\n\
+         full diagnostic: {v}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes eu-1tkk.7.7 (metadata-in-span), part of the diagnostics overhaul epic eu-1tkk.7 §4.2 Phase 1.

A declaration's Smid was minted from `decl.syntax().text_range()` in `extract_rowan_declaration_components` (and two related call sites for monadic block bind names), which spans from the start of any leading backtick metadata through the end of the declaration body. This meant a diagnostic label built from that Smid — e.g. a "called from here" stack-trace frame recording where a declaration's lambda was defined — reported the doc comment's line as the source location instead of the declaration head.

`declaration_span_excluding_metadata()` (new, in `src/core/desugar/rowan_ast.rs`) starts the span at the declaration head (falling back to the full range only when there is no head, which shouldn't normally happen) while leaving the end position unchanged, and is used at all three call sites that previously read the raw declaration range directly.

## Verification

Before assuming this was a live bug, I checked `tests/diagnostics/corpus/metadata_span.meta.toml`'s `xfail_reason`, which notes the *original* span issue this fixture tracked was believed superseded by a different (Phase 2 trace-curation) gap. I reproduced independently with `eu --error-format json` and `eu dump ast --debug-format`: the bug **is** still real. The fixture's JSON diagnostic included a secondary `"called from here"` label at line 1 (the backtick doc comment attached to `scale`) instead of line 2 (`scale`'s declaration head) — confirmed via `eu dump ast --debug-format`, which shows the `DECLARATION` node's range starting at `DECL_META`, not `DECL_HEAD`.

## Fault-injection verification

Added `tests/diagnostics_metadata_span_test.rs`, which runs the fixture through `eu --error-format json` and asserts no diagnostic label (primary or secondary) reports the metadata's line.

- With the fix reverted (`git stash` on `rowan_ast.rs` only), the new test **FAILS**, reproducing the exact regression: a `"called from here"` label at line 1.
- With the fix restored, the test **PASSES**.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` suite are clean, including `diagnostics_invariants`, `diagnostics_json_emission`, and the new `diagnostics_metadata_span_test`.

`tests/diagnostics/corpus/metadata_span.meta.toml`'s `xfail` is left untouched — it remains `xfail` for the unrelated Phase 2 trace-curation gap described in its `xfail_reason` (the transparent `[prelude]:1463 map` frame with no user frame), which this PR does not address.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite, including `diagnostics_invariants`, `diagnostics_json_emission`, `diagnostics_metadata_span_test`)
- [x] Fault-injection: broke the fix, confirmed new test FAILs; restored, confirmed it PASSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py2HEaF87JJWPcDBiBic3g