### PR TITLE
fix(blob): fire eager_args at self-recursive prelude call sites — linearises count/sum/filter/map/str.len (eu-e3c3i)

### DIFF
--- a/src/eval/stg/compiler.rs
+++ b/src/eval/stg/compiler.rs
@@ -1626,10 +1626,29 @@ impl<'rt> Compiler<'rt> {
 
     /// Compile a core expression into STG syntax
     pub fn compile(&self, expr: RcExpr) -> Result<Rc<StgSyn>, CompileError> {
+        self.compile_with_self_recurse(expr, None)
+    }
+
+    /// Compile a standalone expression while treating `self_recurse` as
+    /// the name of the enclosing recursive binding (eu-e3c3i).
+    ///
+    /// Self-recursive call sites referencing that name — `Var::Free` in a
+    /// peeled prelude binding compiled by `xtask prelude-compile` — are
+    /// then detected by `is_self_recursive` and get `eager_args` argument
+    /// resolution (`create_arg_array_eager`), preventing the O(N²)
+    /// per-iteration indirection-chain build-up on lazily-threaded
+    /// parameters. This supplies structurally what whole-unit compilation
+    /// derives from `demand.recursive`. Headless render type only (the
+    /// render paths never compile peeled bindings).
+    pub fn compile_with_self_recurse(
+        &self,
+        expr: RcExpr,
+        self_recurse: Option<&str>,
+    ) -> Result<Rc<StgSyn>, CompileError> {
         let mut binder = LetBinder::root();
         match self.render_type {
             RenderType::Headless => {
-                let body = self.compile_body(&mut binder, expr, None)?;
+                let body = self.compile_body(&mut binder, expr, self_recurse)?;
                 binder.set_body(body)?;
             }
             RenderType::RenderDoc => {
@@ -1715,7 +1734,20 @@ impl<'rt> Compiler<'rt> {
             }
             Expr::Meta(s, body, meta) => {
                 let m = self.compile_binding(binder, meta.clone(), *s, Demand::default(), None)?;
-                let b = self.compile_binding(binder, body.clone(), *s, Demand::default(), None)?;
+                // `self_recurse` must thread through to `body` (eu-e3c3i),
+                // mirroring the identical fix in `compile_binding`'s Meta
+                // arm: a documented binding is `Meta({doc, type}, Lam(...))`
+                // at compile time, so dropping the context here would lose
+                // self-recursive call-site detection (and hence
+                // `eager_args`) for every documented recursive binding —
+                // which is all of the prelude's recursive combinators.
+                let b = self.compile_binding(
+                    binder,
+                    body.clone(),
+                    *s,
+                    Demand::default(),
+                    self_recurse,
+                )?;
                 Ok(Box::new(Holder::new(dsl::with_meta(m, b))))
             }
             Expr::Operator(_, _, _, body) => self.compile_body(binder, body.clone(), self_recurse),

--- a/src/eval/stg/mod.rs
+++ b/src/eval/stg/mod.rs
@@ -348,3 +348,33 @@ pub fn compile(
     .with_user_demand_sigs(settings.user_demand_sigs.clone());
     compiler.compile(expr)
 }
+
+/// Like `compile`, but with a self-recursion context for the compiled
+/// expression (eu-e3c3i).
+///
+/// Used by `xtask prelude-compile` when compiling each peeled prelude
+/// binding independently: the binding's recursive self-reference is
+/// `Var::Free(<own name>)` after peeling, so demand analysis cannot mark
+/// it `recursive`. Passing the binding's own name here lets the compiler
+/// detect self-recursive call sites and set `eager_args` on them, which
+/// prevents the per-iteration `Atom{Ref::L}` indirection-chain build-up
+/// on lazily-threaded parameters (the O(N²) behind eu-e3c3i). See
+/// `Compiler::compile_with_self_recurse`.
+pub fn compile_named(
+    settings: &StgSettings,
+    expr: RcExpr,
+    runtime: &dyn Runtime,
+    self_recurse: Option<&str>,
+) -> Result<Rc<StgSyn>, CompileError> {
+    let compiler = compiler::Compiler::new(
+        settings.generate_annotations,
+        settings.render_type,
+        settings.suppress_updates,
+        settings.suppress_inlining,
+        settings.suppress_optimiser,
+        runtime.intrinsics(),
+        settings.prelude_globals.clone(),
+    )
+    .with_user_demand_sigs(settings.user_demand_sigs.clone());
+    compiler.compile_with_self_recurse(expr, self_recurse)
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -358,8 +358,27 @@ fn cmd_prelude_compile() -> Result<()> {
 
     let mut forms: Vec<LambdaForm> = Vec::with_capacity(binding_bodies.len());
     for (name, body) in &binding_bodies {
-        let stg = eucalypt::eval::stg::compile(&stg_settings, body.clone(), runtime.as_ref())
-            .with_context(|| format!("STG compile binding '{name}'"))?;
+        // Compile with the binding's own name as the self-recursion context
+        // (eu-e3c3i). After peeling, a binding's recursive self-reference is
+        // `Var::Free(<own name>)` — invisible to demand analysis, which can
+        // only mark `demand.recursive` on bindings inside a Let/LetRec scope.
+        // Passing the name here lets the STG compiler detect self-recursive
+        // call sites and set `eager_args` on them, so the VM resolves their
+        // `Ref::L` arguments via `create_arg_array_eager` instead of building
+        // a fresh `Atom{Ref::L}` indirection per iteration. Without this,
+        // every lazily-threaded parameter of a self-recursive prelude
+        // combinator (e.g. `foldl`'s `op`) accumulates an unmemoised
+        // indirection chain that is re-walked on every recursive step —
+        // the O(N²) behind eu-e3c3i (`count`/`sum`/`filter`/`str.len`).
+        // This supplies exactly the `demand.recursive`-derived context that
+        // source-mode whole-unit compilation gives these same bindings.
+        let stg = eucalypt::eval::stg::compile_named(
+            &stg_settings,
+            body.clone(),
+            runtime.as_ref(),
+            Some(name.as_str()),
+        )
+        .with_context(|| format!("STG compile binding '{name}'"))?;
         // Wrap the compiled STG body as a 0-arity updatable thunk.
         //
         // Simple bindings (e.g. `x = 1 + 2`) compile to a `Let { bindings:


### PR DESCRIPTION
## Summary

Fixes eu-e3c3i: the prelude's named self-recursive HOFs (`count`, `sum`, `filter`, `map`, hence `str.len`) were **O(N²)** under the shipped blob prelude while exactly linear under `EU_SOURCE_PRELUDE=1`. Root cause (full diagnosis: `docs/superpowers/reports/2026-07-25-blob-quadratic-rootcause.md`, PR #1066): blob-compiled self-recursive calls built their argument arrays with the lazy `create_arg_array`, wrapping the lazily-threaded operator parameter in a fresh non-updateable `Atom{Ref::L}` indirection closure per iteration — a chain of k links re-walked at step k. The VM's existing countermeasure (`create_arg_array_eager`, selected by `eager_args = is_self_recursive`) never fired in the blob because its trigger is a demand-analysis product (`demand.recursive`) that the per-binding xtask compile cannot produce, and because `compile_body`'s `Expr::Meta` arm dropped the `self_recurse` context.

**The fix (2 changes, ~15 lines of logic):**
1. `xtask prelude-compile` passes each peeled binding's **own name** as the self-recursion context (`stg::compile_named`) — supplying structurally what whole-unit source compilation derives from `demand.recursive`.
2. `compile_body`'s `Expr::Meta` arm threads `self_recurse` through to the body, mirroring the identical existing fix in `compile_binding`'s Meta arm (documented bindings are `Meta({doc,type}, Lam(..))` at compile time).

**Effect (deterministic HeapSyn ticks, measured-verified):** blob `count` goes from `0.5N² + 210.5N + 223` (exactly quadratic) to `203N + 228` (exactly linear); `sum` → `212N + 237`; `filter…count` linear; `str.len` on a 49 KB string from **>20 s hang** to **92 ms**. Blob size unchanged (598,731 bytes — only boolean flags differ); wire format untouched; laziness preserved (`create_arg_array_eager` passes the existing closure — still a shared, memoisable thunk — instead of allocating an alias wrapper; it forces nothing).

> **Recorded review required before merge** (shipped-blob shape / engine-adjacent change): per CLAUDE.md "Recorded review before merge", a review comment from someone other than the author must appear on this PR first. Do not merge without it.

## Gate 1 — mutual/indirect recursion audit (whole prelude, 352 peeled bindings)

Audited the full compiled reference graph (nodes = 352 prelude global slots, edges = `⊗slot` references in each compiled body, SCCs via Kosaraju over `eu dump runtime`).

**Direct self-recursive (self-edge): 28 bindings** —
`io`, `stream-advance`, `coalesce`, `deep-transform`, `max-of`, `min-of`, `take`, `drop`, `drop-while`, `repeat`, `foldl`, `foldr`, `scanl`, `scanr`, `iterate`, `iota`, `cycle`, `map`, `map2`, `interleave`, `window`, `window-all`, `group-consecutive-by`, `qsort`, `merge-at`, `deep-merge-at`, `vec`, `arr`.

**Bindings that actually receive eager sites under the fix: 23** (verified by a temporary compile-time eager-site counter, since removed):
`coalesce`, `cycle`, `deep-merge-at`, `deep-transform`(2), `drop`, `drop-while`, `foldl`, `foldr`, `group-consecutive-by`, `interleave`, `iota`, `iterate`, `map`, `map2`, `merge-at`, `qsort`(2), `repeat`, `scanl`, `scanr`, `stream-advance`, `take`, `window`, `window-all` — every perf-relevant recursive HOF is covered.

**The 5 self-edge bindings without eager sites, each explained:**
- `max-of`, `min-of` — first-order self-recursion whose self-call sits inside a `cond([...])` **list literal**; `compile_list_body` does not thread `self_recurse` (in source mode either — behaviour identical in both modes). Not subject to the quadratic: they thread no lazy parameter, and their single re-passed argument is seq'd to WHNF each iteration so the wrapper chain caps at one hop. **Measured on the fixed shipped blob: `max-of` = `294N + 151`, exactly linear** (N=1k–8k).
- `io`, `vec`, `arr` — namespace blocks; the self-edge is a reference to their own block (member lookups), not a recursive call. Nothing to eager-ize.

**Mutually/indirectly recursive (multi-member SCCs): exactly 1** — `__dbg-after ↔ ▶` (the stderr debug-trace operator and its wrapper helper, `lib/prelude.eu:1320-1321`). Not caught by the name shortcut — and **not perf-relevant**: it is a debugging aid doing one mutual bounce per traced call, not a recursion over data, and it threads no lazy accumulator. Note this is **parity, not a regression**: source mode's `eager_args` also only fires on a direct self-name match, so mutual pairs get no eager treatment there either. No stop condition.

## Gate 2 — parity with source-mode `demand.recursive`

The effective eager sets are identical by construction, and behaviourally verified:
- In **both** modes, `eager_args` fires only at a call site whose callee name equals the enclosing `self_recurse_name` — i.e. a **direct self-call**. Source requires `demand.recursive` to seed the name; a direct self-call implies membership of a cycle, so every such binding is marked `recursive` by source demand analysis. Blob-with-fix passes the name unconditionally, but without a direct self-call the flag can never fire — so the effective sets coincide (the 23 above).
- Divergences, stated: (a) source also marks **indirect** cycle members `recursive` (e.g. the `▶` pair) — but eager still needs a self-name match, so no effective difference; (b) the blob shortcut supplies the context to non-recursive bindings too — a no-op absent a self-call; the only theoretical false positive is an inner local binding *shadowing* the binding's own name, which would merely eager-ize a harmless site (`create_arg_array_eager` is semantics-preserving); none observed — the 23-binding eager set is a strict subset of the 28 self-edge set, all genuinely self-recursive; (c) `max-of`/`min-of`'s list-literal self-calls are missed in **both** modes (see Gate 1) — parity preserved.
- Behavioural cross-check: fixed-blob per-bench ticks now land essentially on source-mode's numbers (e.g. 016: blob-fixed 31,967,231 vs source 31,750,007; baseline blob was 56,113,902).

## Gate 3 — Meta-arm threading safety

`compile_body`'s Meta arm previously hard-coded `self_recurse = None`; it now forwards the caller's context, mirroring `compile_binding`'s Meta arm (which was already fixed, with the same rationale, for the source path). When the context is `None` — every non-recursive compile, and all user-code paths except inside a `demand.recursive` binding — behaviour is bit-identical. When it is `Some(name)`, the only effect is `eager_args` on direct self-calls, which is semantics-preserving by construction (argument closures are passed as-is instead of alias-wrapped; nothing is forced). Evidence: full suites on both engines (below) including `tick_parity_test` and the bytecode/HeapSyn differential tests; byte-identical bench outputs; and the canonical suite's allocation counts are **bit-identical before/after** on every one of the 8 benches.

## Gate 4 — full verification

- **`cargo test --no-fail-fast` (default bytecode engine):** all binaries green — 1357 lib + conform + differential + diagnostics + fuzz + io_args + lsp (111) + property + tick_parity — **except the 3 known pre-existing blob-mode failures**: harness `test_193_1tkk_7_12_curated_trace` and `diagnostics_invariants::{secondary_labels_do_not_excerpt_library_internals, debug_trace_restores_the_uncurated_trace}` — all three are **eu-7x0r**'s tracked blob-mode diagnostics failures. **Pre-existence verified directly this session**: the same three fail identically on unmodified `master@8efc367a` with the baseline blob (`de68f848…`). Harness otherwise 505/506.
- **`EU_HEAPSYN=1 cargo test --no-fail-fast`:** identical picture — 1357 lib + all integration binaries green except the same 3 pre-existing eu-7x0r failures (harness 505/506).
- **`EU_GC_VERIFY=2 EU_GC_STRESS=1` (release harness):** default engine 505/506, HeapSyn 505/506 — sole failure `test_193` (pre-existing) in both; no GC verification panics at level 2 with stress collections enabled.
- **Blob determinism:** two consecutive `cargo xtask prelude-compile` runs byte-identical (sha256 `c2ff6873a510a91f…`, 598,731 bytes). Baseline blob regenerates reproducibly too (`de68f848…`).
- **Win confirmed on the regenerated SHIPPED blob** (embedded via the normal build, no overrides): `count` 203,228 / 406,228 / 812,228 / 1,624,228 ticks at N=1k/2k/4k/8k (= `203N+228` exactly); `sum` `212N+237`; `filter…count` linear; correct results on both engines (count=8000, sum=31996000 at N=8000); `str.len` 49 KB = 92 ms (baseline: >20 s timeout).

### PROTOCOL before/after — canonical suite

Toolchain: rustc stable aarch64-apple-darwin, Darwin 25.5.0. **Load disclosure: load average 4–10 throughout (other agents active) — per PROTOCOL §2/§5 the tick table is measured-verified (deterministic, load-immune); the wall table is capped at measured-single and is corroborating context only.** Baseline binary = `master@8efc367a` + blob `de68f848…`; fixed binary = this branch + blob `c2ff6873…`. HeapSyn `-S` ticks:

| Bench | base ticks | fixed ticks | Δ | base allocs | fixed allocs |
|---|--:|--:|--:|--:|--:|
| 015_block_merge | 96,128,347 | 82,541,872 | **−14.1%** | 480,264 | 480,264 (=) |
| 016_import_export_yaml | 56,113,902 | 31,967,231 | **−43.0%** | 1,942,766 | 1,942,766 (=) |
| 017_import_export_toml | 55,940,578 | 31,793,907 | **−43.2%** | 1,306,616 | 1,306,616 (=) |
| 018_string_scale | 46,044,700 | 45,995,706 | −0.1% | 395,650 | 395,650 (=) |
| 019_list_scale | 51,219,477 | 33,156,485 | **−35.3%** | 160,676 | 160,676 (=) |
| 020_lookup_curve | 1,500,879 | 1,443,585 | −3.8% | 5,595,923 | 5,595,923 (=) |
| 021_io_loop | 3,971,302 | 2,962,309 | **−25.4%** | 545,675 | 545,675 (=) |
| 022_hof_fold | 87,500,411 | 84,700,417 | −3.2% | 8,700,143 | 8,700,143 (=) |

Every bench improves or holds; no regressions; allocation counts bit-identical on all 8 (the fix changes evaluation order of nothing that allocates — it only removes alias-wrapper indirections, whose allocations are evidently balanced by eager array construction). Fixed-blob ticks now sit at source-mode levels (016 source = 31,750,007; 019 source = 32,871,336 per the 2026-07-24 n8c5e report).

Wall (default bytecode engine, interleaved base/fix, median-of-5 with min..max, **measured-single**, loaded machine):

| Bench | base median (min..max) | fixed median (min..max) | Δ median |
|---|--:|--:|--:|
| 015_block_merge | 3.025 (2.963..3.713) | 2.767 (2.590..3.100) | −8.5% |
| 016_import_export_yaml | 1.910 (1.858..2.473) | 1.252 (1.202..1.521) | **−34.5%** |
| 017_import_export_toml | 1.738 (1.714..1.751) | 1.052 (1.038..1.075) | **−39.5%** |
| 018_string_scale | 1.074 (1.068..1.098) | 1.092 (1.078..1.161) | +1.7% (noise band; ticks −0.1%) |
| 019_list_scale | 1.290 (1.266..1.368) | 0.791 (0.787..0.815) | **−38.7%** |
| 020_lookup_curve | 2.302 (2.286..2.312) | 2.327 (2.324..2.341) | +1.1% (noise band; ticks −3.8%) |
| 021_io_loop | 2.757 (2.745..2.847) | 2.780 (2.682..2.862) | +0.8% (subprocess-dominated; ticks −25.4%) |
| 022_hof_fold | 1.702 (1.695..1.718) | 1.665 (1.662..1.669) | −2.2% |

Also verified: rendered output byte-identical base-vs-fix (spot-checked 019; the harness `RESULT: PASS` assertions cover the rest).

## Gate 5 — lint/format

`cargo fmt --all` (no changes) and `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz
