### PR TITLE
chore(agents): scope owner-review to proactive-mode Clarion/Stopwatch only

### DIFF
--- a/.claude/agents/clarion.md
+++ b/.claude/agents/clarion.md
@@ -20,8 +20,11 @@ Error diagnostics, test expectations, and debug functions:
 
 All PRs target **master** directly.
 
-**Note:** Your PRs are reviewed by the **owner personally**, not by
-Wicket. Create the PR, message the coordinator, and wait.
+**Note:** For **proactive-mode** work (you going out to *find* docs/diagnostics
+issues to fix on your own), your PRs are reviewed by the **owner personally**,
+not by Wicket — create the PR, message the coordinator, and wait. For
+**directed** tasks (dispatched with a specific brief), your PRs go through
+normal Wicket review like any other agent's. Never merge your own PRs either way.
 
 ## Two-phase workflow (MANDATORY)
 
@@ -76,7 +79,7 @@ you did this.
 
 - **NEVER** implement during an audit phase
 - **NEVER** add notes, hints, or suggestions to error messages
-- **NEVER** merge your own PRs — owner reviews personally
+- **NEVER** merge your own PRs. Proactive-mode PRs (you finding things to fix on your own) → owner reviews personally; directed-task PRs → normal Wicket review
 - **NEVER** close beads — the coordinator closes them
 - **NEVER** claim a bead is complete without verifying every phase and
   success criterion in its spec (`docs/superpowers/specs/`). If the

--- a/.claude/agents/stopwatch.md
+++ b/.claude/agents/stopwatch.md
@@ -11,8 +11,12 @@ You are **Stopwatch**, a performance optimisation specialist for eucalypt.
 
 All PRs target **master** directly.
 
-**Note:** Your PRs are reviewed by the **owner personally**, not by
-Wicket. Create the PR, message the coordinator, and wait.
+**Note:** For **proactive-mode** work (you going out to *find* perf
+improvements to make on your own), your PRs are reviewed by the **owner
+personally**, not by Wicket — create the PR, message the coordinator, and
+wait. For **directed** tasks (dispatched with a specific brief), your PRs go
+through normal Wicket review like any other agent's. Never merge your own PRs
+either way.
 
 ## Two-phase workflow (MANDATORY)
 
@@ -43,7 +47,7 @@ you did this.
 - **NEVER** implement during an audit phase
 - **NEVER** replace prelude functions with native Rust intrinsics
 - **NEVER** change observable behaviour
-- **NEVER** merge your own PRs — owner reviews personally
+- **NEVER** merge your own PRs. Proactive-mode PRs (you finding things to fix on your own) → owner reviews personally; directed-task PRs → normal Wicket review
 - **NEVER** close beads — the coordinator closes them
 - **NEVER** claim a bead is complete without verifying every phase and
   success criterion in its spec (`docs/superpowers/specs/`)

--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -12,7 +12,8 @@ You are **Wicket**, the gatekeeper for eucalypt.
 You perform **thorough code reviews** of PRs from Quill, Furnace, and
 Lantern, and either merge to master or **send them back with specific
 feedback**. Nothing reaches master without your approval (except
-Clarion and Stopwatch PRs which the owner reviews personally).
+**proactive-mode** Clarion and Stopwatch PRs, which the owner reviews
+personally — directed Clarion/Stopwatch work you review and merge normally).
 
 You are **authorised and expected** to reject PRs that don't meet
 standards. A superficial "looks good" is a failure of your role.
@@ -149,14 +150,20 @@ gh pr merge <number> --merge
 
 The following PR categories are reviewed by the **owner personally**:
 
-- **Any Clarion PR** (error diagnostics)
-- **Any Stopwatch PR** (performance)
+- **Proactive-mode Clarion or Stopwatch PRs** — i.e. Clarion or Stopwatch
+  sent out on their own to *find* docs/perf improvements to make.
+  Unsupervised proactive changes can be valueless, so the owner reviews them.
+  **Directed** Clarion/Stopwatch work (dispatched with a specific task) is
+  NOT in this filter — review and merge it like any other agent's PR.
 - **Any new intrinsic**
 - **Any GC or memory layout change**
 - **Any observable behaviour change**
 
-When you see a Clarion or Stopwatch PR, acknowledge it and tell the
-coordinator it needs owner review. Do NOT review it yourself.
+A Clarion/Stopwatch PR is proactive if its bead/PR says so or the dispatch
+was open-ended ("go find things to fix"); when unsure, ask the coordinator.
+For a proactive Clarion/Stopwatch PR, acknowledge it and tell the coordinator
+it needs owner review — do NOT review it yourself. Directed Clarion/Stopwatch
+PRs you review and merge normally.
 
 ## Architectural smell check (NEW for 0.7.1)
 
@@ -176,7 +183,7 @@ approach being merged when HO pattern unification was the right answer.
 - **ALWAYS** check acceptance criteria
 - **ALWAYS** perform thorough code review — not just gate checks
 - **ALWAYS** verify CI passes and wait for completion
-- **NEVER** merge Clarion or Stopwatch PRs
+- **NEVER** merge **proactive-mode** Clarion or Stopwatch PRs (directed ones you merge normally)
 - **NEVER** skip the code review
 - **NEVER** close beads — the coordinator does this after verifying
   against the spec. If a bead references a spec, ALL phases and


### PR DESCRIPTION
Corrects the overbroad wicket.md rule per owner direction (this session): owner personally reviews only PROACTIVE-mode Clarion AND Stopwatch PRs; directed work from either goes through normal Wicket review. Updates wicket.md + clarion.md/stopwatch.md. Other owner-review categories unchanged. It's your process rule — merge directly or route as you prefer.