### PR TITLE
feat(diagnostics): thread prelude blame table through the blob path (eu-1tkk.7.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to eucalypt are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Prelude blame-table plumbing reaches the shipped (blob-based) release binary (eu-1tkk.7.11 Phase 2)** — `` ` :transparent ``/`` ` :boundary `` blame declarations (merged in #1051) now flow through to the pre-compiled `lib/prelude.blob`: `map`/`filter`/`foldl`/`foldr`/`drop`/`mapcat` are declared `:transparent`, `nth`/`head`/`tail`/`lookup`/`lookup-or` are declared `:boundary`; `cargo xtask prelude-compile` reconciles the desugar-time `BlameSpec` vocabulary into a new `PreludeBlob.blame: HashMap<String, FrameKind>` table. A new `Smid::global_slot`/`Smid::as_global_slot` pair reserves a disjoint sub-range of the `Smid` `u32` space for "which prelude global slot", stamped onto each blob global's reconstructed lambda form at the two blob-mode reconstruction chokepoints (`StandardRuntime::globals()`, xtask's bytecode pre-encode loop) instead of the historical `Smid::default()` — restoring enough identity for a blob-mode error trace to name the prelude combinator responsible, without resurrecting a raw xtask-sourced Smid that would index into the wrong `SourceMap`. `PreludeBlob::classify`/`slot_name`/`blame_for` give the Phase 2 frame classifier (eu-1tkk.7.12, not yet implemented) the trace-Smid → declared-blame-class lookup it needs. Verified live: the design spec's own flagship specimen (`xs nth(10)` on a 3-element list) now carries a global-slot Smid in its blob-mode trace that resolves to `nth`, declared `Boundary` — exactly the case `[prelude]:NNNN`-with-zero-user-frames was meant to fix. Load-time/build-time only; the VM tick/allocation hot path is unaffected. Bumps `BYTECODE_WIRE_FORMAT_VERSION` to v5 (stale-blob fallback to source-compile still applies to old blobs)
+
 ## [0.13.1] - 2026-07-20
 
 ### Changed

--- a/build.rs
+++ b/build.rs
@@ -25,9 +25,17 @@ use std::path::Path;
 /// - v4: `PreludeBlob::type_summary` (`PreludeSummary`) field removed — it
 ///   was write-only (sole writer `xtask`, zero readers; its only consumer
 ///   was deleted in PR #1012) (eu-2sa6.20).
+/// - v5: `PreludeBlob::blame` field added (binding name → declared
+///   `:transparent`/`:boundary` classification), and blob-mode global
+///   reconstruction (`StandardRuntime::globals()`, xtask's bytecode
+///   pre-encode loop) now stamps each prelude global's `LambdaForm::
+///   Lambda.annotation` with a `Smid::global_slot(..)` identity instead of
+///   always `Smid::default()` — not a serialised-shape change on its own,
+///   but bundled into the same version bump as the `blame` field it feeds
+///   (eu-1tkk.7.11).
 ///
 /// MUST match `BYTECODE_WIRE_FORMAT_VERSION` in `xtask/src/main.rs`.
-const BYTECODE_WIRE_FORMAT_VERSION: u32 = 4;
+const BYTECODE_WIRE_FORMAT_VERSION: u32 = 5;
 
 /// Compute the blob source hash: `SHA-256(prelude source ‖ wire-format version)`.
 fn blob_source_hash(source_bytes: &[u8]) -> [u8; 32] {

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -297,7 +297,8 @@ snoc(x, l): l ++ [x]
 (x ‖ xs): __CONS(x, xs)
 
 ` { doc: "`head(xs)` - return the head item of list `xs`, panic if empty."
-    type: s"[a] → a" }
+    type: s"[a] → a"
+    blame: :boundary }
 head: __HEAD
 
 ` { doc: "`↑xs` - return first element of list `xs`. Tight-binding prefix operator."
@@ -329,7 +330,8 @@ coalesce(xs): (xs nil?) then(null, (xs head)✓ then(xs head, xs tail coalesce))
 head-or(d, xs): xs nil? then(d, xs head)
 
 ` { doc: "`tail(xs)` - return list `xs` without the head item. [] causes error."
-    type: s"[a] → [a]" }
+    type: s"[a] → [a]"
+    blame: :boundary }
 tail: __TAIL
 
 ` { doc: "`tail-or(xs, d)` - return list `xs` without the head item or `d` for empty list."
@@ -421,7 +423,8 @@ block: __BLOCK
 has(s, b): b map-values(const(true)) lookup-or(s, false)
 
 ` { doc: "`lookup(s, b)` - look up symbol `s` in block `b`, error if not found."
-    type: s"symbol → Dict(a) → a?" }
+    type: s"symbol → Dict(a) → a?"
+    blame: :boundary }
 lookup(s, b): __LOOKUP(s, b)
 
 ` { doc: "`lookup-in(b, s)` - look up symbol `s` in block `b`, error if not found."
@@ -429,7 +432,8 @@ lookup(s, b): __LOOKUP(s, b)
 lookup-in(b, s): __LOOKUP(s, b)
 
 ` { doc: "`lookup-or(s, d, b)` - look up symbol `s` in block `b`, default `d` if not found."
-    type: s"symbol → a → {..} → any | a" }
+    type: s"symbol → a → {..} → any | a"
+    blame: :boundary }
 lookup-or(s, d, b): __LOOKUPOR(s, d, b)
 
 ` { doc: "`lookup-or-in(b, s, d)` - look up symbol `s` in block `b`, default `d` if not found."
@@ -1325,7 +1329,8 @@ __dbg-after(f, x): ▶(f(x))
 take(n, l): __IF((n zero?) ∨ (l nil?), [], cons(l head, take(n dec, l tail)))
  
 ` { doc: "`drop(n, l)` - return result of dropping integer `n` elements from list `l`."
-    type: s"number → [a] → [a]" }
+    type: s"number → [a] → [a]"
+    blame: :transparent }
 drop(n, l): __IF((n zero?), l, drop(n dec, l tail))
 
 ` { doc: "`rotate(n, l)` - rotate list `l` left by `n` positions."
@@ -1376,7 +1381,8 @@ split-after(p?, l): {
 split-when(p?, l): split-after(p? complement, l)
 
 ` { doc: "`nth(n, l)` - return `n`th item of list if it exists, otherwise error."
-    type: s"number → [a] → a?" }
+    type: s"number → [a] → a?"
+    blame: :boundary }
 nth(n, l): l drop(n) head
 
 ` "`update-nth(n, f, l)` - apply `f` to element at index `n` in list `l`.
@@ -1399,7 +1405,8 @@ update-first(p?, f, l): {
 repeat(i): __CONS(i, repeat(i))
 
 ` { doc: "`foldl(op, i, l)` - left fold operator `op` over list `l` starting from value `i`."
-    type: s"(b → a → b) → b → [a] → b" }
+    type: s"(b → a → b) → b → [a] → b"
+    blame: :transparent }
 foldl(op, i, l): if(l nil?, i, foldl(op, op(i, l head), l tail))
 
 ` { doc: "`reduce(op, l)` - left fold with no initial value; uses first element as seed. Panics on empty list."
@@ -1407,7 +1414,8 @@ foldl(op, i, l): if(l nil?, i, foldl(op, op(i, l head), l tail))
 reduce(op, l): foldl(op, l head, l tail)
 
 ` { doc: "`foldr(op, i, l)` - right fold operator `op` over list `l` ending with value `i`."
-    type: s"(a → b → b) → b → [a] → b" }
+    type: s"(a → b → b) → b → [a] → b"
+    blame: :transparent }
 foldr(op, i, l): if(l nil?, i, op(l head, foldr(op, i, l tail)))
 
 ` { doc: "`scanl(op, i, l)` - left scan operator `op` over list `l` starting from value `i`."
@@ -1459,7 +1467,8 @@ butlast(l): l reverse tail reverse
 cycle(l): if(l nil?, [], l ++ cycle(l))
 
 ` { doc: "`map(f, l)` - map function `f` over list `l`."
-    type: s"(a → b) → [a] → [b]" }
+    type: s"(a → b) → [a] → [b]"
+    blame: :transparent }
 map(f, l): if(l nil?, l, cons(l head f, l tail map(f)))
 
 ` { doc: "`f <$> l` - map function `f` over list `l`"
@@ -1494,7 +1503,8 @@ interleave(a, b): if(a nil?, b, cons(a head, interleave(b, a tail)))
 cross(f, xs, ys): xs mapcat({x: •}.(ys map(f(x))))
 
 ` { doc: "`filter(p?, l)` - return list of elements of list `l` that satisfy predicate `p?`."
-    type: s"(a → bool) → [a] → [a]" }
+    type: s"(a → bool) → [a] → [a]"
+    blame: :transparent }
 filter(p?, l): foldr({x: • xs: • }.(if(x p?, cons(x, xs), xs)), [], l)
 
 ` { doc: "`remove(p?, l)` - return list of elements of list `l` that do not satisfy predicate `p?`."
@@ -1521,7 +1531,8 @@ prepend: flip(append)
 concat(ls): foldr(append, [], ls)
 
 ` { doc: "`mapcat(f, l)` - map items in l with `f` and concatenate the resulting lists."
-    type: s"(a → [b]) → [a] → [b]" }
+    type: s"(a → [b]) → [a] → [b]"
+    blame: :transparent }
 mapcat(f): concat ∘ map(f)
 
 ` { doc: "`zip-apply(fs, vs)` - apply fns in list `fs` to corresponding values in list `vs`, until shorter is exhausted."

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -235,6 +235,18 @@ impl SourceMap {
 
     /// Retrieve the SourceInfo for a given Smid value
     pub fn source_info_for_smid(&self, smid: Smid) -> Option<&SourceInfo> {
+        // A `Smid::global_slot` identity must never resolve to a `SourceInfo`
+        // — it indexes a disjoint "which prelude global slot" space, not
+        // this `SourceMap`. Without this explicit guard, rejection is only
+        // incidental: `smid.get()` for a global-slot value is ~2.1 billion,
+        // which happens to fall outside `self.source`'s bounds today purely
+        // because no real source file is anywhere near that size. That
+        // safety margin is not a contract — an explicit guard makes the
+        // rejection structural, independent of `self.source`'s length
+        // (eu-1tkk.7.11).
+        if smid.as_global_slot().is_some() {
+            return None;
+        }
         if let Some(idx) = smid.get() {
             self.source.get(idx)
         } else {
@@ -691,6 +703,38 @@ mod tests {
         let mut source_map = SourceMap::new();
         let smid = source_map.add(0, Span::new(0u32, 0u32));
         assert_eq!(smid.as_global_slot(), None);
+    }
+
+    /// `source_info_for_smid` must reject a global-slot identity explicitly
+    /// (structurally, via `as_global_slot`), not merely by chance because
+    /// its huge index falls out of `self.source`'s bounds today. Add a real
+    /// entry to `source_map` first as a sanity check for the ordinary path.
+    ///
+    /// Note on fault-injection: deleting the guard clause outright is not
+    /// observable by this (or any practically-sized) test, precisely
+    /// because the guard is *defence in depth* — the fallback bounds check
+    /// already rejects a ~2.1-billion index against any realistically
+    /// small `self.source`. What this test does catch (verified live) is a
+    /// broken/inverted guard condition: flipping `is_some()` to `is_none()`
+    /// makes the ordinary-Smid sanity assertion above fail immediately,
+    /// proving the guard is genuinely wired in and checked on every call,
+    /// not dead code.
+    #[test]
+    fn source_info_for_smid_rejects_global_slot_identity() {
+        let mut source_map = SourceMap::new();
+        let real_smid = source_map.add(0, Span::new(0u32, 5u32));
+        assert!(
+            source_map.source_info_for_smid(real_smid).is_some(),
+            "sanity: an ordinary Smid must still resolve"
+        );
+
+        for slot in [0u32, 1, 236, !GLOBAL_SLOT_TAG] {
+            let smid = Smid::global_slot(slot);
+            assert!(
+                source_map.source_info_for_smid(smid).is_none(),
+                "global_slot({slot}) must never resolve to a SourceInfo"
+            );
+        }
     }
 
     /// A real `SourceMap` Smid must never collide with a `global_slot`

--- a/src/common/sourcemap.rs
+++ b/src/common/sourcemap.rs
@@ -11,10 +11,26 @@ use std::{fmt, ops::Range};
 /// A handle that points to a source location in a source map.
 ///
 /// Serialises as a `u32` (0 = synthetic/invalid, 1.. = source positions).
-/// Pre-compiled blobs use `Smid::default()` (0) for all prelude locations.
+/// Pre-compiled blobs use `Smid::default()` (0) for the vast majority of
+/// prelude locations (inner nodes within a combinator's compiled body) —
+/// a raw Smid baked at `xtask` build time would index into a `SourceMap`
+/// the loading process never populated, so it is elided at reconstruction.
+/// The one exception is a blob global's own entry-point identity: see
+/// [`Smid::global_slot`], which reserves a disjoint sub-range of this
+/// same `u32` space for "which prelude global slot" rather than "which
+/// source position" (eu-1tkk.7.11).
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Smid(Option<NonZeroU32>);
+
+/// Tag bit distinguishing a [`Smid::global_slot`] identity from a real
+/// `SourceMap` index.
+///
+/// Real Smids are minted sequentially from 1 by `SourceMap::add*` and never
+/// approach this range for any realistic source file (billions of AST
+/// nodes), so a tagged value can never collide with a genuine source
+/// position — but it must never be used to index into a `SourceMap`.
+const GLOBAL_SLOT_TAG: u32 = 0x8000_0000;
 
 impl Default for Smid {
     /// The default SMID is invalid.
@@ -77,6 +93,41 @@ impl Smid {
             Some(n) => format!("__{n}"),
             None => "__<nosmid>".to_string(),
         }
+    }
+
+    /// Construct a Smid identifying a prelude-blob global slot, not a
+    /// `SourceMap` index (eu-1tkk.7.11).
+    ///
+    /// Used by blob-mode STG-arena reconstruction (`StgArena::
+    /// reconstruct_form_annotated`) to stamp a reconstructed lambda form's
+    /// annotation with "which prelude global slot this came from" instead
+    /// of the usual `Smid::default()` — restoring enough identity for
+    /// Phase 2's blame classifier to name the combinator, without
+    /// resurrecting a raw xtask-sourced Smid that would index into a
+    /// `SourceMap` the loading process never populated (see the struct doc
+    /// comment above).
+    ///
+    /// `slot` is the *prelude-relative* slot index (matching
+    /// `PreludeBlob::name_to_slot` / `StandardRuntime`'s `prelude_names`),
+    /// not the full `Ref::G` global index. Only the low 31 bits are
+    /// retained (masked with `!GLOBAL_SLOT_TAG`) — the prelude has on the
+    /// order of hundreds of bindings, nowhere near this limit.
+    pub fn global_slot(slot: u32) -> Smid {
+        Smid(NonZeroU32::new(GLOBAL_SLOT_TAG | (slot & !GLOBAL_SLOT_TAG)))
+    }
+
+    /// If this Smid was constructed by [`Smid::global_slot`], return the
+    /// slot it identifies. Returns `None` for an ordinary source-map Smid,
+    /// a synthetic Smid, or the invalid/default Smid.
+    pub fn as_global_slot(&self) -> Option<u32> {
+        self.0.and_then(|n| {
+            let v = n.get();
+            if v & GLOBAL_SLOT_TAG != 0 {
+                Some(v & !GLOBAL_SLOT_TAG)
+            } else {
+                None
+            }
+        })
     }
 }
 
@@ -609,5 +660,62 @@ mod tests {
         let trace = [Smid::default(), smid, Smid::default()];
         let out = source_map.format_trace(&trace, &files);
         assert!(out.contains("x.eu:1:1"));
+    }
+
+    // ── Smid::global_slot / as_global_slot (eu-1tkk.7.11) ───────────────────
+
+    #[test]
+    fn global_slot_round_trips() {
+        for slot in [0u32, 1, 42, 295, 65535] {
+            let smid = Smid::global_slot(slot);
+            assert_eq!(smid.as_global_slot(), Some(slot));
+        }
+    }
+
+    #[test]
+    fn global_slot_is_valid_and_not_a_source_index() {
+        let smid = Smid::global_slot(7);
+        assert!(smid.is_valid());
+        // A global-slot Smid must never be mistaken for a real SourceMap
+        // index by code that only checks `get()`/`is_valid()`.
+        assert_ne!(smid.get(), None);
+    }
+
+    #[test]
+    fn as_global_slot_is_none_for_default_smid() {
+        assert_eq!(Smid::default().as_global_slot(), None);
+    }
+
+    #[test]
+    fn as_global_slot_is_none_for_ordinary_source_smid() {
+        let mut source_map = SourceMap::new();
+        let smid = source_map.add(0, Span::new(0u32, 0u32));
+        assert_eq!(smid.as_global_slot(), None);
+    }
+
+    /// A real `SourceMap` Smid must never collide with a `global_slot`
+    /// identity — the whole point of the tag bit. Adds a batch of ordinary
+    /// Smids (as a real large source file would) and confirms none of them
+    /// decode as a global slot.
+    #[test]
+    fn ordinary_smids_never_collide_with_global_slot_tag() {
+        let mut source_map = SourceMap::new();
+        for i in 0..10_000u32 {
+            let smid = source_map.add(0, Span::new(i, i));
+            assert_eq!(
+                smid.as_global_slot(),
+                None,
+                "ordinary Smid #{i} misidentified as a global slot"
+            );
+        }
+    }
+
+    #[test]
+    fn global_slot_masks_out_of_range_input_rather_than_colliding_with_tag() {
+        // A slot value that already has the tag bit set (pathological input,
+        // never produced by real callers) must still decode back to the
+        // masked value, not silently misbehave.
+        let smid = Smid::global_slot(GLOBAL_SLOT_TAG | 3);
+        assert_eq!(smid.as_global_slot(), Some(3));
     }
 }

--- a/src/core/desugar/desugarer.rs
+++ b/src/core/desugar/desugarer.rs
@@ -6,8 +6,13 @@ use crate::{
         sourcemap::{Smid, SourceMap},
     },
     core::{
-        binding::Var, doc::DeclarationDocumentation, error::CoreError, expr::*,
-        metadata::DeprecationSpec, target::*, unit::TranslationUnit,
+        binding::Var,
+        doc::DeclarationDocumentation,
+        error::CoreError,
+        expr::*,
+        metadata::{BlameSpec, DeprecationSpec},
+        target::*,
+        unit::TranslationUnit,
     },
     syntax::input::*,
 };
@@ -50,6 +55,13 @@ pub struct Desugarer<'smap> {
     ///
     /// Maps fully-qualified declaration name to its deprecation spec.
     deprecations: HashMap<String, DeprecationSpec>,
+    /// Blame classifications discovered during desugaring (eu-1tkk.7.11).
+    ///
+    /// Maps declaration name to its declared `BlameSpec`. See
+    /// `TranslationUnit::blame`'s doc comment for why this side channel
+    /// exists (metadata's `blame` key is stripped before it could survive
+    /// as runtime `Expr::Meta`).
+    blame: HashMap<String, BlameSpec>,
     /// Stack of names
     stack: Vec<String>,
     /// All parsed content for translation
@@ -123,6 +135,7 @@ impl<'smap> Desugarer<'smap> {
             imported_targets: HashSet::new(),
             docs: Vec::new(),
             deprecations: HashMap::new(),
+            blame: HashMap::new(),
             stack: vec![],
             contents,
             source_map,
@@ -235,6 +248,7 @@ impl<'smap> Desugarer<'smap> {
                 own_targets,
                 docs: self.docs.clone(),
                 deprecations: self.deprecations.clone(),
+                blame: self.blame.clone(),
             };
             self.file.pop();
             Ok(unit)
@@ -501,5 +515,17 @@ impl<'smap> Desugarer<'smap> {
     /// tracks nesting context but is not included in the deprecation key.
     pub fn record_deprecation(&mut self, name: &str, spec: DeprecationSpec) {
         self.deprecations.insert(name.to_string(), spec);
+    }
+
+    /// Record a declaration's blame classification (eu-1tkk.7.11).
+    ///
+    /// Called from `rowan_declaration_to_binding` when `metadata.blame` is
+    /// present, mirroring `record_deprecation` above. This is the *only*
+    /// place the classification survives past desugar — it is not wired
+    /// into codegen, and `strip_desugar_phase_metadata` removes `blame`
+    /// from any metadata block that would otherwise persist as runtime
+    /// `Expr::Meta`.
+    pub fn record_blame(&mut self, name: &str, spec: BlameSpec) {
+        self.blame.insert(name.to_string(), spec);
     }
 }

--- a/src/core/desugar/rowan_ast.rs
+++ b/src/core/desugar/rowan_ast.rs
@@ -2614,6 +2614,14 @@ fn rowan_declaration_to_binding(
         desugarer.record_deprecation(&components.name, spec);
     }
 
+    // Handle blame classification (eu-1tkk.7.11) — recorded via the
+    // desugarer's side channel, not wired into codegen. See
+    // `Desugarer::record_blame`'s doc comment for why: `blame` is
+    // consumed at Phase 2 trace-classification time, not compile time.
+    if let Some(spec) = metadata.blame {
+        desugarer.record_blame(&components.name, spec);
+    }
+
     // Handle target metadata
     if let Some(target) = &metadata.target {
         desugarer.record_target(

--- a/src/core/unit.rs
+++ b/src/core/unit.rs
@@ -2,7 +2,7 @@
 use crate::core::doc::DeclarationDocumentation;
 use crate::core::error::CoreError;
 use crate::core::expr::RcExpr;
-use crate::core::metadata::DeprecationSpec;
+use crate::core::metadata::{BlameSpec, DeprecationSpec};
 use crate::core::target::Target;
 use crate::syntax::export::embed::Embed;
 use crate::syntax::export::pretty;
@@ -34,6 +34,16 @@ pub struct TranslationUnit {
     /// binding verification to emit warnings when a deprecated
     /// declaration is referenced.
     pub deprecations: HashMap<String, DeprecationSpec>,
+    /// Blame classifications discovered during desugaring (eu-1tkk.7.11).
+    ///
+    /// Maps declaration name to its declared `BlameSpec` (`:transparent` /
+    /// `:boundary`). `strip_desugar_phase_metadata` removes `blame` from
+    /// any metadata block that survives desugaring as a runtime `Expr::
+    /// Meta` — this side channel (mirroring `deprecations` above) is the
+    /// only place the classification survives past desugar. Consumed by
+    /// `cargo xtask prelude-compile` (via `loader.core().blame`) to build
+    /// `PreludeBlob::blame`; never read at codegen time.
+    pub blame: HashMap<String, BlameSpec>,
 }
 
 impl TranslationUnit {
@@ -52,6 +62,8 @@ impl TranslationUnit {
     pub fn merge_with(self, other: Self) -> Result<TranslationUnit, CoreError> {
         let mut deprecations = self.deprecations;
         deprecations.extend(other.deprecations);
+        let mut blame = self.blame;
+        blame.extend(other.blame);
         Ok(TranslationUnit {
             expr: self.expr.merge_in(other.expr)?,
             targets: self.targets.union(&other.targets).cloned().collect(),
@@ -62,6 +74,7 @@ impl TranslationUnit {
                 .collect(),
             docs: other.docs, // don't include docs from prior inputs
             deprecations,
+            blame,
         })
     }
 
@@ -90,6 +103,7 @@ impl TranslationUnit {
         let mut own_targets = HashSet::new();
         let mut docs = vec![];
         let mut deprecations = HashMap::new();
+        let mut blame = HashMap::new();
         let mut entries = vec![];
 
         for (k, u) in keys.iter().zip(units) {
@@ -98,6 +112,7 @@ impl TranslationUnit {
             own_targets.extend(u.own_targets.iter().map(|t| t.under(key)));
             docs.extend(u.docs.iter().map(|d| d.under(key)));
             deprecations.extend(u.deprecations.clone());
+            blame.extend(u.blame.clone());
             entries.push((key.to_string(), u.expr.clone()));
         }
 
@@ -107,6 +122,7 @@ impl TranslationUnit {
             own_targets,
             docs,
             deprecations,
+            blame,
         })
     }
 
@@ -148,6 +164,7 @@ impl TranslationUnit {
             own_targets: self.own_targets.clone(),
             docs: self.docs.clone(),
             deprecations: self.deprecations.clone(),
+            blame: self.blame.clone(),
         })
     }
 }

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -632,6 +632,7 @@ pub fn run_type_checker_from_blob_core(
             own_targets: Default::default(),
             docs: Vec::new(),
             deprecations: Default::default(),
+            blame: Default::default(),
         };
         loader.inject_prelude_units(vec![(input.clone(), unit)]);
         injected.insert(input);

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -560,6 +560,7 @@ impl SourceLoader {
                 own_targets: std::collections::HashSet::new(),
                 docs: Vec::new(),
                 deprecations: std::collections::HashMap::new(),
+                blame: std::collections::HashMap::new(),
             };
             self.translation_units.insert(input.clone(), unit);
             return Ok(&self.translation_units[input]);

--- a/src/eval/stg/arena.rs
+++ b/src/eval/stg/arena.rs
@@ -390,10 +390,48 @@ impl StgArena {
     ///
     /// Panics if any index is out of range (indicates a malformed blob).
     pub fn reconstruct(&self, root: NodeIdx) -> Result<Rc<StgSyn>, BlobReconstructError> {
-        self.reconstruct_node(root)
+        self.reconstruct_node(root, None)
     }
 
-    fn reconstruct_node(&self, idx: NodeIdx) -> Result<Rc<StgSyn>, BlobReconstructError> {
+    /// Reconstruct a lambda form, elided-Ann/`Smid::default()` behaviour
+    /// unchanged from the historical `reconstruct_form`.
+    pub fn reconstruct_form(&self, idx: FormIdx) -> Result<LambdaForm, BlobReconstructError> {
+        self.reconstruct_form_impl(idx, None)
+    }
+
+    /// Reconstruct a lambda form, stamping every nested `Lambda` form's
+    /// `annotation` with `global_annotation` instead of the usual
+    /// `Smid::default()` (eu-1tkk.7.11).
+    ///
+    /// `global_annotation` is expected to be a [`Smid::global_slot`] value
+    /// identifying which prelude global this form tree belongs to — not a
+    /// real `SourceMap` index — so restoring it does not risk resolving
+    /// against the wrong `SourceMap` (see [`Smid`]'s struct doc comment on
+    /// why raw xtask-sourced Smids are normally elided). The same
+    /// identity is stamped uniformly across every `Lambda` reachable from
+    /// `idx` (including inner `Let`/`LetRec` bindings), mirroring how
+    /// `Desugarer::new_smid` tags every Smid minted while desugaring
+    /// inside a declaration with that declaration's name on the
+    /// source-compiled-prelude path.
+    ///
+    /// Used only at the two blob-mode global-reconstruction chokepoints
+    /// (`StandardRuntime::globals()` and the xtask bytecode pre-encode
+    /// loop) — every other caller of `reconstruct`/`reconstruct_form`
+    /// (the pretty-printer, `__args`/`__io` runtime overrides) is
+    /// unaffected and keeps the historical `Smid::default()` behaviour.
+    pub fn reconstruct_form_annotated(
+        &self,
+        idx: FormIdx,
+        global_annotation: Smid,
+    ) -> Result<LambdaForm, BlobReconstructError> {
+        self.reconstruct_form_impl(idx, Some(global_annotation))
+    }
+
+    fn reconstruct_node(
+        &self,
+        idx: NodeIdx,
+        global_annotation: Option<Smid>,
+    ) -> Result<Rc<StgSyn>, BlobReconstructError> {
         let node = self
             .nodes
             .get(idx as usize)
@@ -405,12 +443,18 @@ impl StgArena {
         // are meaningless at runtime.  Elide them so they do not overwrite
         // the user's call-site annotation in vm.annotation.
         if let ArenaStgSyn::Ann { body, .. } = node {
-            return self.reconstruct_node(*body);
+            return self.reconstruct_node(*body, global_annotation);
         }
-        Ok(Rc::new(self.reconstruct_arena_syn(node)?))
+        Ok(Rc::new(
+            self.reconstruct_arena_syn(node, global_annotation)?,
+        ))
     }
 
-    fn reconstruct_arena_syn(&self, node: &ArenaStgSyn) -> Result<StgSyn, BlobReconstructError> {
+    fn reconstruct_arena_syn(
+        &self,
+        node: &ArenaStgSyn,
+        global_annotation: Option<Smid>,
+    ) -> Result<StgSyn, BlobReconstructError> {
         Ok(match node {
             ArenaStgSyn::Atom { evaluand } => StgSyn::Atom {
                 evaluand: evaluand.clone(),
@@ -420,12 +464,14 @@ impl StgArena {
                 branches,
                 fallback,
             } => StgSyn::Case {
-                scrutinee: self.reconstruct_node(*scrutinee)?,
+                scrutinee: self.reconstruct_node(*scrutinee, global_annotation)?,
                 branches: branches
                     .iter()
-                    .map(|(tag, idx)| Ok((*tag, self.reconstruct_node(*idx)?)))
+                    .map(|(tag, idx)| Ok((*tag, self.reconstruct_node(*idx, global_annotation)?)))
                     .collect::<Result<_, BlobReconstructError>>()?,
-                fallback: fallback.map(|idx| self.reconstruct_node(idx)).transpose()?,
+                fallback: fallback
+                    .map(|idx| self.reconstruct_node(idx, global_annotation))
+                    .transpose()?,
             },
             ArenaStgSyn::Cons { tag, args } => StgSyn::Cons {
                 tag: *tag,
@@ -458,16 +504,16 @@ impl StgArena {
             ArenaStgSyn::Let { bindings, body } => StgSyn::Let {
                 bindings: bindings
                     .iter()
-                    .map(|&idx| self.reconstruct_form(idx))
+                    .map(|&idx| self.reconstruct_form_impl(idx, global_annotation))
                     .collect::<Result<_, BlobReconstructError>>()?,
-                body: self.reconstruct_node(*body)?,
+                body: self.reconstruct_node(*body, global_annotation)?,
             },
             ArenaStgSyn::LetRec { bindings, body } => StgSyn::LetRec {
                 bindings: bindings
                     .iter()
-                    .map(|&idx| self.reconstruct_form(idx))
+                    .map(|&idx| self.reconstruct_form_impl(idx, global_annotation))
                     .collect::<Result<_, BlobReconstructError>>()?,
-                body: self.reconstruct_node(*body)?,
+                body: self.reconstruct_node(*body, global_annotation)?,
             },
             // Ann nodes are elided in reconstruct_node() above.
             ArenaStgSyn::Ann { .. } => unreachable!("Ann handled in reconstruct_node"),
@@ -480,13 +526,13 @@ impl StgArena {
                 handler,
                 or_else,
             } => StgSyn::DeMeta {
-                scrutinee: self.reconstruct_node(*scrutinee)?,
-                handler: self.reconstruct_node(*handler)?,
-                or_else: self.reconstruct_node(*or_else)?,
+                scrutinee: self.reconstruct_node(*scrutinee, global_annotation)?,
+                handler: self.reconstruct_node(*handler, global_annotation)?,
+                or_else: self.reconstruct_node(*or_else, global_annotation)?,
             },
             ArenaStgSyn::Seq { scrutinee, body } => StgSyn::Seq {
-                scrutinee: self.reconstruct_node(*scrutinee)?,
-                body: self.reconstruct_node(*body)?,
+                scrutinee: self.reconstruct_node(*scrutinee, global_annotation)?,
+                body: self.reconstruct_node(*body, global_annotation)?,
             },
             ArenaStgSyn::LookupLit {
                 smid,
@@ -508,13 +554,17 @@ impl StgArena {
                 primop_id: *primop_id,
                 left: left.clone(),
                 right: right.clone(),
-                inner: self.reconstruct_node(*inner)?,
+                inner: self.reconstruct_node(*inner, global_annotation)?,
             },
             ArenaStgSyn::BlackHole => StgSyn::BlackHole,
         })
     }
 
-    pub fn reconstruct_form(&self, idx: FormIdx) -> Result<LambdaForm, BlobReconstructError> {
+    fn reconstruct_form_impl(
+        &self,
+        idx: FormIdx,
+        global_annotation: Option<Smid>,
+    ) -> Result<LambdaForm, BlobReconstructError> {
         let form = self
             .forms
             .get(idx as usize)
@@ -525,16 +575,20 @@ impl StgArena {
         Ok(match form {
             ArenaLambdaForm::Lambda { bound, body, .. } => LambdaForm::Lambda {
                 bound: *bound,
-                body: self.reconstruct_node(*body)?,
-                // Clear xtask-sourced annotations — they are meaningless
-                // at runtime and would pollute user error locations.
-                annotation: Smid::default(),
+                body: self.reconstruct_node(*body, global_annotation)?,
+                // Clear xtask-sourced (real `SourceMap`) annotations —
+                // they are meaningless at runtime and would pollute user
+                // error locations. `global_annotation`, when supplied via
+                // `reconstruct_form_annotated`, is a `Smid::global_slot`
+                // value instead — a distinct, disjoint identity space, not
+                // a raw source Smid — so restoring it is safe.
+                annotation: global_annotation.unwrap_or_default(),
             },
             ArenaLambdaForm::Thunk { body } => LambdaForm::Thunk {
-                body: self.reconstruct_node(*body)?,
+                body: self.reconstruct_node(*body, global_annotation)?,
             },
             ArenaLambdaForm::Value { body } => LambdaForm::Value {
-                body: self.reconstruct_node(*body)?,
+                body: self.reconstruct_node(*body, global_annotation)?,
             },
         })
     }

--- a/src/eval/stg/blob.rs
+++ b/src/eval/stg/blob.rs
@@ -36,6 +36,7 @@
 //! | `source_hash` | SHA-256 of `lib/prelude.eu`; checked by `build.rs` | — | — | `build.rs` staleness check | — |
 //! | `nodes` / `forms_pool` / `binding_entries` | Shared STG arena: compiled lambda forms for every prelude global | binding (compiled) | `stg` (post `eu dump stg`) | HeapSyn engine loader | derived (compiled, not a source-structure snapshot) |
 //! | `name_to_slot` | Binding name → global slot index | — | — | STG compiler (`Ref::G` resolution), loader | — |
+//! | `blame` | Binding name → declared blame classification (`:transparent`/`:boundary`) | binding | desugared (side channel, `TranslationUnit::blame`) | Phase 2 trace classifier (eu-1tkk.7.11/.7.12) | derived (reconciled `BlameSpec` → `FrameKind`) |
 //! | `operators` | Operator fixity/precedence, extracted pre-`cook` | merged | pre-`cook` (desugared-adjacent) | `cook`'s `Distributor` seeding | derived (extracted subset, not a full snapshot) |
 //! | `monad_specs` / `monad_type_hints` | Monad namespace specs (e.g. `:for`) and LSP type hints | merged | desugared | Desugarer seeding, LSP | derived |
 //! | `inlinable_bindings` | Pre-expanded, `Ref::G`-linked, `Lam(_, true, _)`-tagged combinator bodies | binding | derived from desugared | `inject_prelude_inlinable_bindings` (pre-inline injection into user code) | **derived** (pre-expanded/re-tagged — not a stage snapshot, hence no "core" in the name) |
@@ -60,6 +61,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    common::{diagnostic_json::FrameKind, sourcemap::Smid},
     core::expr::RcExpr,
     driver::unit_interface::OperatorInfo,
     eval::{
@@ -125,6 +127,21 @@ pub struct PreludeBlob {
     /// Binding name → index into `binding_entries` (= global slot − `INTRINSIC_COUNT`).
     #[serde(with = "crate::common::serde_sorted")]
     pub name_to_slot: HashMap<String, usize>,
+
+    /// Binding name → declared blame classification (eu-1tkk.7.11).
+    ///
+    /// Populated from `SourceLoader::core().blame` (a `BlameSpec`,
+    /// `core::metadata`) by `cargo xtask prelude-compile`, reconciled to
+    /// `FrameKind` (`common::diagnostic_json`) here so this table is
+    /// directly consumable by the Phase 2 trace classifier — never `User`
+    /// (that classification only ever applies to a real user-file frame).
+    /// Only combinators that declare `` ` :transparent `` / `` ` :boundary
+    /// `` appear; absence is not itself meaningful (most prelude
+    /// combinators declare no blame contract yet). See
+    /// [`PreludeBlob::classify`] for the end-to-end trace-Smid → `FrameKind`
+    /// lookup the classifier is expected to call.
+    #[serde(default, with = "crate::common::serde_sorted")]
+    pub blame: HashMap<String, FrameKind>,
 
     /// Operator metadata for seeding cook's `Distributor`.
     #[serde(with = "crate::common::serde_sorted")]
@@ -211,6 +228,46 @@ impl PreludeBlob {
             postcard::from_bytes(&self.desugared_unit_cores).ok()
         }
     }
+
+    // ── Blame classification (eu-1tkk.7.11) ─────────────────────────────────
+    //
+    // Three composable steps, given a trace Smid: `Smid::as_global_slot`
+    // (not a `PreludeBlob` method — call it on the Smid directly) → `slot_name`
+    // → `blame_for`. `classify` chains the last two for the common case.
+    // Cold-path only (error reporting), not the VM tick/allocation hot path
+    // — `slot_name`'s linear scan over `name_to_slot` (hundreds of entries)
+    // is fine here; a caller classifying many frames in one report should
+    // build its own slot→name `Vec` once from `name_to_slot` instead (the
+    // runtime already does this as `StandardRuntime::prelude_names`).
+
+    /// Resolve a prelude-relative global slot (as decoded from a trace Smid
+    /// via [`Smid::as_global_slot`]) back to its binding name, via
+    /// `name_to_slot`.
+    pub fn slot_name(&self, slot: u32) -> Option<&str> {
+        self.name_to_slot
+            .iter()
+            .find(|(_, &v)| v as u32 == slot)
+            .map(|(k, _)| k.as_str())
+    }
+
+    /// Look up a binding's declared blame classification by name.
+    pub fn blame_for(&self, name: &str) -> Option<FrameKind> {
+        self.blame.get(name).copied()
+    }
+
+    /// End-to-end: a trace `Smid` → the declared blame class of the
+    /// prelude global it identifies, if the Smid is a
+    /// [`Smid::global_slot`] identity *and* that global declared a blame
+    /// contract. `None` covers both "not a blob global-slot Smid at all"
+    /// (e.g. a real user-source Smid) and "a recognised global slot with
+    /// no declared contract" — the caller decides how to treat that
+    /// ambiguity (the design's default is to treat an undeclared prelude
+    /// combinator as `Transparent`, never silently `User`).
+    pub fn classify(&self, smid: Smid) -> Option<FrameKind> {
+        let slot = smid.as_global_slot()?;
+        let name = self.slot_name(slot)?;
+        self.blame_for(name)
+    }
 }
 
 #[cfg(test)]
@@ -226,6 +283,7 @@ mod tests {
             forms_pool: vec![],
             binding_entries: vec![],
             name_to_slot: HashMap::new(),
+            blame: HashMap::new(),
             operators: HashMap::new(),
             monad_specs: HashMap::new(),
             monad_type_hints: HashMap::new(),
@@ -672,5 +730,98 @@ mod tests {
                 blob.forms_pool.len()
             );
         }
+    }
+
+    // ── blame table (eu-1tkk.7.11) ──────────────────────────────────────────
+
+    #[test]
+    fn blame_round_trips_through_postcard() {
+        let mut blob = minimal_blob();
+        blob.blame.insert("nth".to_string(), FrameKind::Boundary);
+        blob.blame.insert("map".to_string(), FrameKind::Transparent);
+
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.blame.get("nth"), Some(&FrameKind::Boundary));
+        assert_eq!(restored.blame.get("map"), Some(&FrameKind::Transparent));
+    }
+
+    /// An older blob with no `blame` field must still deserialise (the
+    /// stale-blob hash check forces a version bump to reject truly old
+    /// blobs, but `#[serde(default)]` is defence in depth) — decoding to
+    /// an empty map, not an error.
+    #[test]
+    fn blame_defaults_to_empty_when_absent_from_wire_bytes() {
+        // Simulate an old blob by encoding a struct with the same shape
+        // minus `blame`, then decoding it as `PreludeBlob`. Postcard is a
+        // schema-less positional format, so we can't literally omit a
+        // struct field and re-decode — instead assert the property that
+        // actually matters: a freshly-built blob with an explicitly empty
+        // `blame` map round-trips to an empty map (the `#[serde(default)]`
+        // path for a field genuinely absent from old bytes is exercised by
+        // every other `#[serde(default)]` field in this struct via the
+        // same mechanism; this test documents the expected steady state).
+        let blob = minimal_blob();
+        assert!(blob.blame.is_empty());
+        let bytes = blob.to_bytes().unwrap();
+        let restored = PreludeBlob::from_bytes(&bytes).unwrap();
+        assert!(restored.blame.is_empty());
+    }
+
+    #[test]
+    fn slot_name_and_blame_for_and_classify_compose() {
+        let mut blob = minimal_blob();
+        blob.name_to_slot.insert("nth".to_string(), 236);
+        blob.blame.insert("nth".to_string(), FrameKind::Boundary);
+
+        assert_eq!(blob.slot_name(236), Some("nth"));
+        assert_eq!(blob.slot_name(999), None);
+        assert_eq!(blob.blame_for("nth"), Some(FrameKind::Boundary));
+        assert_eq!(blob.blame_for("no-such-binding"), None);
+
+        assert_eq!(
+            blob.classify(Smid::global_slot(236)),
+            Some(FrameKind::Boundary)
+        );
+        // A slot with no declared blame contract classifies to `None`, not
+        // a silent default — the caller decides how to treat that.
+        blob.name_to_slot.insert("split-when".to_string(), 235);
+        assert_eq!(blob.classify(Smid::global_slot(235)), None);
+        // An ordinary (non-global-slot) Smid never classifies.
+        assert_eq!(blob.classify(Smid::default()), None);
+    }
+
+    #[test]
+    #[cfg(prelude_blob_ok)]
+    fn embedded_blob_has_declared_blame_for_nth_and_map() {
+        let bytes = crate::driver::resources::PRELUDE_BLOB_BYTES;
+        let blob = PreludeBlob::from_bytes(bytes).expect("embedded blob should deserialise");
+
+        assert!(
+            !blob.blame.is_empty(),
+            "prelude blob must have blame classifications after prelude-compile"
+        );
+        assert_eq!(
+            blob.blame.get("nth"),
+            Some(&FrameKind::Boundary),
+            "'nth' must be declared :boundary"
+        );
+        assert_eq!(
+            blob.blame.get("map"),
+            Some(&FrameKind::Transparent),
+            "'map' must be declared :transparent"
+        );
+
+        // End-to-end: the global-slot Smid for 'nth' must classify via the
+        // blob's own tables (slot_name / blame_for composed via classify).
+        let nth_slot = *blob
+            .name_to_slot
+            .get("nth")
+            .expect("nth must have a global slot") as u32;
+        assert_eq!(
+            blob.classify(Smid::global_slot(nth_slot)),
+            Some(FrameKind::Boundary)
+        );
     }
 }

--- a/src/eval/stg/runtime.rs
+++ b/src/eval/stg/runtime.rs
@@ -315,7 +315,11 @@ impl Runtime for StandardRuntime {
                         }
                     }
                 }
-                match arena.reconstruct_form(entry_idx) {
+                // Stamp the global-slot identity (eu-1tkk.7.11) so blame
+                // classification has something to key on for this prelude
+                // combinator, without resurrecting a raw xtask-sourced Smid
+                // (see `reconstruct_form_annotated`'s doc comment).
+                match arena.reconstruct_form_annotated(entry_idx, Smid::global_slot(i as u32)) {
                     Ok(form) => gs.push(form),
                     Err(e) => {
                         eprintln!(

--- a/src/wasm_pipeline.rs
+++ b/src/wasm_pipeline.rs
@@ -209,6 +209,7 @@ fn run_pipeline(source: &str, format: &str, mode: ParseMode) -> Result<String, P
         own_targets: HashSet::new(),
         docs: Vec::new(),
         deprecations: HashMap::new(),
+        blame: HashMap::new(),
     };
     let io_unit = TranslationUnit {
         expr: create_io_pseudoblock(None).apply_name(Smid::default(), "__io"),
@@ -216,6 +217,7 @@ fn run_pipeline(source: &str, format: &str, mode: ParseMode) -> Result<String, P
         own_targets: HashSet::new(),
         docs: Vec::new(),
         deprecations: HashMap::new(),
+        blame: HashMap::new(),
     };
     let build_unit = TranslationUnit {
         expr: build_meta_core.apply_name(Smid::default(), "__build"),
@@ -223,6 +225,7 @@ fn run_pipeline(source: &str, format: &str, mode: ParseMode) -> Result<String, P
         own_targets: HashSet::new(),
         docs: Vec::new(),
         deprecations: HashMap::new(),
+        blame: HashMap::new(),
     };
 
     // 7. Merge all units

--- a/tests/diagnostics_blame_plumbing_test.rs
+++ b/tests/diagnostics_blame_plumbing_test.rs
@@ -1,0 +1,118 @@
+//! Regression test for eu-1tkk.7.11 (Phase 2 blob blame-table plumbing).
+//!
+//! Prior to this change, every prelude frame in a blob-mode (shipped-binary)
+//! error trace carried `Smid::default()` — no identity at all — because
+//! `xtask/src/main.rs` compiles the prelude with `generate_annotations:
+//! false`, and blob-mode STG-arena reconstruction (`StgArena::
+//! reconstruct_form`) unconditionally zeroed any Smid it did carry (a raw
+//! xtask-sourced Smid would index into a `SourceMap` the loading process
+//! never populated). This meant Phase 2's blame classifier (`PreludeBlob::
+//! blame`, declared via `` ` :transparent ``/`` ` :boundary `` in
+//! `lib/prelude.eu`) had nothing to classify on the path that actually
+//! ships: the *material* it needs was unreachable, even once declared.
+//!
+//! `Smid::global_slot`/`Smid::as_global_slot` plus `StgArena::
+//! reconstruct_form_annotated` restore a disjoint, collision-free identity
+//! (which prelude global slot, not a source position) at the two blob-mode
+//! reconstruction chokepoints (`StandardRuntime::globals()` for the HeapSyn
+//! engine, xtask's bytecode pre-encode loop for the bytecode engine). This
+//! test asserts that identity actually reaches a live error trace under the
+//! default (bytecode, blob) engine — not just that the blob's static tables
+//! are populated (see `src/eval/stg/blob.rs`'s
+//! `embedded_blob_has_declared_blame_for_nth_and_map` for that).
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static CASE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// Run `eu` under `EU_ERROR_TRACE_DUMP=1` on `src` and return combined
+/// stdout+stderr.
+fn run_trace_dump(src: &str) -> String {
+    let n = CASE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("eu-blame-plumbing-{}-{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("case.eu");
+    std::fs::write(&path, src).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_eu"))
+        .env("EU_ERROR_TRACE_DUMP", "1")
+        .args(["--heap-limit-mib", "2048"])
+        .arg(&path)
+        .output()
+        .expect("run eu");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    format!("{stdout}{stderr}")
+}
+
+/// Parse every `smid=NNNN` occurrence out of an `EU_ERROR_TRACE_DUMP=1`
+/// dump (see `ExecutionError::format_smid_detail`'s `"smid={index} ..."`
+/// format) and return the decoded `u32` values.
+fn extract_smid_indices(dump: &str) -> Vec<u32> {
+    dump.split("smid=")
+        .skip(1)
+        .filter_map(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+        .filter_map(|digits| digits.parse::<u32>().ok())
+        .collect()
+}
+
+/// `ExecutionError::format_smid_detail` prints `Smid::get()` (a 0-based
+/// index: `raw NonZeroU32 - 1`), not the raw stored value `Smid::global_slot`
+/// encodes into. Reconstruct the actual `Smid` from a printed index.
+fn smid_from_printed_index(index: u32) -> eucalypt::common::sourcemap::Smid {
+    eucalypt::common::sourcemap::Smid::from(index + 1)
+}
+
+/// The epic's own flagship specimen (design spec §4.3's before/after
+/// example): `xs nth(10)` on a 3-element list. Under the default
+/// bytecode+blob engine, the resulting trace must carry at least one Smid
+/// that decodes as a global-slot identity — proving blame-table material is
+/// actually reachable from a live error, not just present in the blob's
+/// static tables.
+#[test]
+fn blob_mode_trace_carries_a_global_slot_smid_for_nth_out_of_range() {
+    let dump = run_trace_dump("xs: [1, 2, 3]\nresult: xs nth(10)\n");
+
+    let global_slot_smids: Vec<u32> = extract_smid_indices(&dump)
+        .into_iter()
+        .filter_map(|idx| smid_from_printed_index(idx).as_global_slot())
+        .collect();
+
+    assert!(
+        !global_slot_smids.is_empty(),
+        "expected at least one global-slot Smid in the blob-mode trace dump, found none.\n\
+         dump:\n{dump}"
+    );
+}
+
+/// Stronger assertion for the same specimen: the global-slot identity must
+/// resolve, via the embedded blob's own `name_to_slot`/`blame` tables, to
+/// the declared `Boundary` combinator the design spec's before/after
+/// example names explicitly (`nth`) — not merely to *some* prelude global.
+#[test]
+#[cfg(prelude_blob_ok)]
+fn blob_mode_trace_global_slot_resolves_to_declared_boundary_combinator() {
+    use eucalypt::common::diagnostic_json::FrameKind;
+    use eucalypt::eval::stg::blob::PreludeBlob;
+
+    let blob = PreludeBlob::from_bytes(eucalypt::driver::resources::PRELUDE_BLOB_BYTES)
+        .expect("embedded blob should deserialise");
+
+    let dump = run_trace_dump("xs: [1, 2, 3]\nresult: xs nth(10)\n");
+
+    let resolved_names: Vec<(String, FrameKind)> = extract_smid_indices(&dump)
+        .into_iter()
+        .filter_map(|idx| smid_from_printed_index(idx).as_global_slot())
+        .filter_map(|slot| blob.slot_name(slot).map(|n| n.to_string()))
+        .filter_map(|name| blob.blame_for(&name).map(|kind| (name, kind)))
+        .collect();
+
+    assert!(
+        resolved_names
+            .iter()
+            .any(|(name, kind)| name == "nth" && *kind == FrameKind::Boundary),
+        "expected the trace to resolve a global-slot Smid to 'nth' (declared :boundary); \
+         resolved names: {resolved_names:?}\ndump:\n{dump}"
+    );
+}

--- a/tests/diagnostics_blame_plumbing_test.rs
+++ b/tests/diagnostics_blame_plumbing_test.rs
@@ -20,6 +20,22 @@
 //! default (bytecode, blob) engine — not just that the blob's static tables
 //! are populated (see `src/eval/stg/blob.rs`'s
 //! `embedded_blob_has_declared_blame_for_nth_and_map` for that).
+//!
+//! The whole file is gated on `#[cfg(prelude_blob_ok)]`: every assertion
+//! here is specific to a build that actually has `lib/prelude.blob`
+//! embedded (i.e. `cargo xtask prelude-compile` ran before `cargo
+//! build`/`cargo test`). CI's plain "Test Suite" job deliberately runs
+//! `cargo test` without that step, to keep the source-prelude fallback path
+//! exercised — under that build `eu` falls back to compiling the prelude
+//! from source at runtime, every prelude Smid is a real (non-tagged) source
+//! position, and these assertions would not apply. Gating the whole file
+//! (rather than just the `#[test]` fns) means the helper functions below
+//! aren't flagged as dead code by `cargo clippy -D warnings` in a
+//! blob-less build (e.g. the "Lint" CI job, which also never generates a
+//! blob). The dedicated "Bytecode + blob harness" / "GC-verified harness"
+//! CI jobs do generate the blob first and so do exercise this file.
+#![cfg(prelude_blob_ok)]
+
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -91,7 +107,6 @@ fn blob_mode_trace_carries_a_global_slot_smid_for_nth_out_of_range() {
 /// the declared `Boundary` combinator the design spec's before/after
 /// example names explicitly (`nth`) — not merely to *some* prelude global.
 #[test]
-#[cfg(prelude_blob_ok)]
 fn blob_mode_trace_global_slot_resolves_to_declared_boundary_combinator() {
     use eucalypt::common::diagnostic_json::FrameKind;
     use eucalypt::eval::stg::blob::PreludeBlob;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -52,8 +52,9 @@ mod engine_ab;
 /// MUST match `BYTECODE_WIRE_FORMAT_VERSION` in the crate root `build.rs`.
 /// See that constant's doc comment for the version history (v2: eu-2sa6.11
 /// Let/LetRec binding count widened `u16` → `u32`; v4: eu-2sa6.20
-/// `PreludeBlob::type_summary` field removed).
-const BYTECODE_WIRE_FORMAT_VERSION: u32 = 4;
+/// `PreludeBlob::type_summary` field removed; v5: eu-1tkk.7.11
+/// `PreludeBlob::blame` field + blob-mode global-slot Smid identity).
+const BYTECODE_WIRE_FORMAT_VERSION: u32 = 5;
 
 fn main() -> Result<()> {
     let mut args = std::env::args().skip(1);
@@ -196,6 +197,22 @@ fn cmd_prelude_compile() -> Result<()> {
     if !tc_warnings.is_empty() {
         eprintln!("  {} type-check warning(s) (non-fatal)", tc_warnings.len());
     }
+
+    // Blame classifications declared on prelude combinators (eu-1tkk.7.11).
+    //
+    // `desugar_phase_blame` is read from the desugared unit's side channel
+    // (`TranslationUnit::blame`, populated by `Desugarer::record_blame` —
+    // metadata's `blame` key is desugar-phase-only and does not survive as
+    // runtime `Expr::Meta`, so it cannot be re-extracted from `core_expr`
+    // here). Independent of `generate_annotations`/Smid generation
+    // entirely: this is plain desugar-time metadata, captured before the
+    // STG-compile step below (which runs with `generate_annotations:
+    // false`) even begins.
+    let desugar_phase_blame = loader.core().blame.clone();
+    println!(
+        "  blame classifications declared: {}",
+        desugar_phase_blame.len()
+    );
 
     // ── 4. Peel the merged Let expression into individual binding bodies ──────
     // After merge_units + cook, the prelude is a nested Let where all
@@ -397,11 +414,19 @@ fn cmd_prelude_compile() -> Result<()> {
             nodes: nodes.clone(),
             forms: forms_pool.clone(),
         };
+        // Stamp the same global-slot identity (eu-1tkk.7.11) that
+        // `StandardRuntime::globals()` stamps at load time, so the baked
+        // bytecode path and the HeapSyn arena-reconstruction path agree on
+        // which prelude global each reconstructed form identifies.
         let prelude_forms: Vec<LambdaForm> = binding_entries
             .iter()
-            .map(|&e| {
+            .enumerate()
+            .map(|(i, &e)| {
                 arena
-                    .reconstruct_form(e)
+                    .reconstruct_form_annotated(
+                        e,
+                        eucalypt::common::sourcemap::Smid::global_slot(i as u32),
+                    )
                     .expect("reconstruct prelude form for bytecode encode")
             })
             .collect();
@@ -429,6 +454,30 @@ fn cmd_prelude_compile() -> Result<()> {
         desugared_unit_cores.len(),
     );
 
+    // ── 9b. Reconcile BlameSpec (source vocabulary) → FrameKind (blob/classifier
+    // vocabulary) for the blob's blame table (eu-1tkk.7.11) ───────────────────
+    //
+    // Tolerant by construction: only names that both declared a blame
+    // contract AND survived peeling into an actual global slot are kept —
+    // a combinator without blame metadata simply isn't in the table (the
+    // classifier treats absence as "no declared contract", not an error).
+    let blame: HashMap<String, eucalypt::common::diagnostic_json::FrameKind> = desugar_phase_blame
+        .into_iter()
+        .filter(|(name, _)| name_to_slot.contains_key(name.as_str()))
+        .map(|(name, spec)| {
+            let kind = match spec {
+                eucalypt::core::metadata::BlameSpec::Transparent => {
+                    eucalypt::common::diagnostic_json::FrameKind::Transparent
+                }
+                eucalypt::core::metadata::BlameSpec::Boundary => {
+                    eucalypt::common::diagnostic_json::FrameKind::Boundary
+                }
+            };
+            (name, kind)
+        })
+        .collect();
+    println!("  blame classifications retained in blob: {}", blame.len());
+
     // ── 10. Serialise and write ───────────────────────────────────────────────
     let blob = PreludeBlob {
         source_hash,
@@ -436,6 +485,7 @@ fn cmd_prelude_compile() -> Result<()> {
         forms_pool,
         binding_entries,
         name_to_slot,
+        blame,
         operators,
         monad_specs,
         monad_type_hints,


### PR DESCRIPTION
## Summary

Phase 2 of the 0.14 Diagnostics Overhaul (eu-1tkk.7.11 part 2, closing the blob half). The blame vocabulary (`BlameSpec`, `extract_blame_spec`, `:transparent`/`:boundary` metadata) merged in #1051 only reached the source-compiled-prelude path (per the checkpoint spike `spike/furnace-diagnostics-phase2-blob-scope`, commit `8b468dba`, and the Phase 2 plan `docs/superpowers/plans/2026-07-22-diagnostics-phase2-curated-trace.md`). This PR makes that material *reachable* on the shipped, blob-based release binary — it does not implement the Phase 2 classifier itself (eu-1tkk.7.12, still open) and does not flip any corpus fixtures.

- **`lib/prelude.eu`**: declares `` ` :transparent `` on `map`/`filter`/`foldl`/`foldr`/`drop`/`mapcat`, `` ` :boundary `` on `nth`/`head`/`tail`/`lookup`/`lookup-or` — merged into each declaration's existing `{ doc:, type: }` metadata block (backtick-attaches-to-next-declaration honoured).
- **`TranslationUnit::blame` / `Desugarer::record_blame`**: a new side channel mirroring `deprecations`. `blame` is desugar-phase-only metadata (stripped by `strip_desugar_phase_metadata` before it could survive as runtime `Expr::Meta`), so `cargo xtask prelude-compile` reads it via `loader.core().blame` — independent of `generate_annotations`/Smid generation entirely.
- **`PreludeBlob.blame: HashMap<String, FrameKind>`**: reconciles the source `BlameSpec` vocabulary to the blob/classifier `FrameKind` vocabulary (`common::diagnostic_json`), populated in xtask's per-binding loop, tolerant of combinators with no declared contract.
- **`Smid::global_slot` / `Smid::as_global_slot`**: a disjoint, collision-free sub-range of the `Smid` `u32` space (top bit tagged) identifying "which prelude global slot" rather than "which source position" — safe to restore at blob-mode reconstruction without resurrecting a raw xtask-sourced Smid that would index into the wrong `SourceMap`.
- **`StgArena::reconstruct_form_annotated`**: stamps this identity onto every reconstructed `Lambda` form (the historical `reconstruct`/`reconstruct_form` are untouched — same `Smid::default()` behaviour). Wired in at exactly the two blob-mode reconstruction chokepoints named in scope: `StandardRuntime::globals()` and xtask's bytecode pre-encode loop, so the HeapSyn and bytecode engines agree.
- **`PreludeBlob::classify`/`slot_name`/`blame_for`**: the classifier-facing API for eu-1tkk.7.12 — given a trace `Smid`, `as_global_slot()` → slot → name (via `name_to_slot`) → blame class.
- **Wire format**: bumps `BYTECODE_WIRE_FORMAT_VERSION` to **v5** in both `build.rs` and `xtask/src/main.rs` (kept in sync, doc comments updated). Confirmed the stale-blob fallback still degrades to source-compile, not a hard failure.

## Verified live

The design spec's own flagship specimen (§4.3): `xs nth(10)` on a 3-element list. Under the default bytecode+blob engine, `EU_ERROR_TRACE_DUMP=1` now shows a stack-trace entry whose Smid decodes (via `as_global_slot`) to slot 236, which resolves through the *embedded* blob's own `name_to_slot`/`blame` tables to `nth`, declared `Boundary` — exactly the class of bug (`[prelude]:NNNN` with zero identity) the epic exists to fix. Two new integration tests in `tests/diagnostics_blame_plumbing_test.rs` gate this end-to-end against the real `eu` binary + embedded blob (not just the blob's static tables).

**Hot path**: load-time/build-time only, as designed. Confirmed the pre-encoded bytecode `program.code` byte length is unchanged (269213 bytes, before and after) — the Smid stamping happens purely at reconstruction time from data (the enumeration index) already present in the blob, adding zero bytes to the compiled code stream. Blob size delta: **596625 → 596703 bytes (+78 bytes)**, entirely attributable to the new `PreludeBlob.blame` table (11 entries).

## Fault-injection verification (per epic requirement)

Every new assertion was broken, confirmed FAIL, restored, confirmed PASS:
- `Smid::as_global_slot` (forced `None`) → `sourcemap::tests` round-trip/collision tests failed.
- `PreludeBlob::classify` (forced `None`) → `blob::tests::slot_name_and_blame_for_and_classify_compose` and `embedded_blob_has_declared_blame_for_nth_and_map` failed.
- `Desugarer::record_blame` (made a no-op) → blob regenerated with 0 blame entries; `embedded_blob_has_declared_blame_for_nth_and_map` and the stronger live-trace integration test both failed (the weaker "carries *a* global-slot Smid" test correctly still passed, since that mechanism is independent of blame declarations).
- `StgArena::reconstruct_form_annotated` (made a no-op, falling back to `None`) → blob regenerated; both new integration tests in `diagnostics_blame_plumbing_test.rs` failed.

## Test results

- `cargo fmt --all --check`: clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test` (bytecode, default): green, **except two pre-existing failures unrelated to this change** — confirmed via `git stash` + rebuild that both reproduce **identically on unmodified `origin/master`** with a freshly regenerated blob:
  - `diagnostics_invariants.rs::corpus_satisfies_invariants` — a stale `xfail` marker on `tests/diagnostics/corpus/metadata_span.eu` (the fixture's JSON trace is already empty with a user-file primary on master; `metadata_span.meta.toml`'s xfail reason describes source-path-only behaviour and needs a maintainer to update the sidecar — out of scope here).
  - 5 `harness_test.rs` typecheck tests (010/011/013/063/085) — pre-existing checker/eval divergence tracked by eu-ntwg.1.
- `EU_HEAPSYN=1 cargo test`: same result (same two pre-existing failures, nothing new).
- `EU_GC_VERIFY=2 EU_GC_STRESS=1 cargo test --lib` and `--test harness_test`: green (same two pre-existing harness failures, no GC-related issues).

## Not in scope (per dispatch)

Did not touch `swap_args`/`DirectApp`, #1050's continuation code, or clarion's error.rs classifier. Did not attempt to flip any corpus fixtures or implement curation — that's eu-1tkk.7.12.

## Review

Blob wire format + `Smid` semantics are shared with clarion's Phase 2 classifier work — **recorded review from a non-author required before merge**, per CLAUDE.md's "Recorded review before merge" rule (GC/memory, blob wire format). Do not merge without that review comment on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py2HEaF87JJWPcDBiBic3g