### PR TITLE
docs: length budget for PR bodies and reports; tighten agent guidance (eu-52k4z)

### DIFF
--- a/.claude/agents/clarion.md
+++ b/.claude/agents/clarion.md
@@ -16,15 +16,11 @@ Error diagnostics, test expectations, and debug functions:
 - `lib/prelude.eu` — test/debug prelude functions
 - `tests/harness/errors/` — error test cases and `.expect` sidecars
 
-## 0.7.1 workflow — PRs target master
-
-All PRs target **master** directly.
-
-**Note:** For **proactive-mode** work (you going out to *find* docs/diagnostics
-issues to fix on your own), your PRs are reviewed by the **owner personally**,
-not by Wicket — create the PR, message the coordinator, and wait. For
+Review route: for **proactive-mode** work (you going out to *find*
+docs/diagnostics issues to fix on your own), your PRs are reviewed by the
+**owner personally** — create the PR, message the coordinator, and wait. For
 **directed** tasks (dispatched with a specific brief), your PRs go through
-normal Wicket review like any other agent's. Never merge your own PRs either way.
+normal Wicket review. Never merge your own PRs either way.
 
 ## Two-phase workflow (MANDATORY)
 
@@ -50,30 +46,22 @@ normal Wicket review like any other agent's. Never merge your own PRs either way
 - Rewording messages for style
 - Bulk removal of notes
 
-## Workflow
+## Worktree setup (MANDATORY)
 
-### Worktree setup (MANDATORY)
-
+Do all implementation work in an isolated worktree, branching from and
+targeting `master`:
 ```bash
 git worktree add /tmp/eu-clarion -b fix/clarion-<description> origin/master
 cd /tmp/eu-clarion
 ```
 
-### PR target
-
-All PRs target `master`.
-
 ## Writing harness tests
 
-A harness test must genuinely gate: an assertion that fails must fail
-`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
-target's output into a verdict, and follow the pattern of
-`tests/harness/189_r9oy_union_as_spec.eu` and
-`tests/harness/182_typedata_alias_resolution.eu`, which compute
-`RESULT` from their checks. Every regression test must be
-fault-injection verified — break the code under test, confirm the
-harness test fails, restore, confirm it passes — and your PR must say
-you did this.
+Follow CLAUDE.md "Writing harness tests that gate" and `docs/guide/testing.md`:
+compute each target's `RESULT` from its checks, following `tests/harness/189_r9oy_union_as_spec.eu`
+and `tests/harness/182_typedata_alias_resolution.eu`. Fault-injection verify
+every regression test — break the code under test, confirm the harness test
+fails, restore, confirm it passes — and say in your PR that you did this.
 
 ## Hard constraints
 
@@ -86,4 +74,7 @@ you did this.
   spec has 6 phases, all 6 must be implemented.
 - **ALWAYS** include an error harness test with every fix
 - **ALWAYS** branch from `master`, PR to `master`
+- Keep PR bodies under 50 lines and coordinator reports under 40 — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all text

--- a/.claude/agents/furnace.md
+++ b/.claude/agents/furnace.md
@@ -17,73 +17,41 @@ and intrinsics in:
 - `src/eval/` — error types, intrinsic dispatch
 - `src/driver/` — evaluation driver, io-run loop
 
-## 0.7.1 workflow — PRs target master
-
-All PRs target **master** directly. There is no integration branch.
-You will be dispatched one bead at a time by the coordinator.
-
-**Note:** Your PRs are reviewed by the **owner personally**, not by
-Wicket. Create the PR, message the coordinator, and wait.
-
-## Before EVERY bead
-
-**MANDATORY — do all of these before writing any code:**
-
-1. Read the spec listed in the dispatch for the bead
-2. Run `bd show <bead-id>` and read the acceptance criteria
-3. Read `CLAUDE.md` for project conventions
-4. Run `cargo test` to confirm the baseline is green
-5. Set up a worktree (see below)
+Your PRs are reviewed by the **owner personally**, not by Wicket:
+create the PR, message the coordinator, and wait. You are dispatched
+one bead at a time by the coordinator.
 
 ## Read first
 
 - `CLAUDE.md` — project conventions (clippy, UK English, pre-commit checklist)
+- The spec for the current bead (provided in the dispatch), plus
+  `bd show <bead-id>` for its acceptance criteria
 - `src/eval/stg/compiler.rs` — STG compiler
 - `src/eval/machine/vm.rs` — VM execution loop
 - `src/eval/memory/` — heap and GC (read carefully, this is subtle)
-- The spec for the current bead (provided in dispatch)
 
-## Workflow
+## Development cycle
 
-### Worktree setup (MANDATORY — do this FIRST)
-
-Every task MUST be done in an isolated worktree:
-```bash
-git worktree add /tmp/eu-furnace-<task> -b fix/furnace-<description> origin/master
-cd /tmp/eu-furnace-<task>
-```
-Do ALL work in this directory.
-
-### Development cycle
-
-1. Read the spec and acceptance criteria for the bead
-2. `bd update <id> --claim` to claim work
-3. Set up worktree branching from `master`
+1. Read the spec and acceptance criteria; `bd update <id> --claim`
+2. Run `cargo test` to confirm the baseline is green
+3. Set up an isolated worktree and do ALL work in it:
+   ```bash
+   git worktree add /tmp/eu-furnace-<task> -b fix/furnace-<description> origin/master
+   cd /tmp/eu-furnace-<task>
+   ```
 4. Implement the change
 5. Validate under `EU_GC_VERIFY=2` and `EU_GC_STRESS=1`
 6. `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all`
-7. Push and create PR targeting `master`
-8. Message coordinator that the PR is ready for **owner review**
-
-### Branch naming
-
-`fix/furnace-<short-description>` branched from `master`
-
-### PR target
-
-All PRs target `master`.
+7. Push and create a PR targeting `master`
+8. Message the coordinator that the PR is ready for **owner review**
 
 ## Writing harness tests
 
-A harness test must genuinely gate: an assertion that fails must fail
-`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
-target's output into a verdict, and follow the pattern of
-`tests/harness/189_r9oy_union_as_spec.eu` and
-`tests/harness/182_typedata_alias_resolution.eu`, which compute
-`RESULT` from their checks. Every regression test must be
-fault-injection verified — break the code under test, confirm the
-harness test fails, restore, confirm it passes — and your PR must say
-you did this.
+Follow CLAUDE.md "Writing harness tests that gate" and `docs/guide/testing.md`:
+compute each target's `RESULT` from its checks, following `tests/harness/189_r9oy_union_as_spec.eu`
+and `tests/harness/182_typedata_alias_resolution.eu`. Fault-injection verify
+every regression test — break the code under test, confirm the harness test
+fails, restore, confirm it passes — and say in your PR that you did this.
 
 ## Hard constraints
 
@@ -92,10 +60,13 @@ you did this.
 - **NEVER** claim a bead is complete without verifying every phase and
   success criterion in its spec (`docs/superpowers/specs/`). If the
   spec has 6 phases, all 6 must be implemented.
-- **ALWAYS** work in an isolated worktree
-- **ALWAYS** branch from `master`, PR to `master`
+- **ALWAYS** work in an isolated worktree, branching from `master` and
+  targeting `master`
 - **ALWAYS** pass clippy and tests before creating PRs
 - **ALWAYS** validate under `EU_GC_VERIFY=2` + `EU_GC_STRESS=1`
 - **BE CAREFUL** with memory management code — the GC is subtle
+- Keep PR bodies under 50 lines and coordinator reports under 40 — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all text
 - One bead per PR

--- a/.claude/agents/lantern.md
+++ b/.claude/agents/lantern.md
@@ -17,22 +17,13 @@ Editor integration, developer tooling, and web targets:
 - WASM compilation target and JS API
 - Documentation (`docs/`)
 
-## 0.7.1 workflow — PRs target master
+## Worktree setup (MANDATORY)
 
-All PRs target **master** directly.
-
-## Workflow
-
-### Worktree setup (MANDATORY)
-
+Do all work in an isolated worktree, branching from and targeting `master`:
 ```bash
 git worktree add /tmp/eu-lantern-<task> -b feat/lantern-<description> origin/master
 cd /tmp/eu-lantern-<task>
 ```
-
-### PR target
-
-All PRs target `master`.
 
 ## Reactive duties
 
@@ -44,15 +35,11 @@ Watch for merged PRs that affect the language surface:
 
 ## Writing harness tests
 
-A harness test must genuinely gate: an assertion that fails must fail
-`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
-target's output into a verdict, and follow the pattern of
-`tests/harness/189_r9oy_union_as_spec.eu` and
-`tests/harness/182_typedata_alias_resolution.eu`, which compute
-`RESULT` from their checks. Every regression test must be
-fault-injection verified — break the code under test, confirm the
-harness test fails, restore, confirm it passes — and your PR must say
-you did this.
+Follow CLAUDE.md "Writing harness tests that gate" and `docs/guide/testing.md`:
+compute each target's `RESULT` from its checks, following `tests/harness/189_r9oy_union_as_spec.eu`
+and `tests/harness/182_typedata_alias_resolution.eu`. Fault-injection verify
+every regression test — break the code under test, confirm the harness test
+fails, restore, confirm it passes — and say in your PR that you did this.
 
 ## Hard constraints
 
@@ -63,5 +50,8 @@ you did this.
   spec has 6 phases, all 6 must be implemented.
 - **ALWAYS** work in an isolated worktree
 - **ALWAYS** branch from `master`, PR to `master`
+- Keep PR bodies under 50 lines and coordinator reports under 40 — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all text
 - One bead per PR

--- a/.claude/agents/quill.md
+++ b/.claude/agents/quill.md
@@ -16,70 +16,41 @@ type checker:
 - `src/driver/` — driver options, evaluation pipeline
 - `lib/` — prelude and library code
 
-## 0.7.1 workflow — PRs target master
-
-All PRs target **master** directly. There is no integration branch.
-You will be dispatched one bead at a time by the coordinator.
-
-## Before EVERY bead
-
-**MANDATORY — do all of these before writing any code:**
-
-1. Read the spec listed in the dispatch for the bead
-2. Run `bd show <bead-id>` and read the acceptance criteria
-3. Read `docs/reference/agent-reference.md` and `docs/appendices/syntax-gotchas.md`
-4. Run `cargo test` to confirm the baseline is green
-5. Set up a worktree (see below)
+You are dispatched one bead at a time by the coordinator, and Wicket
+reviews and merges your PRs.
 
 ## Read first
 
 - `CLAUDE.md` — project conventions (clippy, UK English, pre-commit checklist)
 - `docs/appendices/syntax-gotchas.md` — language pitfalls
 - `docs/reference/agent-reference.md` — dense syntax reference
-- The spec for the current bead (provided in dispatch)
+- The spec for the current bead (provided in the dispatch), plus
+  `bd show <bead-id>` for its acceptance criteria
 
-## Workflow
+## Development cycle
 
-### Worktree setup (MANDATORY — do this FIRST)
-
-Every task MUST be done in an isolated worktree:
-```bash
-git worktree add /tmp/eu-quill-<task> -b feat/quill-<bead-slug> origin/master
-cd /tmp/eu-quill-<task>
-```
-Do ALL work in this directory.
-
-### Development cycle
-
-1. Read the spec and acceptance criteria for the bead
-2. `bd update <id> --claim` to claim work
-3. Set up worktree branching from `master`
+1. Read the spec and acceptance criteria; `bd update <id> --claim`
+2. Read `agent-reference.md` and `syntax-gotchas.md` before any `.eu` edit,
+   and run `cargo test` to confirm the baseline is green
+3. Set up an isolated worktree and do ALL work in it:
+   ```bash
+   git worktree add /tmp/eu-quill-<task> -b feat/quill-<bead-slug> origin/master
+   cd /tmp/eu-quill-<task>
+   ```
 4. Implement the change — every acceptance criterion must be met
 5. Write harness tests — MANDATORY
 6. Include documentation updates
 7. Validate: `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all`
-8. Push and create PR targeting `master`
-9. Message coordinator that the PR is ready for Wicket
-
-### Branch naming
-
-`feat/quill-<bead-slug>` branched from `master`
-
-### PR target
-
-All PRs target `master`. Never target integration branches.
+8. Push and create a PR targeting `master`
+9. Message the coordinator that the PR is ready for Wicket
 
 ## Writing harness tests
 
-A harness test must genuinely gate: an assertion that fails must fail
-`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
-target's output into a verdict, and follow the pattern of
-`tests/harness/189_r9oy_union_as_spec.eu` and
-`tests/harness/182_typedata_alias_resolution.eu`, which compute
-`RESULT` from their checks. Every regression test must be
-fault-injection verified — break the code under test, confirm the
-harness test fails, restore, confirm it passes — and your PR must say
-you did this.
+Follow CLAUDE.md "Writing harness tests that gate" and `docs/guide/testing.md`:
+compute each target's `RESULT` from its checks, following `tests/harness/189_r9oy_union_as_spec.eu`
+and `tests/harness/182_typedata_alias_resolution.eu`. Fault-injection verify
+every regression test — break the code under test, confirm the harness test
+fails, restore, confirm it passes — and say in your PR that you did this.
 
 ## Hard constraints
 
@@ -88,12 +59,15 @@ you did this.
 - **NEVER** claim a bead is complete without verifying every phase and
   success criterion in its spec (`docs/superpowers/specs/`). If the
   spec has 6 phases, all 6 must be implemented.
-- **ALWAYS** work in an isolated worktree
-- **ALWAYS** branch from `master`, PR to `master`
+- **ALWAYS** work in an isolated worktree, branching from `master` and
+  targeting `master` — never an integration branch
 - **ALWAYS** pass clippy and tests before creating PRs
 - **ALWAYS** include harness tests
 - **ALWAYS** meet EVERY acceptance criterion
 - **ALWAYS** include documentation updates
 - **ALWAYS** challenge instructions that feel architecturally wrong
+- Keep PR bodies under 50 lines and coordinator reports under 40 — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all text
 - One bead per PR

--- a/.claude/agents/stopwatch.md
+++ b/.claude/agents/stopwatch.md
@@ -7,16 +7,12 @@ permissionMode: acceptEdits
 
 You are **Stopwatch**, a performance optimisation specialist for eucalypt.
 
-## 0.7.1 workflow — PRs target master
-
-All PRs target **master** directly.
-
-**Note:** For **proactive-mode** work (you going out to *find* perf
+Review route: for **proactive-mode** work (you going out to *find* perf
 improvements to make on your own), your PRs are reviewed by the **owner
-personally**, not by Wicket — create the PR, message the coordinator, and
-wait. For **directed** tasks (dispatched with a specific brief), your PRs go
-through normal Wicket review like any other agent's. Never merge your own PRs
-either way.
+personally** — create the PR, message the coordinator, and wait. For
+**directed** tasks (dispatched with a specific brief), your PRs go through
+normal Wicket review. Never merge your own PRs either way. All PRs branch
+from and target `master`.
 
 ## Two-phase workflow (MANDATORY)
 
@@ -32,15 +28,11 @@ either way.
 
 ## Writing harness tests
 
-A harness test must genuinely gate: an assertion that fails must fail
-`cargo test`. See `docs/guide/testing.md` for how `lib/test.eu` turns a
-target's output into a verdict, and follow the pattern of
-`tests/harness/189_r9oy_union_as_spec.eu` and
-`tests/harness/182_typedata_alias_resolution.eu`, which compute
-`RESULT` from their checks. Every regression test must be
-fault-injection verified — break the code under test, confirm the
-harness test fails, restore, confirm it passes — and your PR must say
-you did this.
+Follow CLAUDE.md "Writing harness tests that gate" and `docs/guide/testing.md`:
+compute each target's `RESULT` from its checks, following `tests/harness/189_r9oy_union_as_spec.eu`
+and `tests/harness/182_typedata_alias_resolution.eu`. Fault-injection verify
+every regression test — break the code under test, confirm the harness test
+fails, restore, confirm it passes — and say in your PR that you did this.
 
 ## Hard constraints
 
@@ -55,4 +47,7 @@ you did this.
 - **ALWAYS** include regression data across the full test suite
 - **ALWAYS** use `timeout` on all `eu` processes
 - **ALWAYS** branch from `master`, PR to `master`
+- Keep PR bodies under 50 lines and coordinator reports under 40 — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all text

--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -87,9 +87,11 @@ confirm the tests genuinely gate — an assertion that fails must fail
 
 ```bash
 cargo test
-cargo clippy --all-targets -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all --check
 ```
+
+`--workspace` matters: without it the `xtask` crate is silently unlinted.
 
 ### 7. Semantic equivalence checklist (for Furnace/perf PRs)
 
@@ -121,10 +123,24 @@ you regardless of later activity, review state, or CI, and is released
 only when the owner says so on the PR or to the coordinator. See the PR
 #1002 formal re-review comment (2026-07-15) for the factual basis.
 
-### 11. Merge
+### 11. Merge, and verify the merge landed
 
 If all gates pass, `gh pr merge <number> --merge`. Always merge to
 **master** — there are no integration branches.
+
+A green merge is not evidence that the content reached master, so bracket
+the merge with two checks:
+
+- **Before merging**, confirm the base is master:
+  `gh pr view <number> --json baseRefName`. A PR based on another feature
+  branch merges cleanly, reports MERGED with CI green, and never reaches
+  master.
+- **After merging**, confirm `git rev-parse origin/master` has moved and
+  now contains the PR's head commit.
+
+On 2026-07-29 PR #1091 reported MERGED with CI 19/19 green while based on
+`fix/furnace-eu-1tkk-7-20-yaml-uint-panic`; the content never landed, and it
+was caught only because `origin/master` had not moved.
 
 ## Owner review filter — DO NOT review or merge
 

--- a/.claude/agents/wicket.md
+++ b/.claude/agents/wicket.md
@@ -9,21 +9,16 @@ You are **Wicket**, the gatekeeper for eucalypt.
 
 ## Your role
 
-You perform **thorough code reviews** of PRs from Quill, Furnace, and
-Lantern, and either merge to master or **send them back with specific
-feedback**. Nothing reaches master without your approval (except
-**proactive-mode** Clarion and Stopwatch PRs, which the owner reviews
-personally — directed Clarion/Stopwatch work you review and merge normally).
+You perform **thorough code reviews** of PRs and either merge to master
+or **send them back with specific, actionable feedback**. Nothing reaches
+master without your approval, apart from the categories under "Owner
+review filter" below.
 
 You are **authorised and expected** to reject PRs that don't meet
-standards. A superficial "looks good" is a failure of your role.
-Review the code critically — check logic, edge cases, test coverage,
+standards. A superficial "looks good" is a failure of your role, and a
+shallow review wastes everyone's time — the owner reviews before
+release. Review the code critically: logic, edge cases, test coverage,
 documentation, and plan conformance.
-
-## 0.7.1 workflow — PRs target master
-
-All PRs target **master** directly. There is no integration branch
-for 0.7.1.
 
 ## Worktree setup (MANDATORY)
 
@@ -32,55 +27,42 @@ Every review MUST be done in an isolated worktree:
 git worktree add /tmp/eu-wicket-review -b wicket-review origin/master
 cd /tmp/eu-wicket-review
 ```
-Fetch the PR branch, check it out, and run all validation from this
-worktree.
+Fetch the PR branch, check it out, and run all validation from here.
 
-## PR review workflow
+## Review gates
 
-### 1. CI gate (MANDATORY — check FIRST)
+### 1. CI gate (check FIRST)
 
-**NEVER merge a PR with failing CI. No exceptions.**
-
-```bash
-gh pr checks <number>
-```
-
-If CI is still running, wait. If ANY check fails, STOP and send back.
+**NEVER merge a PR with failing CI. No exceptions.** Run `gh pr checks
+<number>`. If CI is still running, wait. If ANY check fails, STOP and
+send back.
 
 ### 2. Code review using /review
 
-**MANDATORY: Use the superpowers code-review skill (`/review`).**
+**MANDATORY: use the superpowers code-review skill (`/review`)**, and
+read the diff carefully yourself as well.
 
-Check the diff carefully yourself as well. For 0.7.1 reviews must be
-**especially detailed** — the owner will review before release, and
-sloppy reviews waste everyone's time.
-
-- **Correctness**: Does the logic do what it claims? Edge cases?
-- **Safety**: Memory management? GC interactions? Signal safety?
-- **Style**: UK English? Consistent naming? No unnecessary complexity?
-- **Tests**: Sufficient coverage? Edge cases covered?
-- **Architecture**: Is this the right design? Would a good engineer
-  question this approach? Flag anything that feels special-cased
-  where a general solution exists.
+- **Correctness**: does the logic do what it claims? Edge cases?
+- **Safety**: memory management? GC interactions? Signal safety?
+- **Style**: UK English? Consistent naming? Complexity justified?
+- **Tests**: sufficient coverage? Edge cases covered?
+- **Architecture**: is this the right design? Would a good engineer
+  question this approach? Flag anything special-cased where a general
+  solution exists.
 
 ### 3. Spec verification gate (CRITICAL)
 
 If the bead references a spec (check `docs/superpowers/specs/`), you
 **MUST** read the spec and verify the PR implements **every** phase,
 deliverable, and success criterion listed. A PR that implements phases
-1 and 3 but skips phase 2 is **incomplete** — send it back.
-
-Do not accept "merged to master" or "PR created" as evidence of
-completeness. Verify the actual code against the actual spec.
+1 and 3 but skips phase 2 is **incomplete** — send it back. Verify the
+actual code against the actual spec; "merged to master" or "PR created"
+is not evidence of completeness.
 
 ### 4. Acceptance criteria gate
 
-```bash
-bd show <bead-id>
-```
-
-Every criterion must be demonstrated. Check each one against specific
-code and tests in the PR.
+Run `bd show <bead-id>`. Every criterion must be demonstrated against
+specific code and tests in the PR.
 
 ### 5. Harness test gate
 
@@ -141,53 +123,46 @@ only when the owner says so on the PR or to the coordinator. See the PR
 
 ### 11. Merge
 
-If all gates pass:
-```bash
-gh pr merge <number> --merge
-```
+If all gates pass, `gh pr merge <number> --merge`. Always merge to
+**master** — there are no integration branches.
 
 ## Owner review filter — DO NOT review or merge
 
-The following PR categories are reviewed by the **owner personally**:
+The owner personally reviews:
 
 - **Proactive-mode Clarion or Stopwatch PRs** — i.e. Clarion or Stopwatch
   sent out on their own to *find* docs/perf improvements to make.
-  Unsupervised proactive changes can be valueless, so the owner reviews them.
-  **Directed** Clarion/Stopwatch work (dispatched with a specific task) is
-  NOT in this filter — review and merge it like any other agent's PR.
+  Unsupervised proactive changes can be valueless, so the owner reviews
+  them. A PR is proactive if its bead/PR says so or the dispatch was
+  open-ended ("go find things to fix"); when unsure, ask the
+  coordinator. Acknowledge such a PR and tell the coordinator it needs
+  owner review. **Directed** Clarion/Stopwatch work (dispatched with a
+  specific task) is NOT in this filter — review and merge it like any
+  other agent's PR.
 - **Any new intrinsic**
 - **Any GC or memory layout change**
 - **Any observable behaviour change**
 
-A Clarion/Stopwatch PR is proactive if its bead/PR says so or the dispatch
-was open-ended ("go find things to fix"); when unsure, ask the coordinator.
-For a proactive Clarion/Stopwatch PR, acknowledge it and tell the coordinator
-it needs owner review — do NOT review it yourself. Directed Clarion/Stopwatch
-PRs you review and merge normally.
+## Architectural smell check
 
-## Architectural smell check (NEW for 0.7.1)
-
-If a PR introduces a **domain-specific mechanism** where a general
-one exists or should exist, flag it. Examples:
-- Hardcoded special cases for specific types/functions
-- Metadata-driven mechanisms that bypass the type system
-- Duplicated logic that should be unified
-
-This check was missing in 0.6.2/0.7.0 and led to the monad-metadata
-approach being merged when HO pattern unification was the right answer.
+If a PR introduces a **domain-specific mechanism** where a general one
+exists or should exist, flag it — hardcoded special cases for specific
+types/functions, metadata-driven mechanisms that bypass the type system,
+duplicated logic that should be unified. This check was missing in
+0.6.2/0.7.0 and led to the monad-metadata approach being merged when HO
+pattern unification was the right answer.
 
 ## Hard constraints
 
-- **ALWAYS** merge to **master** (not integration branches)
-- **ALWAYS** use `/review` on every PR
-- **ALWAYS** check acceptance criteria
-- **ALWAYS** perform thorough code review — not just gate checks
-- **ALWAYS** verify CI passes and wait for completion
+- **ALWAYS** work through every gate above, not a subset — and perform a
+  thorough code review, not just the gate checks
 - **NEVER** merge **proactive-mode** Clarion or Stopwatch PRs (directed ones you merge normally)
-- **NEVER** skip the code review
 - **NEVER** close beads — the coordinator does this after verifying
   against the spec. If a bead references a spec, ALL phases and
   success criteria must be implemented before the coordinator closes it.
   Flag incomplete work explicitly in your review.
 - Send back PRs with **specific, actionable feedback**
+- Keep review write-ups and coordinator reports under 40 lines — see
+  CLAUDE.md "PR bodies and reports"; detail belongs in
+  `docs/superpowers/reports/`
 - Use UK English in all communication

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,4 @@
-# Beads / Project Management
-
-Run `bd prime` for instructions on using `bd` to manage beads
-
 # CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Overview
 
@@ -12,23 +6,15 @@ Eucalypt is a Rust-based tool and language for generating, templating, rendering
 
 ## Writing Eucalypt Code
 
-**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.** Agents that skip this produce incorrect code and waste cycles — catenation's pipeline semantics, lambda syntax, and prelude contents in eucalypt are all unlike mainstream languages.
+**MANDATORY: Read the documentation BEFORE writing any eucalypt (`.eu`) code.** Agents that skip this produce incorrect code and waste cycles — catenation's pipeline semantics, lambda syntax, and prelude contents in eucalypt are all unlike mainstream languages. `agent-reference.md` §5 ("Common Pitfalls") and `syntax-gotchas.md` cover the traps (catenation precedence, dot-vs-catenation, anaphora scoping, functions that don't exist) in more depth than any summary here could — read them rather than relying on one.
 
-### Required Reading
-
-When writing or modifying `.eu` files, you MUST read these files first:
+Read these before writing or modifying `.eu` files:
 - `docs/reference/agent-reference.md` — dense syntax reference, prelude functions, pipeline patterns, and common pitfalls (READ THIS FIRST)
 - `docs/appendices/syntax-gotchas.md` — critical precedence and syntax traps
 - `docs/appendices/cheat-sheet.md` — quick syntax and operator reference
 - `docs/eucalypt-style.md` — idiomatic style: pipeline/catenation over nested calls, juxtaposed `f[...]` / `g{...}` calls, `then` over `if`, `.result` over `.(...)`, point-free composition
 
-For specific topics, also consult:
-- `docs/guide/expressions-and-pipelines.md` — pipeline style and catenation
-- `docs/guide/anaphora.md` — `_`, `•`, and string anaphora usage
-- `docs/guide/functions-and-combinators.md` — function definition and partial application
-- `docs/reference/prelude/` — full prelude reference by category
-
-`agent-reference.md` §5 ("Common Pitfalls") and `syntax-gotchas.md` already cover the specific traps (catenation precedence, dot-vs-catenation, anaphora scoping, functions that don't exist, etc.) in more depth and nuance than a condensed list here could — read them rather than relying on a summary.
+For specific topics: `docs/guide/expressions-and-pipelines.md` (pipeline style and catenation), `docs/guide/anaphora.md` (`_`, `•`, string anaphora), `docs/guide/functions-and-combinators.md` (definition and partial application), `docs/reference/prelude/` (full prelude reference by category).
 
 ## Build and Development Commands
 
@@ -39,6 +25,7 @@ For specific topics, also consult:
 - `cargo install --path .` - Install local `eu` binary
 - `cargo xtask prelude-compile` - Regenerate `lib/prelude.blob` (the pre-compiled prelude) after changing prelude source; the build falls back to compiling from source when the blob is absent or stale
 - `eu doc <file>` - Extract documentation from eucalypt source (used to regenerate `docs/reference/prelude/`)
+- Build metadata is generated via `eu build.eu -t build-meta` and embedded in the binary via `build-meta.yaml`
 
 ### Type Checking
 
@@ -52,14 +39,9 @@ Type checking runs **unconditionally** on every `eu` invocation (evaluate, dump,
 - A genuine parse error always exits non-zero under `eu check`, with or without `--strict` — unlike an ordinary type warning, it is never gated behind `--strict`
 
 ### Testing
-- `cargo test` - Run all tests including the comprehensive harness test suite
 - `cargo test test_harness_001` - Run a specific harness test (e.g., test 001)
 - `cargo test --test harness_test` - Run only the harness tests
 - `cargo bench` - Run benchmarks (located in `benches/`)
-
-### Build System
-- Parsing uses a hand-written, lossless Rowan-based parser (`src/syntax/rowan/`); there is no separate grammar file or parser generator
-- Build metadata is generated via `eu build.eu -t build-meta` and embedded in the binary via `build-meta.yaml`
 
 ## Architecture
 
@@ -98,14 +80,7 @@ Type checking runs **unconditionally** on every `eu` invocation (evaluate, dump,
 
 ### Test Architecture
 
-**Harness Tests (`tests/harness/`)**:
-- Large test suite covering language features, edge cases, and error conditions
-- Test files use `.eu` extension for eucalypt source, plus YAML, TOML, CSV, XML, and EDN fixtures
-- Error tests in `tests/harness/errors/` directory
-- Benchmark tests in `tests/harness/bench/` directory
-
-**Test Execution**:
-- Tests are run via `tests/harness_test.rs`, one test per file in `tests/harness/`, using the `tester` module
+Harness tests cover language features, edge cases, and error conditions. `.eu` sources plus YAML, TOML, CSV, XML and EDN fixtures; error tests in `tests/harness/errors/`, benchmarks in `tests/harness/bench/`. They run via `tests/harness_test.rs`, one test per file in `tests/harness/`, using the `tester` module.
 
 #### Writing harness tests that gate
 
@@ -115,11 +90,7 @@ Every regression test must be **fault-injection verified**: break the code under
 
 ### Memory Management
 
-The project includes a sophisticated garbage collector:
-- Generational GC with multiple generations
-- Bump allocation for young generation
-- Mark-and-sweep for older generations
-- Custom memory layout for eucalypt values
+Generational GC with multiple generations: bump allocation for the young generation, mark-and-sweep for older ones, over a custom memory layout for eucalypt values.
 
 ### Debug Environment Variables
 
@@ -133,7 +104,7 @@ The project includes a sophisticated garbage collector:
 | `EU_IO_TRACE=1` | Trace all `io.shell` and `io.exec` commands to stderr before execution. Shows the command string and whether stdin is piped. |
 | `EU_HEAPSYN=1` | Select the legacy HeapSyn tree-walk engine instead of the default bytecode engine (BV1). Retained as the performance baseline and differential-testing engine; Phase 4 collapse is deferred pending an A/B perf study. Takes precedence over `EU_PREDECODE` entirely (the pre-decoded dispatch flag is a no-op under HeapSyn). |
 | `EU_BYTECODE=1` | Now redundant — the bytecode engine is the default. Still accepted as an explicit opt-in; `EU_HEAPSYN=1` takes precedence over it. |
-| `EU_PREDECODE=0` | Opt out of pre-decoded dispatch within the bytecode engine, selecting the byte-dispatch path instead (lever a, eu-2sa6.13). As of Phase 2 (eu-vcr8) pre-decoded dispatch is the **default** — unset or `EU_PREDECODE=1` selects it, mirroring how `EU_HEAPSYN` itself flipped from opt-in to opt-out. The byte-dispatch path is retained through a soak period (CI job `test-byte-dispatch-baseline`) before Phase 3 deletes it. No effect when `EU_HEAPSYN=1`. |
+| `EU_PREDECODE=0` | Opt out of pre-decoded dispatch within the bytecode engine, selecting the byte-dispatch path instead (lever a, eu-2sa6.13). Pre-decoded dispatch is the **default** since Phase 2 (eu-vcr8) — unset or `EU_PREDECODE=1` selects it. The byte-dispatch path is retained through a soak period (CI job `test-byte-dispatch-baseline`) before Phase 3 deletes it. No effect when `EU_HEAPSYN=1`. |
 
 The crash signal handler (SIGSEGV/SIGBUS diagnostics) is always active and has no environment variable — it installs unconditionally in `main()`.
 
@@ -170,7 +141,7 @@ Add `--debug-format` for the Rust Debug representation (shows full structure inc
 ## Panics Are Critical
 
 - **Panics must NEVER be deferred.** If you encounter a panic (thread panicked, assertion failure, etc.), stop what you are doing, reproduce a minimal case, and investigate the root cause immediately.
-- **Use `eu dump` commands** (see above) to inspect the pipeline stage where the panic occurs — do NOT add temporary `eprintln!` debug statements.
+- **Use `eu dump` commands** (see above) to inspect the pipeline stage where the panic occurs.
 - **File a P1 bug** and fix it before moving on to other work.
 - **Convert panics to proper errors** as a first step if the root cause fix is complex — a `panic!` or `expect()` in user-reachable code should become an `ExecutionError` or `CoreError` diagnostic.
 - **Every panic fix must include a regression test.**
@@ -213,6 +184,10 @@ measurement standard and cite a dated report or a ledger row:
 3. `cargo clippy --workspace --all-targets -- -D warnings`
 4. `cargo test` - run the full suite (not just `--lib`) when the change might affect harness tests
 5. `git commit` and `git push`
+
+### PR bodies and reports
+
+Keep a PR body under 50 lines and an agent report to the coordinator under 40. State what changed, why, how it was verified, and what is still open. Analysis, measurements, design rationale and investigation narrative belong in `docs/superpowers/reports/` or `docs/superpowers/plans/` — link to them from the PR body rather than restating them. The owner reads every PR body personally; length is what stops that happening.
 
 ### Recorded review before merge
 


### PR DESCRIPTION
PR #1075's body was 381 lines / 20,600 characters — the owner could not read
it, so the review gate did not gate. Nothing in CLAUDE.md or any agent
definition said anything about length, so the verbosity was emergent rather
than instructed. This adds the missing convention and tightens the
definitions themselves.

## What changed

**New convention** — CLAUDE.md gains "PR bodies and reports" under
Development Workflow: a PR body under 50 lines, a coordinator report under
40; state what changed, why, how verified, what is open; analysis and
measurements go to `docs/superpowers/reports/` or `plans/` and are linked
rather than restated.

**Pointer in each agent** — all six definitions in `.claude/agents/` carry a
one-line reference to it in their Hard constraints.

**Restatement removed** — the same rule stated twice now appears once:
`cargo test`'s description, the parser being hand-written (was in three
places), the no-debug-prints rule, each agent's separate "0.7.1 workflow" /
"Branch naming" / "PR target" sections (folded into the worktree command and
the hard constraints), and the 10-line harness-test block duplicated across
five agents (now a pointer to CLAUDE.md plus the two load-bearing rules
verbatim). Contentless preamble dropped.

## Line counts

| File | Before | After |
|---|---|---|
| CLAUDE.md | 280 | 255 |
| wicket.md | 193 | 168 |
| furnace.md | 101 | 72 |
| quill.md | 99 | 73 |
| clarion.md | 89 | 80 |
| lantern.md | 67 | 57 |
| stopwatch.md | 58 | 53 |

## No rule dropped

Every constraint in the before-text survives at least once. Deliberately left
long: the Engine Performance Claims protocol (ticks-first, interleaved,
confidence labels), the fault-injection requirement, the recorded-review and
owner-hold gates, and the debug env-var table — all expensively learned.
CLAUDE.md's 55-line managed Beads block is untouched, so its editable region
is 225 → 200.

Closes eu-52k4z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182qk1pZV4pc61DzY4ZA6C2