### PR TITLE
feat(aoc25): apply 0.14 process parallelism to the AoC corpus and re-baseline PERFORMANCE.md (eu-oaxd3)

### DIFF
--- a/examples/aoc25/PERFORMANCE.md
+++ b/examples/aoc25/PERFORMANCE.md
@@ -4,7 +4,132 @@ Performance characteristics of the AoC 2025 eucalypt example programs, benchmark
 
 ---
 
-## Summary (0.11.0)
+## Summary (0.14 re-baseline — figures pending)
+
+The corpus is due a re-baseline on 0.14: the summary below dates from 0.11.0
+and the project has since shipped 0.12, 0.12.1, 0.13.x and 0.14 (which made
+the bytecode engine the default). Six examples now use the 0.14 process
+parallelism combinators (`par-sum`, `par-max`, `par-map`, `par-concat`) at
+genuinely independent map sites — see the next section for the sites, the
+verification, and the exact measurement commands. Figures will be filled in
+during a dedicated measurement window on a quiet machine; every figure will
+carry a confidence label per `docs/superpowers/engine-ab/PROTOCOL.md`
+(measured-verified / measured-single / projected).
+
+| Example | 0.11.0 wall (historical) | 0.14 sequential | 0.14 parallel (forced fork) | Speedup | Confidence |
+|---------|--------------------------|-----------------|------------------------------|---------|------------|
+| day01-p1 | 0.527s | | — | — | |
+| day01-p2 | 0.500s | | — | — | |
+| day02-p1 | 0.007s | | — | — | |
+| day02-p2 | 0.030s | | — | — | |
+| day03-p1 | 0.556s | | — | — | |
+| day03-p2 | 1.149s | | — | — | |
+| day04-p1 | 1.559s | | | | |
+| day04-p2 | >600s | | — | — | |
+| day05-p1 | 1.462s | | | | |
+| day05-p2 | 0.028s | | — | — | |
+| day06-p1 | 0.636s | | — | — | |
+| day06-p2 | 3.966s | | — | — | |
+| day07-p1 | 1.231s | | — | — | |
+| day07-p2 | 2.495s | | — | — | |
+| day08-p1 | 6.082s | | | | |
+| day08-p2 | >600s | | | | |
+| day09-p1 | 5.005s | | | | |
+| day09-p2 | >600s | | — | — | |
+| day10-p1 | 10.99s | | | | |
+| day10-p2 | >600s | | — | — | |
+| day11-p1 | 1.593s | | — | — | |
+| day11-p2 | 146.5s | | | | |
+| day12-p1 | 0.197s | | — | — | |
+
+A `—` in the parallel column means the example has no `par-*` site (either no
+independent map, or the site was assessed and rejected — see below).
+day08-p2 inherits the `window-pairs` conversion from day08-p1 but remains a
+>600s timeout; parallelism does not change its asymptotics.
+
+---
+
+## Process parallelism (0.14)
+
+Six sites were converted to the experimental `par-*` combinators
+(macOS/Linux; each is semantically identical to its sequential form). All
+conversions were verified to produce the same answer as the unconverted
+program on the real puzzle input, on both the sequential-fallback path and
+the forked path (`EU_PP_THRESHOLD=2`, fork confirmed via `EU_PP_TRACE=1`),
+plus the embedded example-input tests.
+
+| Example | Site | Combinator | Elements (real input) | Rationale |
+|---------|------|------------|-----------------------|-----------|
+| day04-p1 | `solve`: row sums of `survivals(grid)` | `par-sum(sum)` | 135 | each row's 3×3 convolution sums are independent |
+| day05-p1 | `solve`: per-ID freshness test | `par-sum(fresh-bit(ranges))` | 1,000 | each ID's range membership is independent |
+| day08-p1 | `window-pairs`: per-suffix pair batches | `par-concat(batch)` | 1,000 | each suffix's encoded-pair batch is independent; parent then sorts |
+| day09-p1 | `best-area`: per-suffix max area | `par-max(best-from)` | 495 | each suffix's pairwise-max is independent |
+| day10-p1 | `solve`: per-machine DFS solve | `par-sum(parse-machine ; solve-machine)` | 185 | machines are fully independent; heaviest per-element work in the corpus |
+| day11-p2 | `solve2`: four inclusion-exclusion DP passes | `par-map(count-paths("svr"))` | 4 | coarsest-grain site; each pass is an independent ~35s DP |
+
+**Sites assessed and rejected:**
+
+- **day06-p2** — the right-to-left grouping fold (`cols foldl(col-step, ...)`)
+  carries `[total, nums]` state between columns; no independent map. The
+  per-column `map(parse-col)` is independent but trivial per element.
+- **day07-p1/p2** — beam propagation folds a `[beam, count]` state row by
+  row; each row depends on the previous beam vector. No independent map.
+- **day11-p1** — a single DP pass over one topological order; sequential by
+  construction.
+- **day04-p2, day09-p2, day10-p2** — iteration-bound or search-bound
+  timeouts; parallelism does not change their asymptotics (day08-p2 inherits
+  its conversion incidentally from `window-pairs`).
+- Trivial examples (day01–day03, day05-p2, day06-p1, day12-p1) — under ~1s
+  with cheap per-element work; fork and serialisation cost cannot pay.
+
+**Threshold finding:** every converted site is below the default 1,024-element
+fork threshold (the corpus maximum is 1,000), so by default the `par-*` calls
+take the sequential fallback and the converted programs behave exactly as
+before. Demonstrating parallel speedup on this corpus requires lowering
+`EU_PP_THRESHOLD`. This is itself a finding for the feature: AoC-scale outer
+maps (tens to hundreds of heavy elements) sit below a threshold calibrated
+for many-thousand-element maps, and per-element cost is invisible to the
+element-count heuristic.
+
+### Measurement plan (pending window)
+
+Per `docs/superpowers/engine-ab/PROTOCOL.md` discipline: one release binary
+for both arms, quiet machine (load < 1), interleaved arm pairs (seq, par,
+seq, par, …), 5 pairs per example, wall median-of-5 with spread, nothing
+under ~200 ms admitted to ratio analysis (all six targets are >1s
+sequential), platform recorded (macOS ARM64, Apple Silicon), `EU_PP_WORKERS`
+default and core count recorded. Ticks are not comparable across the fork
+boundary, so the seq/par comparison is wall-only; tick counts are recorded
+for the sequential arm only.
+
+From `examples/aoc25/`, with `EU` the release binary under test:
+
+```sh
+# Sequential arm (threshold forced above any list size — explicit fallback)
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day04.eu -t part-1
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day05.eu -t part-1
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day08.eu -t part-1
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day09.eu -t part-1
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day10.eu -t part-1
+EU_PP_THRESHOLD=999999999 timeout 600 $EU --heap-limit-mib 12288 day11.eu -t part-2
+
+# Parallel arm (threshold forced below every converted site's element count)
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day04.eu -t part-1
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day05.eu -t part-1
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day08.eu -t part-1
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day09.eu -t part-1
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day10.eu -t part-1
+EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day11.eu -t part-2
+```
+
+One pilot run per arm per example with `EU_PP_TRACE=1` confirms which path
+was taken (expected: `sequential (below threshold)` vs `forked N workers`);
+timed runs are then made without the trace. Unconverted examples are
+re-baselined with the sequential-arm command only.
+
+---
+
+## Historical summary (0.11.0)
 
 | Example | 0.10.0 | 0.11.0 | Δ wall | Ticks | Allocs | Bottleneck |
 |---------|--------|--------|--------|-------|--------|------------|

--- a/examples/aoc25/PERFORMANCE.md
+++ b/examples/aoc25/PERFORMANCE.md
@@ -4,48 +4,59 @@ Performance characteristics of the AoC 2025 eucalypt example programs, benchmark
 
 ---
 
-## Summary (0.14 re-baseline — figures pending)
+## Summary (0.14 re-baseline, 2026-08-04)
 
-The corpus is due a re-baseline on 0.14: the summary below dates from 0.11.0
-and the project has since shipped 0.12, 0.12.1, 0.13.x and 0.14 (which made
-the bytecode engine the default). Six examples now use the 0.14 process
-parallelism combinators (`par-sum`, `par-max`, `par-map`, `par-concat`) at
-genuinely independent map sites — see the next section for the sites, the
-verification, and the exact measurement commands. Figures will be filled in
-during a dedicated measurement window on a quiet machine; every figure will
-carry a confidence label per `docs/superpowers/engine-ab/PROTOCOL.md`
-(measured-verified / measured-single / projected).
+Re-baselined on 0.14 (bytecode engine default). Six examples now use the
+0.14 process parallelism combinators (`par-sum`, `par-max`, `par-map`,
+`par-concat`) at genuinely independent map sites — see the next section for
+the sites, the verification, the measurement session conditions, and the
+findings. Sequential and parallel arms ran interleaved on the same clean
+release binary; wall figures are median-of-5 with min–max spread in
+parentheses. The machine carried moderate background load (load average
+2.9–6.1), so per `docs/superpowers/engine-ab/PROTOCOL.md` every wall figure
+is labelled **measured-single** (one session; not yet independently
+reproduced on a quiet machine).
 
 | Example | 0.11.0 wall (historical) | 0.14 sequential | 0.14 parallel (forced fork) | Speedup | Confidence |
 |---------|--------------------------|-----------------|------------------------------|---------|------------|
-| day01-p1 | 0.527s | | — | — | |
-| day01-p2 | 0.500s | | — | — | |
-| day02-p1 | 0.007s | | — | — | |
-| day02-p2 | 0.030s | | — | — | |
-| day03-p1 | 0.556s | | — | — | |
-| day03-p2 | 1.149s | | — | — | |
-| day04-p1 | 1.559s | | | | |
-| day04-p2 | >600s | | — | — | |
-| day05-p1 | 1.462s | | | | |
-| day05-p2 | 0.028s | | — | — | |
-| day06-p1 | 0.636s | | — | — | |
-| day06-p2 | 3.966s | | — | — | |
-| day07-p1 | 1.231s | | — | — | |
-| day07-p2 | 2.495s | | — | — | |
-| day08-p1 | 6.082s | | | | |
-| day08-p2 | >600s | | | | |
-| day09-p1 | 5.005s | | | | |
-| day09-p2 | >600s | | — | — | |
-| day10-p1 | 10.99s | | | | |
-| day10-p2 | >600s | | — | — | |
-| day11-p1 | 1.593s | | — | — | |
-| day11-p2 | 146.5s | | | | |
-| day12-p1 | 0.197s | | — | — | |
+| day01-p1 | 0.527s | 0.098s (2%) | — | — | measured-single |
+| day01-p2 | 0.500s | 0.104s (11%) | — | — | measured-single |
+| day02-p1 | 0.007s | 0.034s (9%) | — | — | measured-single |
+| day02-p2 | 0.030s | 0.048s (2%) | — | — | measured-single |
+| day03-p1 | 0.556s | 0.338s (2%) | — | — | measured-single |
+| day03-p2 | 1.149s | 0.716s (3%) | — | — | measured-single |
+| day04-p1 | 1.559s | 0.615s (3%) | 0.104s (9%) | 5.9× | measured-single (par arm sub-200ms) |
+| day04-p2 | >600s | >600s | — | — | measured-single (n=1 probe) |
+| day05-p1 | 1.462s | 0.489s (2%) | 0.107s (11%) | 4.6× | measured-single (par arm sub-200ms) |
+| day05-p2 | 0.028s | 0.063s (5%) | — | — | measured-single |
+| day06-p1 | 0.636s | 0.073s (4%) | — | — | measured-single |
+| day06-p2 | 3.966s | 0.310s (3%) | — | — | measured-single |
+| day07-p1 | 1.231s | 0.358s (1%) | — | — | measured-single |
+| day07-p2 | 2.495s | 0.337s (3%) | — | — | measured-single |
+| day08-p1 | 6.082s | 3.445s (1%) | 0.712s (12%) | 4.8× | measured-single |
+| day08-p2 | >600s | >600s | — | — | measured-single (n=1 probe) |
+| day09-p1 | 5.005s | 2.002s (3%) | 0.478s (7%) | 4.2× | measured-single |
+| day09-p2 | >600s | >600s | — | — | measured-single (n=1 probe) |
+| day10-p1 | 10.99s | 7.858s (3%) | 1.091s (43%*) | 7.2× | measured-single |
+| day10-p2 | >600s | >600s | — | — | measured-single (n=1 probe) |
+| day11-p1 | 1.593s | 0.150s (2%) | — | — | measured-single |
+| day11-p2 | 146.5s | 4.429s (3%) | 1.161s (2%) | 3.8× | measured-single |
+| day12-p1 | 0.197s | 0.106s (3%) | — | — | measured-single |
+
+\* day10-p1 parallel spread is one 1.55s outlier in five runs (others
+1.077–1.122s); the median is robust to it.
 
 A `—` in the parallel column means the example has no `par-*` site (either no
 independent map, or the site was assessed and rejected — see below).
-day08-p2 inherits the `window-pairs` conversion from day08-p1 but remains a
->600s timeout; parallelism does not change its asymptotics.
+day08-p2 inherits the `window-pairs` conversion from day08-p1 but its
+parallel arm is not reported: parallelism does not change its asymptotics.
+
+The sequential column is itself news: the 0.12–0.14 engine work (bytecode
+default, pre-decoded dispatch, lookup and codegen improvements) has made the
+whole corpus dramatically faster than the 0.11.0 baseline — most notably
+day11-p2 (146.5s → 4.4s) and day06-p2 (3.97s → 0.31s). The per-day
+bottleneck analyses below the historical summary describe the 0.10/0.11
+engines and should be read as historical.
 
 ---
 
@@ -91,16 +102,26 @@ maps (tens to hundreds of heavy elements) sit below a threshold calibrated
 for many-thousand-element maps, and per-element cost is invisible to the
 element-count heuristic.
 
-### Measurement plan (pending window)
+### Measurement session (2026-08-04)
 
-Per `docs/superpowers/engine-ab/PROTOCOL.md` discipline: one release binary
-for both arms, quiet machine (load < 1), interleaved arm pairs (seq, par,
-seq, par, …), 5 pairs per example, wall median-of-5 with spread, nothing
-under ~200 ms admitted to ratio analysis (all six targets are >1s
-sequential), platform recorded (macOS ARM64, Apple Silicon), `EU_PP_WORKERS`
-default and core count recorded. Ticks are not comparable across the fork
-boundary, so the seq/par comparison is wall-only; tick counts are recorded
-for the sequential arm only.
+Per `docs/superpowers/engine-ab/PROTOCOL.md` discipline: one clean-built
+release binary for both arms (master, rustc 1.97.1), interleaved arm pairs
+(seq, par, seq, par, …), 5 pairs per converted example, 5 sequential runs
+per unconverted example, wall median-of-5 with min–max spread. Platform:
+macOS ARM64, Apple M3 Max, 14 cores; `EU_PP_WORKERS` unset (the driver chose
+13 workers for large lists, 4 for day11-p2's 4-element list). Every run
+carried `EU_PP_TRACE=1`; the trace log confirms all 30 parallel-arm runs
+forked and all 30 sequential-arm runs took the fallback. **Deviations from
+protocol:** the machine carried moderate background load (load average
+2.9–6.1), so all figures are measured-single; and the day04-p1/day05-p1
+parallel-arm medians (~105 ms) sit below the ~200 ms ratio floor, so those
+two speedup ratios are indicative rather than load-bearing. Ticks are not
+comparable across the fork boundary, so the seq/par comparison is wall-only.
+
+The seq/par comparison is threshold-forced: the sequential arm pins
+`EU_PP_THRESHOLD` above any list size, the parallel arm pins it to 2. With
+the combinators' defaults (threshold 1,024) every converted site runs the
+sequential fallback — see the threshold finding above.
 
 From `examples/aoc25/`, with `EU` the release binary under test:
 
@@ -122,10 +143,49 @@ EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day10.eu -t part-1
 EU_PP_THRESHOLD=2 timeout 600 $EU --heap-limit-mib 12288 day11.eu -t part-2
 ```
 
-One pilot run per arm per example with `EU_PP_TRACE=1` confirms which path
-was taken (expected: `sequential (below threshold)` vs `forked N workers`);
-timed runs are then made without the trace. Unconverted examples are
-re-baselined with the sequential-arm command only.
+Unconverted examples were re-baselined with the sequential-arm command only.
+
+### Finding: does process parallelism pay on this corpus?
+
+**Yes — strongly, at every site with a genuinely independent outer map and
+non-trivial per-element work, but only once the fork threshold is lowered.**
+All six converted sites achieved 3.8×–7.2× wall speedup on a 14-core M3 Max
+(measured-single; see the summary table). Specifically:
+
+- **Coarse-grained heavy elements pay best.** day10-p1 (185 machines, each
+  an expensive DFS) achieved 7.2×, the corpus best.
+- **Even fine-grained elements pay.** day05-p1's per-element work is a
+  ~186-range membership test, ~0.5 ms each, and still achieved 4.6× —
+  fork-and-serialise overhead is low enough that modest per-element work
+  amortises it at corpus scale (~1,000 elements).
+- **Tiny lists of huge elements pay.** day11-p2's 4-element `par-map` over
+  ~1.1s DP passes achieved 3.8× against a ceiling of ~4× (the full-graph
+  pass is the critical path).
+- **Serialisation of large results is affordable.** day08-p1's `par-concat`
+  returns ~150,000 encoded numbers across the boundary and still achieved
+  4.8×.
+
+**The negative findings:**
+
+- **The default threshold excludes the entire corpus.** `par-*` falls back
+  to sequential below 1,024 elements; the corpus's largest independent map
+  is 1,000 elements (day05-p1, day08-p1). Every conversion is therefore a
+  no-op by default, and every speedup above required `EU_PP_THRESHOLD` to be
+  lowered. The element-count heuristic is also blind to per-element cost:
+  day10-p1 (185 elements × heavy DFS, 7.2× available) and day11-p2 (4
+  elements × ~1.1s DP, 3.8× available) are precisely the shapes the
+  threshold is designed to reject. A cost-aware or user-tunable-per-call
+  threshold would let this corpus benefit without environment variables.
+- **State-carrying folds have nothing to convert.** day06-p2 and
+  day07-p1/p2 thread an accumulator through every element; day11-p1 is a
+  single DP pass. No independent map exists, so process parallelism cannot
+  apply without algorithmic restructuring.
+- **Trivial programs cannot pay.** Everything under ~0.35s sequential is
+  dominated by startup and parse; fork cost has nothing to amortise
+  against.
+- **Parallelism does not rescue asymptotics.** The 0.11.0-era timeouts are
+  loop/search-bound; the conversion day08-p2 inherits from `window-pairs`
+  does not change what makes it slow.
 
 ---
 

--- a/examples/aoc25/day04.eu
+++ b/examples/aoc25/day04.eu
@@ -56,7 +56,10 @@ survivals(grid): zip-with(zip-with(accessible?), grid, block-sums(grid))
 
 parse(data): data map(to-bits)
 
-solve(grid): survivals(grid) map(sum) sum
+` "Total accessible rolls. Row sums are independent, so they run under
+`par-sum` (same value as `map(sum) sum`; parallel on macOS/Linux when
+the row count clears the size threshold)."
+solve(grid): survivals(grid) par-sum(sum)
 
 ` "One removal step: returns [new-grid, count-removed]."
 remove-step[grid, _]: {

--- a/examples/aoc25/day05.eu
+++ b/examples/aoc25/day05.eu
@@ -27,7 +27,13 @@ is-fresh?(ranges, id): ranges any(contains-id?(id))
 
 parse(data): data split-when(= "") bimap(map(parse-range), filter(!= "") ; map(num))
 
-solve(ranges, ids): ids filter(is-fresh?(ranges)) count
+` "1 if `id` falls within any fresh range, else 0."
+fresh-bit(ranges, id): is-fresh?(ranges, id) then(1, 0)
+
+` "Count of fresh IDs. Each ID's range test is independent, so the tests
+run under `par-sum` (same value as `filter(is-fresh?(ranges)) count`;
+parallel on macOS/Linux when the ID list clears the size threshold)."
+solve(ranges, ids): ids par-sum(fresh-bit(ranges))
 
 ` "Merge a new range into [merged-so-far, current-range].  If the new
 range overlaps or is adjacent, extend current; otherwise emit current

--- a/examples/aoc25/day08.eu
+++ b/examples/aoc25/day08.eu
@@ -52,11 +52,14 @@ pairs-at(w, i, [h : t]): point-pairs(h, t take(w), i, i + 1)
 
 ` "Generate candidate pairs: each point paired with the next w points.
 Requires pts to be x-sorted so that nearby indices approximate spatial
-proximity. Low values of w may miss close pairs that are far apart in x."
-window-pairs(w, pts):
-  tails(pts)
-    zip-with(pairs-at(w), ℕ)
-    concat
+proximity. Low values of w may miss close pairs that are far apart in x.
+Each suffix's pair batch is independent, so generation runs under
+`par-concat` (same value as `zip-with(pairs-at(w), ℕ) concat` over the
+tails; parallel on macOS/Linux when the point count clears the size
+threshold)."
+window-pairs(w, pts): {
+  batch([i, suffix]): pairs-at(w, i, suffix)
+}.(zip(ℕ, tails(pts)) par-concat(batch))
 
 ` "Count elements in each consecutive group (run-length encoding)."
 count-groups: group-consecutive ; map(count)

--- a/examples/aoc25/day09.eu
+++ b/examples/aoc25/day09.eu
@@ -35,12 +35,12 @@ area(a, b): zip-with(-, a, b) map(abs ; (+ 1)) product
 best-from(ps): ps tail map(area(ps head)) max-of
 
 ` "Max area over all distinct pairs of points.
-Uses foldl instead of max-map to avoid materialising an intermediate
-list of areas — each tail is processed and discarded in turn."
+Each suffix's best area is independent of the others, so the per-suffix
+maxima run under `par-max` (same value as `map(best-from) max-of`;
+parallel on macOS/Linux when the suffix list clears the size threshold)."
 best-area(pts): {
-  step(best, suffix): max(best, best-from(suffix))
   tls: tails(pts) filter(count ; (> 1))
-}.(foldl(step, 0, tls))
+}.(tls par-max(best-from))
 
 parse(data): data filter(!= "") map(parse-coord)
 

--- a/examples/aoc25/day10.eu
+++ b/examples/aoc25/day10.eu
@@ -66,8 +66,12 @@ solve-machine[target, buttons]: {
   solved?(k): has-solution?(k, target, buttons)
 }.(ℕ take(nb + 1) filter(solved?) min-of-or(nb + 1))
 
+` "Sum of minimum presses across machines. Machines are independent, so
+the per-machine solves run under `par-sum` (same value as
+`map(parse-machine ; solve-machine) sum`; parallel on macOS/Linux when
+the machine list clears the size threshold)."
 solve(data):
-  data filter(!= "") map(parse-machine ; solve-machine) sum
+  data filter(!= "") par-sum(parse-machine ; solve-machine)
 
 ` { target: :test
     import: "ex1=inputs/day10-ex1.txt" }

--- a/examples/aoc25/day11.eu
+++ b/examples/aoc25/day11.eu
@@ -92,14 +92,20 @@ part-1: solve(input)
 
 ` "Count paths from 'svr' to 'out' visiting both 'dac' and 'fft'.
 By inclusion-exclusion over graph variants with required nodes removed:
-  through_both = total - no_dac - no_fft + neither"
+  through_both = total - no_dac - no_fft + neither
+The four dynamic programming passes are independent, so they run under
+`par-map` over the graph variants (counts come back in variant order:
+total, no-dac, no-fft, neither; parallel on macOS/Linux when the
+variant list clears the size threshold — four elements need
+EU_PP_THRESHOLD lowered to fork)."
 solve2(data): {
   g: parse-graph(data)
-  total: g count-paths("svr")
-  no-dac: g remove-node("dac") count-paths("svr")
-  no-fft: g remove-node("fft") count-paths("svr")
-  neither: g remove-node("dac") remove-node("fft") count-paths("svr")
-}.(total - no-dac - no-fft + neither)
+  variants: [g,
+             g remove-node("dac"),
+             g remove-node("fft"),
+             g remove-node("dac") remove-node("fft")]
+  counts: variants par-map(count-paths("svr"))
+}.((counts !! 0) - (counts !! 1) - (counts !! 2) + (counts !! 3))
 
 ` { target: :test2
     import: "ex2=inputs/day11-ex2.txt" }


### PR DESCRIPTION
## What

- Convert six genuinely independent map sites in the AoC-2025 examples to the
  0.14 `par-*` combinators: day04-p1 (`par-sum` over row sums), day05-p1
  (`par-sum` over per-ID range tests), day08-p1 (`par-concat` over per-suffix
  pair batches), day09-p1 (`par-max` over per-suffix areas), day10-p1
  (`par-sum` over per-machine DFS solves), day11-p2 (`par-map` over the four
  inclusion-exclusion DP passes).
- Re-baseline `examples/aoc25/PERFORMANCE.md` on 0.14 (replacing the stale
  0.11.0 summary): sequential column for the whole corpus, parallel column,
  per-figure confidence labels, and an explicit pays/doesn't-pay finding.

## Why

Bead **eu-oaxd3**: the AoC corpus is the most realistic workload and most
visible worked example; it now demonstrates the experimental parallelism
combinators and quantifies what they are worth.

## Measured (macOS ARM64, M3 Max 14-core; median-of-5, interleaved arms, one
clean release binary; measured-single — moderate load)

| Example | 0.14 seq | par (forced fork) | Speedup |
|---|---|---|---|
| day04-p1 | 0.615s | 0.104s | 5.9× |
| day05-p1 | 0.489s | 0.107s | 4.6× |
| day08-p1 | 3.445s | 0.712s | 4.8× |
| day09-p1 | 2.002s | 0.478s | 4.2× |
| day10-p1 | 7.858s | 1.091s | 7.2× |
| day11-p2 | 4.429s | 1.161s | 3.8× |

**Headline finding:** the default 1,024-element fork threshold exceeds the
corpus maximum (1,000 elements), so every converted site runs the sequential
fallback by default; all speedups required lowering `EU_PP_THRESHOLD`.
Details, rejected sites, and negative findings in PERFORMANCE.md.

## Verification

- All six conversions produce identical answers to the unconverted programs
  on the real puzzle inputs, on both the sequential-fallback and forked
  (`EU_PP_THRESHOLD=2`) paths; embedded example tests pass with forking
  forced. Fork/fallback per timed run audited via `EU_PP_TRACE=1`.
- No Rust changes; no rebuild needed (examples only).

Do NOT close bead eu-oaxd3 on merge commentary — closure is handled at merge
per the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182qk1pZV4pc61DzY4ZA6C2