### PR TITLE
chore: add dual MIT OR Apache-2.0 licence (eu-7i4r)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -514,6 +514,14 @@ jobs:
       - release-candidate-windows
     steps:
 
+      # Checked out into a subdirectory purely to source the licence texts
+      # that ship inside each release tarball; keeping it out of the workspace
+      # root avoids any collision with the downloaded artefacts below (notably
+      # the generated CHANGELOG.md).
+      - uses: actions/checkout@v4
+        with:
+          path: repo
+
       - uses: actions/download-artifact@v4
         with:
           name: eu_darwin
@@ -538,14 +546,17 @@ jobs:
         run: |
           mkdir eucalypt-x86_64-linux
           cp eu_amd64 eucalypt-x86_64-linux/eu
+          cp repo/LICENSE repo/LICENSE-MIT repo/LICENSE-APACHE eucalypt-x86_64-linux/
           tar -cvzf eucalypt-x86_64-linux.tgz eucalypt-x86_64-linux
 
           mkdir eucalypt-aarch64-linux
           cp eu_aarch64 eucalypt-aarch64-linux/eu
+          cp repo/LICENSE repo/LICENSE-MIT repo/LICENSE-APACHE eucalypt-aarch64-linux/
           tar -cvzf eucalypt-aarch64-linux.tgz eucalypt-aarch64-linux
 
           mkdir eucalypt-aarch64-osx
           cp eu_darwin eucalypt-aarch64-osx/eu
+          cp repo/LICENSE repo/LICENSE-MIT repo/LICENSE-APACHE eucalypt-aarch64-osx/
           tar -cvzf eucalypt-aarch64-osx.tgz eucalypt-aarch64-osx
 
       - name: Generate SHA256SUMS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "eucalypt"
 version = "0.14.0"
 authors = ["gmorpheme <github@gmorpheme.net>"]
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [features]
 default = []

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018-2026 Curve Logic
+
+Eucalypt is dual-licensed under either of
+
+  * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE), or
+    http://www.apache.org/licenses/LICENSE-2.0)
+  * MIT License ([LICENSE-MIT](LICENSE-MIT), or
+    http://opensource.org/licenses/MIT)
+
+at your option. This is the customary dual licence of the Rust ecosystem;
+you may use this software under the terms of either licence.
+
+The SPDX expression for the project as a whole is:
+
+  MIT OR Apache-2.0
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in this work by you, as defined in the Apache-2.0
+licence, shall be dual-licensed as above, without any additional terms or
+conditions.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2026 Curve Logic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -81,4 +81,20 @@ cargo install --path .
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+Copyright (c) 2018-2026 Curve Logic.
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or
+  http://opensource.org/licenses/MIT)
+
+at your option. See [LICENSE](LICENSE) for a summary.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Install a local `eu` binary:
 cargo install --path .
 ```
 
-## License
+## Licence
 
 Copyright (c) 2018-2026 Curve Logic.
 
@@ -96,5 +96,5 @@ at your option. See [LICENSE](LICENSE) for a summary.
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
-license, shall be dual licensed as above, without any additional terms or
+licence, shall be dual licensed as above, without any additional terms or
 conditions.

--- a/ci/formula.eu
+++ b/ci/formula.eu
@@ -7,6 +7,7 @@ class Eucalypt < Formula
   homepage {dq}https://curvelogic.github.io/eucalypt/{dq}
   url {dq}https://github.com/curvelogic/eucalypt/releases/download/{version}/eucalypt-aarch64-osx.tgz{dq}
   sha256 {dq}{sha256}{dq}
+  license any_of: [{dq}MIT{dq}, {dq}Apache-2.0{dq}]
   bottle :unneeded
 
   def install

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -378,3 +378,17 @@ common: sa set.intersect(sb) set.to-list //=> [3, 4]
 combined: sa set.union(sb) set.to-list sort-nums //=> [1, 2, 3, 4, 5, 6]
 diff: sa set.diff(sb) set.to-list sort-nums //=> [1, 2]
 ```
+
+## Project
+
+### What licence is eucalypt released under?
+
+Eucalypt is dual-licensed under the Apache License, Version 2.0 and the
+MIT License, at your option — the customary dual licence of the Rust
+ecosystem. The full texts are in
+[LICENSE-APACHE](https://github.com/curvelogic/eucalypt/blob/master/LICENSE-APACHE)
+and
+[LICENSE-MIT](https://github.com/curvelogic/eucalypt/blob/master/LICENSE-MIT).
+
+Unless you state otherwise, any contribution you submit for inclusion in
+the project is dual-licensed on the same terms.

--- a/editors/tree-sitter-eucalypt/Cargo.toml
+++ b/editors/tree-sitter-eucalypt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tree-sitter-eucalypt"
 description = "Eucalypt grammar for tree-sitter"
 version = "0.0.1"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "eucalypt"]
 categories = ["parsing", "text-editors"]

--- a/editors/tree-sitter-eucalypt/README.md
+++ b/editors/tree-sitter-eucalypt/README.md
@@ -92,4 +92,11 @@ Eucalypt is a functional language for generating, templating, and rendering stru
 
 ## License
 
-MIT
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](../../LICENSE-MIT) or
+  http://opensource.org/licenses/MIT)
+
+at your option.

--- a/editors/tree-sitter-eucalypt/README.md
+++ b/editors/tree-sitter-eucalypt/README.md
@@ -90,7 +90,7 @@ Eucalypt is a functional language for generating, templating, and rendering stru
 - **Metadata**: `` ` "description" `` before declarations
 - **Comments**: `# line comment`
 
-## License
+## Licence
 
 Licensed under either of
 

--- a/editors/tree-sitter-eucalypt/package-lock.json
+++ b/editors/tree-sitter-eucalypt/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tree-sitter-eucalypt",
       "version": "0.1.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "node-addon-api": "^7.1.0",
         "node-gyp-build": "^4.8.0"

--- a/editors/tree-sitter-eucalypt/package.json
+++ b/editors/tree-sitter-eucalypt/package.json
@@ -23,7 +23,7 @@
     "src/**"
   ],
   "author": "Greg Hawkins",
-  "license": "MIT",
+  "license": "MIT OR Apache-2.0",
   "dependencies": {
     "node-addon-api": "^7.1.0",
     "node-gyp-build": "^4.8.0"

--- a/editors/tree-sitter-eucalypt/pyproject.toml
+++ b/editors/tree-sitter-eucalypt/pyproject.toml
@@ -10,12 +10,13 @@ keywords = ["incremental", "parsing", "tree-sitter", "eucalypt"]
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: Apache Software License",
   "Topic :: Software Development :: Compilers",
   "Topic :: Text Processing :: Linguistic",
   "Typing :: Typed"
 ]
 requires-python = ">=3.8"
-license.text = "MIT"
+license.text = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [project.urls]

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "eucalypt",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "Language support for Eucalypt (.eu files)",
   "version": "0.1.0",
   "publisher": "curvelogic",
-  "license": "MIT",
+  "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/curvelogic/eucalypt"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "eucalypt-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [[bin]]


### PR DESCRIPTION
Resolves **eu-7i4r**. Adds a licence to the previously-unlicensed repository (all-rights-reserved by default), for the 0.14 release.

## Owner decision (already made)

- **Licence:** dual `MIT OR Apache-2.0` — the Rust-ecosystem norm.
- **Copyright holder:** `Curve Logic`
- **Year range:** 2018–2026 (first commit 2018-03-28).

## Changes

- **`LICENSE-MIT`** — standard MIT text, `Copyright (c) 2018-2026 Curve Logic`.
- **`LICENSE-APACHE`** — verbatim canonical Apache-2.0 text (see verification below).
- **`LICENSE`** — short pointer file so the existing (previously broken) README link resolves.
- **`Cargo.toml`, `xtask/Cargo.toml`, `fuzz/Cargo.toml`** — add `license = "MIT OR Apache-2.0"`.
- **`README.md`** — replace the `## License` section (which linked to a non-existent `LICENSE`) with the conventional dual-licence statement plus the standard Rust contribution clause.
- **Editor/package metadata** — `editors/tree-sitter-eucalypt` (`Cargo.toml`, `package.json`, `pyproject.toml`, `README.md`) and `editors/vscode/package.json` updated from `MIT` to the dual expression, so sub-package metadata is consistent.
- **`ci/formula.eu`** — Homebrew formula now emits a `license any_of: ["MIT", "Apache-2.0"]` stanza.
- **`.github/workflows/build-rust.yaml`** — the release job checks out the repo and copies all three licence files into each release tarball.
- **`docs/faq.md`** — new "What licence is eucalypt released under?" entry.

## Packaging metadata note

This PR touches packaging/distribution metadata (Cargo `license` fields, npm/pyproject metadata, the Homebrew formula, and the release workflow), so a recorded non-author review applies before merge.

## Verification

- Apache-2.0 text is byte-for-byte canonical: fetched from `https://www.apache.org/licenses/LICENSE-2.0.txt` and the installed `LICENSE-APACHE` has the identical SHA-256 `cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30` (202 lines, all nine numbered sections + APPENDIX present).
- `cargo metadata --no-deps` reports `license = "MIT OR Apache-2.0"` for both `eucalypt` and `xtask`.
- `cargo build`, `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings` (zero warnings, no `#[allow]` suppressions), and full `cargo test` all pass.
- README `[LICENSE](LICENSE)` link now resolves to a real file.
- Homebrew formula rendered locally to confirm the `license` stanza emits correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz
