### PR TITLE
bench: rescale hof_fold to clear engine-ab 200ms floor (eu-9vm0)

### DIFF
--- a/tests/harness/bench/022_hof_fold.eu
+++ b/tests/harness/bench/022_hof_fold.eu
@@ -1,18 +1,24 @@
 "Higher-order / env-walk benchmark (workload class C). Freezes the
-ad-hoc env-walk fold `range(0,10000) foldl((_+_),0)` that ROADMAP
-section 7 and the A/B reports used as the O(n^2) env-walk case, so it
-stops being an uncommitted spike. Both engines share the O(n^2)
-cactus-environment-walk ceiling here (review A D5; BV3 register-frame
-territory), so this is informational for the bc/hs comparison rather
-than a win for either engine. sum 0..9999 == 49995000. Runs >1s on the
-faster engine."
+ad-hoc env-walk fold `range(0,N) foldl((_+_),0)` that ROADMAP section 7
+and the A/B reports used as the env-walk case, so it stops being an
+uncommitted spike. sum 0..399999 == 79999800000. Runs >1s on both
+engines.
+
+SIZE HISTORY: originally N=10000, chosen when both engines shared an
+O(n^2) cactus-environment-walk ceiling here. The eu-rb5n/eu-npp9
+HOF-combinator demand-analysis fusion fix (PR #1016) collapsed that walk
+to linear and dropped hs_ticks 52.2M -> 2.18M, leaving the bench at
+~65ms wall -- startup-dominated noise, below the engine-ab protocol's
+200ms floor (eu-9vm0). N is now 400000 (=> ~1.1s on both engines),
+restoring it to the canonical suite's >1s band. It exercises a linear
+HOF fold / env walk; it is no longer the O(n^2) case it was cut for."
 
 # (_ + _) is a two-argument add; the range is the fold's list (catenated last).
-grand: range(0, 10000) foldl((_ + _), 0)
+grand: range(0, 400000) foldl((_ + _), 0)
 
 ` { target: :bench-hof-fold
     verify: ["default-expectation"] }
 bench-hof-fold: {
   total: grand
-  RESULT: if(grand = 49995000, :PASS, :FAIL)
+  RESULT: if(grand = 79999800000, :PASS, :FAIL)
 }


### PR DESCRIPTION
## What

`022_hof_fold` had fallen out of the engine-ab canonical suite's validity envelope. The eu-rb5n/eu-npp9 HOF-combinator demand-analysis fusion fix (PR #1016) collapsed its O(n²) cactus-environment-walk to **linear** (hs_ticks 52.2M → 2.18M), leaving it at ~65–80 ms wall — startup-dominated noise below the [PROTOCOL.md](docs/superpowers/engine-ab/PROTOCOL.md) 200 ms floor. Any bc/hs ratio computed from it was invalid. Flagged by `eu-9vm0`.

This scales the workload back into the canonical **>1 s band**:
- `range(0, 10000)` → `range(0, 400000)`
- `RESULT` sum assertion `49995000` → `79999800000` (sum 0..399999)
- Docstring rewritten to record that the workload is now **linear**, not the O(n²) case the bench was originally cut for.

## Substantive note

Scaling N restores the >1 s band but does **not** restore what the bench tested. It is now a linear HOF-fold/env-walk workload; eucalypt no longer has a committed bench for the O(n²) env-walk case (BV3 register-frame territory). If that case is still wanted it needs a new construction that defeats fusion — tracked as a follow-up thought on `eu-9vm0`.

## Verification (measured-single, clean `cargo build --release`, regenerated prelude blob)

| | bc (default) | hs (`EU_HEAPSYN=1`) |
|---|---|---|
| N=400 000 | ~1.09 s (1.09–1.10) | ~1.09 s (1.09–1.10) |

- Byte-identical output on both engines, `RESULT: PASS`.
- `test_bench_022_hof_fold` passes under `cargo test` **and** `EU_HEAPSYN=1 cargo test`.
- **Fault-injection verified:** wrong expected sum → `FAILED`; restored → `ok`.

## Sibling checks (same eu-9vm0 blast radius)

- `018_string_scale`: still clears the band (bc ~1.06 s, hs ~1.13 s). No change.
- `019_list_scale`: still genuinely **O(n²)** (bc 1.24 s / hs 1.63 s at N=6000; ~4–11× per 2× N; N=48000 times out). No change.

Labels are **measured-single** (one session, this machine, bc/hs run in blocks not interleaved) — fine for bench sizing; not a gating ratio claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)