### PR TITLE
fix(loading): git imports broken end-to-end (eu-9vkqn)

### DIFF
--- a/docs/guide/imports-and-modules.md
+++ b/docs/guide/imports-and-modules.md
@@ -195,6 +195,21 @@ result: lib-function(42)
 The `commit` field is mandatory and should be a full SHA. This ensures
 the import is repeatable and cacheable.
 
+A relative import declared *inside* the fetched file (e.g. `{ import:
+"other.eu" }`) is itself fetched from the same repository and commit,
+so a multi-file library works exactly as it would via a simple import.
+
+Like a simple import, a git import can be namespaced by prefixing the
+repository-relative path with `name=`:
+
+```eu,notest
+{ import: { git: "https://github.com/user/eu-lib"
+            commit: "abc123def456"
+            import: "lib=lib/helpers.eu" } }
+
+result: lib.lib-function(42)
+```
+
 Multiple git imports can be listed alongside simple imports:
 
 ```eu,notest

--- a/docs/reference/agent-reference.md
+++ b/docs/reference/agent-reference.md
@@ -507,10 +507,17 @@ host: cfg.host
 ` { import: "math.eu" }
 calculations: { result: advanced-calc(10) }
 
-# Git import
+# Git import (transitive relative imports inside the fetched file
+# are also resolved from the same repo/commit, not the local filesystem)
 { import: { git: "https://github.com/user/lib"
             commit: "abc123def456"
             import: "helpers.eu" } }
+
+# Namespaced git import — prefix the repo-relative path with "name="
+{ import: { git: "https://github.com/user/lib"
+            commit: "abc123def456"
+            import: "x=helpers.eu" } }
+x.some-function()
 
 # Streaming imports (lazy, for large files)
 { import: "events=jsonl-stream@events.jsonl" }

--- a/docs/reference/import-formats.md
+++ b/docs/reference/import-formats.md
@@ -113,6 +113,28 @@ Just as with simple imports, several git imports may be listed:
 
 ...and simple imports and git imports may be freely mixed.
 
+If the imported file itself declares further relative imports (e.g.
+`{ import: "helpers.eu" }`), those are fetched from the same repository
+at the same commit — not resolved against the local filesystem — so a
+multi-file library works exactly as it would via a simple import.
+
+#### Namespacing a git import
+
+A git import can be namespaced under a name, exactly like a simple
+import, by prefixing the repository-relative path in `import` with
+`name=`:
+
+```eu,notest
+{ import: { git: "https://github.com/gmorpheme/eu.aws"
+            commit: "0140232cf882a922bdd67b520ed56f0cddbd0637"
+            import: "aws=aws/cloudformation.eu" } }
+
+stack: aws.template(...)
+```
+
+Without the `name=` prefix the imported file's declarations are
+spliced directly into scope, the same as an unnamed simple import.
+
 ## YAML import features
 
 When importing YAML files, eucalypt supports several YAML features that

--- a/docs/reference/import-formats.md
+++ b/docs/reference/import-formats.md
@@ -105,6 +105,13 @@ import is repeatable and cacheable.
 
 `import` identifies the file within the repository to import.
 
+Fetched files are cached under `<home>/.eu/cache/git/`, keyed by
+repository URL and commit, so repeat imports of the same file at the
+same commit are served from the cache without any git or network
+operations. `<home>` is the user's home directory, unless the
+`EU_CACHE_HOME` environment variable is set, in which case it is used
+instead — useful for isolating the cache (e.g. in tests).
+
 Just as with simple imports, several git imports may be listed:
 
 ```eu

--- a/src/core/expr.rs
+++ b/src/core/expr.rs
@@ -1299,8 +1299,42 @@ impl Extract<Fixity> for RcExpr {
 
 impl Extract<Input> for RcExpr {
     fn extract(&self) -> Option<Input> {
+        // Plain import specifiers are simple string/symbol literals, e.g.
+        // `"helpers.eu"` or `"cfg=config.yaml"`.
         let repr: Option<String> = self.extract();
-        repr.and_then(|s| Input::from_str(s.as_ref()).ok())
+        if let Some(s) = repr {
+            return Input::from_str(s.as_ref()).ok();
+        }
+
+        // A git import is written as a block literal:
+        //   { git: "url", commit: "sha", import: "path" }
+        // Block literals with simple (non-recursive) bindings desugar to a
+        // `Let` wrapping the field bindings around an `Expr::Block` of bound
+        // variable references, rather than a `Block` of literals directly —
+        // `instantiate_lets` inlines that `Let` back into a plain `Block` of
+        // literals so the field lookups below see literal values.
+        let inlined = self.clone().instantiate_lets();
+        if let Expr::Block(_, entries) = &*inlined.inner {
+            let url: Option<String> = entries.get("git").and_then(|e| e.extract());
+            let commit: Option<String> = entries.get("commit").and_then(|e| e.extract());
+            let path: Option<String> = entries.get("import").and_then(|e| e.extract());
+            if let (Some(url), Some(commit), Some(path)) = (url, commit, path) {
+                // A git import can be namespaced the same way a plain
+                // filesystem import can, by prefixing the repository-relative
+                // path with `name=` (see `parse_git_import_block` in
+                // `syntax::import`, which this mirrors so both extraction
+                // sites agree on the resulting `Locator::Git`/name split).
+                let (name, path) = crate::syntax::input::split_name_prefix(&path);
+                let path = path.to_string();
+                let input = Input::from(Locator::Git { url, commit, path });
+                return Some(match name {
+                    Some(n) => input.with_name(&n),
+                    None => input,
+                });
+            }
+        }
+
+        None
     }
 }
 

--- a/src/driver/source.rs
+++ b/src/driver/source.rs
@@ -26,6 +26,34 @@ pub enum ParsedAst {
     Soup(Soup),
 }
 
+/// Records the git repository/commit a cached file was fetched from, keyed
+/// by the file's absolute cache path.
+///
+/// A file fetched via a git import (`{ git: ..., commit: ..., import: ... }`)
+/// may itself declare ordinary relative imports (`{ import: "helpers.eu" }`).
+/// Those transitive imports live in the *same* repository at the *same*
+/// commit, so they must be fetched the same way rather than resolved as
+/// plain filesystem paths (which would only succeed by the accident of a
+/// same-named file already existing somewhere on the local lib path — the
+/// cache only ever contains the individual files explicitly requested, not
+/// a full working copy of the repository).
+///
+/// `load_tree` looks up the currently-loading file's cache path in
+/// `SourceLoader::git_context` and, if found, sets it as
+/// `SourceLoader::current_git_context` for the duration of loading that
+/// file's transitive imports; `SourceLoader::load` consults
+/// `current_git_context` to redirect plain relative `Locator::Fs` imports to
+/// the git cache instead of the local filesystem.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+struct GitContext {
+    url: String,
+    commit: String,
+    /// Directory (relative to the repository root) containing the file
+    /// this context was recorded for.
+    repo_dir: PathBuf,
+}
+
 impl Desugarable for ParsedAst {
     fn desugar(
         &self,
@@ -121,6 +149,16 @@ pub struct SourceLoader {
     /// resolution (the `eu` binary, the tester) retrieve these via
     /// `type_aliases()` after `prepare()` completes.
     early_type_aliases: HashMap<String, crate::core::typecheck::types::Type>,
+    /// Git repository/commit context for cached files, keyed by their
+    /// absolute cache path — see [`GitContext`].
+    #[cfg(not(target_arch = "wasm32"))]
+    git_context: HashMap<PathBuf, GitContext>,
+    /// The git context active while loading the transitive imports of the
+    /// file currently being processed by `load_tree`, if any. Saved and
+    /// restored around that file's import loop, exactly like `lib_path`'s
+    /// push/pop of the importing file's directory — see [`GitContext`].
+    #[cfg(not(target_arch = "wasm32"))]
+    current_git_context: Option<GitContext>,
 }
 
 impl Default for SourceLoader {
@@ -145,6 +183,10 @@ impl Default for SourceLoader {
             #[cfg(not(target_arch = "wasm32"))]
             prelude_blob: None,
             early_type_aliases: HashMap::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            git_context: HashMap::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            current_git_context: None,
         }
     }
 }
@@ -172,6 +214,10 @@ impl SourceLoader {
             prelude_blob: None,
             pending_parse_errors: Vec::new(),
             early_type_aliases: HashMap::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            git_context: HashMap::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            current_git_context: None,
         }
     }
 
@@ -213,17 +259,45 @@ impl SourceLoader {
 
     /// Load an input (and transitive imports)
     pub fn load(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        // Resolve git imports to a local cached path before any other dispatch.
+        // Resolve an explicit git import (`{ git: ..., commit: ..., import: ...
+        // }`) to a local cached path before any other dispatch.
         #[cfg(not(target_arch = "wasm32"))]
         if let Locator::Git { url, commit, path } = input.locator() {
-            let cached_path = crate::import::git::resolve_git_import(url, commit, path)
-                .map_err(|e| EucalyptError::Source(Box::new(e)))?;
-            let resolved = Input::new(
-                Locator::Fs(cached_path),
-                input.name().clone(),
-                input.format(),
-            );
-            return self.load(&resolved);
+            let (url, commit, path) = (url.clone(), commit.clone(), path.clone());
+            let name = input.name().clone();
+            let format = input.format().to_string();
+            let alias_locator = input.locator().clone();
+            return self.load_from_git(&url, &commit, &path, name, &format, alias_locator);
+        }
+
+        // A plain relative filesystem import encountered while loading the
+        // transitive imports of a git-fetched file (`current_git_context` is
+        // set by `load_tree` for the duration) must itself be fetched from
+        // the same repository/commit — the cache only ever contains the
+        // individual files explicitly requested, not a full working copy of
+        // the repository, so ordinary filesystem resolution would either
+        // fail outright or (worse) silently pick up an unrelated same-named
+        // file from the local lib path.
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Locator::Fs(path) = input.locator() {
+            if path.is_relative() {
+                if let Some(ctx) = self.current_git_context.clone() {
+                    let repo_path = ctx.repo_dir.join(path);
+                    // Git paths always use forward slashes regardless of host OS.
+                    let repo_path = repo_path.to_string_lossy().replace('\\', "/");
+                    let name = input.name().clone();
+                    let format = input.format().to_string();
+                    let alias_locator = input.locator().clone();
+                    return self.load_from_git(
+                        &ctx.url,
+                        &ctx.commit,
+                        &repo_path,
+                        name,
+                        &format,
+                        alias_locator,
+                    );
+                }
+            }
         }
 
         let fmt = input.format();
@@ -235,6 +309,67 @@ impl SourceLoader {
         } else {
             self.load_simple(input)
         }
+    }
+
+    /// Fetch `path` from `url`@`commit` via the git cache, record its
+    /// [`GitContext`] for transitive imports, load its content, and alias
+    /// `alias_locator` — the caller's original locator, either an explicit
+    /// `Locator::Git` or a plain relative `Locator::Fs` encountered inside a
+    /// git-fetched file — to the resulting file id.
+    ///
+    /// The alias matters twice over:
+    ///
+    /// - Desugar-phase import metadata (see `Extract<Input>` for `RcExpr` in
+    ///   `core::expr`) is derived independently from the source text and
+    ///   knows nothing of git-context redirection: a git-fetched file's own
+    ///   `{ import: "helpers.eu" }` re-extracts as a plain
+    ///   `Locator::Fs("helpers.eu")`, so [`Self::translate`]'s content
+    ///   lookup must be able to find the already-loaded content under that
+    ///   original locator too, not only under the resolved cache path.
+    /// - For `.eu` content, the *import graph node* itself is registered
+    ///   under `alias_locator` (via [`Self::load_tree_as`]) rather than the
+    ///   resolved cache path, so that a transitive import discovered inside
+    ///   this file becomes an edge from the *same* node the importer's own
+    ///   analysis already points at — keeping the whole git-fetched tree in
+    ///   one connected component reachable by `ImportGraph::unit_inputs`'s
+    ///   BFS from the top-level input.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn load_from_git(
+        &mut self,
+        url: &str,
+        commit: &str,
+        path: &str,
+        name: Option<String>,
+        format: &str,
+        alias_locator: Locator,
+    ) -> Result<usize, EucalyptError> {
+        let cached_path = crate::import::git::resolve_git_import(url, commit, path)
+            .map_err(|e| EucalyptError::Source(Box::new(e)))?;
+
+        let repo_dir = Path::new(path)
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default();
+        self.git_context.insert(
+            cached_path.clone(),
+            GitContext {
+                url: url.to_string(),
+                commit: commit.to_string(),
+                repo_dir,
+            },
+        );
+
+        let file_id = if format == "eu" {
+            let alias_input = Input::new(alias_locator.clone(), name, format);
+            self.load_tree_as(&Locator::Fs(cached_path), &alias_input)?
+        } else {
+            let resolved = Input::new(Locator::Fs(cached_path), name, format);
+            self.load(&resolved)?
+        };
+
+        self.locators.entry(alias_locator).or_insert(file_id);
+
+        Ok(file_id)
     }
 
     /// Loads from a data format that does not support imports
@@ -304,13 +439,52 @@ impl SourceLoader {
     /// Load and parse import-graph of eucalypt files starting with the one
     /// specified by locator
     fn load_tree(&mut self, input: &Input) -> Result<usize, EucalyptError> {
-        let locator = input.locator();
-        let file_id = self.load_eucalypt(locator)?;
+        self.load_tree_as(input.locator(), input)
+    }
+
+    /// Load and parse the import-graph of an `.eu` file whose content lives
+    /// at `content_locator`, but whose *import graph identity* — the
+    /// `Input` used both to register this file's own node in the
+    /// `ImportGraph` and as the key other files' import metadata will look
+    /// it up by — is `graph_input`.
+    ///
+    /// For an ordinary file these coincide (`load_tree` calls this with
+    /// `input.locator()` and `input` both derived from the same value). They
+    /// diverge for a git-fetched file: its content lives at a path in the
+    /// local git cache, but it must be registered in the graph under its
+    /// *original* locator (the explicit `Locator::Git`, or the plain
+    /// relative `Locator::Fs` it was declared under inside its importer) so
+    /// that other files' independently-derived import metadata — which
+    /// knows nothing about cache paths — can still find it. See
+    /// [`Self::load_from_git`].
+    fn load_tree_as(
+        &mut self,
+        content_locator: &Locator,
+        graph_input: &Input,
+    ) -> Result<usize, EucalyptError> {
+        let file_id = self.load_eucalypt(content_locator)?;
 
         // Implement import analysis for Rowan AST
         let ast = self.asts.get(&file_id).expect("AST was just loaded");
-        let inputs = self.imports.analyse_rowan_ast(input.clone(), ast)?;
+        let inputs = self.imports.analyse_rowan_ast(graph_input.clone(), ast)?;
         self.imports.check_for_cycles()?;
+
+        // If this file was itself fetched from a git repository, set up its
+        // `GitContext` for the duration of loading its transitive imports —
+        // `load()` consults `current_git_context` to redirect plain
+        // relative `Locator::Fs` imports to the git cache instead of the
+        // local filesystem. Saved and restored exactly like the `lib_path`
+        // push/pop below. (`driver::source` is excluded entirely from
+        // wasm32 builds — see `driver::mod` — so no wasm32 fallback is
+        // needed here.)
+        let git_ctx = match content_locator {
+            Locator::Fs(path) => self.git_context.get(path).cloned(),
+            _ => None,
+        };
+        let saved_git_context = self.current_git_context.clone();
+        if git_ctx.is_some() {
+            self.current_git_context = git_ctx;
+        }
 
         // Resolve imports relative to the importing file's directory.
         //
@@ -319,7 +493,7 @@ impl SourceLoader {
         // to the global lib_path. We achieve this by temporarily extending
         // the lib_path with the importing file's directory whilst loading
         // its transitive imports.
-        let import_dir = self.find_source_dir(locator);
+        let import_dir = self.find_source_dir(content_locator);
         if let Some(dir) = import_dir {
             self.lib_path.push(dir);
             for import_input in inputs {
@@ -331,6 +505,8 @@ impl SourceLoader {
                 self.load(&import_input)?;
             }
         }
+
+        self.current_git_context = saved_git_context;
 
         Ok(file_id)
     }

--- a/src/import/git.rs
+++ b/src/import/git.rs
@@ -28,8 +28,26 @@ fn url_hash(url: &str) -> String {
     format!("{hash:016x}")
 }
 
-/// Return the base cache directory: `~/.eu/cache/git/`.
+/// Return the base cache directory: `<home>/.eu/cache/git/`.
+///
+/// `<home>` is `dirs::home_dir()` by default. If the `EU_CACHE_HOME`
+/// environment variable is set, it is used instead — this exists so tests
+/// (and anyone else who needs an isolated cache) can redirect the cache
+/// location portably.
+///
+/// A plain `HOME` override is not portable for this purpose: on Windows,
+/// `dirs::home_dir()` resolves via the OS profile API rather than the
+/// `HOME` environment variable, so setting `HOME` alone has no effect
+/// there and the cache would silently fall back to the real user profile
+/// directory.
 fn git_cache_base() -> Result<PathBuf, SourceError> {
+    if let Some(override_home) = std::env::var_os("EU_CACHE_HOME") {
+        return Ok(PathBuf::from(override_home)
+            .join(".eu")
+            .join("cache")
+            .join("git"));
+    }
+
     let home = dirs::home_dir().ok_or_else(|| {
         SourceError::InvalidSource(
             "cannot determine home directory for git cache".to_string(),

--- a/src/syntax/import.rs
+++ b/src/syntax/import.rs
@@ -227,6 +227,32 @@ fn read_rowan_soup_imports(
                         }
                     }
 
+                    // Check declaration body for imports (recursive) — but
+                    // skip `import:` declarations themselves. Those are
+                    // already fully handled by the dedicated scrape above
+                    // (`scrape_rowan_imports`), which understands plain
+                    // paths, lists of paths, and git-import descriptor
+                    // blocks. Recursing into an `import:` declaration's own
+                    // body here would misinterpret a git-import block's
+                    // `git`/`commit`/`import` fields as further, unrelated
+                    // import declarations — the in-repository file path
+                    // field is coincidentally also named `import`, and
+                    // would otherwise be scraped a second time as a bogus
+                    // plain filesystem import.
+                    let is_import_decl = decl
+                        .head()
+                        .map(|head| {
+                            matches!(
+                                head.classify_declaration(),
+                                crate::syntax::rowan::ast::DeclarationKind::Property(prop)
+                                    if prop.text() == "import"
+                            )
+                        })
+                        .unwrap_or(false);
+                    if is_import_decl {
+                        continue;
+                    }
+
                     // Check declaration body for imports (recursive)
                     if let Some(body) = decl.body() {
                         if let Some(body_soup) = body.soup() {
@@ -354,7 +380,19 @@ fn parse_git_import_block(
     let commit = commit.ok_or(ImportError::GitImportMissingCommit)?;
     let path = path.ok_or_else(|| ImportError::GitImportMissingField("import path".to_string()))?;
 
-    Ok(Some(Input::from(Locator::Git { url, commit, path })))
+    // A git import can be namespaced the same way a plain filesystem import
+    // can, by prefixing the repository-relative path with `name=`:
+    //   { git: "...", commit: "...", import: "x=lib/xml.eu" }
+    // binds the imported file's declarations under `x.` rather than
+    // splicing them directly into scope.
+    let (name, path) = crate::syntax::input::split_name_prefix(&path);
+    let path = path.to_string();
+
+    let input = Input::from(Locator::Git { url, commit, path });
+    Ok(Some(match name {
+        Some(n) => input.with_name(&n),
+        None => input,
+    }))
 }
 
 /// Extract the text value of the first string literal found in a soup.

--- a/src/syntax/input.rs
+++ b/src/syntax/input.rs
@@ -253,6 +253,21 @@ impl From<Locator> for Input {
     }
 }
 
+/// Split a `name=rest` import specifier into its optional name prefix and
+/// the remainder, on the first `=`. Used both for ordinary string import
+/// specifiers (via [`Input::from_str`]) and for the repository-relative
+/// path field of a git-import descriptor block (`{ git: ..., commit: ...,
+/// import: "name=path" }`), so that a git import can be namespaced the same
+/// way a plain filesystem import can.
+pub fn split_name_prefix(s: &str) -> (Option<String>, &str) {
+    if let Some(i) = s.find('=') {
+        let (n, rem) = s.split_at(i);
+        (Some(String::from(n.trim())), rem[1..].trim())
+    } else {
+        (None, s.trim())
+    }
+}
+
 impl FromStr for Input {
     type Err = SyntaxError;
 
@@ -457,6 +472,23 @@ pub mod tests {
                 name: None,
                 format: String::from("eu")
             })
+        );
+    }
+
+    /// eu-9vkqn: the `name=` splitter shared by `Input::from_str` and the
+    /// git-import descriptor path field (both `parse_git_import_block` in
+    /// `syntax::import` and `Extract<Input>` in `core::expr`), so that a
+    /// git import can be namespaced the same way a plain import can.
+    #[test]
+    pub fn test_split_name_prefix() {
+        assert_eq!(
+            split_name_prefix("x=lib/xml.eu"),
+            (Some(String::from("x")), "lib/xml.eu")
+        );
+        assert_eq!(split_name_prefix("lib/xml.eu"), (None, "lib/xml.eu"));
+        assert_eq!(
+            split_name_prefix(" x = lib/xml.eu "),
+            (Some(String::from("x")), "lib/xml.eu")
         );
     }
 }

--- a/tests/git_import_test.rs
+++ b/tests/git_import_test.rs
@@ -13,16 +13,21 @@
 //!     (desugar-phase import metadata understanding a git-import
 //!     descriptor block — `Extract<Input>` in `src/core/expr.rs`).
 //!
-//! Each test runs the compiled `eu` binary as a subprocess with `HOME`
-//! overridden to an isolated temporary directory, so the git cache
-//! (`~/.eu/cache/git/...`) never touches the real `~/.eu/cache` and each
-//! test gets a fresh cache. The repro `.eu` file lives in a directory
-//! entirely separate from the git repository checkout, so a passing
-//! result can only come from the git-cache path — not from an ordinary
-//! relative filesystem import coincidentally finding the checked-out
-//! working tree file of the same name (see eu-9vkqn's investigation notes:
-//! this exact coincidence masked the underlying bug during manual
-//! reproduction).
+//! Each test runs the compiled `eu` binary as a subprocess with
+//! `EU_CACHE_HOME` (see `git_cache_base` in `src/import/git.rs`) overridden
+//! to an isolated temporary directory, so the git cache
+//! (`<home>/.eu/cache/git/...`) never touches the real cache location and
+//! each test gets a fresh cache. `HOME` is set too, but `EU_CACHE_HOME` is
+//! what actually isolates the cache portably: `dirs::home_dir()` (the
+//! fallback without the override) resolves via the OS profile API on
+//! Windows, not the `HOME` environment variable, so `HOME` alone would
+//! silently leave the cache pointed at the real user profile there. The
+//! repro `.eu` file lives in a directory entirely separate from the git
+//! repository checkout, so a passing result can only come from the
+//! git-cache path — not from an ordinary relative filesystem import
+//! coincidentally finding the checked-out working tree file of the same
+//! name (see eu-9vkqn's investigation notes: this exact coincidence masked
+//! the underlying bug during manual reproduction).
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -92,18 +97,28 @@ fn make_git_fixture() -> (tempfile::TempDir, String) {
     (repo_dir, commit)
 }
 
-/// Run `eu <path>` with `HOME` overridden to `home_dir` (isolating the git
-/// cache) and no other lib-path additions, returning the completed
-/// `Output`. The subject file's own directory is still searched (that's
-/// ordinary, unrelated-to-git relative import resolution), but nothing
-/// else is on the lib path, so a relative import can only succeed via the
-/// git cache or a file that is genuinely alongside the subject file.
+/// Run `eu <path>` with the git cache location overridden to `home_dir`
+/// (via `EU_CACHE_HOME` — see `git_cache_base` in `src/import/git.rs`) and
+/// no other lib-path additions, returning the completed `Output`.
+///
+/// `HOME` is set too, for good measure on platforms/tools that consult it
+/// directly, but `EU_CACHE_HOME` is what actually isolates the cache:
+/// `dirs::home_dir()` (what `git_cache_base` falls back to without the
+/// override) resolves via the OS profile API on Windows, not the `HOME`
+/// environment variable, so `HOME` alone would not isolate the cache
+/// there.
+///
+/// The subject file's own directory is still searched (that's ordinary,
+/// unrelated-to-git relative import resolution), but nothing else is on
+/// the lib path, so a relative import can only succeed via the git cache
+/// or a file that is genuinely alongside the subject file.
 fn run_eu_with_isolated_home(subject: &Path, home_dir: &Path) -> std::process::Output {
     Command::new(eu_binary())
         .arg("--heap-limit-mib")
         .arg("512")
         .arg(subject)
         .env("HOME", home_dir)
+        .env("EU_CACHE_HOME", home_dir)
         .output()
         .expect("failed to run eu binary")
 }

--- a/tests/git_import_test.rs
+++ b/tests/git_import_test.rs
@@ -1,0 +1,236 @@
+//! Hermetic end-to-end tests for git imports (`{ import: { git: ...,
+//! commit: ..., import: ... } }`) — eu-9vkqn.
+//!
+//! These tests exercise the full pipeline against a **local** git
+//! repository (via a `file://` URL) so they never touch the network:
+//!
+//! (a) the fetch/cache path (`src/import/git.rs`'s `resolve_git_import`),
+//! (b) the transitive-import walk resolving a relative import declared
+//!     *inside* the git-fetched file from the same repository/commit
+//!     rather than the local filesystem (`SourceLoader::load`/`load_tree`
+//!     in `src/driver/source.rs`), and
+//! (c) name binding from the git-imported unit actually resolving
+//!     (desugar-phase import metadata understanding a git-import
+//!     descriptor block — `Extract<Input>` in `src/core/expr.rs`).
+//!
+//! Each test runs the compiled `eu` binary as a subprocess with `HOME`
+//! overridden to an isolated temporary directory, so the git cache
+//! (`~/.eu/cache/git/...`) never touches the real `~/.eu/cache` and each
+//! test gets a fresh cache. The repro `.eu` file lives in a directory
+//! entirely separate from the git repository checkout, so a passing
+//! result can only come from the git-cache path — not from an ordinary
+//! relative filesystem import coincidentally finding the checked-out
+//! working tree file of the same name (see eu-9vkqn's investigation notes:
+//! this exact coincidence masked the underlying bug during manual
+//! reproduction).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Path to the `eu` binary built by cargo for this test run.
+fn eu_binary() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_eu"))
+}
+
+/// Run `git <args>` in `cwd`, with a fixed author/committer identity so the
+/// test doesn't depend on the host's git config, panicking on failure.
+fn run_git(args: &[&str], cwd: &Path) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "eu-test")
+        .env("GIT_AUTHOR_EMAIL", "eu-test@example.invalid")
+        .env("GIT_COMMITTER_NAME", "eu-test")
+        .env("GIT_COMMITTER_EMAIL", "eu-test@example.invalid")
+        .output()
+        .expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed:\nstdout: {}\nstderr: {}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Build a small two-file eucalypt "library" git repository fixture in a
+/// fresh temp dir, with `lib/xml.eu` importing `lib/helpers.eu` (a
+/// transitive, relative import — see (b) above) and both files' bindings
+/// exercised by the harness. Returns `(repo_dir, commit_sha)`.
+fn make_git_fixture() -> (tempfile::TempDir, String) {
+    let repo_dir = tempfile::tempdir().expect("create repo tempdir");
+
+    std::fs::create_dir_all(repo_dir.path().join("lib")).expect("create lib dir");
+    std::fs::write(
+        repo_dir.path().join("lib/helpers.eu"),
+        "escape(s): \"{}!\"(s)\n",
+    )
+    .expect("write helpers.eu");
+    std::fs::write(
+        repo_dir.path().join("lib/xml.eu"),
+        concat!(
+            "{ import: \"helpers.eu\" }\n",
+            "leaf(t, a, c): { tag: t  attrs: a  content: c }\n",
+            "to-xml(l): \"<{}>{}</{}>\"(l.tag, escape(l.content), l.tag)\n",
+        ),
+    )
+    .expect("write xml.eu");
+
+    run_git(&["init", "-q"], repo_dir.path());
+    run_git(&["add", "lib/helpers.eu", "lib/xml.eu"], repo_dir.path());
+    run_git(&["commit", "-q", "-m", "add xml lib"], repo_dir.path());
+
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_dir.path())
+        .output()
+        .expect("failed to run git rev-parse");
+    assert!(output.status.success(), "git rev-parse HEAD failed");
+    let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(commit.len(), 40, "expected a full git SHA, got {commit:?}");
+
+    (repo_dir, commit)
+}
+
+/// Run `eu <path>` with `HOME` overridden to `home_dir` (isolating the git
+/// cache) and no other lib-path additions, returning the completed
+/// `Output`. The subject file's own directory is still searched (that's
+/// ordinary, unrelated-to-git relative import resolution), but nothing
+/// else is on the lib path, so a relative import can only succeed via the
+/// git cache or a file that is genuinely alongside the subject file.
+fn run_eu_with_isolated_home(subject: &Path, home_dir: &Path) -> std::process::Output {
+    Command::new(eu_binary())
+        .arg("--heap-limit-mib")
+        .arg("512")
+        .arg(subject)
+        .env("HOME", home_dir)
+        .output()
+        .expect("failed to run eu binary")
+}
+
+fn assert_success(output: &std::process::Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context}: eu exited with status {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+/// Unnamed git import: fetch, transitive import, and name binding all in
+/// one hermetic pass — the core regression test for eu-9vkqn layers 1 and 2.
+#[test]
+fn git_import_fetches_transitively_and_binds_names() {
+    let (repo, commit) = make_git_fixture();
+    let home = tempfile::tempdir().expect("create home tempdir");
+
+    // The subject file lives in its own directory, entirely separate from
+    // the git checkout, so there is no `lib/` directory alongside it that
+    // an ordinary (non-git) relative import could coincidentally resolve
+    // against.
+    let subject_dir = tempfile::tempdir().expect("create subject tempdir");
+    let subject = subject_dir.path().join("repro.eu");
+    std::fs::write(
+        &subject,
+        format!(
+            concat!(
+                "{{ import: {{ git: \"file://{}\"\n",
+                "            commit: \"{}\"\n",
+                "            import: \"lib/xml.eu\" }} }}\n",
+                "result: leaf(\"a\", {{}}, \"b\") to-xml\n",
+            ),
+            repo.path().display(),
+            commit,
+        ),
+    )
+    .expect("write repro.eu");
+
+    let output = run_eu_with_isolated_home(&subject, home.path());
+    assert_success(&output, "first (cold-cache) run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // `to-xml` calls the transitively-imported `escape`, which appends
+    // "!" — so a correct result depends on (a) the fetch, (b) the
+    // transitive import resolving from the git cache, and (c) both
+    // `leaf` and `to-xml` binding from the git-imported unit.
+    assert!(
+        stdout.contains("<a>b!</a>"),
+        "expected rendered XML with escaped content, got: {stdout}"
+    );
+
+    // (a) the fetch/cache path: both files should now be cached under the
+    // isolated HOME, keyed by commit.
+    let cached_xml = find_cached_file(home.path(), "xml.eu");
+    let cached_helpers = find_cached_file(home.path(), "helpers.eu");
+    assert!(
+        cached_xml.is_some(),
+        "expected lib/xml.eu to be cached under the isolated HOME"
+    );
+    assert!(
+        cached_helpers.is_some(),
+        "expected lib/helpers.eu to be cached under the isolated HOME (transitive import)"
+    );
+
+    // Re-run against the now-warm cache: should still succeed, purely from
+    // cache (no further git operations required — see `git.rs`'s "Fast
+    // path: already cached" behaviour).
+    let output2 = run_eu_with_isolated_home(&subject, home.path());
+    assert_success(&output2, "second (warm-cache) run");
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("<a>b!</a>"),
+        "expected the same result on a warm-cache run, got: {stdout2}"
+    );
+}
+
+/// Named git import (`import: "x=lib/xml.eu"`): the imported unit's
+/// bindings should be namespaced under `x.`, exactly like a named plain
+/// filesystem import — eu-9vkqn layer 3.
+#[test]
+fn named_git_import_namespaces_bindings() {
+    let (repo, commit) = make_git_fixture();
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let subject_dir = tempfile::tempdir().expect("create subject tempdir");
+    let subject = subject_dir.path().join("repro.eu");
+    std::fs::write(
+        &subject,
+        format!(
+            concat!(
+                "{{ import: {{ git: \"file://{}\"\n",
+                "            commit: \"{}\"\n",
+                "            import: \"x=lib/xml.eu\" }} }}\n",
+                "result: x.leaf(\"a\", {{}}, \"b\") x.to-xml\n",
+            ),
+            repo.path().display(),
+            commit,
+        ),
+    )
+    .expect("write repro.eu");
+
+    let output = run_eu_with_isolated_home(&subject, home.path());
+    assert_success(&output, "named git import run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("<a>b!</a>"),
+        "expected rendered XML via namespaced x.leaf/x.to-xml, got: {stdout}"
+    );
+}
+
+/// Search `home_dir/.eu/cache/git` recursively for a file named `name`.
+fn find_cached_file(home_dir: &Path, name: &str) -> Option<PathBuf> {
+    fn walk(dir: &Path, name: &str) -> Option<PathBuf> {
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = walk(&path, name) {
+                    return Some(found);
+                }
+            } else if path.file_name().and_then(|n| n.to_str()) == Some(name) {
+                return Some(path);
+            }
+        }
+        None
+    }
+    walk(&home_dir.join(".eu").join("cache").join("git"), name)
+}


### PR DESCRIPTION
## Summary

Fixes eu-9vkqn: git imports (`{ import: { git: ..., commit: ..., import: ... } }`) were broken end-to-end. Three independent root causes, all in the git-import path added by eu-9tah.3.

### 1. Loader lost the resolved cache path for transitive imports

`SourceLoader`'s git-import cache (`src/import/git.rs`) only ever fetches the *individual file* requested, via `git show <commit>:<path>` — it never clones a full working copy. When the fetched file itself declares an ordinary relative import (`{ import: "helpers.eu" }`), that import was resolved against the local filesystem lib path instead of the same repo/commit, so it either failed outright (`could not read 'helpers.eu'`) or — worse — could silently pick up an unrelated same-named file.

Fix: `SourceLoader` now threads a `GitContext` (url/commit/repo-relative dir) through `load`/`load_tree`. While loading the transitive imports of a git-fetched file, `current_git_context` is set; a plain relative `Locator::Fs` import encountered during that window is redirected to fetch from the same repository (`load_from_git`). The import-graph node for a git-fetched file is registered under its *original* locator (the explicit `Locator::Git`, or the relative `Locator::Fs` it was declared under in its importer) rather than the resolved cache path — via a new `load_tree_as` — so the whole git-fetched subtree stays one connected component reachable by BFS from the top-level input, and other files' independently-derived import metadata can still find it.

### 2. Name binding from the git-imported unit was missing entirely

Worse than the originally-reported "leaf resolves, to-xml doesn't" — a hermetic single-file repro (no transitive imports at all) showed **no** names binding.

Root cause: `Extract<Input>` for `RcExpr` (`src/core/expr.rs`) only recognised a plain string import specifier. A git-import descriptor block (`{ git: ..., commit: ..., import: ... }`) desugars to a `Let` wrapping the field bindings around an `Expr::Block` — not the plain string `Extract<Input>` expected — so it silently returned `None`, and the desugar-phase import splicing (`translate_import`) skipped the import entirely.

Fixed by recognising the block shape (after `instantiate_lets`, which inlines the `Let` back to a `Block` of literals) and reconstructing the matching `Locator::Git`.

A second, independent bug in the same area: `read_rowan_soup_imports` (`src/syntax/import.rs`) recursed into *every* declaration's body looking for nested imports — including the `import:` declaration itself. For a git block this re-scraped its own `git`/`commit`/`import` fields as if they were unrelated import declarations, adding a bogus plain `Locator::Fs("lib/xml.eu")` alongside the correct `Locator::Git` (the git descriptor's repo-relative-path field is coincidentally *also* named `import`). Fixed by skipping `import:` declarations in that recursive scan — they're already fully handled by the dedicated scrape just above it.

### 3. Named git imports didn't work (docs mismatch)

`import: "x=lib/xml.eu"` was documented but not implemented — the whole string was used as the literal repository path, so `git show` failed with `path 'x=lib/xml.eu' does not exist`.

Implemented properly (smaller than it sounds, and matches the documented behaviour): a new `syntax::input::split_name_prefix` helper — shared by `parse_git_import_block` and `Extract<Input>`, so both extraction sites agree on the same `Locator::Git`/name split — splits the `name=` prefix the same way plain imports already do, and namespaces the binding via the existing named-import machinery (`Input::with_name`).

## Hermetic regression test

`tests/git_import_test.rs` — a Rust integration test (cleaner than a harness `.eu` file for git/network setup, per the bead's guidance):

- Builds a small two-file eucalypt library in a **local** git repository (`git init`/`commit` in a temp dir), imported via a `file://` URL — no network access.
- Runs the compiled `eu` binary as a subprocess with `HOME` overridden to an isolated temp dir (via `Command::env`, not process-wide mutation — safe under parallel test execution), so the git cache never touches the real `~/.eu/cache`.
- The subject `.eu` file lives in a directory entirely separate from the git checkout, so a passing result can only come from the git-cache path, not from an ordinary relative import coincidentally finding the checked-out working tree file of the same name (this exact coincidence masked the bug during manual investigation).
- `git_import_fetches_transitively_and_binds_names`: covers (a) fetch/cache, (b) the transitive import (`lib/xml.eu` importing `lib/helpers.eu`) resolving from the cache, and (c) name binding (`leaf`/`to-xml`) from the git-imported unit — plus a second, warm-cache run.
- `named_git_import_namespaces_bindings`: covers namespaced git imports (bug 3).

**Fault-injection verified**: reverted each of the three fixes independently (`Extract<Input>`'s git-block recognition; the `GitContext`/transitive-fetch machinery in `source.rs`; the `read_rowan_soup_imports` recursive-scan skip; the naming support) and confirmed the corresponding test(s) FAIL with the exact originally-reported error text (`could not read 'helpers.eu'`, `unresolved variable 'to-xml'`/`'leaf'`, `could not read 'lib/xml.eu'`, `path "x=lib/xml.eu" does not exist`) — then restored each and confirmed the suite is green again.

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` — clean (git-import code is gated `#[cfg(not(target_arch = "wasm32"))]`; `driver::source` itself is excluded from wasm32 builds entirely)
- [x] `cargo build --target wasm32-unknown-unknown --lib` — builds
- [x] `cargo test` (full suite) — 1353+ lib tests, 506 harness tests, all other integration suites, and the new `git_import_test` (2 tests) all pass
- [x] Fault-injection verified for all three fixes (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz