### PR TITLE
chore(ci): lint xtask by adding --workspace to clippy (eu-yoas)

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   audit:
     name: Security Audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ measurement standard and cite a dated report or a ledger row:
 
 ## Code Quality, Style, and Security
 
-- **Never allow clippy warnings**: fix every one (don't suppress with `#[allow(...)]`) unless the user explicitly permits it. Use `cargo clippy --all-targets -- -D warnings` — `--all-targets` matters, since `--lib` alone misses tests and benches that CI validates.
+- **Never allow clippy warnings**: fix every one (don't suppress with `#[allow(...)]`) unless the user explicitly permits it. Use `cargo clippy --workspace --all-targets -- -D warnings` — `--all-targets` matters, since `--lib` alone misses tests and benches that CI validates, and `--workspace` matters, since without it the `xtask` crate is silently unlinted.
 - **Use UK English spelling** throughout code, comments, and documentation: optimisation, utilisation, colour, etc.
 - **Fix dependabot/security alerts immediately**, with the same urgency as a build failure or clippy warning — treat them as blocking a PR. Prefer replacing deprecated dependencies over suppressing warnings (e.g. `atty` → `std::io::IsTerminal`).
 
@@ -210,7 +210,7 @@ measurement standard and cite a dated report or a ledger row:
 **ALWAYS run these commands before committing, in order, to avoid CI failures:**
 1. `rustup update stable` - CI uses `dtolnay/rust-toolchain@stable` (latest stable), so a stale local toolchain causes clippy discrepancies ("local passes, CI fails"); run this weekly
 2. `cargo fmt --all`
-3. `cargo clippy --all-targets -- -D warnings`
+3. `cargo clippy --workspace --all-targets -- -D warnings`
 4. `cargo test` - run the full suite (not just `--lib`) when the change might affect harness tests
 5. `git commit` and `git push`
 


### PR DESCRIPTION
## Summary

Closes the CI blind spot in eu-yoas: the `xtask` crate was never linted by CI because the Lint job's clippy invocation lacked `--workspace`.

- **CI change**: `.github/workflows/build-rust.yaml` — the existing `Run clippy` step under the `lint` job now runs `cargo clippy --workspace --all-targets -- -D warnings` (was missing `--workspace`). Also updated the `CLAUDE.md` pre-commit checklist to the same command, so local `cargo clippy` matches CI.
- **Warnings fixed**: none needed. The bead cited two latent warnings at `xtask/src/engine_ab.rs:420` and `xtask/src/main.rs:215`. Under the current stable toolchain (rustc/clippy 1.97.0) `cargo clippy --workspace --all-targets -- -D warnings` is clean — verified via a `cargo clean -p xtask` + full rebuild and by inspecting the clippy JSON diagnostic stream (zero warnings workspace-wide, including xtask's `bin` target). These appear to have been incidentally resolved by later refactors touching those files (eu-rb5n Z, eu-1tkk.7.11) between the bead's filing (2026-07-13) and now, or by a clippy version change. No `#[allow(...)]` suppressions were added or needed.

## Same-file overlap note

PR #1057 (`ci/lantern-eu-1tkk.7.19-blob-cargo-test`, also mine) is under review and **adds a new job** to this same file (`.github/workflows/build-rust.yaml`). This PR's diff is a single-line change to the existing `Run clippy` step under the pre-existing `lint` job, kept deliberately minimal and localised to avoid touching anything #1057 added, to minimise merge-conflict risk between the two PRs.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (confirmed after `cargo clean -p xtask`)
- [x] `cargo fmt --all` — no diff beyond the two intended edits
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-rust.yaml'))"`
- [x] Diff reviewed to confirm no overlap with PR #1057's new job

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz