### PR TITLE
Phase 1 location correctness: prelude-primary suppression, call-site preference, function-value wording (eu-1tkk.7.8/.9/.10, eu-m93j)

### DIFF
--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -436,54 +436,6 @@ fn compress_trace_cycles(elements: Vec<String>) -> Vec<String> {
     result
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// `Smid::get()` must never panic on an invalid (default/synthetic) Smid.
-    ///
-    /// Both trace producers (the HeapSyn VM and the bytecode machine) today
-    /// pre-filter invalid Smids before pushing them onto env/stack traces, so
-    /// this cannot currently happen in practice. This is a defensive
-    /// regression test: a future trace source that fails to pre-filter must
-    /// not be able to crash error reporting (eu-1tkk.7.10).
-    #[test]
-    fn get_returns_none_for_invalid_smid() {
-        assert_eq!(Smid::default().get(), None);
-    }
-
-    #[test]
-    fn get_returns_index_for_valid_smid() {
-        let mut source_map = SourceMap::new();
-        let smid = source_map.add(0, Span::new(0u32, 0u32));
-        assert_eq!(smid.get(), Some(0));
-    }
-
-    /// `format_trace` must gracefully skip an invalid Smid rather than panic,
-    /// even though today's trace producers never hand it one.
-    #[test]
-    fn format_trace_skips_invalid_smid_without_panicking() {
-        let source_map = SourceMap::new();
-        let files: SimpleFiles<String, String> = SimpleFiles::new();
-        let trace = [Smid::default()];
-        let out = source_map.format_trace(&trace, &files);
-        assert_eq!(out, "");
-    }
-
-    /// A trace mixing a valid, resolvable Smid with an invalid one must
-    /// render only the valid entry, not panic on the invalid one.
-    #[test]
-    fn format_trace_skips_invalid_smid_amongst_valid_ones() {
-        let mut source_map = SourceMap::new();
-        let mut files: SimpleFiles<String, String> = SimpleFiles::new();
-        let file_id = files.add("x.eu".to_string(), "hello".to_string());
-        let smid = source_map.add(file_id, Span::new(0u32, 5u32));
-        let trace = [Smid::default(), smid, Smid::default()];
-        let out = source_map.format_trace(&trace, &files);
-        assert!(out.contains("x.eu:1:1"));
-    }
-}
-
 /// Map internal intrinsic names to user-facing display names.
 ///
 /// Returns `None` for internal machinery that should be filtered out
@@ -609,5 +561,53 @@ pub fn intrinsic_display_name(name: &str) -> Option<&str> {
 
         // Unknown — not an intrinsic
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Smid::get()` must never panic on an invalid (default/synthetic) Smid.
+    ///
+    /// Both trace producers (the HeapSyn VM and the bytecode machine) today
+    /// pre-filter invalid Smids before pushing them onto env/stack traces, so
+    /// this cannot currently happen in practice. This is a defensive
+    /// regression test: a future trace source that fails to pre-filter must
+    /// not be able to crash error reporting (eu-1tkk.7.10).
+    #[test]
+    fn get_returns_none_for_invalid_smid() {
+        assert_eq!(Smid::default().get(), None);
+    }
+
+    #[test]
+    fn get_returns_index_for_valid_smid() {
+        let mut source_map = SourceMap::new();
+        let smid = source_map.add(0, Span::new(0u32, 0u32));
+        assert_eq!(smid.get(), Some(0));
+    }
+
+    /// `format_trace` must gracefully skip an invalid Smid rather than panic,
+    /// even though today's trace producers never hand it one.
+    #[test]
+    fn format_trace_skips_invalid_smid_without_panicking() {
+        let source_map = SourceMap::new();
+        let files: SimpleFiles<String, String> = SimpleFiles::new();
+        let trace = [Smid::default()];
+        let out = source_map.format_trace(&trace, &files);
+        assert_eq!(out, "");
+    }
+
+    /// A trace mixing a valid, resolvable Smid with an invalid one must
+    /// render only the valid entry, not panic on the invalid one.
+    #[test]
+    fn format_trace_skips_invalid_smid_amongst_valid_ones() {
+        let mut source_map = SourceMap::new();
+        let mut files: SimpleFiles<String, String> = SimpleFiles::new();
+        let file_id = files.add("x.eu".to_string(), "hello".to_string());
+        let smid = source_map.add(file_id, Span::new(0u32, 5u32));
+        let trace = [Smid::default(), smid, Smid::default()];
+        let out = source_map.format_trace(&trace, &files);
+        assert!(out.contains("x.eu:1:1"));
     }
 }

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -60,8 +60,16 @@ impl Smid {
         self.0.is_some()
     }
 
-    pub fn get(self) -> usize {
-        (self.0.expect("Invalid SMID").get() - 1) as usize
+    /// Convert to a zero-based index into `SourceMap::source`, if valid.
+    ///
+    /// Returns `None` for an invalid (default/synthetic) Smid rather than
+    /// panicking. Both trace producers (the HeapSyn VM and the bytecode
+    /// machine) pre-filter invalid Smids before pushing them onto env/stack
+    /// traces, so every current caller sees `Some` in practice — but this
+    /// guard means a future unfiltered trace source cannot panic during
+    /// error reporting (eu-1tkk.7.10).
+    pub fn get(self) -> Option<usize> {
+        self.0.map(|n| (n.get() - 1) as usize)
     }
 
     pub fn sym_name(&self) -> String {
@@ -153,7 +161,7 @@ impl SourceMap {
     /// different annotation
     pub fn annotated(&mut self, smid: Smid, annotation: String) -> Smid {
         let new_smid = Smid::new(self.source.len());
-        let new_info = if let Some(info) = self.source.get(smid.get()) {
+        let new_info = if let Some(info) = smid.get().and_then(|idx| self.source.get(idx)) {
             SourceInfo {
                 annotation: Some(annotation),
                 ..*info
@@ -171,17 +179,13 @@ impl SourceMap {
 
     /// Retrieve the SourceInfo for something that has a SMID
     pub fn source_info(&self, expr: &dyn HasSmid) -> Option<&SourceInfo> {
-        if expr.smid().is_valid() {
-            self.source.get(expr.smid().get())
-        } else {
-            None
-        }
+        expr.smid().get().and_then(|idx| self.source.get(idx))
     }
 
     /// Retrieve the SourceInfo for a given Smid value
     pub fn source_info_for_smid(&self, smid: Smid) -> Option<&SourceInfo> {
-        if smid.is_valid() {
-            self.source.get(smid.get())
+        if let Some(idx) = smid.get() {
+            self.source.get(idx)
         } else {
             None
         }
@@ -308,7 +312,7 @@ impl SourceMap {
         let mut elements: Vec<_> = trace
             .iter()
             .filter_map(|smid| {
-                let info = self.source.get(smid.get())?;
+                let info = self.source.get(smid.get()?)?;
 
                 // Determine the display name: prefer intrinsic display name,
                 // then annotation (function name), then source snippet
@@ -430,6 +434,54 @@ fn compress_trace_cycles(elements: Vec<String>) -> Vec<String> {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Smid::get()` must never panic on an invalid (default/synthetic) Smid.
+    ///
+    /// Both trace producers (the HeapSyn VM and the bytecode machine) today
+    /// pre-filter invalid Smids before pushing them onto env/stack traces, so
+    /// this cannot currently happen in practice. This is a defensive
+    /// regression test: a future trace source that fails to pre-filter must
+    /// not be able to crash error reporting (eu-1tkk.7.10).
+    #[test]
+    fn get_returns_none_for_invalid_smid() {
+        assert_eq!(Smid::default().get(), None);
+    }
+
+    #[test]
+    fn get_returns_index_for_valid_smid() {
+        let mut source_map = SourceMap::new();
+        let smid = source_map.add(0, Span::new(0u32, 0u32));
+        assert_eq!(smid.get(), Some(0));
+    }
+
+    /// `format_trace` must gracefully skip an invalid Smid rather than panic,
+    /// even though today's trace producers never hand it one.
+    #[test]
+    fn format_trace_skips_invalid_smid_without_panicking() {
+        let source_map = SourceMap::new();
+        let files: SimpleFiles<String, String> = SimpleFiles::new();
+        let trace = [Smid::default()];
+        let out = source_map.format_trace(&trace, &files);
+        assert_eq!(out, "");
+    }
+
+    /// A trace mixing a valid, resolvable Smid with an invalid one must
+    /// render only the valid entry, not panic on the invalid one.
+    #[test]
+    fn format_trace_skips_invalid_smid_amongst_valid_ones() {
+        let mut source_map = SourceMap::new();
+        let mut files: SimpleFiles<String, String> = SimpleFiles::new();
+        let file_id = files.add("x.eu".to_string(), "hello".to_string());
+        let smid = source_map.add(file_id, Span::new(0u32, 5u32));
+        let trace = [Smid::default(), smid, Smid::default()];
+        let out = source_map.format_trace(&trace, &files);
+        assert!(out.contains("x.eu:1:1"));
+    }
 }
 
 /// Map internal intrinsic names to user-facing display names.

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -1533,12 +1533,20 @@ pub fn return_fun(
             }
         }
         BcContinuation::LookupLitForce { smid, .. } => {
+            // A literal `.key` lookup forced its target and found a function
+            // rather than a block. This is a lookup-target type error, not a
+            // callability error — reporting it via `NotCallable` with
+            // actual_type = "function" produced the self-contradictory
+            // "tried to call a function as a function" (eu-m93j). The key
+            // name is not included here: this dispatch-loop free function
+            // has no access to the symbol pool (see `format_lookup_on_function`
+            // doc comment) — the HeapSyn engine's equivalent path resolves it.
             let ann = if smid.is_valid() {
                 smid
             } else {
                 state.annotation
             };
-            return Err(ExecutionError::NotCallable(ann, "function".to_string()));
+            return Err(ExecutionError::LookupOnFunction(ann, None));
         }
         BcContinuation::CaptureEnd => {
             state.capture_end_pending = true;

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -455,6 +455,22 @@ fn not_callable_notes(actual_type: &str) -> Vec<String> {
     }
 }
 
+/// Generate contextual notes for `UnexpectedFunction` errors: a function
+/// value (an unsaturated lambda or a partial application) found where a
+/// non-function value was expected. Deliberately does not suggest
+/// `block.field` — the value is a function, never a block (eu-1tkk.7.9).
+fn unexpected_function_notes() -> Vec<String> {
+    vec![
+        "a function value cannot be used directly here; it must first be called with \
+         all of its remaining arguments"
+            .to_string(),
+        "this can happen when a function is under-applied (missing an argument), or when \
+         low-precedence catenation groups an expression differently than intended — \
+         add parentheses to disambiguate"
+            .to_string(),
+    ]
+}
+
 /// Format a "not callable" error message with the actual type of value found
 fn format_not_callable(actual_type: &str) -> String {
     if actual_type.is_empty() {
@@ -465,6 +481,28 @@ fn format_not_callable(actual_type: &str) -> String {
              help: only functions and blocks can be called with arguments\n  \
              help: this often means too many arguments were passed to a function"
         )
+    }
+}
+
+/// Format a "lookup on a function" error message: `.key` syntax was used on
+/// a value that evaluated to a function rather than a block.
+///
+/// `key` is `None` on the bytecode engine's fast path, which does not have
+/// the symbol pool available at this point in the dispatch loop (the
+/// HeapSyn engine always resolves it — see `Machine::return_fun`).
+fn format_lookup_on_function(key: Option<&str>) -> String {
+    match key {
+        Some(key) => format!(
+            "cannot look up key '{key}' on a function value\n  \
+             help: '.' looks up keys in blocks; the value before '.' must be a block, not a function\n  \
+             help: if the function returns a block when called, call it first, \
+             e.g. 'f(x).{key}' instead of 'f.{key}'"
+        ),
+        None => "cannot look up a key on a function value\n  \
+             help: '.' looks up keys in blocks; the value before '.' must be a block, not a function\n  \
+             help: if the function returns a block when called, call it first, \
+             e.g. 'f(x).key' instead of 'f.key'"
+            .to_string(),
     }
 }
 
@@ -619,6 +657,29 @@ pub enum ExecutionError {
     UnknownIntrinsic(Smid, String),
     #[error("{}", format_not_callable(.1))]
     NotCallable(Smid, String),
+    /// A literal `.key` lookup was performed on a value that evaluated to a
+    /// function rather than a block.
+    ///
+    /// Distinct from `NotCallable` (raised for `f(x)` call syntax on a
+    /// non-callable value): this is the opposite mistake — `.` syntax was
+    /// used, which performs a key lookup and requires a block, but the
+    /// receiver evaluated to a function/lambda instead. Reporting this via
+    /// `NotCallable` with `actual_type = "function"` previously produced the
+    /// self-contradictory "tried to call a function as a function"
+    /// (eu-m93j).
+    #[error("{}", format_lookup_on_function(.1.as_deref()))]
+    LookupOnFunction(Smid, Option<String> /* key name, if resolvable */),
+    /// A function value (an unsaturated lambda or a partial application)
+    /// was found where a non-function value (e.g. a number or string) was
+    /// expected.
+    ///
+    /// Function values have no data-constructor tag, so before this variant
+    /// existed the fallback path defaulted to reporting them as a `block`
+    /// (`NoBranchForDataTag` with a synthetic `Block` tag), which produced a
+    /// self-contradictory message and a misdirecting `did you mean
+    /// block.field?` hint for a value that was never a block (eu-1tkk.7.9).
+    #[error("type mismatch: expected {1}, found a function")]
+    UnexpectedFunction(Smid, &'static str /* expected kind, e.g. "number" */),
     #[error("{}", format_not_value(.1))]
     NotValue(Smid, String),
     #[error("bad regex: {}\n  help: the pattern '{}' is not a valid regular expression", .1.1, .1.0)]
@@ -780,6 +841,8 @@ impl HasSmid for ExecutionError {
             ExecutionError::TypeMismatch(s, _) => *s,
             ExecutionError::UnknownIntrinsic(s, _) => *s,
             ExecutionError::NotCallable(s, _) => *s,
+            ExecutionError::LookupOnFunction(s, _) => *s,
+            ExecutionError::UnexpectedFunction(s, _) => *s,
             ExecutionError::NotValue(s, _) => *s,
             ExecutionError::NotScalar(s) => *s,
             ExecutionError::NoBranchForDataTag(s, _, _) => *s,
@@ -1089,6 +1152,7 @@ impl ExecutionError {
                 ]
             }
             ExecutionError::NotCallable(_, type_name) => not_callable_notes(type_name),
+            ExecutionError::UnexpectedFunction(..) => unexpected_function_notes(),
             ExecutionError::LookupFailure(_, detail) => lookup_failure_notes(&detail.0, &detail.1),
             ExecutionError::CannotReturnFunToCase(_, expected_tags) => {
                 let expects_bool = expected_tags.contains(&DataConstructor::BoolTrue.tag())

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -1181,9 +1181,12 @@ impl ExecutionError {
 
     /// Format a Smid with all available detail for trace dump diagnostics
     fn format_smid_detail(smid: Smid, source_map: &SourceMap) -> String {
-        if !smid.is_valid() {
+        // `smid.get()` returns `None` for an invalid Smid; render that case
+        // directly rather than indexing, so this debug helper can never panic
+        // on an invalid Smid (eu-1tkk.7.10).
+        let Some(index) = smid.get() else {
             return "invalid (no location)".to_string();
-        }
+        };
         match source_map.source_info_for_smid(smid) {
             Some(info) => {
                 let file_part = match info.file {
@@ -1198,9 +1201,9 @@ impl ExecutionError {
                     Some(ann) => format!("ann=\"{ann}\""),
                     None => "ann=none".to_string(),
                 };
-                format!("smid={} {file_part} {span_part} {ann_part}", smid.get())
+                format!("smid={index} {file_part} {span_part} {ann_part}")
             }
-            None => format!("smid={} (no source info)", smid.get()),
+            None => format!("smid={index} (no source info)"),
         }
     }
 

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -914,11 +914,23 @@ impl ExecutionError {
 
         // Determine the best primary source location:
         // - Prefer a user-file location (the call site in user code) over a
-        //   prelude/resource location (the site of the failure inside a library).
+        //   prelude/resource location (the site of the failure inside a library)
+        //   or a metadata-only (locationless/synthetic) Smid. This is a general
+        //   rule, not special-cased to any one error variant (eu-1tkk.7.8):
+        //   a prelude or synthetic Smid is never the primary when a user-file
+        //   Smid is available anywhere.
         // - If the error's own Smid already points to a user file, use that.
-        // - Otherwise, search the environment trace (innermost call annotations)
-        //   then the stack trace for the first user-file Smid.
-        // - As a last resort, fall back to any Smid with a file location.
+        // - Otherwise, search the *stack* trace (the actual pending call chain —
+        //   nearest call sites) before the *environment* trace (the lexical
+        //   scope chain of the erroring closure — definition sites) for the
+        //   first user-file Smid. A call site is normally more actionable for
+        //   blame than a definition site (eu-1tkk.7.8): re-examined from the
+        //   prior env-trace-first order, which promoted definition sites.
+        // - As a last resort — no user-file Smid anywhere — fall back to any
+        //   Smid with a file location (may be prelude), but only tentatively:
+        //   see the unconditional user-file filter below, which clears this
+        //   fallback back out to `None` rather than show a misleading
+        //   prelude/synthetic location as if it were precise.
         let error_info = source_map.source_info(inner);
         let error_has_user_file = error_info
             .and_then(|info| info.file)
@@ -928,10 +940,12 @@ impl ExecutionError {
         let primary_file_span: Option<(usize, codespan::Span)> = if error_has_user_file {
             error_info.and_then(|info| info.file.zip(info.span))
         } else {
-            // Try to find a user-file location in the traces
+            // Try to find a user-file location in the traces: nearest pending
+            // call site (stack trace) first, then lexical/definition scope
+            // (env trace) as a fallback.
             let user_smid = source_map
-                .first_user_source_smid(env_trace)
-                .or_else(|| source_map.first_user_source_smid(stack_trace));
+                .first_user_source_smid(stack_trace)
+                .or_else(|| source_map.first_user_source_smid(env_trace));
 
             if let Some(smid) = user_smid {
                 source_map
@@ -944,8 +958,8 @@ impl ExecutionError {
                     .and_then(|info| info.file.zip(info.span))
                     .or_else(|| {
                         let smid = source_map
-                            .first_source_smid(env_trace)
-                            .or_else(|| source_map.first_source_smid(stack_trace))?;
+                            .first_source_smid(stack_trace)
+                            .or_else(|| source_map.first_source_smid(env_trace))?;
                         source_map
                             .source_info_for_smid(smid)
                             .and_then(|info| info.file.zip(info.span))
@@ -953,19 +967,18 @@ impl ExecutionError {
             }
         };
 
-        // For assertion failures, suppress a non-user-file primary label.
+        // Suppress a non-user-file primary label, for every error variant.
         //
-        // When `//=` fails, the env and stack traces often contain only
-        // prelude frames (the `//=` wrapper body's internal evaluation).
-        // Showing the prelude's `//=` definition as the primary error site
-        // is confusing — users want to see their own code.  If we cannot
-        // find a user-file location, it is less misleading to show no
-        // primary label than to show prelude internals.
-        let primary_file_span = if matches!(inner, ExecutionError::AssertionFailed(..)) {
-            primary_file_span.filter(|(file, _)| source_map.is_user_file(*file))
-        } else {
-            primary_file_span
-        };
+        // The traces often contain only prelude frames (deep library
+        // recursion, or a `//=` wrapper body's internal evaluation). Showing
+        // a prelude location as the primary error site is confusing — it
+        // looks precise but is not user-actionable. If no user-file location
+        // can be found anywhere (error's own Smid, stack trace, env trace),
+        // it is less misleading to show no primary label than to show
+        // prelude/synthetic internals as if they were the culprit
+        // (eu-1tkk.7.8; previously special-cased to `AssertionFailed` only).
+        let primary_file_span =
+            primary_file_span.filter(|(file, _)| source_map.is_user_file(*file));
 
         // Apply the primary label.  We clear any label that source_map.diagnostic()
         // may have set (which could be a prelude location) and replace it with the
@@ -973,7 +986,7 @@ impl ExecutionError {
         if let Some((file, span)) = primary_file_span {
             diag.labels.clear();
             diag.labels.push(Label::primary(file, span));
-        } else if matches!(inner, ExecutionError::AssertionFailed(..)) {
+        } else {
             // No user-file location found: clear any prelude label that
             // source_map.diagnostic() may have placed, so the diagnostic
             // shows only the error message without a confusing prelude pointer.
@@ -986,11 +999,11 @@ impl ExecutionError {
         // from the primary label (to avoid redundant markers).  Limited to 3
         // secondary labels to keep output readable.
         //
-        // For assertion failures without a user-file primary label, skip
-        // secondary labels entirely: they would only show prelude internals
-        // (the `//=` wrapper body), which adds noise rather than insight.
-        let show_secondary =
-            !matches!(inner, ExecutionError::AssertionFailed(..)) || primary_file_span.is_some();
+        // Without a user-file primary label, skip secondary labels entirely:
+        // they would only show prelude internals, which adds noise rather
+        // than insight (eu-1tkk.7.8; previously special-cased to
+        // `AssertionFailed` only).
+        let show_secondary = primary_file_span.is_some();
 
         {
             let mut secondary_labels: Vec<Label<usize>> = vec![];
@@ -1313,5 +1326,131 @@ impl ExecutionError {
             ExecutionError::TypeMismatch(..) => Some("EU-EVAL-TYPE"),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod location_selection_tests {
+    //! Unit tests for `to_diagnostic`'s location-selection logic
+    //! (eu-1tkk.7.8), isolated from message/blame-vocabulary concerns by
+    //! constructing a `SourceMap` and `ExecutionError::Traced` directly
+    //! rather than running real eucalypt source through the pipeline.
+
+    use super::*;
+    use codespan::Span;
+    use codespan_reporting::diagnostic::LabelStyle;
+    use std::ops::Range;
+
+    /// Find the primary label in a diagnostic's label list. `to_diagnostic`
+    /// may also attach up to 3 secondary "called from here" labels from the
+    /// env trace, so tests must not assume the primary is the only label.
+    fn primary_label(
+        diag: &Diagnostic<usize>,
+    ) -> Option<&codespan_reporting::diagnostic::Label<usize>> {
+        diag.labels.iter().find(|l| l.style == LabelStyle::Primary)
+    }
+
+    /// A `SourceMap` with one resource (prelude) file and one user file,
+    /// plus the file ids to add Smids against.
+    fn mk_source_map() -> (SourceMap, usize, usize) {
+        let mut sm = SourceMap::new();
+        let user_file = 0usize;
+        let prelude_file = 1usize;
+        sm.mark_resource_file(prelude_file);
+        (sm, user_file, prelude_file)
+    }
+
+    /// When the error's own Smid and every Smid in both traces are
+    /// prelude-only (the `hof_bad_arg` / `nth_out_of_range` / `swap_args`
+    /// diagnostics-corpus pattern: a deep library-internal failure with no
+    /// reachable user frame), the primary label must be suppressed rather
+    /// than showing a prelude location as if it were the culprit.
+    #[test]
+    fn suppresses_prelude_primary_when_no_user_smid_anywhere() {
+        let (mut sm, _user_file, prelude_file) = mk_source_map();
+        let prelude_smid = sm.add(prelude_file, Span::new(10u32, 12u32));
+        let inner = ExecutionError::NoBranchForDataTag(prelude_smid, 0, vec![1]);
+        let traced = ExecutionError::Traced(
+            Box::new(inner),
+            Box::new((vec![prelude_smid], vec![prelude_smid])),
+        );
+
+        let diag = traced.to_diagnostic(&sm);
+
+        assert!(
+            diag.labels.is_empty(),
+            "expected no primary label when no user Smid exists anywhere in \
+             the error's own Smid or either trace, got {:?}",
+            diag.labels
+        );
+    }
+
+    /// A user-file Smid reachable via a trace must become the primary, even
+    /// when the error's own Smid is prelude-only.
+    #[test]
+    fn prefers_user_smid_in_trace_over_prelude_own_smid() {
+        let (mut sm, user_file, prelude_file) = mk_source_map();
+        let prelude_smid = sm.add(prelude_file, Span::new(10u32, 12u32));
+        let user_smid = sm.add(user_file, Span::new(3u32, 7u32));
+        let inner = ExecutionError::NoBranchForDataTag(prelude_smid, 0, vec![1]);
+        let traced = ExecutionError::Traced(Box::new(inner), Box::new((vec![], vec![user_smid])));
+
+        let diag = traced.to_diagnostic(&sm);
+
+        let primary = primary_label(&diag).expect("expected a primary label");
+        assert_eq!(primary.file_id, user_file);
+        assert_eq!(primary.range, Range::from(Span::new(3u32, 7u32)));
+    }
+
+    /// When a user-file Smid is available in both the stack trace (the
+    /// pending call chain — call sites) and the env trace (the lexical
+    /// scope chain — definition sites) at *different* locations, the stack
+    /// trace's call site must win. Re-examines the prior env-trace-first
+    /// order, which promoted the lexical definition site over the call
+    /// site (eu-1tkk.7.8).
+    #[test]
+    fn prefers_stack_trace_call_site_over_env_trace_definition_site() {
+        let (mut sm, user_file, prelude_file) = mk_source_map();
+        let prelude_smid = sm.add(prelude_file, Span::new(10u32, 12u32));
+        let env_user_smid = sm.add(user_file, Span::new(0u32, 5u32));
+        let stack_user_smid = sm.add(user_file, Span::new(20u32, 25u32));
+        let inner = ExecutionError::NoBranchForDataTag(prelude_smid, 0, vec![1]);
+        let traced = ExecutionError::Traced(
+            Box::new(inner),
+            Box::new((vec![env_user_smid], vec![stack_user_smid])),
+        );
+
+        let diag = traced.to_diagnostic(&sm);
+
+        let primary = primary_label(&diag).expect("expected a primary label");
+        assert_eq!(
+            primary.range,
+            Range::from(Span::new(20u32, 25u32)),
+            "expected the stack-trace (call site) Smid to be preferred over \
+             the env-trace (definition site) Smid, got range {:?}",
+            primary.range
+        );
+    }
+
+    /// When the error's own Smid is already a user-file location, it is
+    /// used directly without consulting either trace.
+    #[test]
+    fn uses_error_own_smid_when_already_user_file() {
+        let (mut sm, user_file, prelude_file) = mk_source_map();
+        let own_smid = sm.add(user_file, Span::new(1u32, 2u32));
+        let other_user_smid = sm.add(user_file, Span::new(50u32, 55u32));
+        let prelude_smid = sm.add(prelude_file, Span::new(10u32, 12u32));
+        let inner = ExecutionError::NoBranchForDataTag(own_smid, 0, vec![1]);
+        // Traces contain a *different* user Smid and a prelude Smid; the
+        // error's own (already user-file) Smid must still win.
+        let traced = ExecutionError::Traced(
+            Box::new(inner),
+            Box::new((vec![prelude_smid], vec![other_user_smid])),
+        );
+
+        let diag = traced.to_diagnostic(&sm);
+
+        let primary = primary_label(&diag).expect("expected a primary label");
+        assert_eq!(primary.range, Range::from(Span::new(1u32, 2u32)));
     }
 }

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1325,14 +1325,20 @@ impl MachineState {
                     self.closure = SynClosure::new(body, environment);
                     self.annotation = annotation;
                 }
-                Continuation::LookupLitForce { smid, .. } => {
-                    // A function is not a block — raise type error
+                Continuation::LookupLitForce { key, smid, .. } => {
+                    // A literal `.key` lookup forced its target and found a
+                    // function rather than a block. This is a lookup-target
+                    // type error, not a callability error — reporting it via
+                    // `NotCallable` with actual_type = "function" produced
+                    // the self-contradictory "tried to call a function as a
+                    // function" (eu-m93j).
                     let ann = if smid.is_valid() {
                         smid
                     } else {
                         self.nearest_stack_annotation(view)
                     };
-                    return Err(ExecutionError::NotCallable(ann, "function".to_string()));
+                    let key_name = self.symbol_pool.resolve(key).to_string();
+                    return Err(ExecutionError::LookupOnFunction(ann, Some(key_name)));
                 }
                 Continuation::CaptureEnd => {
                     self.capture_end_pending = true;

--- a/src/eval/stg/support.rs
+++ b/src/eval/stg/support.rs
@@ -105,8 +105,26 @@ pub fn num_arg(
             )),
         )),
         Err(_) => {
-            // resolve_native failed — likely a Cons (block/list). Inspect the
-            // tag so the error message includes useful context.
+            // resolve_native failed — the value is either a data constructor
+            // (block/list) or a function (an unsaturated lambda or a partial
+            // application; the two are indistinguishable at this layer, so
+            // both are reported uniformly). A function has no data tag, so
+            // check arity first: defaulting straight to `Block.tag()` here
+            // (as this used to) mislabelled every function value as a block
+            // and triggered the misdirecting 'did you mean block.field?'
+            // hint for a value that was never a block (eu-1tkk.7.9).
+            if machine
+                .resolve_closure(view, arg)
+                .map(|c| c.arity() > 0)
+                .unwrap_or(false)
+            {
+                return Err(ExecutionError::UnexpectedFunction(
+                    machine.annotation(),
+                    "number",
+                ));
+            }
+            // Otherwise it is a genuine Cons (block/list). Inspect the tag
+            // so the error message includes useful context.
             let tag = cons_tag_of(machine, view, arg).unwrap_or(DataConstructor::Block.tag());
             Err(ExecutionError::NoBranchForDataTag(
                 machine.annotation(),

--- a/tests/diagnostics/corpus/catenation_arith.meta.toml
+++ b/tests/diagnostics/corpus/catenation_arith.meta.toml
@@ -4,7 +4,11 @@ region_start_line = 2
 region_end_line = 2
 expected_class = "function"
 # No xfail: the invariant gate (eu-1tkk.7.3) checks structural location/trace
-# properties only, and this fixture now satisfies all five. The underlying
-# message-content bug (eu-1tkk.7.9: partial applications reported as 'block'
-# instead of their own kind) is real but out of this gate's scope — tracked
-# separately by eu-1tkk.7.9.
+# properties only, and this fixture now satisfies all five. The message-content
+# bug this fixture also demonstrated (eu-1tkk.7.9: a function value reported
+# as 'block', with a misdirecting 'did you mean block.field?' hint) was out
+# of this structural gate's scope but has now been fixed separately: `num_arg`
+# (src/eval/stg/support.rs) checks arity before defaulting an untagged value
+# to `Block.tag()`, raising the new `ExecutionError::UnexpectedFunction`
+# instead. See tests/harness/errors/192_1tkk_7_9_function_not_block.eu for the
+# message-wording regression test.

--- a/tests/diagnostics/corpus/hof_bad_arg.meta.toml
+++ b/tests/diagnostics/corpus/hof_bad_arg.meta.toml
@@ -4,4 +4,4 @@ region_start_line = 2
 region_end_line = 2
 expected_class = "function"
 xfail = true
-xfail_reason = "eu-1tkk.7.8/.11: primary lands in [prelude]:1463 with zero user frames"
+xfail_reason = "eu-1tkk.7.11: no user Smid reaches the trace at all (env/stack trace are entirely prelude frames — 'map's internal recursion), so eu-1tkk.7.8's location-selection fix (never show a prelude primary when a user Smid is available) correctly suppresses the primary to null rather than showing the misleading [prelude]:1463 it used to. Getting an actual user primary here needs eu-1tkk.7.11's blame/curation work to surface the user call site into the trace in the first place."

--- a/tests/diagnostics/corpus/lookup_on_function.meta.toml
+++ b/tests/diagnostics/corpus/lookup_on_function.meta.toml
@@ -5,6 +5,10 @@ region_end_line = 2
 expected_class = "lookup"
 # No xfail: the invariant gate (eu-1tkk.7.3) checks structural location/trace
 # properties only, and this fixture now satisfies all five (primary is
-# in_user_file at the right line). The underlying message-content bug
-# (eu-m93j: self-contradictory 'tried to call a function as a function') is
-# real but out of this gate's scope — tracked separately by eu-m93j.
+# in_user_file at the right line). The message-content bug this fixture also
+# demonstrated (eu-m93j: self-contradictory 'tried to call a function as a
+# function') was out of this structural gate's scope but has now been fixed
+# separately: a `.key` lookup on a function value raises the new
+# `ExecutionError::LookupOnFunction` instead of a fabricated `NotCallable`.
+# See tests/harness/errors/191_m93j_lookup_on_function.eu for the
+# message-wording regression test.

--- a/tests/diagnostics/corpus/nth_out_of_range.meta.toml
+++ b/tests/diagnostics/corpus/nth_out_of_range.meta.toml
@@ -4,4 +4,4 @@ region_start_line = 2
 region_end_line = 2
 expected_class = "range"
 xfail = true
-xfail_reason = "eu-1tkk.7.11: reports 'tail of empty list' at [prelude]:1329, wrong op, 15 prelude frames"
+xfail_reason = "eu-1tkk.7.11: reports 'tail of empty list', wrong op, 15 prelude frames, and no user Smid reaches env/stack trace at all. eu-1tkk.7.8's location-selection fix now correctly suppresses the primary (null rather than the misleading [prelude]:1329 it used to show), but the underlying wrong-error/no-user-frame problem is Phase 2 blame/curation territory."

--- a/tests/diagnostics/corpus/swap_args.meta.toml
+++ b/tests/diagnostics/corpus/swap_args.meta.toml
@@ -4,4 +4,4 @@ region_start_line = 2
 region_end_line = 2
 expected_class = "number"
 xfail = true
-xfail_reason = "eu-1tkk.7.8/.11: primary lands in [prelude]:1329 (inside drop's recursion), not the user call-site"
+xfail_reason = "eu-1tkk.7.11: no user Smid reaches the trace at all (env/stack trace are entirely prelude frames inside drop's recursion), so eu-1tkk.7.8's location-selection fix (never show a prelude primary when a user Smid is available) correctly suppresses the primary to null rather than showing the misleading [prelude]:1329 it used to. Getting an actual user primary — the nth(xs, 0) call site — needs eu-1tkk.7.11's blame/curation work to surface it into the trace in the first place."

--- a/tests/harness/errors/191_m93j_lookup_on_function.eu
+++ b/tests/harness/errors/191_m93j_lookup_on_function.eu
@@ -1,0 +1,2 @@
+add(x, y): x + y
+result: add.x

--- a/tests/harness/errors/191_m93j_lookup_on_function.eu.expect
+++ b/tests/harness/errors/191_m93j_lookup_on_function.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "cannot look up (a key|key '\w+') on a function value"

--- a/tests/harness/errors/192_1tkk_7_9_function_not_block.eu
+++ b/tests/harness/errors/192_1tkk_7_9_function_not_block.eu
@@ -1,0 +1,2 @@
+add(x, y): x + y
+result: add(1) + 1

--- a/tests/harness/errors/192_1tkk_7_9_function_not_block.eu.expect
+++ b/tests/harness/errors/192_1tkk_7_9_function_not_block.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "type mismatch: expected number, found a function"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2727,6 +2727,33 @@ pub fn test_error_180() {
 }
 
 #[test]
+/// A static `.key` lookup on a value that evaluates to a function (not a
+/// block) used to report the self-contradictory "tried to call a function
+/// as a function" (NotCallable with actual_type = "function"). After the
+/// fix it raises `LookupOnFunction`, reporting the actual mistake — a key
+/// lookup on a non-block — instead of a fabricated call (eu-m93j). Checked
+/// on both engines (`cargo test` for bytecode, `EU_HEAPSYN=1 cargo test`
+/// for HeapSyn); the pattern accepts either engine's wording, since only
+/// the HeapSyn engine's `return_fun` has the symbol pool available to
+/// resolve the key name into the message.
+pub fn test_191_m93j_lookup_on_function() {
+    run_error_test(&error_opts("191_m93j_lookup_on_function.eu"));
+}
+
+#[test]
+/// `add(1) + 1`: a partial application (1 of 2 args supplied) used in
+/// arithmetic. Function values have no data-constructor tag, so `num_arg`
+/// used to default straight to `Block.tag()`, reporting "found block" and a
+/// misdirecting "did you mean block.field?" hint for a value that was never
+/// a block. After the fix, `num_arg` checks arity first and raises
+/// `ExecutionError::UnexpectedFunction`, reporting "found a function"
+/// instead (eu-1tkk.7.9). Also covers the `catenation_arith` diagnostics
+/// corpus fixture's underlying message-content bug.
+pub fn test_192_1tkk_7_9_function_not_block() {
+    run_error_test(&error_opts("192_1tkk_7_9_function_not_block.eu"));
+}
+
+#[test]
 /// W4p2 integration: valid declarations structurally equivalent to those
 /// that would survive error recovery evaluate correctly end-to-end.
 /// Paired with test_error_164/165 to prove the full recovery story:


### PR DESCRIPTION
## Summary

Implements the core of Diagnostics Overhaul Phase 1 (`eu-1tkk.7`) — location correctness — per `docs/superpowers/specs/2026-07-21-diagnostics-overhaul-design.md` §4.2. Four beads, one coherent unit (all in `src/eval/error.rs` / `src/common/sourcemap.rs` / `src/eval/stg/support.rs` / both engines' `return_fun`):

### eu-1tkk.7.8 — Location selection
`ExecutionError::to_diagnostic` now:
1. **Generalises the previously `AssertionFailed`-only suppression** of a non-user-file primary label to every error variant: a prelude-file or metadata-only Smid is never shown as primary when no user-file Smid exists anywhere (error's own Smid, stack trace, env trace). Secondary labels are suppressed in step, for the same reason.
2. **Swaps the trace search order** from env-trace-then-stack-trace to stack-trace-then-env-trace when hunting for a substitute user-file Smid. The stack trace holds the actual pending call chain (call sites); the env trace holds the lexical scope chain of the erroring closure (definition sites) — call sites are normally more actionable for blame.

Four new unit tests (`src/eval/error.rs`, `location_selection_tests` module) construct a `SourceMap` + `ExecutionError::Traced` directly, isolating location-selection logic from message/blame-vocabulary concerns, per the design spec's "each independently fault-injection tested."

Verified against the `hof_bad_arg` / `nth_out_of_range` / `swap_args` diagnostics-corpus xfails: their JSON primary now reports `null` instead of a misleading `[prelude]:NNN` line. This does **not** flip their xfail markers — their env/stack traces contain zero user-file Smids at all (confirmed via `EU_ERROR_TRACE_DUMP=1` / `--error-format json`), so no ordering/suppression change at this layer can surface a user location that was never captured in the trace; that needs `eu-1tkk.7.11`'s blame/curation work. Updated their `xfail_reason` comments to describe the corrected failure mode.

### eu-m93j — lookup-on-function nonsense
A static `.key` lookup on a value that evaluates to a function (not a block) raised `NotCallable` with `actual_type = "function"`, producing the self-contradictory "tried to call a function as a function." Added `ExecutionError::LookupOnFunction`, raised from both engines' `LookupLitForce` continuation in `return_fun`, with the message "cannot look up key 'x' on a function value" + accurate help. The HeapSyn engine resolves the key name via its symbol pool; the bytecode engine's `return_fun` is a free function in the hot dispatch loop with no symbol-pool access at this point, so it omits the key name (`LookupOnFunction`'s key field is `Option<String>`) rather than threading a new parameter through `step`/`step_predecoded` for a wording nicety.

### eu-1tkk.7.9 — Wrong-noun (partial applications reported as "block")
A function value (an unsaturated lambda or a partial application, e.g. `add(1) + 1` or `xs foldl(+, 0) + 1` under catenation's low precedence) has no data-constructor tag, so `num_arg` defaulted straight to `Block.tag()`, reporting "found block" and a misdirecting "did you mean block.field?" hint. `num_arg` now checks the closure's arity (via the already engine-neutral `AbiClosure::arity()`) before falling back to the block-tag path, raising the new `ExecutionError::UnexpectedFunction` ("found a function") instead — fixing both engines from one shared call site.

**Scope note:** partial applications and anaphoric lambdas are not distinguishable at this runtime layer (STG lambdas carry no provenance flag), so both get the single honest kind "a function" rather than a fabricated distinction between "a partial application" and "an anaphoric function." Doing better needs compiler-side plumbing (out of scope here, and adjacent to territory reserved for a parallel agent this cycle).

### eu-1tkk.7.10 — Panic-safety
`Smid::get()` panicked via `.expect("Invalid SMID")` on an invalid Smid, and `SourceMap::format_trace` called it unguarded while iterating a trace slice — safe today only because both trace producers pre-filter invalid Smids before pushing them onto env/stack traces. Changed `Smid::get()` to return `Option<usize>` instead of panicking, updating its 6 call sites (all confined to `sourcemap.rs` + a debug helper in `error.rs`).

## Fault-injection verification (per test, stated explicitly)

- **`191_m93j_lookup_on_function.eu`**: reverted both engines' `LookupLitForce` arms to the old `NotCallable("function")` code → confirmed FAIL (old message) on both `cargo test` and `EU_HEAPSYN=1 cargo test` → restored → confirmed PASS on both.
- **`192_1tkk_7_9_function_not_block.eu`**: reverted `num_arg`'s arity check → confirmed FAIL, reproducing the exact "found block" / "did you mean block.field?" message → restored → confirmed PASS on both engines.
- **`sourcemap.rs` panic-safety tests (4)**: reverted `Smid::get()` and its call sites to the prior panicking implementation (via `git show HEAD`) while keeping the new tests → build fails to compile against the reverted `usize`-returning `get()` (a genuine `cargo test` FAIL) → restored → confirmed PASS (1317-test lib suite).
- **`location_selection_tests` (4)**: reverted the ordering swap alone → `prefers_stack_trace_call_site_over_env_trace_definition_site` FAILed with the wrong range → restored → PASS. Reverted the suppression generalisation alone → `suppresses_prelude_primary_when_no_user_smid_anywhere` FAILed (showed the prelude label) → restored → PASS. The other two tests passed throughout both reverts, correctly isolating each change.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` (lib 1321, harness 504 on both `cargo test` and `EU_HEAPSYN=1 cargo test`, `diagnostics_invariants`, `diagnostics_json_emission`, property, tick-parity, conform, fuzz, io_args, lsp, bytecode_io_differential) — all green

## Beads

- `eu-1tkk.7.8` — done (see scope note on `swap_args`/`hof_bad_arg` above; blocked further by `eu-1tkk.7.11`)
- `eu-1tkk.7.9` — done, with the honest single-kind scope note above
- `eu-m93j` — done (HeapSyn resolves the key name; bytecode omits it — see scope note above)
- `eu-1tkk.7.10` — done

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py2HEaF87JJWPcDBiBic3g