### PR TITLE
docs(pp): process-parallelism design spec — par-map + safe reductions, COW-fork (eu-u9xj.6)

### DIFF
--- a/docs/superpowers/specs/2026-07-24-ef1-combined-effect-monad-design.md
+++ b/docs/superpowers/specs/2026-07-24-ef1-combined-effect-monad-design.md
@@ -1,0 +1,285 @@
+# EF1 — Combined effect monad (`do`) — design
+
+**Status:** draft for owner review · **Date:** 2026-07-24 · **Bead:** eu-1tkk.2 (EF1) · **Epic:** eu-1tkk (0.14)
+
+> Working name `do` throughout. Not final — see §9. Code blocks show the
+> *shape and code-sharing structure*; exact prelude spelling (argument order,
+> `map` vs `io.map`, etc.) is finalised against prelude conventions during
+> implementation, not asserted here.
+
+## 1. Purpose & scope
+
+Today `io`, `state`, `random`, `let` and `for` are each an independent
+`monad{bind, return}` with no supported path to use their capabilities
+*together* — a stateful, seeded, IO-driven pipeline has to hand-thread
+`(state, seed)` through every step. EF1's near-term goal is **a convenient,
+elegant way to use IO + state + random together**.
+
+**In scope (0.14):**
+- A single combined effect monad (working name `do`) that threads a
+  `{ state, seed }` context alongside IO, usable via block metadata:
+  `{ :do … }`.
+- Its operation surface delegates to the existing `io` / `state` / `random`
+  monads (no re-implementation of effects).
+- A terse `do.st` lift so the existing state lens operators (`=!` / `%!`) and
+  any state action are usable inside a `do` block.
+- Deprecate the redundant `exec` *runners* on `state` and `random` (advisory
+  `deprecated` metadata) so `exec` uniformly means "execute a command".
+- Pure `:let` and list `:for` compose by **nesting**, not by mixing block
+  metadata.
+
+**Explicitly out of scope:**
+- Mixing different block metadata within one block (`{ :io …; :state … }`) —
+  rejected: it cannot be done without endangering syntactic integrity, and the
+  combined monad makes it unnecessary.
+- Parallel `do`-native operators for lens set/modify (e.g. `=!!` / `%!!`) —
+  considered and deferred (§8); `do.st(:k =! v)` reuses the state operators for
+  now.
+- A custom bracket pair for `do` — deferred until the monad exists and earns
+  one (§9).
+- The 0.15+ unified/typed effect context and post-1.0 algebraic effect-rows
+  (ROADMAP EF1.2 / EF1.3).
+- Any type-checker effect tracking (`do` is an ordinary parametric type via the
+  existing `__type_hint` mechanism, like `IO(a)` today).
+
+## 2. Verified mechanics this builds on
+
+Everything below is confirmed against the current tree; the design uses only
+these, no new syntax:
+
+1. **Monadic block form.** `{ :name decls }.expr` — `:name` is *block metadata*
+   (shorthand for `{ { monad: name } decls }`), not a per-declaration marker.
+   Each declaration `n: action` under it is one `bind` step. Return is `.(expr)`
+   (explicit) or implicit (a block of the bound names). Example
+   (`docs/guide/state-monad.md`):
+
+   ```
+   action: { :state
+     n: state.query(_.count)
+     _: state.put(:count, n + 1)
+   }.(n)
+   ```
+
+2. **Defining a monad + enabling its block metadata.** A block carrying
+   `monad:` metadata registers a namespace (`lib/state.eu`):
+
+   ```
+   `{ monad: s"state → {value: a, state: state}" }
+   state: monad{bind: state-bind, return: state-ret} { get: … put: … run(a,i): a(i) … }
+   ```
+
+3. **Derived combinators for free.** `monad(m)` derives `map`, `then`,
+   `and-then`, `join`, `sequence`, `map-m`, `filter-m` from `bind`/`return`
+   (`lib/prelude.eu`). The combined monad reuses this — the combinators are
+   derived, not written.
+
+4. **Pure value-threading monads.** `state` is `state → {value, state}`;
+   `random` is `stream → {value, rest}` (a state monad over the seed stream).
+   Both are pure — only `io` is driver-interpreted (its `IoBind`/`IoAction`
+   tree is walked by the driver *after* pure evaluation).
+
+5. **Generalised-lookup nesting.** A monadic block on the RHS of a lookup
+   inherits the LHS bindings (`docs/guide/monads.md`):
+   `{ x: 1, y: 2 }.{ :let z: x + y }`.
+
+6. **Partial application & non-lambda functions.** `f(a, b): …` called as
+   `f(a)` yields a function awaiting `b`; anonymous behaviour uses anaphora
+   (`(_ + 1)`, `(.value)`) and sections (`(+ 1)`) — there are **no arrow
+   lambdas** (`->` is `const`).
+
+## 3. The `do` monad
+
+**A `do` action is a function `ctx → IO<{ value, ctx }>`**, where the context
+is `ctx = { state: <block>, seed: <random stream> }`. IO carries the context
+through its *value* channel, so `io.bind` already handles the delicate
+`world`-token sequencing and `do` only threads `ctx` on top. This is a
+state+seed layer over IO (a small, fixed RWS-over-IO shape — **not** a general
+transformer stack).
+
+`return` / `bind` (shape; written with named continuations, no arrow lambdas):
+
+```
+do-return(v, ctx): io.return({ value: v, ctx: ctx })
+
+do-bind(m, f, ctx): io.bind(m(ctx), resume(f))
+resume(f, r):       f(r.value)(r.ctx)          # r is the IO-produced {value, ctx}
+
+do: monad{ bind: do-bind, return: do-return } { … members from §4 … }
+```
+
+Partial application makes `do.return(v)` = `do-return(v)` (the `ctx →` action)
+and `do.bind(m, f)` = `do-bind(m, f)`.
+
+**Runners** (each yields an IO action the driver then runs). Only `run` and
+`eval` are named — `exec` is reserved for the io command capability (§4/§9), so
+the rarely-needed final-context result is just `run` projected:
+
+```
+do.run(a, ctx0):  a(ctx0)                      # IO<{value, ctx}>   — both
+do.eval(a, ctx0): io.map(a(ctx0), (.value))    # IO<value>          — usual entry
+# final context only (niche): run then project .ctx
+```
+
+## 4. Operation surface — delegation, not duplication
+
+The **only genuinely new code** is `do-bind`/`do-return` (§3) plus three lift
+functions. Every actual effect stays in `io`/`state`/`random`; `do`'s members
+are thin wrappers.
+
+Lifts (shape — same partial-application style as §3; `do.lift-io(a)` is
+`do-lift-io(a)` awaiting `ctx`, i.e. the `ctx →` action — **no** anonymous
+`(ctx): …` form is assumed):
+
+```
+do-lift-io(action, ctx):     io.map(action, pair-ctx(ctx))               # ctx unchanged
+do-lift-state(saction, ctx):  io.return(thread-state(ctx, saction(ctx.state)))
+do-lift-random(raction, ctx): io.return(thread-seed(ctx, raction(ctx.seed)))
+
+pair-ctx(ctx, v):       { value: v, ctx: ctx }
+thread-state(ctx, s):   { value: s.value, ctx: { state: s.state, seed: ctx.seed } }
+thread-seed(ctx, r):    { value: r.value, ctx: { state: ctx.state, seed: r.rest  } }
+```
+
+`do.lift-io` / `do.lift-state` / `do.lift-random` are these helpers exposed as
+members; the surface below applies them partially (`do.lift-state(state.get)`
+is a `do` action).
+
+Surface members (names proposed; delegate to existing ops):
+
+```
+# io capabilities
+do.shell(c):     do.lift-io(io.shell(c))
+do.shell-with(o,c): do.lift-io(io.shell-with(o, c))
+do.exec(args):   do.lift-io(io.exec(args))        # exec kept for the io command
+
+# state capabilities
+do.get:          do.lift-state(state.get)
+do.put(k, v):    do.lift-state(state.put(k, v))
+do.modify(k, f): do.lift-state(state.modify(k, f))
+do.query(f):     do.lift-state(state.query(f))
+do.st:           do.lift-state                     # terse alias — lift any state action
+
+# random capabilities (underlying random action names to be confirmed vs the random namespace)
+do.random:       do.lift-random(random.<next>)     # the primitive random draw
+do.choose(xs):   do.lift-random(random.<choose>(xs))
+
+# pure
+do.pure(v):      do.return(v)
+```
+
+`map` / `then` / `and-then` / `sequence` / `map-m` / `filter-m` are **derived**
+via `monad(do)` — no new code.
+
+**State lens operators reused via `do.st`.** The state monad's `=!` (set a lens
+focus) and `%!` (modify a lens focus) operators produce state actions, so they
+work inside a `do` block through the terse lift — no new operators, no
+duplication:
+
+```
+{ :do  _: do.st(:count =! 0)   _: do.st(:total %! (+ 1)) }
+```
+
+Parallel `do`-native operators (e.g. `=!!` / `%!!`) were considered and deferred
+(§8); `do.st` is the near-term surface.
+
+**Sharing strategy chosen: (a) thin delegating wrappers** (above). Considered
+(b) structural auto-derivation — since monads are blocks, map each namespace's
+members through its lift and merge — but a uniform "lift after the op" across
+members of *different arities* (`get`=0, `shell`=1, `exec`=list) is an unproven
+generic-composition problem; not banked for 0.14. Left as a possible future
+tidy-up (§8).
+
+## 5. `:let` / `:for` compose by nesting, not metadata-mixing
+
+- **Pure intermediate value** inside a `do` pipeline: `n: do.pure(expr)` — or,
+  post-hoc on a plain result, generalised-lookup nesting `result.{ :let … }`
+  (§2.5).
+- **Effectful iteration / traversal** (the effectful analogue of `:for`):
+  `do.map-m(f, xs)` / `do.sequence(actions)` — derived, reused.
+- **Pure comprehension**: an ordinary `{ :for … }` block as a sub-expression
+  (it evaluates to a plain list, usable as any value).
+
+No `do`-block ever carries foreign block metadata; `:let`/`:for` stay their own
+blocks, embedded as expressions.
+
+## 6. Worked example (canonical io + state + random)
+
+```
+# proposed do.* names; block form / .(…) / runner shape are verified
+gather: { :do
+  files: do.shell("ls")
+  pick:  do.choose(files.stdout lines)
+  _:     do.modify(:seen, (+ 1))
+}.(pick)
+
+main: do.eval(gather, { state: { seen: 0 }, seed: io.RANDOM_SEED })
+```
+
+One block, one monad, all three capabilities as native `do.*` actions, state
+and seed threaded automatically, no hand-rolled `(state, seed)` plumbing and no
+mixed block metadata.
+
+## 7. Testing
+
+- Harness tests under `tests/harness/` following the gating conventions
+  (`docs/guide/testing.md`): a `{ :do … }` pipeline exercising all three
+  effects, asserting both the returned value and the threaded final state/seed
+  via `do.run(a, ctx0)` projected with `.ctx`.
+- Determinism: seed via `--seed` so `random` steps are reproducible.
+- IO steps use the existing `--allow-io` gate and `requires_io` test marker.
+- Parity: assert `do`-mediated effects match the same effects run through the
+  underlying `io`/`state`/`random` monads directly (proves delegation added no
+  semantic drift).
+- Each test computes its `RESULT` from its checks; every new test is
+  fault-injection verified.
+
+## 8. Open questions / to prototype (not asserted)
+
+1. **Feasibility of `do-bind` over `io.bind`** — the load-bearing risk. IO's
+   `world`-token threading is documented as delicate; confirm `ctx` riding the
+   IO value channel composes correctly under the driver's stashing/GC-rooting,
+   on **both** engines. Prototype first.
+2. **Exact prelude spelling** — argument order and whether `io.map`/`io.bind`
+   take `(action, f)` or `(f, action)`; finalise against prelude idiom.
+3. **Structural auto-derivation (§4b)** — is a clean arity-generic lift
+   feasible, to shrink the wrapper list to near-zero?
+4. **`:let`/`:for` embedding ergonomics** — validate the nesting forms in §5
+   read as well in practice as on paper.
+5. **Parallel `do`-native lens operators** (`=!!` / `%!!`, lexer-confirmed a
+   single token distinct from `=!` and `!!`) — considered and **deferred**;
+   `do.st(:k =! v)` reuses state's operators for now. Revisit if `do.st` proves
+   too heavy in real use, or as part of the 0.15 unified context.
+
+## 9. Naming (resolved for the draft; `do` remains a working name)
+
+- **`do`** (working name): reads well as block metadata `{ :do … }`; reads
+  slightly oddly as a namespace, `do.choose(…)`. Owner can live with it, and
+  nothing downstream depends on it — we spec against `do` and can rename at the
+  end.
+- Alternatives floated and set aside: `io*`, `IO`, `eu` — `io*`/`IO` imply
+  *IO-only* and under-sell that this equally carries state and random.
+- **`exec` resolved:** `exec` belongs to the **io command** capability
+  (`do.exec(args)`, matching `io.exec`). The runners are **`do.run`** (value +
+  context) and **`do.eval`** (value only); the niche final-context result is
+  `do.run` projected with `.ctx`, so no runner needs the `exec` name.
+- **Deprecate the `exec` *runners* on the other monads** so `exec` means
+  "execute a command" everywhere. `state.exec` / `random.exec` get advisory
+  `deprecated` metadata (warns on stderr; error under `eu check --strict`; still
+  works):
+
+  ```
+  ` { deprecated: "use state.run(a, i).state" replaced-by: "run" }
+  exec(action, initial): action(initial).state
+  ```
+
+  Migration: `state.run(a, i).state` / `random.run(a, s).rest`.
+- Bracket pair: deferred until `{ :do … }` is in use.
+
+## 10. Summary
+
+A single `do` monad threads a `{ state, seed }` context over IO. New code is
+only `bind`/`return` + three lifts; all effects and all derived combinators are
+reused from `io`/`state`/`random`/`monad()`. Capabilities appear as native
+`do.*` actions; `:let`/`:for` compose by nesting. No mixed block metadata, no
+new syntax, no transformer stack — the ergonomic win with eucalypt's syntactic
+integrity intact.

--- a/docs/superpowers/specs/2026-07-25-pp-parallelism-design.md
+++ b/docs/superpowers/specs/2026-07-25-pp-parallelism-design.md
@@ -1,0 +1,209 @@
+# PP — Process-level parallelism (par-map + safe reductions) — design
+
+**Status:** draft for owner review · **Date:** 2026-07-25 · **Bead:** eu-u9xj.6 (PP) · **Epic:** eu-1tkk (0.14)
+
+> The eucalypt-facing surface (combinators) is shown in real catenation syntax.
+> The transport (fork / mmap arena / value serialisation) is native Rust and is
+> described at the design level, not as final APIs. Combinator member names are
+> proposed. The whole design is gated on the §9 feasibility spike.
+
+## 1. Purpose & scope
+
+Speed up the **embarrassingly-parallel** slice of real workloads by evaluating
+independent computations in separate OS processes, without surrendering the
+single-threaded lazy-pure heap (Principle 4).
+
+**Motivation is measured, not assumed.** A survey of the 12 AoC 2025 puzzles
+(examples/aoc25/) found PP genuinely helps exactly the shape
+`data map(heavy-independent-fn) reduce(assoc-op)`:
+
+| Candidate | Now | Shape |
+|---|---|---|
+| day09 p1 — all-pairs area max | ~3 min | `points par-max(best-from)` |
+| day10 p2 — N independent ILP solvers | ~80 s | `machines par-sum(solve)` |
+| day08 — ~250k independent pair distances | ~17 s+ | par-map over pairs (combine is sequential) |
+| day05 p1 (moderate), day11 p2 (~4-wide) | — | secondary |
+
+The two **slowest** puzzles (day04 p2 CA-fixpoint, day09 p2 branch-and-bound)
+are **inherently sequential** — PP cannot help them. This is a real speedup on a
+real slice, **not** a blanket "make AoC fast".
+
+**In scope (v1):**
+- `par-map` + a **safe, provably-associative reduction vocabulary** (`par-sum`,
+  `par-max`, `par-min`, `par-concat`).
+- **Unix COW-fork** transport; results-only across an mmap arena.
+- A **value serialiser** (data only) — v1 is *not* gated on BV5.
+
+**Explicitly out of scope:**
+- **General `par-fold(op, z)`** — associativity is uncheckable; a non-associative
+  op would silently violate "never semantically observable". Deferred behind an
+  explicit opt-in if ever needed.
+- **Inherently sequential algorithms** — state-threading folds, CA-style
+  fixpoints, branch-and-bound sharing a prune bound. Named, not attempted.
+- **Shared-memory / `Send`+`Sync` heap (Model B)** — rejected by Principle 4.
+- **Windows / portable spawn model** — needs BV5; tracked separately as
+  **eu-9udwg** (depends on eu-lb0r).
+
+## 2. Constraints this builds on (verified)
+
+1. The heap is a **single-threaded `UnsafeCell`**; GC is **stop-the-world, no
+   background thread** (ROADMAP §Principle 4, GC notes). So `fork()` happens at a
+   quiescent, single-threaded point — the precondition for a safe COW fork.
+2. Evaluation is **pure**; the only effect is IO-action *values* interpreted by
+   the driver. So a pure `f` has no side effects to race, and a parallel merge is
+   order-independent.
+3. Parallelism is **process-level and isolated** — never shared-memory mutation.
+
+## 3. Surface — combinators (real catenation syntax)
+
+All follow the prelude idiom (receiver is the **last** argument; define
+`f(args…, list)`, call `list f(args…)`). Every combinator is **semantically
+identical to its sequential form** — a pure performance advisory.
+
+```
+# parallel map — returns the mapped list IN ORDER (≡ `xs map(f)`)
+result: points par-map(expensive-score)
+
+# fused parallel map-then-associative-reduce — only W partials cross the boundary
+best:   points par-max(best-from)      # ≡ points map(best-from) max
+total:  machines par-sum(solve)        # ≡ machines map(solve) sum
+lo:     items par-min(cost)
+all:    chunks par-concat(expand)      # associative list concat
+```
+
+- `par-map(f, xs)` → list of `f(xs[i])` in index order. Use when you need the
+  mapped list itself.
+- `par-sum(f, xs)` / `par-max(f, xs)` / `par-min(f, xs)` / `par-concat(f, xs)` →
+  **fused** map + associative reduce. Each worker reduces its own chunk locally,
+  so only one partial per worker crosses — the efficient form, and what the AoC
+  candidates want. (To reduce an existing list rather than fuse a map, pass
+  `identity`; but the whole point is that the *heavy* work is `f`.)
+
+**Contract on `f`:** pure (no IO), and its results (and `xs`'s elements) must be
+**serialisable data** (§6). `par-*` is **strict** — it forces `xs`'s spine to
+partition, and forces each result to normal form to serialise it. For the finite,
+fully-consumed lists these workloads use, that matches the sequential result
+exactly.
+
+## 4. Mechanism — Unix COW-fork, results-only
+
+`par-map(f, xs)`:
+1. **Force the spine of `xs`**; get N and index access. Choose worker count W
+   (§7). If W ≤ 1 or N below threshold → **transparent sequential fallback**
+   (just run `xs map(f)`); no fork, identical result.
+2. **`fork()` W workers.** Each child inherits the *entire* heap **copy-on-write**
+   — `f`, `xs`, prelude, program state are all present for free. **No code or
+   input is serialised.**
+3. Each worker evaluates `f(xs[i])` for its **contiguous index chunk** in its own
+   COW heap (forcing its own elements — no cross-process sharing, no duplicated
+   work), and writes each **fully-forced result** into a shared
+   **`mmap(MAP_SHARED)` arena** at its index-addressed slot.
+4. Parent **`waitpid`s (join)**, reads results back from the arena into its heap,
+   reassembles **in index order** → deterministic regardless of worker timing.
+
+`par-sum`/`par-max`/… are identical except step 3 is a **worker-local partial
+reduction** (one partial per worker), and the parent combines the W partials with
+the associative op — so only W values cross, not N.
+
+**Determinism:** index-ordered slots for `par-map`; worker-index-ordered partial
+combine (with an associative op) for the reductions. Both are byte-for-byte equal
+to the sequential result.
+
+## 5. Why not gated on BV5
+
+Because fork inherits the *code*, the only thing that crosses the boundary is
+**result values**. So v1 needs a **value serialiser** (§6), not serialisable
+*bytecode*. BV5 (eu-lb0r) is only needed by the **spawn** model (fresh workers
+loading a serialised program), which is the Windows/portable path — **eu-9udwg**,
+deferred.
+
+## 6. Value serialisation scope
+
+Serialisable (can cross the arena): numbers, strings, symbols, booleans, null,
+lists of serialisable, blocks of serialisable. **Not** serialisable: functions /
+closures, IO-action values, anything carrying an un-flattenable captured
+environment. A non-serialisable result (or `xs` element) is a **runtime error at
+the boundary** (decided) — `par-map` returning closures/IO-actions is a
+programmer mistake worth surfacing, not silently papering over. (The error names
+the offending value's kind and the combinator.)
+
+## 6a. Arena — sizing & disposal
+
+Results are variable-size and unknown ahead of time, but in the target workloads
+they are **small** (a number / small tuple per element) even when the compute is
+heavy. So:
+
+**Sizing — over-provision *virtual*, pay only *physical*.** The arena is a
+`MAP_SHARED | MAP_ANONYMOUS` region created **before** the fork (children inherit
+it; MAP_SHARED makes writes mutually visible), sized to a generous **configurable
+cap** (default derived from N with a ceiling). Anonymous pages are **demand-zero**
+— physical memory equals only the bytes actually written, so a large virtual cap
+costs address space, not RAM. The arena is split into **W per-worker segments**:
+worker *w* owns a contiguous index chunk and writes its results length-prefixed
+into segment *w*, in order. The parent reads segments in index order → global
+index order, deterministic. **No cross-process atomics, no growth/remap.** A
+worker overflowing its segment → error (rare, given small results).
+
+**Disposal — trivial and crash-safe.** Because the mapping is **anonymous** (no
+backing file, no named kernel resource), the parent `munmap`s the arena after
+`waitpid` + reading results back, and each worker's mapping is reclaimed by the OS
+when that worker exits (at join). Nothing to `unlink`; no leftover temp files or
+state even if the parent dies mid-op — process death frees all mappings.
+
+## 7. Cost model (advisory)
+
+Because it is semantically ≡ sequential, PP can be conservative:
+- **Worker count** W = `min(cores - 1, N)` by default.
+- **Fork only above a threshold** (small default N, tunable) — below it, run
+  sequentially. eucalypt can't cheaply estimate `f`'s cost, so the gate is on N
+  (plus an optional explicit hint later, e.g. a `{ workers: … }` option block).
+- Fork + arena + result-serialisation has real per-op overhead; the win requires
+  heavy per-element `f`. When it doesn't pay, the fallback makes it a no-op cost
+  beyond the spine force.
+
+## 8. Testing
+
+- **Determinism / equivalence:** every `par-*` result is asserted **byte-identical
+  to its sequential equivalent** across worker counts (W=1,2,4,…) and input sizes
+  — the core "never semantically observable" guarantee.
+- **Speedup:** ≥ 1.5× wall on a real data-parallel case (a scaled day09-p1 /
+  day10-p2 shape) on 4+ cores, per the ROADMAP success bar.
+- **Fallback:** small-N and W≤1 produce identical results with no fork.
+- **GC integrity:** `EU_GC_VERIFY=2` clean in parent and workers.
+- Each harness test computes RESULT from its checks; fault-injection verified.
+
+## 9. Feasibility spike (the gate — before any real build)
+
+Forking a process whose heap is our custom managed GC heap (Immix mmap blocks,
+`UnsafeCell`) is *probably* fork-safe but must be **proven** first (this session's
+discipline). The spike: fork the VM at a quiescent point, have a child force a
+trivial `f(x)`, serialise **one value** through an `mmap(MAP_SHARED)` arena back
+to the parent, and run **`EU_GC_VERIFY=2` on both sides**. It must establish:
+
+1. The managed heap survives COW fork with no GC corruption in child or parent
+   (block mmap flags, allocator/GC invariants across the fork point).
+2. The mmap arena is correctly shared and readable across fork/join.
+3. FD / signal-handler / crash-handler (the unconditional SIGSEGV handler in
+   `main()`) inheritance is sane in the child.
+4. Rough per-fork + per-value-serialise cost (feeds the §7 threshold).
+
+If any of these fail or prove costly, revisit before speccing the combinators
+further — the whole COW-fork model rests on this.
+
+**Resolved:** non-serialisable → runtime error (§6); worker/threshold heuristic
+`W = min(cores-1, N)` + N-threshold (§7); arena over-provisioned anon-shared with
+per-worker segments, munmap-on-join disposal (§6a).
+
+**Remaining minor:** the default arena virtual-cap value and its N-scaling (§6a);
+whether reductions expose an explicit worker-count hint in v1 (leaning no —
+advisory default is enough).
+
+## 10. Summary
+
+`par-map` + a safe reduction vocabulary (`par-sum`/`par-max`/`par-min`/
+`par-concat`), each semantically ≡ its sequential form. Implemented by Unix
+COW-fork: workers inherit code+inputs for free, only results (or worker-local
+partials) cross an mmap arena, reassembled deterministically in index order.
+Needs a value serialiser, **not** BV5; Windows/spawn is deferred (eu-9udwg).
+Serves a measured slice of real workloads (day09-p1, day10-p2, day08-gen); does
+not touch inherently-sequential work. Gated on a fork-safety feasibility spike.


### PR DESCRIPTION
Design spec for PP (eu-u9xj.6). par-map + a safe associative reduction vocabulary (par-sum/par-max/par-min/par-concat), each semantically identical to its sequential form. Unix COW-fork transport: workers inherit code+inputs copy-on-write, only results (or worker-local partials) cross an mmap arena (anon-shared, per-worker segments, munmap-on-join), reassembled deterministically in index order. Needs a value serialiser, not BV5; Windows/spawn deferred (eu-9udwg). Motivation measured against the AoC corpus. Opens with a fork-safety feasibility spike. Design only — no code.