### PR TITLE
fix(pp): remove par-* predicted-benefit threshold (eu-2obtj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to eucalypt are documented here.
 
 ## [0.15.0] - Unreleased
 
+### Changed
+
+- **`par-*` no longer gates on a predicted-benefit element-count threshold (eu-2obtj)** — owner decision, 2026-08-04: `par-*` is already an explicit caller opt-in (writing it instead of the sequential form already says "fork this"), so the runtime should not second-guess that with a size heuristic. `DEFAULT_THRESHOLD` in `src/eval/stg/parallel/driver.rs` moves from 1024 to 2, so the only remaining count condition is the degenerate `n < 2` (nothing to parallelise); the AoC-2025 corpus findings that drove this (`examples/aoc25/PERFORMANCE.md`) showed the old 1024-element gate rejecting exactly the workloads where forking paid most — 185 heavy elements at 7.2×, 4 very heavy elements at 3.8×, both far below the threshold. Feasibility fallbacks (worker fault, per-element arena cap, single core, non-Unix) are unchanged; `par-*` remains advisory and semantically identical to its sequential form either way. `EU_PP_THRESHOLD` remains as a tuning/testing escape hatch. Measured fixed per-call fork overhead: ~2–3ms on macOS ARM64 (measured-single; `docs/superpowers/reports/2026-08-04-eu-2obtj-fork-overhead.md`), now documented in the prelude advisory and `docs/guide/parallelism.md` so callers can judge whether a cheap tiny list is worth forking. Slated for backport to a 0.14.1 maintenance patch
+
 ## [0.14.0] - 2026-08-02
 
 ### Breaking changes

--- a/docs/guide/parallelism.md
+++ b/docs/guide/parallelism.md
@@ -5,11 +5,11 @@
 >
 > **macOS/Linux only.** The mechanism is a POSIX `fork()`, so it is not
 > available on Windows. `par-*` still works there — every call falls back to
-> the ordinary sequential form, exactly as it does below the size threshold on
-> a supported platform — it just never forks, so there is no parallelism
-> speed-up, and `EU_PP_TRACE` has no effect on Windows. See [What is different
-> from `map`](#what-is-different-from-map) below: the value is identical
-> either way.
+> the ordinary sequential form, exactly as it does whenever the fork
+> mechanism is unavailable on a supported platform — it just never forks, so
+> there is no parallelism speed-up, and `EU_PP_TRACE` has no effect on
+> Windows. See [What is different from `map`](#what-is-different-from-map)
+> below: the value is identical either way.
 
 Eucalypt can evaluate a map over independent elements in parallel worker
 processes. The vocabulary is small and deliberately boring: each combinator
@@ -36,14 +36,27 @@ output.
 
 ## When it helps
 
-Parallel evaluation pays when `f` is genuinely expensive and there are many
-elements. Below a threshold (1024 elements by default) eucalypt does not
-bother: it runs the sequential map instead, because forking costs more than
-it saves on a small list. It also stays sequential when only one core is
+`par-*` is an explicit opt-in: writing it instead of the sequential form
+already says "fork this", so eucalypt no longer second-guesses that decision
+with a predicted-benefit size gate. It forks whenever there are at least two
+elements and the platform allows. It stays sequential only when there is
+nothing to parallelise (fewer than two elements), when only one core is
 available, on platforms without `fork`, and inside hosts that have not
 declared themselves safe to fork from — the language server, the WASM build,
 and the test harness all run `par-*` sequentially. The answer is the same in
 every case.
+
+Because the gate is gone, the caller is the one who should judge whether a
+workload is worth forking. The fixed per-call cost of the fork mechanism
+itself — process fork plus the shared arena, isolated from the
+serialise/deserialise codec both paths already pay — measures **~2–3ms** on
+macOS ARM64 (Apple Silicon, measured-single, moderate background load; see
+`docs/superpowers/reports/2026-08-04-eu-2obtj-fork-overhead.md` for the
+session). That is the amount a tiny,
+cheap `par-map` adds over the plain sequential form: worth it for anything
+with real per-element cost, easily lost in noise for a handful of trivial
+elements. `EU_PP_THRESHOLD` (below) remains available to force the
+sequential path back on for such cases, or for testing.
 
 ## What is different from `map`
 
@@ -108,6 +121,7 @@ par-sum: 12 elements — sequential (below threshold)
 ```
 
 `EU_PP_WORKERS` sets the worker count and `EU_PP_THRESHOLD` the element count
-below which `par-*` stays sequential — chiefly useful for forcing one path or
-the other while investigating. See
-[Debugging](../development/debugging.md) for the full list.
+below which `par-*` stays sequential (default 2, i.e. every call with two or
+more elements forks) — a tuning/testing escape hatch for forcing one path or
+the other while investigating, not something ordinary use needs to touch.
+See [Debugging](../development/debugging.md) for the full list.

--- a/docs/superpowers/reports/2026-08-04-eu-2obtj-fork-overhead.md
+++ b/docs/superpowers/reports/2026-08-04-eu-2obtj-fork-overhead.md
@@ -1,0 +1,62 @@
+# eu-2obtj: par-* fork-overhead measurement
+
+Owner decision (2026-08-04, recorded on eu-2obtj): remove the `par-*`
+predicted-benefit size gate. `DEFAULT_THRESHOLD` in
+`src/eval/stg/parallel/driver.rs` moves from 1024 to 2, so the only remaining
+count condition is the degenerate `n < 2`. This report records the fork
+overhead measurement cited in the prelude advisory and
+`docs/guide/parallelism.md`.
+
+## Method
+
+Three arms over the same 4-element `[1,2,3,4] par-map(inc)` / `map(inc)`
+computation, on the 0.14.1-track release binary built from this branch:
+
+- **fork** — `par-map`, `EU_PP_THRESHOLD=2` (forces the COW-fork path, the
+  new default shape)
+- **pfb** — `par-map`, `EU_PP_THRESHOLD=999999999` (forces the sequential
+  fallback; shares the exact same serialise/deserialise codec and wrapper as
+  `fork`, so `fork - pfb` isolates the fork+arena mechanism alone)
+- **map** — plain `map(inc)`, no `par-map` at all (baseline, no codec
+  round-trip)
+
+Interleaved fork/pfb/map, 5 rounds, wall-clock via `python3 time.time()`
+around a `timeout 60 eu --heap-limit-mib 12288 <file>` invocation each.
+Ticks are not comparable across the fork boundary (per
+`examples/aoc25/PERFORMANCE.md`), so this is wall-only, matching existing
+practice for this feature. Platform: macOS ARM64 (Apple Silicon). Machine
+carried moderate background load (several other agents active in the same
+session; load average ~5), so per `docs/superpowers/engine-ab/PROTOCOL.md`
+this is **measured-single**, not measured-verified.
+
+## Results
+
+Two interleaved sessions (first discarded one 18.5s outlier — evidently
+contention from concurrent background work, discarded from the reported set,
+second session ran clean):
+
+```
+fork (ms): 87.01 85.63 84.63 84.20 86.04   median 85.63
+pfb  (ms): 83.32 82.44 83.51 82.68 83.89   median 83.32
+map  (ms): 83.43 82.31 83.23 83.95 82.40   median 83.23
+
+fork - pfb: 2.31ms   (fork+arena mechanism cost alone)
+fork - map: 2.40ms   (total par-map-vs-map overhead)
+```
+
+A first session (also 5 rounds each arm) gave consistent deltas (2.45ms /
+2.71ms) once its one 18.5s cold-start outlier is excluded from the median
+(median-of-5 already absorbs it).
+
+## Conclusion
+
+The fixed per-call cost of forking (fork + shared arena, isolated from the
+codec both paths already pay) is **~2–3ms** on macOS ARM64, measured-single.
+Total wall time for these tiny fixtures (~83–87ms) is dominated by process
+startup and compiling the prelude from source (no blob present); the fork
+overhead itself is a small, consistent slice of that. This confirms the
+prelude advisory's guidance: a `par-map` over a handful of trivial elements
+costs a few milliseconds more than `map`, immaterial next to any genuine
+per-element work, but a caller mapping over cheap tiny lists in a hot loop
+should judge that cost for themselves — which is exactly what removing the
+runtime gate now asks them to do.

--- a/examples/aoc25/PERFORMANCE.md
+++ b/examples/aoc25/PERFORMANCE.md
@@ -102,6 +102,14 @@ maps (tens to hundreds of heavy elements) sit below a threshold calibrated
 for many-thousand-element maps, and per-element cost is invisible to the
 element-count heuristic.
 
+**Update (eu-2obtj, 0.14.1):** this finding drove an owner decision to remove
+the predicted-benefit gate entirely — `par-*` now forks whenever there are at
+least two elements (see `docs/guide/parallelism.md`). As of this change, all
+six converted sites above parallelise **by default**; the
+`EU_PP_THRESHOLD=2`/`EU_PP_THRESHOLD=999999999` forcing used throughout this
+document is no longer required to observe the speedups, only to reproduce the
+side-by-side comparison.
+
 ### Measurement session (2026-08-04)
 
 Per `docs/superpowers/engine-ab/PROTOCOL.md` discipline: one clean-built

--- a/lib/prelude.eu
+++ b/lib/prelude.eu
@@ -957,16 +957,24 @@ min-of-or(d, l): l nil? then(d, min-of(l))
 ##
 ## Semantics may change without notice. macOS/Linux only: the mechanism is a
 ## POSIX fork, so it is unavailable on Windows (there it degrades silently to
-## the same sequential fallback used below the size threshold - see
+## the same sequential fallback described below - see
 ## docs/guide/parallelism.md).
 ##
 ## Each combinator is semantically identical to its sequential form - a pure
 ## performance advisory. par-map evaluates a pure f over independent elements
 ## in parallel worker processes (Unix copy-on-write fork) and reassembles the
-## results in index order, falling back transparently to a sequential map
-## below a size threshold, on a single core, or on a non-Unix platform. f must
-## be pure and return serialisable data (numbers, strings, symbols, booleans,
-## null, lists, blocks); a non-serialisable result is a boundary error.
+## results in index order. par-* is an explicit caller opt-in: writing it
+## already says "fork this", so the runtime no longer second-guesses that
+## decision with a predicted-benefit size gate - it forks whenever there are
+## at least two elements and the platform allows. It still falls back
+## transparently to a sequential map on a single core, on a non-Unix
+## platform, or if the fork mechanism itself fails for any reason. The fixed
+## per-call cost of the fork mechanism is small (measured ~2-3ms on macOS
+## ARM64 - see docs/guide/parallelism.md), so callers, not a runtime
+## heuristic, are best placed to judge whether a cheap tiny list is worth
+## forking. f must be pure and return serialisable data (numbers, strings,
+## symbols, booleans, null, lists, blocks); a non-serialisable result is a
+## boundary error.
 
 ## The par-* combinators are strict in the SPINE of xs. __PARMAP's own STG
 ## wrapper (src/eval/stg/parallel/intrinic.rs) forces that spine, via the

--- a/src/eval/stg/parallel/driver.rs
+++ b/src/eval/stg/parallel/driver.rs
@@ -35,12 +35,22 @@ use crate::eval::{
     },
 };
 
-/// Default minimum element count before forking is even considered. Below
-/// this, `par-map` runs sequentially (fork + arena overhead does not pay).
-/// Overridable via `EU_PP_THRESHOLD` (chiefly so tests can force the fork
-/// path on small inputs, and so the default can be tuned).
+/// Default minimum element count before forking is even considered.
+///
+/// `par-*` is an explicit caller opt-in: writing `par-map` over `map` already
+/// says "I want this forked", so the runtime no longer second-guesses that
+/// with a predicted-benefit gate. The corpus evidence that retired the old
+/// 1024-element gate (eu-2obtj) showed it rejecting exactly the workloads
+/// where forking pays most — 185 heavy elements at 7.2x, 4 very heavy
+/// elements at 3.8x — both far below the old threshold. The only remaining
+/// count condition is the degenerate `n < 2`, where there is nothing to
+/// parallelise. `EU_PP_THRESHOLD` remains as a tuning/testing escape hatch
+/// (chiefly so tests can force, or suppress, the fork path deterministically);
+/// it is not needed for ordinary use. See `docs/guide/parallelism.md` for the
+/// measured fixed per-call fork overhead callers should weigh against very
+/// cheap tiny workloads.
 #[cfg(unix)]
-const DEFAULT_THRESHOLD: usize = 1024;
+const DEFAULT_THRESHOLD: usize = 2;
 
 /// Per-element arena byte budget used to size the (virtual, demand-zero)
 /// mapping; a worker whose serialised result set overflows its segment simply

--- a/tests/harness/testdata/pp_small_fork_fixture.eu
+++ b/tests/harness/testdata/pp_small_fork_fixture.eu
@@ -1,0 +1,9 @@
+# eu-2obtj — fixture for test_pp_default_threshold_forks_small_list in
+# harness_test.rs. Deliberately tiny (4 elements): before eu-2obtj the
+# default DEFAULT_THRESHOLD (1024) meant a list this small always took the
+# sequential fallback; after eu-2obtj the default (2) means it forks
+# whenever the platform allows, with no EU_PP_THRESHOLD override needed.
+
+sq(x): x * x
+
+result: [1, 2, 3, 4] par-map(sq)

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -3682,12 +3682,17 @@ pub fn test_pp_default_threshold_forks_small_list() {
     }
 
     // EU_PP_THRESHOLD remains a working escape hatch to force sequential.
+    // `EU_PP_TRACE` (like the rest of the fork machinery) only has an effect
+    // on unix — on Windows `par-*` never forks in the first place, so there
+    // is no trace output to assert on.
     let forced_seq_stderr = run(&[("EU_PP_TRACE", "1"), ("EU_PP_THRESHOLD", "999999999")]);
-    assert!(
-        forced_seq_stderr.contains("sequential"),
-        "expected EU_PP_THRESHOLD=999999999 to force the sequential path, \
-         but the trace says:\n{forced_seq_stderr}"
-    );
+    if cfg!(unix) {
+        assert!(
+            forced_seq_stderr.contains("sequential"),
+            "expected EU_PP_THRESHOLD=999999999 to force the sequential path, \
+             but the trace says:\n{forced_seq_stderr}"
+        );
+    }
 }
 
 /// eu-u9xj.6 (PP) — the parallel driver must survive a collection that

--- a/tests/harness_test.rs
+++ b/tests/harness_test.rs
@@ -3640,6 +3640,56 @@ pub fn test_pp_fork_path_equivalence_both_engines() {
     );
 }
 
+/// eu-2obtj — the DEFAULT threshold now forks whenever a `par-map` has at
+/// least two elements (previously 1024, which excluded every workload this
+/// small). Asserts the NEW default: a 4-element `par-map` forks with **no**
+/// `EU_PP_THRESHOLD` override at all, and that `EU_PP_THRESHOLD` still works
+/// as an escape hatch to force the sequential fallback back on.
+///
+/// Fault-injection verified: reverting `DEFAULT_THRESHOLD` to 1024 makes the
+/// first assertion below fail (the default-config run reports "sequential
+/// (below threshold)" rather than "forked"); restoring the change to 2 makes
+/// it pass again.
+#[test]
+pub fn test_pp_default_threshold_forks_small_list() {
+    let fixture = "tests/harness/testdata/pp_small_fork_fixture.eu";
+
+    let run = |env: &[(&str, &str)]| -> String {
+        let mut cmd = std::process::Command::new(eu_binary());
+        cmd.arg(fixture).arg("--heap-limit-mib").arg("12288");
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        let out = run_with_deadline(cmd, std::time::Duration::from_secs(120))
+            .expect("eu did not complete within the deadline");
+        assert!(
+            out.status.success(),
+            "eu exited non-zero for env {env:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stderr).to_string()
+    };
+
+    // Default configuration — no EU_PP_THRESHOLD override at all. On unix
+    // this must fork: DEFAULT_THRESHOLD is 2, and the fixture has 4 elements.
+    let default_stderr = run(&[("EU_PP_TRACE", "1")]);
+    if cfg!(unix) {
+        assert!(
+            default_stderr.contains("forked"),
+            "expected the default configuration to fork a 4-element par-map \
+             (DEFAULT_THRESHOLD=2), but the trace says:\n{default_stderr}"
+        );
+    }
+
+    // EU_PP_THRESHOLD remains a working escape hatch to force sequential.
+    let forced_seq_stderr = run(&[("EU_PP_TRACE", "1"), ("EU_PP_THRESHOLD", "999999999")]);
+    assert!(
+        forced_seq_stderr.contains("sequential"),
+        "expected EU_PP_THRESHOLD=999999999 to force the sequential path, \
+         but the trace says:\n{forced_seq_stderr}"
+    );
+}
+
 /// eu-u9xj.6 (PP) — the parallel driver must survive a collection that
 /// happens *during* the map.
 ///


### PR DESCRIPTION
## Owner decision (recorded on eu-2obtj, 2026-08-04)

Remove the `par-*` predicted-benefit size gate. `par-*` is already an
explicit caller opt-in — writing it instead of the sequential form already
says "fork this" — so the runtime should not second-guess that with an
element-count heuristic. The AoC-2025 corpus findings
(`examples/aoc25/PERFORMANCE.md`) showed the old 1024-element default
rejecting exactly the workloads where forking paid most: 185 heavy elements
at 7.2x, 4 very heavy elements at 3.8x, both far below the threshold.

## Change

`DEFAULT_THRESHOLD` in `src/eval/stg/parallel/driver.rs`: 1024 -> 2, so the
only remaining count condition is the degenerate `n < 2`. `EU_PP_THRESHOLD`
remains as a tuning/testing escape hatch. Feasibility fallbacks (worker
fault, per-element arena cap, single core, non-Unix) are untouched — `par-*`
stays advisory either way.

Docs updated to match: `lib/prelude.eu` advisory block, `docs/guide/parallelism.md`,
a short note in `examples/aoc25/PERFORMANCE.md`, and a CHANGELOG entry under
`[0.15.0] - Unreleased` (slated for backport to a 0.14.1 maintenance patch).

## Fork overhead

Measured the fixed per-call cost of the fork mechanism itself (isolated from
the shared serialise/deserialise codec both fork and sequential-fallback
paths already pay): **~2-3ms on macOS ARM64**, measured-single (moderate
background load on the measuring machine — not measured-verified). Full
method and two interleaved sessions in
`docs/superpowers/reports/2026-08-04-eu-2obtj-fork-overhead.md`.

## Verification

- `cargo test`: full suite green, 0 failed (real exit code confirmed after
  an earlier pipe-swallowed exit code was caught and rerun cleanly).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- New regression test `test_pp_default_threshold_forks_small_list`
  (`tests/harness_test.rs`) asserts a 4-element `par-map` forks with **no**
  `EU_PP_THRESHOLD` override, and that the override still forces sequential.
  **Fault-injection verified**: reverting `DEFAULT_THRESHOLD` to 1024 makes
  it fail with `sequential (below threshold)`; restoring the fix makes it
  pass again.
- Existing PP tests (fork-path equivalence, GC-stress-during-fork) still
  pass unchanged, including under `EU_GC_VERIFY=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182qk1pZV4pc61DzY4ZA6C2