### PR TITLE
fix(vscode): bump brace-expansion to 5.0.8 (Dependabot #22, high)

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -38,30 +38,39 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/semver": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -116,5 +116,8 @@
     "@types/node": "^25.2.1",
     "@types/vscode": "^1.75.0",
     "typescript": "^5.0.0"
+  },
+  "overrides": {
+    "minimatch": "^10.2.5"
   }
 }


### PR DESCRIPTION
## Summary

Fixes [Dependabot alert #22](https://github.com/curvelogic/eucalypt/security/dependabot/22) (high severity): **brace-expansion** DoS via unbounded expansion length causing an out-of-memory process crash ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)), affecting `editors/vscode/package-lock.json`.

- Vulnerable: `<=5.0.7` (the advisory's range covers all of brace-expansion's prior major lines, 1.x-4.x)
- Patched: `5.0.8`
- **brace-expansion: 2.1.2 -> 5.0.8**

### Why not a plain bump

Our transitive `brace-expansion@2.1.2` came from `minimatch@5.1.9`, itself pinned by the direct dependency `vscode-languageclient@9.0.1`'s `minimatch: "^5.1.0"` range. brace-expansion 5.x changed its module shape (named exports, no longer a callable default), so `minimatch@5.1.9` can't consume it directly — `npm audit fix` (non-force) offers nothing, and `npm audit fix --force` would bump `vscode-languageclient` to `10.1.0`, which in turn requires raising the extension's minimum supported VS Code version from `^1.75.0` to `^1.91.0` — a user-facing product change beyond a dependency bump.

Instead this PR adds a `package.json` `"overrides"` entry pinning `minimatch` to `^10.2.5` (which depends on a compatible `brace-expansion ^5.0.5`, i.e. `>=5.0.8`), while leaving `vscode-languageclient` at `^9.0.1` and `engines.vscode` untouched.

**Verified safe**: `vscode-languageclient@9.0.1`'s compiled JS only ever uses `new minimatch.Minimatch(...)` (in `fileOperations.js`, `notebook.js`, `diagnostic.js`) — never calls `minimatch` as a function directly. `minimatch@10.2.5` still exposes a working `.Minimatch` class with matching glob-match behaviour (checked side by side with a throwaway install).

### Other version moves (collateral, from brace-expansion/minimatch's own dependency trees — no unrelated deps touched)
- `minimatch`: 5.1.9 -> 10.2.5 (override only; **not** a direct dependency bump)
- `balanced-match`: 1.0.2 -> 4.0.4 (brace-expansion's own dependency)
- `vscode-languageclient`: **unchanged** at 9.0.1

## Test plan

- [x] `npm ci` installs cleanly from the regenerated lockfile
- [x] `npm audit` reports **0 vulnerabilities** (was 3 high, all traced to this alert)
- [x] `npm run compile` (`tsc -p ./`) succeeds with no errors — extension source/behaviour unchanged
- [x] Manually verified `minimatch@10.2.5`'s `.Minimatch` class API compatibility with the exact call pattern `vscode-languageclient@9.0.1` uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7q98Ubgo4WKJbS6CWNPFz