### PR TITLE
fix(diag): target_annotation looks through Let/LetRec (eu-7fjiq); narrow DIVERGENCE.md engine claim

### DIFF
--- a/docs/superpowers/reports/2026-07-31-eu-7fjiq-let-annotation-lookthrough.md
+++ b/docs/superpowers/reports/2026-07-31-eu-7fjiq-let-annotation-lookthrough.md
@@ -1,0 +1,146 @@
+# eu-7fjiq: target_annotation Let/LetRec look-through — findings and corpus movement
+
+2026-07-31, Clarion, DIRECTED mode. Branch `fix/clarion-eu-7fjiq-let-annotation`,
+PR to master, reviewed by wicket (not the owner personally — this is a directed
+brief, not a proactive Clarion PR).
+
+## The fix
+
+`Machine::target_annotation` (`src/eval/machine/vm.rs`, HeapSyn engine) and
+`bytecode::machine::target_annotation` (`src/eval/bytecode/machine.rs`, both
+byte-dispatch and pre-decode paths) resolved a thunk's fallback source
+annotation by peeking only the *single leading node* of its compiled body. The
+inliner's argument-sharing `Let` (eu-gua64, PR #1086) can compile `Ann(App)`
+as `Let(..., Ann(App))`, which hides the `Ann` from a single-node peek and
+silently drops the annotation.
+
+Both engines now walk through a leading `Let`/`LetRec` chain to find the
+`Ann`, recursing rather than peeking one level, because repeated inlining can
+stack more than one sharing wrapper. All three dispatch paths (HeapSyn,
+byte-dispatch, pre-decoded bytecode) needed the change — confirmed by
+reproducing the bug under all three before fixing (`eu --heap-limit-mib 4096
+--source-prelude` on the default build, plus `EU_HEAPSYN=1` and
+`EU_PREDECODE=0`).
+
+Verification: 7 new unit tests (3 in `vm.rs`, 4 in `bytecode/machine.rs`,
+covering both dispatch paths) construct a `Let`/nested `Let(LetRec(...))`
+wrapping an `Ann`, call `target_annotation` directly, and assert the smid is
+found. A fourth/eighth negative test asserts a `Let` with no `Ann` anywhere
+in its body still returns `Smid::default()` (no invented location). Fault
+injection: reverting each `target_annotation` to its old single-node-peek
+form makes the corresponding positive tests fail with `Smid(None)` instead of
+the expected smid; restoring the fix makes them pass again. Confirmed for
+both files.
+
+## error_176.eu's verification criterion is NOT met — and why
+
+The bead's own verification target — `tests/harness/errors/error_176.eu`
+under `--source-prelude` regaining the "called from here" secondary at 16:22
+and the "- result at ..." stack-trace line, while keeping the primary at
+19:32 — is **not achieved by this fix**, confirmed empirically (before/after
+binaries, byte-identical output on that fixture with or without the fix).
+
+Root-caused via `EU_ERROR_TRACE_DUMP=1` and direct debug instrumentation
+(temporary, removed before commit):
+
+- `target_annotation`'s fix *does* work correctly for `error_176`: with it,
+  `__shared_e`'s own thunk (the eu-gua64 sharing binding for
+  `make-greeting("world")`) correctly resolves smid 7395 instead of
+  `Smid::default()`. But `__shared_e`'s `Update` continuation is popped
+  (evaluation completes successfully) *before* the `//=` assertion fails, so
+  it is never on the stack — and never in `env_trace` — by the time the error
+  is constructed. Fixing its annotation has no path to the rendered output.
+- The actual missing piece is `result`'s *own* `Update` continuation
+  annotation. `result`'s compiled thunk body is `Let(__shared_e = ...,
+  EXPECT(...))` with **no `Ann` node anywhere along its leading spine at
+  all** — `ProtoLet::take_syntax` (`src/eval/stg/compiler.rs`) never reads
+  the Core `Expr::Let`'s own smid field, so no amount of VM-side look-through
+  can find an annotation that was never emitted. This is a **compiler-side**
+  gap, not a VM-side one.
+- I prototyped wrapping `ProtoLet`'s output in `dsl::ann(smid, ...)` when the
+  Core `Let`'s own smid is valid. It broke primary-location attribution
+  broadly (the diagnostic for `error_176` collapsed to a whole-file span,
+  1:1, because unrelated outer `Let`s — e.g. the top-level block-to-let
+  desugaring — also carry a valid smid and now shadow more specific inner
+  locations). Reverted; this needs a properly scoped design (e.g. limited to
+  the specific sharing-`Let` shape eu-gua64 introduces), not a blanket
+  `ProtoLet` change, and is out of scope for this fix.
+- Separately, `error_176`'s error is raised from inside the `__EXPECT`
+  intrinsic's own sub-evaluation (`render_debug_repr_forced` →
+  `evaluate_to_whnf`), which **restores the caller's stack before
+  propagating an error** — confirmed by the pre-existing test
+  `test_evaluate_to_whnf_impl_restores_caller_state_before_propagating_error`
+  (`vm.rs`). A constructed probe using a plain (non-`//=`) type error, where
+  the error propagates through the ordinary `?` chain with no nested
+  `evaluate_to_whnf`, shows `result`'s Update continuation annotation
+  correctly seeded by the target-eval driver in both fixed and unfixed
+  binaries — i.e. that path doesn't need this fix either, for a different
+  reason.
+
+I could not construct an end-to-end `.eu` harness case where this specific
+fix is the deciding factor in the *rendered* diagnostic — every scenario
+tried is covered by some other annotation mechanism, or (for `error_176`
+itself) blocked by the separate compiler-side gap above. The regression
+tests for this PR are therefore Rust unit tests against `target_annotation`
+directly (see fault-injection above), not a `tests/harness/errors/*.eu` case.
+
+## Corpus movement (0 of 213 differ)
+
+Full `cargo xtask diag-snapshot --bless` run (fresh blob, both prelude
+modes): **0 snapshot files changed**. `git diff --stat
+tests/diagnostics/snapshots` is empty. `DIVERGENCE.md`'s "N of 213" count is
+unchanged. Nothing to re-bless, nothing to explain line-by-line — the fix is
+real (see unit tests) but has no *observable* effect anywhere in the current
+213-fixture corpus under blob or `--source-prelude` mode, for the same
+reason `error_176` doesn't move: every affected `Update` continuation in the
+corpus is either popped before any error surfaces, or covered by another
+already-correct annotation source.
+
+## Bonus finding: EU_HEAPSYN divergence 7 → 6 (eu-l51r7)
+
+While re-running the corpus under `EU_HEAPSYN=1` and `EU_PREDECODE=0` per the
+gates, found that this fix **does** move one fixture in the eu-l51r7 engine
+divergence inventory:
+
+- `errors/085_destructure_short_list`, `--source-prelude`, `EU_HEAPSYN=1`:
+  before this fix, `stack trace:` has 1 frame (`f at 085_...eu:2:1`); with
+  it, 2 frames (`f at 2:21` then `f at 2:1`), matching the blob/default-engine
+  golden exactly. Confirmed by building master (9855417a) unmodified in a
+  scratch worktree and diffing against this branch's binary — same command,
+  same fixture, only the frame count differs.
+- `EU_HEAPSYN=1` divergence: **7 → 6** fixtures (085 no longer diverges).
+- `EU_PREDECODE=0` divergence: unchanged at **6** fixtures (085 was
+  HeapSyn-specific per eu-l51r7's own analysis, and remains so — byte-dispatch
+  never had it).
+- The two non-default sets are now **identical** (6 fixtures each, same
+  list): `errors/049_dot_on_number`, `errors/050_dot_on_string`,
+  `errors/102_dot_on_list_source_loc`, `errors/149_not_value_source_loc`,
+  `errors/191_m93j_lookup_on_function`, `provocations/lookup_on_function`.
+  Before this fix there were two disjoint mechanisms (per eu-l51r7's own
+  note); now there is one.
+- Every remaining divergence is still exactly the documented shape: one
+  `stack trace:` note frame missing, duplicating the primary label's own
+  file:line:col. Confirmed by inspecting the `cargo test` diff output for
+  each of the 6 under both `EU_HEAPSYN=1` and `EU_PREDECODE=0`.
+
+`tests/diagnostics/DIVERGENCE.md` is updated (via `snapshot_engine.rs`'s
+`render_divergence_doc`, so the auto-generated file and the
+`divergence_inventory_is_current` assertion stay in sync) to state plainly
+that its table covers the default engine only, and to record 6/6 (not the
+previously-recorded 7/6) with the eu-l51r7 reference. Recommend the
+coordinator or owner update eu-l51r7 itself with the corrected count; I have
+not touched the bead (Clarion does not close beads, and updating its own
+count felt like the coordinator's/owner's call given it's a P2 owner
+decision record).
+
+## Gates run
+
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`:
+  clean.
+- `cargo test --release` (fresh blob via `cargo xtask prelude-compile`,
+  `rm -f lib/prelude.blob` first per the stale-blob hazard): 23/23 suites
+  green, 0 failed.
+- `EU_HEAPSYN=1 cargo test --release`: 6 diagnostics-snapshot mismatches
+  (the known, now-updated eu-l51r7 set) — everything else green.
+- `EU_PREDECODE=0 cargo test --release`: 6 diagnostics-snapshot mismatches
+  (same set) — everything else green.

--- a/src/eval/bytecode/machine.rs
+++ b/src/eval/bytecode/machine.rs
@@ -2941,6 +2941,18 @@ fn peek_code_ref(decoded: &DecodedProgram, byte_off: CodeRef) -> CodeRef {
 /// `closure.code()` under pre-decode already *is* that ordinal (an `Ann`
 /// offset is aliased straight to its body's ordinal and never gets one of its
 /// own), so no byte-peek is needed on that path (eu-1tkk.7.18).
+///
+/// A binding group can sit ahead of that `Ann` — e.g. the inliner's
+/// argument-sharing `Let` (eu-gua64) wraps `Ann(App)` as `Let(...,
+/// Ann(App))` when a callee's non-duplicable argument is used more than
+/// once — which hides the leading `Ann` from a single-node peek and
+/// silently drops the annotation (eu-7fjiq, matching the identical fix in
+/// `machine::vm::Machine::target_annotation`). Unlike `Op::Ann`, `Op::Let`/
+/// `Op::LetRec` are NOT folded out of dispatch — they allocate bindings and
+/// must still run — so this walks *past* them to find the annotation without
+/// touching how `ordinal_for`/`step`/`step_predecoded` treat them. Repeated
+/// inlining can stack more than one such wrapper, so the walk loops rather
+/// than peeking just one level.
 fn target_annotation(
     prog: &BytecodeProgram,
     decoded: &DecodedProgram,
@@ -2951,18 +2963,48 @@ fn target_annotation(
     }
     if decoded.off_of.is_empty() {
         let code = prog.code.as_slice();
-        let off = closure.code() as usize;
-        if off < code.len() && Op::from_u8(code[off]) == Some(Op::Ann) {
-            let mut pc = off + 1;
-            return Smid::from(read_u32(code, &mut pc));
+        let mut off = closure.code() as usize;
+        loop {
+            if off >= code.len() {
+                return Smid::default();
+            }
+            match Op::from_u8(code[off]) {
+                Some(Op::Ann) => {
+                    let mut pc = off + 1;
+                    return Smid::from(read_u32(code, &mut pc));
+                }
+                Some(Op::Let) | Some(Op::LetRec) => {
+                    // `[op][u32 count][count * form header][u32 body_off]` —
+                    // skip past the bindings to the trailing body offset
+                    // (mirrors the `Op::Let`/`Op::LetRec` decode in `step`).
+                    let mut pc = off + 1;
+                    let count = read_u32(code, &mut pc) as usize;
+                    for _ in 0..count {
+                        read_form_header(code, &mut pc);
+                    }
+                    off = read_u32(code, &mut pc) as usize;
+                }
+                _ => return Smid::default(),
+            }
         }
-        Smid::default()
     } else {
-        decoded
-            .smids
-            .get(closure.code() as usize)
-            .copied()
-            .unwrap_or_default()
+        let mut ord = closure.code() as usize;
+        loop {
+            match decoded.smids.get(ord).copied() {
+                Some(smid) if smid.is_valid() => return smid,
+                Some(_) => {}
+                None => return Smid::default(),
+            }
+            match decoded.instrs.get(ord).map(|i| i.op) {
+                Some(Op::Let) | Some(Op::LetRec) => {
+                    // `Instr::a` holds the body ordinal for Let/LetRec
+                    // (`predecode.rs` `Decoder::decode_node`), so follow it
+                    // rather than re-parsing the byte stream.
+                    ord = decoded.instrs[ord].a as usize;
+                }
+                _ => return Smid::default(),
+            }
+        }
     }
 }
 
@@ -4973,6 +5015,118 @@ mod tests {
         assert_eq!(hdr.kind, crate::eval::bytecode::FORM_THUNK);
         assert_eq!(hdr.arity, 0);
         assert!((hdr.body as usize) < prog.code.len());
+    }
+
+    /// eu-7fjiq: `target_annotation` must look *through* a leading
+    /// `Let`/`LetRec` to find the thunk's leading `Ann`, on both dispatch
+    /// paths — the inliner's argument-sharing `Let` (eu-gua64) compiles
+    /// `Ann(App)` as `Let(..., Ann(App))`, hiding the annotation from a
+    /// single-node peek.
+    ///
+    /// Fault injection: reverting either arm of `target_annotation` to a bare
+    /// byte-offset / ordinal `Ann` check (no `Op::Let`/`Op::LetRec` handling)
+    /// makes the corresponding assertion below fail (`Smid::default()`
+    /// instead of the expected smid).
+    #[test]
+    fn target_annotation_looks_through_let_byte_dispatch() {
+        let smid = Smid::from(42);
+        let syn = dsl::let_(vec![], dsl::ann(smid, dsl::atom(dsl::num(9))));
+        let (prog, root, _) = encode(&syn, &[]);
+
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let env = view.alloc(BcEnvFrame::default()).unwrap().as_ptr();
+        let closure = BcClosure::new(root, env);
+
+        // Byte-dispatch path: an empty `DecodedProgram` signals `off_of` is
+        // empty, so `target_annotation` peeks the raw byte stream.
+        assert_eq!(
+            target_annotation(&prog, &DecodedProgram::default(), &closure),
+            smid,
+            "byte-dispatch: a leading Let wrapping Ann(App) must not hide the smid"
+        );
+    }
+
+    #[test]
+    fn target_annotation_looks_through_let_predecoded() {
+        let smid = Smid::from(42);
+        let syn = dsl::let_(vec![], dsl::ann(smid, dsl::atom(dsl::num(9))));
+        let (prog, root, global_forms) = encode(&syn, &[]);
+        let decoded = decode_program(&prog, root, &global_forms).unwrap();
+
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let env = view.alloc(BcEnvFrame::default()).unwrap().as_ptr();
+        let closure = BcClosure::new(decoded.ordinal(root), env);
+
+        assert_eq!(
+            target_annotation(&prog, &decoded, &closure),
+            smid,
+            "pre-decode: a leading Let wrapping Ann(App) must not hide the smid"
+        );
+    }
+
+    /// As above, but the `Ann` sits behind *two* stacked binding groups
+    /// (`Let(LetRec(Ann(...)))`) — repeated inlining can stack more than one
+    /// sharing wrapper, so the look-through must recurse rather than peek
+    /// only one level deep. Covers both dispatch paths.
+    #[test]
+    fn target_annotation_looks_through_nested_let_letrec() {
+        let smid = Smid::from(99);
+        let syn = dsl::let_(
+            vec![],
+            dsl::letrec_(vec![], dsl::ann(smid, dsl::atom(dsl::num(1)))),
+        );
+        let (prog, root, global_forms) = encode(&syn, &[]);
+
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let env = view.alloc(BcEnvFrame::default()).unwrap().as_ptr();
+
+        assert_eq!(
+            target_annotation(
+                &prog,
+                &DecodedProgram::default(),
+                &BcClosure::new(root, env)
+            ),
+            smid,
+            "byte-dispatch: nested Let/LetRec wrappers must all be looked through"
+        );
+
+        let decoded = decode_program(&prog, root, &global_forms).unwrap();
+        assert_eq!(
+            target_annotation(&prog, &decoded, &BcClosure::new(decoded.ordinal(root), env)),
+            smid,
+            "pre-decode: nested Let/LetRec wrappers must all be looked through"
+        );
+    }
+
+    /// A `Let` whose body genuinely carries no annotation must still fall
+    /// back to `Smid::default()` on both dispatch paths — the look-through
+    /// must not invent a location that was never compiled.
+    #[test]
+    fn target_annotation_let_without_ann_is_default() {
+        let syn = dsl::let_(vec![], dsl::atom(dsl::num(9)));
+        let (prog, root, global_forms) = encode(&syn, &[]);
+
+        let heap = Heap::new();
+        let view = MutatorHeapView::new(&heap);
+        let env = view.alloc(BcEnvFrame::default()).unwrap().as_ptr();
+
+        assert_eq!(
+            target_annotation(
+                &prog,
+                &DecodedProgram::default(),
+                &BcClosure::new(root, env)
+            ),
+            Smid::default()
+        );
+
+        let decoded = decode_program(&prog, root, &global_forms).unwrap();
+        assert_eq!(
+            target_annotation(&prog, &decoded, &BcClosure::new(decoded.ordinal(root), env)),
+            Smid::default()
+        );
     }
 
     use crate::eval::memory::array::Array;

--- a/src/eval/machine/vm.rs
+++ b/src/eval/machine/vm.rs
@@ -1553,17 +1553,33 @@ impl MachineState {
     /// only a `Lambda` form's header carries one; see `LambdaForm::annotation`
     /// in `stg/syntax.rs`) — the compiler instead wraps the thunk's body in a
     /// leading `HeapSyn::Ann` node, so peek that directly (eu-1tkk.7.18).
+    ///
+    /// A binding group can sit ahead of that `Ann` — e.g. the inliner's
+    /// argument-sharing `Let` (eu-gua64) wraps `Ann(App)` as `Let(...,
+    /// Ann(App))` when a callee's non-duplicable argument is used more than
+    /// once — which hides the leading `Ann` from a single-node peek and
+    /// silently drops the annotation (eu-7fjiq). Repeated inlining can stack
+    /// more than one such wrapper (each pass may wrap the previous result in
+    /// its own sharing `Let`), so look through every leading `Let`/`LetRec`
+    /// rather than just one.
     fn target_annotation(closure: &SynClosure) -> Smid {
         if closure.annotation().is_valid() {
             return closure.annotation();
         }
         // SAFETY: closure.code() points at a HeapSyn node in the compiled,
         // immutable STG graph, live for the program's duration — the same
-        // unsafe peek already used at the top of `dispatch`.
-        let code: &HeapSyn = unsafe { &*closure.code().as_ptr() };
-        match code {
-            HeapSyn::Ann { smid, .. } => *smid,
-            _ => Smid::default(),
+        // unsafe peek already used at the top of `dispatch`. Each `body`
+        // pointer walked below is likewise a pointer into that same
+        // immutable graph.
+        let mut code: &HeapSyn = unsafe { &*closure.code().as_ptr() };
+        loop {
+            match code {
+                HeapSyn::Ann { smid, .. } => return *smid,
+                HeapSyn::Let { body, .. } | HeapSyn::LetRec { body, .. } => {
+                    code = unsafe { &*body.as_ptr() };
+                }
+                _ => return Smid::default(),
+            }
         }
     }
 
@@ -2939,7 +2955,7 @@ pub mod tests {
     use crate::eval::stg::syntax::{ex::*, StgSyn};
     use crate::eval::{emit::DebugEmitter, stg::syntax::dsl::*};
 
-    use super::{evaluate_to_whnf_impl, Machine};
+    use super::{evaluate_to_whnf_impl, Machine, MachineState};
 
     lazy_static! {
         static ref EMPTY_INTRINSICS: Vec<Box<dyn StgIntrinsic>> = vec![];
@@ -3344,5 +3360,90 @@ pub mod tests {
             caller_closure.code(),
             "caller closure restored, not left as the sub-run's"
         );
+    }
+
+    /// eu-7fjiq: `target_annotation` must look *through* a leading
+    /// `Let`/`LetRec` to find the thunk's leading `Ann`, not just peek the
+    /// single leading node. A binding group ahead of the `Ann` — e.g. the
+    /// inliner's argument-sharing `Let` (eu-gua64) compiling `Ann(App)` as
+    /// `Let(..., Ann(App))` — must not hide the annotation.
+    ///
+    /// Fault injection: reverting `target_annotation` to a bare
+    /// `match code { HeapSyn::Ann { smid, .. } => *smid, _ => Smid::default() }`
+    /// (no `Let`/`LetRec` arm) makes both `let_through_single_let` and
+    /// `let_through_nested_let_letrec` return `Smid::default()` instead of the
+    /// expected smid, failing the assertions below.
+    #[test]
+    pub fn test_target_annotation_looks_through_let() {
+        let smid = Smid::from(42);
+        let syn = let_(vec![], ann(smid, atom(num(9))));
+
+        let m = Machine::new(Box::new(DebugEmitter::default()), true, None, false, false);
+        let blank = m.mutate(Init, ()).unwrap();
+        let closure = m
+            .mutate(
+                Load {
+                    syntax: syn,
+                    pool: RefCell::new(SymbolPool::new()),
+                },
+                blank,
+            )
+            .unwrap();
+
+        assert_eq!(
+            MachineState::target_annotation(&closure),
+            smid,
+            "a leading Let wrapping Ann(App) must not hide the call-site smid"
+        );
+    }
+
+    /// As above, but with the `Ann` behind *two* stacked binding groups
+    /// (`Let(LetRec(Ann(...)))`) — repeated inlining can stack more than one
+    /// sharing wrapper, so the look-through must recurse rather than peek
+    /// only one level deep.
+    #[test]
+    pub fn test_target_annotation_looks_through_nested_let_letrec() {
+        let smid = Smid::from(99);
+        let syn = let_(vec![], letrec_(vec![], ann(smid, atom(num(1)))));
+
+        let m = Machine::new(Box::new(DebugEmitter::default()), true, None, false, false);
+        let blank = m.mutate(Init, ()).unwrap();
+        let closure = m
+            .mutate(
+                Load {
+                    syntax: syn,
+                    pool: RefCell::new(SymbolPool::new()),
+                },
+                blank,
+            )
+            .unwrap();
+
+        assert_eq!(
+            MachineState::target_annotation(&closure),
+            smid,
+            "nested Let/LetRec wrappers must all be looked through to reach the Ann"
+        );
+    }
+
+    /// A `Let` whose body genuinely carries no annotation (no `Ann` anywhere
+    /// along the leading spine) must still fall back to `Smid::default()` —
+    /// the look-through must not invent a location that was never compiled.
+    #[test]
+    pub fn test_target_annotation_let_without_ann_is_default() {
+        let syn = let_(vec![], atom(num(9)));
+
+        let m = Machine::new(Box::new(DebugEmitter::default()), true, None, false, false);
+        let blank = m.mutate(Init, ()).unwrap();
+        let closure = m
+            .mutate(
+                Load {
+                    syntax: syn,
+                    pool: RefCell::new(SymbolPool::new()),
+                },
+                blank,
+            )
+            .unwrap();
+
+        assert_eq!(MachineState::target_annotation(&closure), Smid::default());
     }
 }

--- a/tests/diagnostics/DIVERGENCE.md
+++ b/tests/diagnostics/DIVERGENCE.md
@@ -18,3 +18,9 @@ The full text of both renderings is in the fixture's `.snap` file under
 | `errors/035_nested_fn_trace` | user tests/harness/errors/035_nested_fn_trace.eu:2:12 | user tests/harness/errors/035_nested_fn_trace.eu:1:11 | 1 (1 user) | 1 (1 user) |
 | `errors/143_bitwise_float` | none | user tests/harness/errors/143_bitwise_float.eu:3:13 | 0 (0 user) | 0 (0 user) |
 | `errors/error_176` | user tests/harness/errors/error_176.eu:19:32 | user tests/harness/errors/error_176.eu:19:32 | 1 (1 user) | 0 (0 user) |
+
+## Engine scope
+
+The table above is for the **default engine** (bytecode, pre-decoded dispatch) only — the shipped default, and the only dispatch path this gate exercises with a real blob. It says nothing about the two non-default paths.
+
+`EU_HEAPSYN=1` and `EU_PREDECODE=0` are not asserted against these goldens at all, and each diverges from them on its own set of fixtures — a separate, already-known issue, not part of the count above. As of eu-l51r7's most recent count: 6 fixtures diverge under `EU_HEAPSYN=1`, and the same 6 diverge under `EU_PREDECODE=0`. In every case the difference is one `stack trace:` note frame missing, duplicating the primary label's own file:line:col — never a wrong location or a missing primary. See eu-l51r7 for the full inventory; the owner ruled this does not block 0.14 (P2, characterised and pinned per-engine rather than fixed).

--- a/tests/diagnostics/snapshot_engine.rs
+++ b/tests/diagnostics/snapshot_engine.rs
@@ -1116,7 +1116,40 @@ pub fn render_divergence_doc(snapshots: &[Snapshot]) -> String {
             snap.source.facts.trace_user_frames,
         ));
     }
+    s.push_str(&engine_scope_note());
     s
+}
+
+/// Static scope caveat, appended after the (per-run-computed) divergence
+/// table above: which engine that table's figures actually cover.
+///
+/// The blob-vs-source table only ever exercises the **default** engine
+/// (bytecode, pre-decoded dispatch) — `eu_binary()` in
+/// `tests/diagnostics_snapshots.rs` spawns the release `eu` this test binary
+/// was built alongside, with no `EU_HEAPSYN`/`EU_PREDECODE` override. The two
+/// non-default dispatch paths are a separate, already-tracked issue
+/// (eu-l51r7): asserted nowhere in this corpus, and they diverge from these
+/// same goldens on a further, disjoint set of fixtures. Recorded by hand
+/// (not computed from a live run of every dispatch path) because capturing
+/// that would need three more full corpus sweeps; update the counts here
+/// whenever eu-l51r7's own inventory moves.
+fn engine_scope_note() -> String {
+    "\n## Engine scope\n\n\
+     The table above is for the **default engine** (bytecode, pre-decoded \
+     dispatch) only — the shipped default, and the only dispatch path this \
+     gate exercises with a real blob. It says nothing about the two \
+     non-default paths.\n\n\
+     `EU_HEAPSYN=1` and `EU_PREDECODE=0` are not asserted against these \
+     goldens at all, and each diverges from them on its own set of \
+     fixtures — a separate, already-known issue, not part of the count \
+     above. As of eu-l51r7's most recent count: 6 fixtures diverge under \
+     `EU_HEAPSYN=1`, and the same 6 diverge under `EU_PREDECODE=0`. In every \
+     case the difference is one `stack trace:` note frame missing, \
+     duplicating the primary label's own file:line:col — never a wrong \
+     location or a missing primary. See eu-l51r7 for the full inventory; the \
+     owner ruled this does not block 0.14 (P2, characterised and pinned \
+     per-engine rather than fixed).\n"
+        .to_string()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Mode

DIRECTED (owner-sanctioned brief relayed by coordinator) — reviewed and merged by wicket in the normal way, not the owner personally.

## Summary

- **eu-7fjiq**: `target_annotation` (both `vm.rs`/HeapSyn and `bytecode/machine.rs`, byte-dispatch + pre-decode) now looks through a leading `Let`/`LetRec` to find the thunk's `Ann`, recursing for repeated inlining. The inliner's argument-sharing `Let` (eu-gua64) can compile `Ann(App)` as `Let(..., Ann(App))`, which hid the annotation from the old single-node peek.
- **eu-l51r7 (DIVERGENCE.md)**: added a static "Engine scope" section (generated via `snapshot_engine.rs`, kept in sync with `divergence_inventory_is_current`) stating the blob-vs-source table covers the default engine only, and recording the non-default-engine trace divergence.

## Full findings — see the linked report

`docs/superpowers/reports/2026-07-31-eu-7fjiq-let-annotation-lookthrough.md` has the complete picture; headline points:

- **error_176.eu's verification criterion is not met by this fix**, and I found out why: the missing secondary/trace there is `result`'s *own* Update continuation, whose thunk body (`Let(__shared_e=..., EXPECT(...))`) has **no `Ann` anywhere** because `ProtoLet` (compiler.rs) never reads Core `Let`'s own smid — a separate, compiler-side gap. I prototyped fixing it; it broke primary-location attribution broadly (unrelated outer `Let`s also have valid smids) and I reverted it. Also found `error_176`'s error goes through `evaluate_to_whnf`, which restores the caller's stack before propagating an error (pre-existing, tested behaviour) — a second, independent reason the frame doesn't surface there.
- **Verification**: 7 new Rust unit tests (not a `.eu` harness case — see report for why one couldn't be constructed) directly exercise `target_annotation` with `Let`/nested `Let(LetRec(Ann))` and a negative (no-`Ann`) case, in both engines/both dispatch paths. Fault-injected: reverting each `target_annotation` to the old single-node peek fails the corresponding tests; restoring passes.
- **Corpus movement: 0 of 213** snapshots changed (`cargo xtask diag-snapshot --bless`, fresh blob) — nothing to re-bless.
- **Bonus**: this fix moves `errors/085_destructure_short_list` from diverging to matching under `EU_HEAPSYN=1`, so eu-l51r7's HeapSyn divergence count is **7 → 6** (now identical to the `EU_PREDECODE=0` set). DIVERGENCE.md updated accordingly; recommend updating eu-l51r7 itself too.

## Gates

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --release` (fresh blob): 23/23 suites green
- `EU_HEAPSYN=1 cargo test --release`: 6 known diagnostics-snapshot mismatches (eu-l51r7, now updated), everything else green
- `EU_PREDECODE=0 cargo test --release`: same 6, everything else green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182qk1pZV4pc61DzY4ZA6C2