### PR TITLE
ci: add blob-mode CI job for diagnostics integration tests (eu-1tkk.7.19)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -155,6 +155,39 @@ jobs:
       - name: Run tick-parity tripwire
         run: cargo test --test tick_parity_test
 
+  diagnostics-blob-mode:
+    name: Diagnostics blob-mode integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # Some integration tests only have teeth with an embedded prelude blob:
+      # tests/diagnostics_blame_plumbing_test.rs is gated wholesale on
+      # `#[cfg(prelude_blob_ok)]` (its assertions are about blob-mode Smid
+      # reconstruction, meaningless under the source-prelude fallback), and
+      # tests/diagnostics_invariants.rs's `corpus_satisfies_invariants` gate
+      # is blob-sensitive in practice even though it isn't cfg-gated. Neither
+      # the plain "Test Suite" job (deliberately blob-less, to keep the
+      # source-prelude fallback exercised) nor the blob-mode harness jobs
+      # ("Bytecode + blob harness", tick-parity, etc., which only run
+      # `eu test tests/harness` or a single non-diagnostics test) run these
+      # under a blob — so today they run in NO CI job at all (eu-1tkk.7.19).
+      - name: Generate prelude blob
+        run: cargo run --package xtask -- prelude-compile
+      # Scoped deliberately: only tests confirmed to PASS under a blob today.
+      # `cargo test --test diagnostics_invariants` as a whole currently fails
+      # two other tests in that file under blob mode
+      # (secondary_labels_do_not_excerpt_library_internals,
+      # debug_trace_restores_the_uncurated_trace — filed as eu-7x0r) and the
+      # harness-level typecheck tests 010/011/013/063/085 are actively red
+      # under blob mode too (eu-rqwh, in progress). Both are pre-existing,
+      # unrelated bugs this job must not force onto master by going red on
+      # merge. Widen the `cargo test` invocations below as each lands.
+      - name: Run blob-mode diagnostics integration tests
+        run: |
+          cargo test --test diagnostics_blame_plumbing_test
+          cargo test --test diagnostics_invariants corpus_satisfies_invariants -- --exact
+
   blob-determinism:
     name: Prelude blob determinism
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes eu-1tkk.7.19. No workflow in `.github/workflows/build-rust.yaml` ran
the full `cargo test` suite with a regenerated prelude blob present:

- the "Test Suite" jobs run plain `cargo test`, deliberately blob-less (to
  keep the source-prelude fallback exercised)
- the blob-mode jobs (`test-bytecode-blob`, `tick-parity`, etc.) generate a
  blob but only run `eu test tests/harness` or a single named
  `cargo test --test` target — never the diagnostics integration tests

Consequence: `tests/diagnostics_blame_plumbing_test.rs` (from #1052,
gated wholesale on `#[cfg(prelude_blob_ok)]`) never ran in CI at all, and
the blob-sensitive `diagnostics_invariants::corpus_satisfies_invariants`
gate was likewise never exercised under the shipped-binary configuration.

## New job: `diagnostics-blob-mode` ("Diagnostics blob-mode integration")

Runs on `ubuntu-latest`, matching the style of the existing `tick-parity`
job:
1. `cargo run --package xtask -- prelude-compile` to regenerate the blob
2. `cargo test --test diagnostics_blame_plumbing_test`
3. `cargo test --test diagnostics_invariants corpus_satisfies_invariants -- --exact`

## Keeping master green — how I scoped this

I generated the blob locally and ran the full `diagnostics_invariants`
test file under it before deciding scope. Result:

- `diagnostics_blame_plumbing_test` (both tests): **pass** under blob
- `diagnostics_invariants::corpus_satisfies_invariants`: **pass** under blob
- `diagnostics_invariants::secondary_labels_do_not_excerpt_library_internals`
  and `::debug_trace_restores_the_uncurated_trace`: **fail** under blob
  (pass without it) — a previously-undiscovered, un-tracked blob-sensitivity
  bug. Filed as **eu-7x0r** so it isn't lost, and deliberately **excluded**
  from this job's scope for now.
- The harness typecheck tests (010/011/013/063/085): confirmed still red
  under blob mode — this is the known, in-progress **eu-rqwh** — and are
  **not** included in this job.

This is option (1) from the bead's guidance: land the infrastructure now,
scoped to what's green today, with a documented TODO (in the job's own
comments) to widen it as eu-rqwh and eu-7x0r land. I did not attempt
option (2) (waiting for eu-rqwh) since that bug is owned by a parallel
Clarion fix and there's no reason to block landing the CI plumbing.

Verified locally, exact job body:
```
rm -f lib/prelude.blob
cargo run --package xtask -- prelude-compile
cargo test --test diagnostics_blame_plumbing_test        # 2 passed
cargo test --test diagnostics_invariants corpus_satisfies_invariants -- --exact  # 1 passed
```

YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`.

## Quality gates

No Rust source touched (YAML-only change), but ran the standard checks
against the current tree for a clean baseline:
- `cargo fmt --all` — no changes
- `cargo clippy --all-targets -- -D warnings` — clean

## Test plan
- [x] YAML syntax validated
- [x] Blob regenerated locally; exact job commands run and confirmed green
- [x] Confirmed (and filed eu-7x0r for) the two diagnostics_invariants
      tests this job deliberately excludes
- [x] Confirmed eu-rqwh's 5 typecheck tests are still red under blob,
      confirming why they're excluded
- [ ] CI green on this PR (this job is new — please confirm it runs and
      passes)

**Review note:** this touches release/CI machinery, so per repo policy it
needs a recorded non-author review before merge — I have not and will not
merge this myself.

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz