### PR TITLE
fix(docs): tag illustrative eu fences as notest to un-break master CI

### DIFF
--- a/docs/superpowers/reports/2026-07-24-ef2-ingestion-profile.md
+++ b/docs/superpowers/reports/2026-07-24-ef2-ingestion-profile.md
@@ -71,7 +71,7 @@ with `-I`/`--allow-io`; `str.split-on(re, s)` is regex-based and native).
 so each `-t` invocation forces only up to that stage (laziness means later
 stages are never touched unless rendered):
 
-```eu
+```eu,notest
 dir: io.args head
 
 ` :target

--- a/docs/superpowers/reports/2026-07-24-n8c5e-blob-inline-perf.md
+++ b/docs/superpowers/reports/2026-07-24-n8c5e-blob-inline-perf.md
@@ -81,7 +81,7 @@ Built a small synthetic (`n: <N>` + four `:target`s: `bench-count`,
 {1000,2000,4000,8000,16000}, run under the same `EU_HEAPSYN=1 -S
 --heap-limit-mib 12288` harness, blob vs `EU_SOURCE_PRELUDE=1`:
 
-```eu
+```eu,notest
 n: <N>
 ` :target
 bench-count: range(0, n) count


### PR DESCRIPTION
## Summary

Master's HEAD (8efc367a at time of writing) is red: the "Test doc examples"
CI step (`scripts/test-doc-examples.py`) scans every markdown file under
`docs/`, including `docs/superpowers/reports/`, and actually executes each
` ```eu ` fenced block. Two already-merged perf reports (#1062, #1064) each
contain one illustrative/template snippet tagged plain ` ```eu ` instead of
the script's own supported ` ```eu,notest ` opt-out:

- `docs/superpowers/reports/2026-07-24-ef2-ingestion-profile.md:74` --
  `dir: io.args head` assumes a CLI arg the doctest harness never supplies,
  so it fails "head of empty list" when run standalone.
- `docs/superpowers/reports/2026-07-24-n8c5e-blob-inline-perf.md:84` --
  `n: <N>` is a template placeholder meant to be substituted with real N
  values in the report's own bench harness, not literal eu source.

Both are illustrative rather than runnable in isolation. This PR tags
them ` ```eu,notest ` so the doctest harness skips them, matching every
other non-runnable snippet in the docs tree. No behavioural change,
docs-only, mechanical opt-out.

I also grepped both files (and every other report merged in the last two
days: `2026-07-24-bv3-value-case-reeval.md`) for any other plain ` ```eu `
blocks that would execute-and-fail: each of the two offending files has
exactly one such block (now fixed), and the bv3 report has none.

## Verification

`python3 scripts/test-doc-examples.py --eu ./target/debug/eu`:
- Before: `Results: 245 passed, 2 failed, 358 skipped, 605 total`
- After: `Results: 245 passed, 0 failed, 360 skipped, 605 total`

## Test plan

- [x] Ran the full doc-examples suite locally against a debug build; 0 failed
- [x] `cargo fmt --all` -- no diff beyond the intended two lines
- [x] Diff is exactly the two fence-tag lines, no other content changed

**Process note:** this is an emergency hotfix to unblock a red master
(root cause: two docs PRs merged over already-red CI). Per the
coordinator's explicit authorisation, I (Wicket) am merging this myself
once CI is green -- a one-off exception to author-not-merger, justified
by red-master urgency and zero behavioural change.

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz