### PR TITLE
fix(diag): drop misleading panic prefix/note, add EU-EVAL-TYPE to UnexpectedFunction

### DIFF
--- a/docs/guide/contracts.md
+++ b/docs/guide/contracts.md
@@ -254,7 +254,7 @@ file. `validate` raises when its first argument is not a type spec at all:
 ```eu,notest
 { import: "contract.eu" }
 r: { a: 1 } validate({ not: "a spec" })
-# error: panic: validate: not a type spec
+# error: validate: not a type spec
 ```
 
 That is a different error from a contract violation, distinguishable both

--- a/src/eval/error.rs
+++ b/src/eval/error.rs
@@ -891,10 +891,14 @@ pub enum ExecutionError {
     /// function so that the "panic:" label appears in the diagnostic.
     #[error("{1}")]
     Panic(Smid, String),
-    /// Error raised by the user's `panic("msg")` call.
+    /// Error raised by a call to the `panic("msg")` intrinsic.
     ///
-    /// Displays with the "panic: " prefix so the user sees their explicit
-    /// call to `panic()` reflected in the error message.
+    /// Displays with the "panic: " prefix by default, so a user sees their
+    /// explicit call to `panic()` reflected in the error message. But the
+    /// prelude raises its own errors through this same intrinsic (e.g.
+    /// `nth`'s out-of-range check), so `to_diagnostic` suppresses the
+    /// prefix whenever the call site's Smid does not resolve to a user file
+    /// (eu-1tkk.7.33) — see the `UserPanic` handling there.
     #[error("panic: {1}")]
     UserPanic(Smid, String),
     /// A structural contract applied with `ensure` rejected its data.
@@ -1112,6 +1116,20 @@ impl ExecutionError {
             .and_then(|info| info.file)
             .map(|fid| source_map.is_user_file(fid))
             .unwrap_or(false);
+
+        // `UserPanic` is raised by the same `panic()` intrinsic whether the
+        // call originates in the user's own program or inside a prelude
+        // function (e.g. `nth`'s out-of-range check, `lib/prelude.eu`). The
+        // "panic: " prefix is only meaningful when the user wrote the
+        // `panic(...)` call themselves — showing it for a library-raised
+        // error makes an ordinary diagnostic (e.g. an out-of-range index)
+        // read as a crash. Drop the prefix whenever the call site is not in
+        // a user file (eu-1tkk.7.33).
+        if let ExecutionError::UserPanic(_, message) = inner {
+            if !error_has_user_file {
+                diag.message = message.clone();
+            }
+        }
 
         let primary_file_span: Option<(usize, codespan::Span)> = if error_has_user_file {
             error_info.and_then(|info| info.file.zip(info.span))
@@ -1411,9 +1429,7 @@ impl ExecutionError {
                 ]
             }
             ExecutionError::HeadOfNonList(_, found) => {
-                let mut notes = vec![
-                    "head and tail require a list (e.g. [1, 2, 3]) as their argument".to_string(),
-                ];
+                let mut notes = vec![];
                 if found.starts_with('"') {
                     notes.push(
                         "to concatenate strings, use string interpolation (e.g. \"{a}{b}\") \
@@ -1429,9 +1445,7 @@ impl ExecutionError {
                 notes
             }
             ExecutionError::TailOfNonList(_, found) => {
-                let mut notes = vec![
-                    "head and tail require a list (e.g. [1, 2, 3]) as their argument".to_string(),
-                ];
+                let mut notes = vec![];
                 if found.starts_with('"') {
                     notes.push(
                         "to concatenate strings, use string interpolation (e.g. \"{a}{b}\") \
@@ -1580,6 +1594,11 @@ impl ExecutionError {
         match self {
             ExecutionError::Traced(inner, _) => inner.code(),
             ExecutionError::TypeMismatch(..) => Some("EU-EVAL-TYPE"),
+            // Same message family as `TypeMismatch` ("type mismatch: expected
+            // X, found Y") — added by eu-1tkk.7.9 to stop function values
+            // being misreported as blocks, but the code allow-list was not
+            // updated to follow (eu-1tkk.7.37).
+            ExecutionError::UnexpectedFunction(..) => Some("EU-EVAL-TYPE"),
             ExecutionError::ContractViolation(..) => Some("EU-EVAL-CONTRACT"),
             ExecutionError::UnrepresentableValue(..) => Some("EU-RENDER-UNREPRESENTABLE"),
             ExecutionError::UnrenderableShape(..) => Some("EU-RENDER-SHAPE"),

--- a/tests/diagnostics/snapshots/errors/042_map_non_list.snap
+++ b/tests/diagnostics/snapshots/errors/042_map_non_list.snap
@@ -10,7 +10,7 @@ warnings: 1
 code: -
 primary: user tests/harness/errors/042_map_non_list.eu:3:16
 help-lines: 0
-note-lines: 2
+note-lines: 1
 secondary-labels: 1
 trace-frames: 1
 trace-user-frames: 1
@@ -32,7 +32,6 @@ error: head requires a list, found 42
   │           │
   │           called from here
   │
-  = head and tail require a list (e.g. [1, 2, 3]) as their argument
   = to create a list from a number, wrap it: '[n]'
   = stack trace:
     - result at 042_map_non_list.eu:3:16

--- a/tests/diagnostics/snapshots/errors/047_str_plus_plus.snap
+++ b/tests/diagnostics/snapshots/errors/047_str_plus_plus.snap
@@ -10,7 +10,7 @@ warnings: 0
 code: -
 primary: none
 help-lines: 0
-note-lines: 3
+note-lines: 2
 secondary-labels: 0
 trace-frames: 0
 trace-user-frames: 0
@@ -19,6 +19,5 @@ prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
 error: head requires a list, found "Hello, "
- = head and tail require a list (e.g. [1, 2, 3]) as their argument
  = to concatenate strings, use string interpolation (e.g. "{a}{b}") or 'str.join-on', not '++' (which is for list append)
  = to get individual characters of a string, use 'str.letters'

--- a/tests/diagnostics/snapshots/errors/078_anon_anaphor_scope.snap
+++ b/tests/diagnostics/snapshots/errors/078_anon_anaphor_scope.snap
@@ -7,7 +7,7 @@ prelude-modes: identical
 exit: 1
 errors: 1
 warnings: 0
-code: -
+code: EU-EVAL-TYPE
 primary: user tests/harness/errors/078_anon_anaphor_scope.eu:5:23
 help-lines: 0
 note-lines: 2
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: type mismatch: expected number, found a function
+error[EU-EVAL-TYPE]: type mismatch: expected number, found a function
   ┌─ tests/harness/errors/078_anon_anaphor_scope.eu:5:23
   │
 5 │ result: [1, 2, 3] map(double(_))

--- a/tests/diagnostics/snapshots/errors/109_unknown_arg.snap
+++ b/tests/diagnostics/snapshots/errors/109_unknown_arg.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: unknown option: --unknown-flag
+error: unknown option: --unknown-flag
   ┌─ tests/harness/errors/109_unknown_arg.eu:2:26
   │
 2 │ main: ["--unknown-flag"] parse-args({})

--- a/tests/diagnostics/snapshots/errors/110_unknown_short_arg.snap
+++ b/tests/diagnostics/snapshots/errors/110_unknown_short_arg.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: unknown option: -x
+error: unknown option: -x
   ┌─ tests/harness/errors/110_unknown_short_arg.eu:2:14
   │
 2 │ main: ["-x"] parse-args({})

--- a/tests/diagnostics/snapshots/errors/111_missing_option_value.snap
+++ b/tests/diagnostics/snapshots/errors/111_missing_option_value.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: option --output requires a value
+error: option --output requires a value
   ┌─ tests/harness/errors/111_missing_option_value.eu:2:20
   │
 2 │ main: ["--output"] parse-args({ output: "default" })

--- a/tests/diagnostics/snapshots/errors/129_head_tail_not_list.snap
+++ b/tests/diagnostics/snapshots/errors/129_head_tail_not_list.snap
@@ -10,7 +10,7 @@ warnings: 1
 code: -
 primary: user tests/harness/errors/129_head_tail_not_list.eu:1:7
 help-lines: 0
-note-lines: 2
+note-lines: 1
 secondary-labels: 0
 trace-frames: 1
 trace-user-frames: 1
@@ -30,7 +30,6 @@ error: head requires a list, found 42
 1 │ x: 42 head
   │       ^^^^
   │
-  = head and tail require a list (e.g. [1, 2, 3]) as their argument
   = to create a list from a number, wrap it: '[n]'
   = stack trace:
     - x at 129_head_tail_not_list.eu:1:7

--- a/tests/diagnostics/snapshots/errors/138_internal_no_panic_prefix.snap
+++ b/tests/diagnostics/snapshots/errors/138_internal_no_panic_prefix.snap
@@ -10,7 +10,7 @@ warnings: 1
 code: -
 primary: user tests/harness/errors/138_internal_no_panic_prefix.eu:1:17
 help-lines: 0
-note-lines: 3
+note-lines: 2
 secondary-labels: 0
 trace-frames: 1
 trace-user-frames: 1
@@ -30,7 +30,6 @@ error: head requires a list, found "hello"
 1 │ result: "hello" head
   │                 ^^^^
   │
-  = head and tail require a list (e.g. [1, 2, 3]) as their argument
   = to concatenate strings, use string interpolation (e.g. "{a}{b}") or 'str.join-on', not '++' (which is for list append)
   = to get individual characters of a string, use 'str.letters'
   = stack trace:

--- a/tests/diagnostics/snapshots/errors/139_list_index_oob.snap
+++ b/tests/diagnostics/snapshots/errors/139_list_index_oob.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
   ┌─ tests/harness/errors/139_list_index_oob.eu:2:19
   │
 2 │ result: [1, 2, 3] nth(10)

--- a/tests/diagnostics/snapshots/errors/181_direct_app_call_site.snap
+++ b/tests/diagnostics/snapshots/errors/181_direct_app_call_site.snap
@@ -10,7 +10,7 @@ warnings: 0
 code: -
 primary: user tests/harness/errors/181_direct_app_call_site.eu:15:9
 help-lines: 0
-note-lines: 1
+note-lines: 0
 secondary-labels: 0
 trace-frames: 2
 trace-user-frames: 1
@@ -24,7 +24,6 @@ error: tail requires a list, found 3
 15 │ result: second(3)
    │         ^^^^^^
    │
-   = head and tail require a list (e.g. [1, 2, 3]) as their argument
    = stack trace:
      - result at 181_direct_app_call_site.eu:15:9
      - in 'nth' at [prelude]

--- a/tests/diagnostics/snapshots/errors/192_1tkk_7_9_function_not_block.snap
+++ b/tests/diagnostics/snapshots/errors/192_1tkk_7_9_function_not_block.snap
@@ -7,7 +7,7 @@ prelude-modes: identical
 exit: 1
 errors: 1
 warnings: 0
-code: -
+code: EU-EVAL-TYPE
 primary: user tests/harness/errors/192_1tkk_7_9_function_not_block.eu:2:9
 help-lines: 0
 note-lines: 2
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: type mismatch: expected number, found a function
+error[EU-EVAL-TYPE]: type mismatch: expected number, found a function
   ┌─ tests/harness/errors/192_1tkk_7_9_function_not_block.eu:2:9
   │
 2 │ result: add(1) + 1

--- a/tests/diagnostics/snapshots/errors/193_1tkk_7_12_curated_trace.snap
+++ b/tests/diagnostics/snapshots/errors/193_1tkk_7_12_curated_trace.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
   ┌─ tests/harness/errors/193_1tkk_7_12_curated_trace.eu:5:12
   │
 5 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/errors/194_8a49h_library_blame.snap
+++ b/tests/diagnostics/snapshots/errors/194_8a49h_library_blame.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: elements called on non-block
+error: elements called on non-block
    ┌─ tests/harness/errors/194_8a49h_library_blame.eu:12:22
    │
 12 │ bad: [:t-record, 42] from-data

--- a/tests/diagnostics/snapshots/errors/195_og3u6_trace_anchor.snap
+++ b/tests/diagnostics/snapshots/errors/195_og3u6_trace_anchor.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
    ┌─ tests/harness/errors/195_og3u6_trace_anchor.eu:15:12
    │
 15 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/errors/202_sv3_contract_bad_spec.snap
+++ b/tests/diagnostics/snapshots/errors/202_sv3_contract_bad_spec.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: validate: not a type spec
+error: validate: not a type spec
   ┌─ tests/harness/errors/202_sv3_contract_bad_spec.eu:7:18
   │
 7 │ result: { a: 1 } validate({ not: "a spec" })

--- a/tests/diagnostics/snapshots/many-decls/many_decls_early_nth.snap
+++ b/tests/diagnostics/snapshots/many-decls/many_decls_early_nth.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
   ┌─ tests/diagnostics/snapshot-corpus/many_decls_early_nth.eu:5:12
   │
 5 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/many-decls/many_decls_late_nth.snap
+++ b/tests/diagnostics/snapshots/many-decls/many_decls_late_nth.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
     ┌─ tests/diagnostics/snapshot-corpus/many_decls_late_nth.eu:907:12
     │
 907 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/many-decls/many_decls_middle_nth.snap
+++ b/tests/diagnostics/snapshots/many-decls/many_decls_middle_nth.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
     ┌─ tests/diagnostics/snapshot-corpus/many_decls_middle_nth.eu:455:12
     │
 455 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/many-decls/many_decls_nested_user_fn.snap
+++ b/tests/diagnostics/snapshots/many-decls/many_decls_nested_user_fn.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
     ┌─ tests/diagnostics/snapshot-corpus/many_decls_nested_user_fn.eu:606:12
     │
 606 │ result: xs take-tenth

--- a/tests/diagnostics/snapshots/provocations/catenation_arith.snap
+++ b/tests/diagnostics/snapshots/provocations/catenation_arith.snap
@@ -7,7 +7,7 @@ prelude-modes: identical
 exit: 1
 errors: 1
 warnings: 0
-code: -
+code: EU-EVAL-TYPE
 primary: user tests/diagnostics/corpus/catenation_arith.eu:2:7
 help-lines: 0
 note-lines: 2
@@ -18,7 +18,7 @@ trace-prelude-frames: 0
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: type mismatch: expected number, found a function
+error[EU-EVAL-TYPE]: type mismatch: expected number, found a function
   ┌─ tests/diagnostics/corpus/catenation_arith.eu:2:7
   │
 2 │ n: xs foldl(+, 0) + 1

--- a/tests/diagnostics/snapshots/provocations/nth_out_of_range.snap
+++ b/tests/diagnostics/snapshots/provocations/nth_out_of_range.snap
@@ -18,7 +18,7 @@ trace-prelude-frames: 1
 prelude-excerpt-lines: 0
 rust-panic: no
 --- stderr ---
-error: panic: index 10 out of range for list of length 3
+error: index 10 out of range for list of length 3
   ┌─ tests/diagnostics/corpus/nth_out_of_range.eu:2:12
   │
 2 │ result: xs nth(10)

--- a/tests/diagnostics/snapshots/provocations/swap_args.snap
+++ b/tests/diagnostics/snapshots/provocations/swap_args.snap
@@ -10,7 +10,7 @@ warnings: 2
 code: -
 primary: user tests/diagnostics/corpus/swap_args.eu:2:9
 help-lines: 0
-note-lines: 1
+note-lines: 0
 secondary-labels: 0
 trace-frames: 2
 trace-user-frames: 1
@@ -36,7 +36,6 @@ error: tail requires a list, found 0
 2 │ result: nth(xs, 0)
   │         ^^^
   │
-  = head and tail require a list (e.g. [1, 2, 3]) as their argument
   = stack trace:
     - result at swap_args.eu:2:9
     - in 'nth' at [prelude]

--- a/tests/harness/errors/202_sv3_contract_bad_spec.eu.expect
+++ b/tests/harness/errors/202_sv3_contract_bad_spec.eu.expect
@@ -1,2 +1,2 @@
 exit: 1
-stderr: "panic: validate: not a type spec"
+stderr: "validate: not a type spec"


### PR DESCRIPTION
## Summary

Three related fixes to error rendering (`src/eval/error.rs`), batched because they touch the same file. Beads: eu-1tkk.7.33, eu-1tkk.7.35, eu-1tkk.7.37.

### eu-1tkk.7.33 — drop the "panic:" prefix for library-raised errors
`UserPanic`'s "panic: " prefix is meant to show the user their own explicit `panic()` call, but the prelude raises its own errors through the same intrinsic (e.g. `nth`'s out-of-range check, `lib/prelude.eu:1435`). `to_diagnostic` now reuses `SourceMap::is_user_file` (already built for exactly this "prelude vs user" distinction) on the panic call site's Smid: the prefix shows only when the call site is in a user file. **Choice**: I picked the selective option (owner's decision left this open) rather than dropping the prefix everywhere, because the infrastructure to distinguish the two call paths already existed and the change was modest (~15 lines in `to_diagnostic`, no new plumbing). Verified both directions: `009_panic.eu`/`137_user_panic.eu` (direct user `panic()`) keep the prefix; `nth(10)`, `parse-args` misuse, `validate` bad-spec (all prelude-internal panics) lose it.

### eu-1tkk.7.35 — delete the misfiring "head and tail require a list" note
Removed the leading note from `HeadOfNonList`/`TailOfNonList` — it misfired in 4 of 6 carrying snapshots (reached via `nth`/`map`/`++`, not `head`/`tail` directly) and was tautological in the other 2. Kept the conditional value-shaped notes (string `++`/`str.letters` advice, "wrap it: `[n]`").

### eu-1tkk.7.37 — UnexpectedFunction gets EU-EVAL-TYPE
Added `UnexpectedFunction` to the code allow-list — same message family as `TypeMismatch` ("type mismatch: expected X, found Y"), just missing the code since eu-1tkk.7.9 introduced it.

**`ComparisonTypeMismatch` verdict: not added.** Its message ("cannot compare incompatible types with '...'") is a different shape, not "type mismatch: expected X, found Y". Notably `NoBranchForDataTag` shares TypeMismatch's *exact* message text and is still deliberately left uncoded, so extending to `ComparisonTypeMismatch` would be scope creep beyond this bead's narrow intent.

## Snapshot diff (reblessed via `cargo xtask diag-snapshot --bless`)
22 snapshots changed, all exactly as intended — reviewed the full diff line by line:
- 13 lose the `panic: ` prefix (`nth` OOB ×6, `parse-args` misuse ×3, `validate` bad-spec, `from-data` library-blame, curated-trace/anchor fixtures). `009_panic`/`137_user_panic` (genuine user `panic()`) are unaffected.
- 6 lose the leading head/tail note (`042_map_non_list`, `047_str_plus_plus`, `129_head_tail_not_list`, `138_internal_no_panic_prefix`, `181_direct_app_call_site`, `swap_args`); conditional notes remain.
- 3 gain `error[EU-EVAL-TYPE]`/`code: EU-EVAL-TYPE` (`078_anon_anaphor_scope`, `192_1tkk_7_9_function_not_block`, `catenation_arith`).

Also updated `tests/harness/errors/202_sv3_contract_bad_spec.eu.expect` and one doc example in `docs/guide/contracts.md` that hardcoded the old "panic: validate: ..." text.

## Fault injection
Reverted `src/eval/error.rs` to HEAD, reran `cargo test --test diagnostics_snapshots`: 22 fixtures failed with exactly the expected diffs (prefix/note/code reappearing or missing). Restored the fix, reran: all green. Confirms the diagnostics-snapshot suite genuinely gates these changes (the `.expect` sidecars use substring matching so don't gate on their own).

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean, no `#[allow]`
- [x] `cargo test` (full suite) — green: 1427 lib tests, 547 harness tests, 17 diagnostics-snapshot tests, all others
- [x] Fault-injection verified (see above)

Not merging — needs a recorded review from a non-author (Wicket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182qk1pZV4pc61DzY4ZA6C2