### PR TITLE
fix(diagnostics): capture user call-site on the DirectApp fast path (eu-1tkk.7)

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1183,7 +1183,6 @@ impl ProtoSyntax for ProtoAppGroup {
 
         // If it's an intrinsic, check whether we should inline the
         // wrapper
-        let mut used_direct_app = false;
         match intrinsic_index.and_then(|index| compiler.intrinsics.get(index)) {
             Some(bif)
                 if !compiler.suppress_inlining
@@ -1231,7 +1230,6 @@ impl ProtoSyntax for ProtoAppGroup {
                     false
                 };
                 if direct && self.smid.is_valid() {
-                    used_direct_app = true;
                     local_binder.set_body(ProtoDirectApp::boxed(
                         f_index,
                         arg_indexes,
@@ -1258,9 +1256,27 @@ impl ProtoSyntax for ProtoAppGroup {
         // Applied whenever source tracking is enabled and the call site has a
         // valid Smid. The IO spec block navigator (block_list_inner) handles
         // Ann nodes transparently, so this is safe for all call sites.
-        // When DirectApp was emitted, the smid is inlined in the node itself,
-        // so we must NOT add an outer Ann wrapper.
-        let stg = if compiler.generate_annotations() && self.smid.is_valid() && !used_direct_app {
+        //
+        // This applies to `DirectApp` call sites too, even though a `DirectApp`
+        // already carries the same smid inline (eu-1tkk.7). The inline smid only
+        // sets the machine's *live* annotation as the node is stepped, and an
+        // exact-arity saturated `DirectApp` pushes no continuation, so that
+        // annotation is overwritten the instant the callee's body is entered and
+        // the user's call site is lost — which is exactly why an error raised
+        // inside the callee (`nth(xs, 0)` with the arguments swapped) used to
+        // surface with a prelude-only trace and no user primary. The `Ann` node
+        // is what survives: it is the leading node of the enclosing thunk's body,
+        // so `target_annotation` finds it when the thunk is forced and stamps the
+        // `Update` continuation with it (eu-1tkk.7.18), and that continuation
+        // stays on the stack for the whole of the callee's evaluation.
+        //
+        // Cost: none on the default engine. Pre-decoded bytecode dispatch folds
+        // `Op::Ann` out at decode time (BV2 design §3, `Decoder::ordinal_for`),
+        // recording its smid in the `smids` side table that the dispatch prologue
+        // already reads unconditionally, so no dispatch step is added. The blob
+        // and source prelude are both compiled with `generate_annotations: false`,
+        // so no prelude call site is affected at all.
+        let stg = if compiler.generate_annotations() && self.smid.is_valid() {
             dsl::ann(self.smid, stg)
         } else {
             stg

--- a/tests/diagnostics/corpus/swap_args.meta.toml
+++ b/tests/diagnostics/corpus/swap_args.meta.toml
@@ -3,5 +3,11 @@ description = "nth(n, l) called with the list and index swapped: nth(xs, 0) inst
 region_start_line = 2
 region_end_line = 2
 expected_class = "number"
-xfail = true
-xfail_reason = "eu-1tkk.7.12 does NOT fix this, verified empirically: with `EU_ERROR_TRACE_DUMP=1` neither the env trace nor the stack trace contains a user Smid — every entry is a prelude frame inside nth's own recursion — so the Phase 2 classifier has no `User` frame to anchor to and curation, which only removes frames, cannot manufacture one. The message itself did improve as a side effect of nth's boundary rephrasing (it now names the offending value: 'tail requires a list, found 0'), but the structural invariants (i)/(iii)/(iv) still fail. Original diagnosis follows. eu-1tkk.7.11: no user Smid reaches the trace at all (env/stack trace are entirely prelude frames inside drop's recursion), so eu-1tkk.7.8's location-selection fix (never show a prelude primary when a user Smid is available) correctly suppresses the primary to null rather than showing the misleading [prelude]:1329 it used to. Getting an actual user primary — the nth(xs, 0) call site — needs eu-1tkk.7.11's blame/curation work to surface it into the trace in the first place."
+# Fixed by eu-1tkk.7 Phase 2 (DirectApp call-site capture): the exact-arity
+# saturated call `nth(xs, 0)` compiles to a `DirectApp`, whose outer `Ann`
+# wrapper the compiler used to suppress. Without that `Ann` no user Smid
+# reached the trace at all (env and stack traces were entirely prelude frames
+# inside drop's recursion) and eu-1tkk.7.8's location selection correctly
+# suppressed the primary to null. Restoring the `Ann` gives the enclosing
+# thunk a leading annotation, which eu-1tkk.7.18's `Update`-continuation
+# stamping carries for the whole of the callee's evaluation.

--- a/tests/diagnostics_invariants.rs
+++ b/tests/diagnostics_invariants.rs
@@ -144,9 +144,15 @@ fn debug_trace_restores_the_uncurated_trace() {
         );
     }
 
-    // `nth`'s internal recursion is a transparent frame in the raw dump and
-    // is gone from the curated trace: proves `--debug-trace` bypasses
-    // curation rather than being an inert flag.
+    // A transparent library frame is present in the raw `--debug-trace` dump
+    // and is gone from the curated trace: proves `--debug-trace` bypasses
+    // curation rather than being an inert flag. Since the DirectApp call-site
+    // fix (eu-1tkk.7) swap_args anchors on the user call site with the named
+    // boundary combinator kept as context — the same shape as
+    // nth_out_of_range below — where it previously curated to nothing because
+    // no user frame reached the trace at all. The test's intent is unchanged:
+    // curation drops every *transparent* frame while keeping the user anchor
+    // and the boundary combinator.
     let path = dir.join("swap_args.eu");
     let raw = frames(&run_debug_trace(&path));
     assert!(
@@ -155,10 +161,19 @@ fn debug_trace_restores_the_uncurated_trace() {
          frame, got {raw:?}"
     );
     let (curated_json, _, _) = run(&path);
+    let curated = frames(&curated_json);
     assert!(
-        frames(&curated_json).is_empty(),
-        "swap_args.eu: expected curation to drop every transparent frame, got {:?}",
-        frames(&curated_json)
+        !curated.iter().any(|(kind, _)| kind == "transparent"),
+        "swap_args.eu: curation must drop every transparent frame the raw dump \
+         carried, got {curated:?}"
+    );
+    assert!(
+        curated.contains(&("boundary".to_string(), "nth".to_string())),
+        "swap_args.eu: curated trace must name the boundary combinator, got {curated:?}"
+    );
+    assert!(
+        curated.iter().any(|(kind, _)| kind == "user"),
+        "swap_args.eu: curated trace must keep the user anchor, got {curated:?}"
     );
 
     // `nth` raises at its own edge, so its boundary frame is in the env

--- a/tests/harness/errors/181_direct_app_call_site.eu
+++ b/tests/harness/errors/181_direct_app_call_site.eu
@@ -1,0 +1,15 @@
+# A user-defined function called at exactly its arity compiles to a
+# `DirectApp` (exact-arity known-callee dispatch, CG1). That fast path
+# saturates the callee without pushing a continuation, and the compiler used
+# to suppress the call site's `Ann` wrapper on the grounds that the smid was
+# already inlined in the `DirectApp` node. The inlined smid only sets the
+# machine's live annotation as the node is stepped, so it was overwritten the
+# instant the callee body was entered.
+#
+# The error here is raised deep inside the prelude (`tail` on a number, via
+# `nth`/`drop`), so with the `Ann` suppressed no user source location reached
+# the diagnostic at all — it rendered with no span and no stack trace.
+# Restoring the wrapper anchors it on the `second(3)` call site (eu-1tkk.7).
+second(xs): nth(1, xs)
+
+result: second(3)

--- a/tests/harness/errors/181_direct_app_call_site.eu.expect
+++ b/tests/harness/errors/181_direct_app_call_site.eu.expect
@@ -1,0 +1,2 @@
+exit: 1
+stderr: "181_direct_app_call_site\.eu:15:9"

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -2727,6 +2727,15 @@ pub fn test_error_180() {
 }
 
 #[test]
+/// An exact-arity call to a user-defined function takes the `DirectApp` fast
+/// path, which used to suppress the call site's `Ann` wrapper; an error raised
+/// inside the prelude then reached the diagnostic with no user location at all.
+/// After the fix the call site anchors the span and the trace (eu-1tkk.7).
+pub fn test_error_181() {
+    run_error_test(&error_opts("181_direct_app_call_site.eu"));
+}
+
+#[test]
 /// A static `.key` lookup on a value that evaluates to a function (not a
 /// block) used to report the self-contradictory "tried to call a function
 /// as a function" (NotCallable with actual_type = "function"). After the


### PR DESCRIPTION
## What

Closes the `swap_args` diagnostics gap on the bytecode **DirectApp fast path**
(0.14 Diagnostics Overhaul, eu-1tkk.7 Phase 2).

An exact-arity saturated call — e.g. `nth(xs, 0)` with the arguments swapped —
compiles to `StgSyn::DirectApp` (CG1 exact-arity known-callee dispatch). The
compiler used to **suppress the enclosing `Ann` wrapper** on a `DirectApp`,
reasoning that the same call-site smid is already inlined in the node. But the
inlined smid only sets the machine's *live* annotation as the node is stepped,
and the `DirectApp` fast path saturates the callee **without pushing any
continuation** — so the user's call site was overwritten the instant the
callee body was entered and never reached the diagnostic. The result was a
prelude-only trace and a suppressed (null) primary.

## Approach — marker, not carve-out

Of the dispatch's two options (a lightweight trace marker vs a boundary
carve-out), **the marker won**, and the cheapest possible marker already
exists: the call-site `Ann` node. Restoring it gives the enclosing thunk's body
a leading `Ann`, which `target_annotation` reads when the thunk is forced and
stamps onto the `Update` continuation (the eu-1tkk.7.18 mechanism, #1050). That
`Update` stays on the stack for the whole of the callee's evaluation, so the
user call site survives to the error.

The change is one condition (`&& !used_direct_app` removed) plus deletion of the
now-dead `used_direct_app` flag.

## Cost: none on the default engine

- **Pre-decoded bytecode dispatch (default)** folds `Op::Ann` out at decode
  time (BV2 design §3, `Decoder::ordinal_for`), recording its smid in the
  `smids` side table the dispatch prologue *already* reads unconditionally — so
  **zero** added dispatch steps.
- The **prelude** (blob and source) is compiled with
  `generate_annotations: false`, so no prelude call site gains an `Ann`.
  Regenerating the blob after this change produced a **byte-identical** file
  (SHA256 `ca273248…` before and after), proving prelude execution is
  unchanged. The extra `Ann`s exist only on **user-file** `DirectApp` sites, and
  only the HeapSyn tree-walk engine steps them.

### Benchmark evidence (canonical engine-ab suite, PROTOCOL.md)

One binary at one path selects both engines via `EU_HEAPSYN`; `--heap-limit-mib
12288`; blob prelude. Binaries: base `098e09b4…` (master `8b501ada`), new
`7773257d…`; blob `ca273248…` (identical both arms). Host Mac15,11, macOS
26.5.1, rustc 1.97.0.

**Deterministic ticks (HeapSyn `-S`, drift-free — measured-verified).** Two
identical readings each; Δ is the HeapSyn cost of stepping the extra user-side
`Ann` nodes:

| bench | base ticks | new ticks | Δ | Δ% |
|---|---|---|---|---|
| 015_block_merge | 96,128,331 | 96,128,347 | +16 | 0.00002% |
| 016_import_yaml | 56,113,887 | 56,113,902 | +15 | 0.00003% |
| 017_import_toml | 55,940,563 | 55,940,578 | +15 | 0.00003% |
| 018_string_scale | 46,042,949 | 46,044,700 | +1,751 | 0.004% |
| 019_list_scale | 51,219,475 | 51,219,477 | +2 | ~0% |
| 020_lookup_curve | 1,497,747 | 1,500,879 | +3,132 | 0.21% |
| 021_io_loop | 3,970,300 | 3,971,302 | +1,002 | 0.025% |
| 022_hof_fold | 2,185,410 | 2,187,911 | +2,501 | 0.11% |

Allocations **identical** on every bench. On the default (bytecode) engine the
`Ann` is folded out at decode, so even these sub-0.2% HeapSyn deltas do not
apply.

**Wall median-of-5, interleaved base-bc/new-bc/base-hs/new-hs (measured-single —
one clean session; the machine was shared with concurrent build agents).**
`new/base` per engine:

| bench | bc new/base | hs new/base |
|---|---|---|
| 015_block_merge | 0.995 | 0.998 |
| 016_import_yaml | 1.021 | 0.989 |
| 017_import_toml | 1.000 | 0.995 |
| 018_string_scale | 1.002 | 0.998 |
| 019_list_scale | 0.998 | 1.025 |
| 020_lookup_curve | 1.004 | 0.998 |
| 021_io_loop | 1.067* | 0.965 |
| 022_hof_fold | 1.008 | 0.990 |

All within the ±15% noise band; `021_io_loop`'s 1.067 is shell-spawn variance
(1000× `io.shell echo`), not compute. Deterministic ticks are the load-bearing
figure; the wall session corroborates them.

**Output identity:** base and new produce byte-identical rendered output on all
eight benches under bytecode pre-decode, byte dispatch (`EU_PREDECODE=0`), and
`EU_HEAPSYN=1`.

## Fixtures flipped

- **`swap_args.eu` — FLIPPED off xfail.** Now reports primary `swap_args.eu:2:9`
  with a user-anchored trace, verified identical under bytecode pre-decode
  (default), byte dispatch (`EU_PREDECODE=0`), `EU_HEAPSYN=1`, and
  `--source-prelude` on both engines.
- **`hof_bad_arg.eu` — stays xfail (eu-gvci left open).** The generic marker
  does **not** fix this case. Per the settling command on the default engine,
  `error_has_user_file` stays `false`. The arity-mismatch error (`xs map(_ + _)`)
  is raised against the live annotation deep in `map`'s Case fallback, **not** by
  forcing a memoised thunk, so there is no `Update` continuation on the failing
  path to carry the restored `Ann` back to the user call site. This is a
  presentation/curation gap (eu-1tkk.7.11/.12), not a DirectApp caller-annotation
  drop. (HeapSyn happens to surface it — it has no DirectApp fast path — but the
  default engine is what the gate keys on.)

## Tests

- **`swap_args.meta.toml`** — `xfail` removed; the invariant gate now guards it
  permanently under the default engine (source prelude, as CI runs it).
- **`tests/harness/errors/181_direct_app_call_site.eu`** (+`.expect`, +
  `test_error_181`) — new regression test: `second(3)` where
  `second(xs): nth(1, xs)` raises inside the prelude; the diagnostic must anchor
  on the user call site `:15:9`. Verified on both engines, both dispatch paths,
  and source prelude.

### Fault-injection verified

Reverted `src/eval/stg/compiler.rs` to the suppressing form
(`&& !used_direct_app`) and confirmed **both** new gates fail:

- `cargo test --test diagnostics_invariants` → `swap_args.eu` violates (i)
  primary-not-in-user-file, (iii) primary-has-no-line, (iv)
  trace-not-user-anchored.
- `cargo test --test harness_test test_error_181` → exit 0 instead of 1.

Restored the fix; both pass again. Done per test.

## Validation

- `cargo test` full suite (source prelude): green (1341 lib + 505 harness + all
  integration).
- `EU_HEAPSYN=1 cargo test --test harness_test`: green (505).
- `EU_GC_VERIFY=2 EU_GC_STRESS=1` on `test_error_181` and
  `diagnostics_invariants`: green.
- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --all`: clean.

## Notes for review

Touches hot-path dispatch code generation, so it needs a **recorded non-author
review** per the merge checklist (wicket). A pre-existing, unrelated gap
(**eu-1tkk.7.17**: the invariant gate is not engine/config-aware) makes
`metadata_span.eu`/`hof_bad_arg.eu` trip when a blob is present or under
`EU_HEAPSYN=1`; confirmed to reproduce on the baseline binary and untouched
here. CI runs the gate under the default engine with a source prelude
(eu-1tkk.7.19), where it is green.

Merge-order heads-up: clarion's #1053 also edits the `xfail_reason` fields of
`swap_args.meta.toml` / `hof_bad_arg.meta.toml`, so whichever of us merges second
needs a trivial rebase on those files — no logic conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz
