### PR TITLE
fix(typecheck): seed monad registries for blob-path eval type check (eu-rqwh)

### DIFF
--- a/src/bin/eu.rs
+++ b/src/bin/eu.rs
@@ -181,16 +181,33 @@ fn run() -> i32 {
     // prelude, alternative prelude) always use `run_type_checker`.
     // See eu-rb5n.
     if !opt.suppress_type_warnings() {
+        // eu-rqwh: carry the blob's own monad registries alongside the
+        // decoded prelude_units, so `run_type_checker_from_blob_core` can
+        // seed them into its fresh `SourceLoader` — that loader injects the
+        // prelude-side units directly (skipping `translate()`, the step
+        // that would otherwise populate these registries), so without this
+        // the user's own `:for`/`:io` monadic-binding metadata is never
+        // recognised on this (blob) path.
         #[cfg(not(target_arch = "wasm32"))]
-        let blob_prelude_units = loader
-            .prelude_blob()
-            .and_then(|b| b.decode_desugared_unit_cores());
+        let blob_check_seed = loader.prelude_blob().and_then(|b| {
+            b.decode_desugared_unit_cores()
+                .map(|units| (units, b.monad_specs.clone(), b.monad_type_hints.clone()))
+        });
         #[cfg(target_arch = "wasm32")]
-        let blob_prelude_units: Option<Vec<(String, eucalypt::core::expr::RcExpr)>> = None;
+        let blob_check_seed: Option<(
+            Vec<(String, eucalypt::core::expr::RcExpr)>,
+            std::collections::HashMap<String, eucalypt::core::desugar::desugarer::MonadSpec>,
+            std::collections::HashMap<String, String>,
+        )> = None;
 
-        let check_result = match &blob_prelude_units {
-            Some(prelude_units) => {
-                eucalypt::driver::check::run_type_checker_from_blob_core(&opt, prelude_units)
+        let check_result = match &blob_check_seed {
+            Some((prelude_units, monad_specs, monad_type_hints)) => {
+                eucalypt::driver::check::run_type_checker_from_blob_core(
+                    &opt,
+                    prelude_units,
+                    monad_specs,
+                    monad_type_hints,
+                )
             }
             None => eucalypt::driver::check::run_type_checker(&opt),
         };

--- a/src/driver/check.rs
+++ b/src/driver/check.rs
@@ -585,6 +585,17 @@ fn tag_for_prelude_side_input(input: &Input) -> Option<&'static str> {
 /// (e.g. a partial or stale blob still produces a correct, if slower,
 /// result).
 ///
+/// `monad_specs`/`monad_type_hints` are the blob's own registries (eu-rqwh).
+/// Injecting `prelude_units` skips `translate()` for the prelude-side
+/// inputs, which is the step that normally populates a fresh
+/// `SourceLoader`'s monad registries (see the "Build order" table on
+/// [`crate::driver::unit_interface::UnitInterface`]). Without seeding them
+/// here directly, `:for`/`:io` monadic-binding metadata in the user's own
+/// file would never be recognised when *it* is translated, so the type
+/// checker's monadic-bind pre-pass would never see the hint it looks for —
+/// the warning would silently fail to fire only on this (blob) path. See
+/// `SourceLoader::seed_monad_registries` for the shared seeding logic.
+///
 /// ## `Smid` cross-process scoping (eu-rb5n / Wicket review)
 ///
 /// The injected `prelude_units` cores carry `Smid` values minted by the
@@ -612,8 +623,14 @@ fn tag_for_prelude_side_input(input: &Input) -> Option<&'static str> {
 pub fn run_type_checker_from_blob_core(
     opt: &EucalyptOptions,
     prelude_units: &[(String, RcExpr)],
+    monad_specs: &HashMap<String, crate::core::desugar::desugarer::MonadSpec>,
+    monad_type_hints: &HashMap<String, String>,
 ) -> Result<PipelineCheckResult, EucalyptError> {
     let mut loader = SourceLoader::new(opt.lib_path().to_vec());
+    // eu-rqwh: seed the monad registries the injected prelude_units' skipped
+    // translate() would otherwise have populated, so :for/:io metadata in
+    // the user's own file (translated below) is recognised as monadic.
+    loader.seed_monad_registries(monad_specs, monad_type_hints);
     let inputs = opt.inputs();
 
     // Inject the prelude-side units the blob supplied a baked core for, and
@@ -1056,8 +1073,9 @@ x: "hello" : "string"
         // `bin/eu.rs` uses, just with a hand-built prelude standing in for
         // the real one.
         let prelude_units = vec![("prelude".to_string(), synthetic_prelude)];
-        let result = run_type_checker_from_blob_core(&opt, &prelude_units)
-            .expect("run_type_checker_from_blob_core");
+        let result =
+            run_type_checker_from_blob_core(&opt, &prelude_units, &HashMap::new(), &HashMap::new())
+                .expect("run_type_checker_from_blob_core");
 
         assert!(
             !result.warnings.is_empty(),

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -697,15 +697,38 @@ impl SourceLoader {
     pub fn set_prelude_blob(&mut self, blob: crate::eval::stg::blob::PreludeBlob) {
         // Seed monad specs from the blob so that :for/:random blocks are
         // recognised during desugaring even when the prelude source is skipped.
+        self.seed_monad_registries(&blob.monad_specs, &blob.monad_type_hints);
+        self.prelude_blob = Some(blob);
+    }
+
+    /// Seed `unit_interface`'s monad registries directly, without taking
+    /// ownership of a `PreludeBlob` or activating blob-mode cook/hoist.
+    ///
+    /// `set_prelude_blob` (above) calls this as part of full blob
+    /// activation. It also stands alone for
+    /// [`crate::driver::check::run_type_checker_from_blob_core`] (eu-rqwh):
+    /// that function's `SourceLoader` injects the blob's baked prelude-side
+    /// units directly via `inject_prelude_units`, which skips `translate()`
+    /// for them — the very step that normally populates these registries
+    /// (see the "Build order" table on [`UnitInterface`]). Without this
+    /// seeding, `:for`/`:io` monadic-binding metadata in the user's own file
+    /// is never recognised during its `translate()` call, so the type
+    /// checker's monadic-bind pre-pass never sees the hint it looks for and
+    /// the mismatch warning silently fails to fire — reproducing exactly on
+    /// the blob path, never on the source-compiled-prelude path (where
+    /// `run_type_checker`'s `SourceLoader` translates the real prelude and
+    /// populates the registries the ordinary way).
+    pub fn seed_monad_registries(
+        &mut self,
+        monad_specs: &HashMap<String, crate::core::desugar::desugarer::MonadSpec>,
+        monad_type_hints: &HashMap<String, String>,
+    ) {
         self.unit_interface
             .monad_specs
-            .extend(blob.monad_specs.iter().map(|(k, v)| (k.clone(), v.clone())));
-        self.unit_interface.monad_type_hints.extend(
-            blob.monad_type_hints
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone())),
-        );
-        self.prelude_blob = Some(blob);
+            .extend(monad_specs.iter().map(|(k, v)| (k.clone(), v.clone())));
+        self.unit_interface
+            .monad_type_hints
+            .extend(monad_type_hints.iter().map(|(k, v)| (k.clone(), v.clone())));
     }
 
     /// Check whether a prelude blob is stored (i.e. the blob path is active).


### PR DESCRIPTION
## Summary

Fixes eu-rqwh (P1): with `lib/prelude.blob` present, plain `eu <file>` (no
subcommand) silently dropped the type-checker warning for `:for`/`:io`
monadic-binding metadata (e.g. `{ :for x: 42 }.(x)`) — execution proceeded
on the mistyped value and crashed with an unrelated runtime error instead.
`eu check --strict` on the same file correctly warned; only the plain-eval
path, only with a blob active, was affected.

## Root cause

`run_type_checker_from_blob_core` (`src/driver/check.rs`) — the eval-path
type check invoked from `bin/eu.rs` whenever a prelude blob is active —
builds a **fresh** `SourceLoader` and injects the blob's already-desugared
prelude-side units directly via `inject_prelude_units`, which
short-circuits `translate()` for those four units (`__build`, `__io`,
`__args`, the prelude itself).

`translate()` is also the step that normally populates
`SourceLoader::unit_interface`'s `monad_specs` / `monad_type_hints`
registries (from the prelude's own desugar pass — see the "Build order"
table on `UnitInterface`). Skipping it left those registries **empty** on
this fresh loader. When the *user's own file* was then translated (this
loader's only real `translate()` call), `seed_desugarer_monad_registries`
seeded nothing, so `:for`/`:io` metadata blocks in user code were never
recognised as monadic-bind syntax during desugar. The resulting core
therefore never carried the `__type_hint` marker the type checker's
monadic-bind pre-pass looks for — so no mismatch warning was ever produced,
on this path only.

`eu check --strict` was unaffected because it always calls
`run_type_checker`, whose `SourceLoader` translates the real prelude source
from scratch and populates the registries the ordinary way, regardless of
whether a blob is present system-wide.

## Fix

- Extracted the monad-registry-seeding logic already present in
  `SourceLoader::set_prelude_blob` into a new, reusable
  `SourceLoader::seed_monad_registries(monad_specs, monad_type_hints)`.
- `run_type_checker_from_blob_core` now takes the blob's `monad_specs` /
  `monad_type_hints` as extra parameters and calls
  `seed_monad_registries` before translating the user's file.
- `bin/eu.rs`'s call site threads the blob's registries through alongside
  the already-decoded `prelude_units`.

Files: `src/driver/source.rs`, `src/driver/check.rs`, `src/bin/eu.rs`.

## Verification

- `cargo xtask prelude-compile` (blob present) + `cargo test --release
  --test harness_test -- test_typecheck_010/011/013/063/085`: all 5 now
  **pass** (previously failing per the bead).
- Removed `lib/prelude.blob` (source-compiled prelude): same 5 tests still
  pass — no regression on that path.
- **Fault injection**: commented out the `seed_monad_registries` call,
  rebuilt with the blob present — confirmed all 5 tests fail with the
  exact "eval path ... does not surface the warning ... checker/eval
  divergence (eu-ntwg.1)" message. Restored the fix, rebuilt, confirmed all
  5 pass again.
- Full `cargo test --release --no-fail-fast`, both with and without the
  blob: **no new failures**. Three pre-existing, blob-only failures
  (`test_193_1tkk_7_12_curated_trace`,
  `secondary_labels_do_not_excerpt_library_internals`,
  `debug_trace_restores_the_uncurated_trace`) were confirmed present on
  unmodified `master` + blob too (via `git stash` A/B) — a separate,
  unrelated blame/trace-curation gap, out of scope for this PR.
- `cargo fmt --all` clean; `cargo clippy --all-targets -- -D warnings`
  clean.

## Follow-up

`eu-1tkk.7.19` (a CI job running `cargo xtask prelude-compile` followed by
the full `cargo test`) is the tracked coverage-gap follow-up that would
have caught this divergence (and the three pre-existing blame/trace
failures above) automatically going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz